### PR TITLE
Update SGX dcap driver for ubuntu 16.04

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_install.sh
+++ b/parts/linux/cloud-init/artifacts/cse_install.sh
@@ -70,10 +70,10 @@ installSGXDrivers() {
     VERSION=$(grep DISTRIB_RELEASE /etc/*-release| cut -f 2 -d "=")
     case $VERSION in
     "18.04")
-        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.13.bin"
+        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.13.bin"
         ;;
     "16.04")
-        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.13.bin"
+        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.13.bin"
         ;;
     "*")
         echo "Version $VERSION is not supported"

--- a/parts/linux/cloud-init/artifacts/cse_install.sh
+++ b/parts/linux/cloud-init/artifacts/cse_install.sh
@@ -70,10 +70,10 @@ installSGXDrivers() {
     VERSION=$(grep DISTRIB_RELEASE /etc/*-release| cut -f 2 -d "=")
     case $VERSION in
     "18.04")
-        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.13.bin"
+        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3.1/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.20.bin"
         ;;
     "16.04")
-        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.13.bin"
+        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3.1/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.20.bin"
         ;;
     "*")
         echo "Version $VERSION is not supported"

--- a/parts/linux/cloud-init/artifacts/cse_install.sh
+++ b/parts/linux/cloud-init/artifacts/cse_install.sh
@@ -70,10 +70,10 @@ installSGXDrivers() {
     VERSION=$(grep DISTRIB_RELEASE /etc/*-release| cut -f 2 -d "=")
     case $VERSION in
     "18.04")
-        SGX_DRIVER_URL="https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer18.04/sgx_linux_x64_driver_1.12_c110012.bin"
+        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.13.bin"
         ;;
     "16.04")
-        SGX_DRIVER_URL="https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer16.04/sgx_linux_x64_driver_1.12_c110012.bin"
+        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.13.bin"
         ;;
     "*")
         echo "Version $VERSION is not supported"

--- a/vhdbuilder/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/vhdbuilder/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -86,10 +86,10 @@ installSGXDrivers() {
     VERSION=$(grep DISTRIB_RELEASE /etc/*-release| cut -f 2 -d "=")
     case $VERSION in
     "18.04")
-        SGX_DRIVER_URL="https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer18.04/sgx_linux_x64_driver_1.12_c110012.bin"
+        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.13.bin"
         ;;
     "16.04")
-        SGX_DRIVER_URL="https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer16.04/sgx_linux_x64_driver_1.12_c110012.bin"
+        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.13.bin"
         ;;
     "*")
         echo "Version $VERSION is not supported"

--- a/vhdbuilder/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/vhdbuilder/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -86,10 +86,10 @@ installSGXDrivers() {
     VERSION=$(grep DISTRIB_RELEASE /etc/*-release| cut -f 2 -d "=")
     case $VERSION in
     "18.04")
-        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.13.bin"
+        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3.1/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.20.bin"
         ;;
     "16.04")
-        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.13.bin"
+        SGX_DRIVER_URL="https://download.01.org/intel-sgx/sgx-dcap/1.3.1/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.20.bin"
         ;;
     "*")
         echo "Version $VERSION is not supported"


### PR DESCRIPTION
Version of Ubuntu 16.04 driver fails to compile on Ubuntu 4.15.0-1077-azure kernel 
From AKS:

"sku": "aks-ubuntu-1604-202004",
"version": "2020.04.16"

I conservatively Updated the version one release... to make it work but version 1.6 of SGX DCAP release also worked without issue.

> https://download.01.org/intel-sgx/sgx-dcap/1.6/linux/distro/ubuntuServer16.04/sgx_linux_x64_driver_1.33.bin