### PR TITLE
Bake SGX device plugin to GEN2 VHDs

### DIFF
--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -59,6 +59,7 @@ phases:
           -e SIG_GALLERY_NAME=${SIG_GALLERY_NAME} \
           -e SIG_IMAGE_NAME=${SIG_IMAGE_NAME} \
           -e SIG_IMAGE_VERSION=${SIG_IMAGE_VERSION} \
+          -e GEN2_SGX_DRIVER_INSTALL=$(GEN2_SGX_DRIVER_INSTALL) \
           ${CONTAINER_IMAGE} make -f packer.mk run-packer
         displayName: Building VHD
       - task: PublishPipelineArtifact@0

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -59,7 +59,6 @@ phases:
           -e SIG_GALLERY_NAME=${SIG_GALLERY_NAME} \
           -e SIG_IMAGE_NAME=${SIG_IMAGE_NAME} \
           -e SIG_IMAGE_VERSION=${SIG_IMAGE_VERSION} \
-          -e GEN2_SGX_DRIVER_INSTALL=$(GEN2_SGX_DRIVER_INSTALL) \
           ${CONTAINER_IMAGE} make -f packer.mk run-packer
         displayName: Building VHD
       - task: PublishPipelineArtifact@0

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -248,6 +248,15 @@ if grep -q "fullgpu" <<< "$FEATURE_FLAGS" && grep -q "gpudaemon" <<< "$FEATURE_F
     systemctlEnableAndStart nvidia-device-plugin || exit 1
 fi
 
+if grep -q "sgxInstall" <<< "$FEATURE_FLAGS"; then
+    SGX_DEVICE_PLUGIN_VERSIONS="1.0"
+    for SGX_DEVICE_PLUGIN_VERSION in ${SGX_DEVICE_PLUGIN_VERSIONS}; do
+        CONTAINER_IMAGE="mcr.microsoft.com/aks/acc/sgx-device-plugin:${SGX_DEVICE_PLUGIN_VERSION}"
+        pullContainerImage "docker" ${CONTAINER_IMAGE}
+        echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
+    done
+fi
+
 TUNNELFRONT_VERSIONS="v1.9.2-v3.0.11 v1.9.2-v4.0.11 v1.9.2-v3.0.12 v1.9.2-v4.0.12"
 for TUNNELFRONT_VERSION in ${TUNNELFRONT_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/aks/hcp/hcp-tunnel-front:${TUNNELFRONT_VERSION}"

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -248,7 +248,7 @@ if grep -q "fullgpu" <<< "$FEATURE_FLAGS" && grep -q "gpudaemon" <<< "$FEATURE_F
     systemctlEnableAndStart nvidia-device-plugin || exit 1
 fi
 
-if grep -q "sgxInstall" <<< "$FEATURE_FLAGS"; then
+if [[ ${GEN2_SGX_DRIVER_INSTALL} == true ]]; then
     SGX_DEVICE_PLUGIN_VERSIONS="1.0"
     for SGX_DEVICE_PLUGIN_VERSION in ${SGX_DEVICE_PLUGIN_VERSIONS}; do
         CONTAINER_IMAGE="mcr.microsoft.com/aks/acc/sgx-device-plugin:${SGX_DEVICE_PLUGIN_VERSION}"

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -248,7 +248,7 @@ if grep -q "fullgpu" <<< "$FEATURE_FLAGS" && grep -q "gpudaemon" <<< "$FEATURE_F
     systemctlEnableAndStart nvidia-device-plugin || exit 1
 fi
 
-if [[ ${GEN2_SGX_DRIVER_INSTALL} == true ]]; then
+if [[ ${GEN2_SGX_DRIVER_INSTALL} == "True" ]]; then
     SGX_DEVICE_PLUGIN_VERSIONS="1.0"
     for SGX_DEVICE_PLUGIN_VERSION in ${SGX_DEVICE_PLUGIN_VERSIONS}; do
         CONTAINER_IMAGE="mcr.microsoft.com/aks/acc/sgx-device-plugin:${SGX_DEVICE_PLUGIN_VERSION}"

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -248,7 +248,7 @@ if grep -q "fullgpu" <<< "$FEATURE_FLAGS" && grep -q "gpudaemon" <<< "$FEATURE_F
     systemctlEnableAndStart nvidia-device-plugin || exit 1
 fi
 
-if [[ ${GEN2_SGX_DRIVER_INSTALL} == "True" ]]; then
+if [[ ${SGX_DRIVER_INSTALL} == "True" ]]; then
     SGX_DEVICE_PLUGIN_VERSIONS="1.0"
     for SGX_DEVICE_PLUGIN_VERSION in ${SGX_DEVICE_PLUGIN_VERSIONS}; do
         CONTAINER_IMAGE="mcr.microsoft.com/aks/acc/sgx-device-plugin:${SGX_DEVICE_PLUGIN_VERSION}"

--- a/vhdbuilder/packer/vhd-image-builder-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-gen2.json
@@ -10,8 +10,7 @@
     "build_id": "{{env `BUILD_ID`}}",
     "commit": "{{env `GIT_VERSION`}}",
     "feature_flags": "{{env `FEATURE_FLAGS`}}",
-    "ubuntu_sku": "{{env `UBUNTU_SKU`}}",
-    "sgx_driver_install": "{{env `GEN2_SGX_DRIVER_INSTALL`}}"
+    "ubuntu_sku": "{{env `UBUNTU_SKU`}}"
   },
   "builders": [
     {
@@ -236,7 +235,7 @@
     {
       "type": "shell",
       "inline": [
-        "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} GEN2_SGX_DRIVER_INSTALL={{user `sgx_driver_install`}} /bin/bash -ux /home/packer/install-dependencies.sh"
+        "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} GEN2_SGX_DRIVER_INSTALL=True /bin/bash -ux /home/packer/install-dependencies.sh"
       ]
     },
     {

--- a/vhdbuilder/packer/vhd-image-builder-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-gen2.json
@@ -235,7 +235,7 @@
     {
       "type": "shell",
       "inline": [
-        "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} GEN2_SGX_DRIVER_INSTALL=True /bin/bash -ux /home/packer/install-dependencies.sh"
+        "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} SGX_DRIVER_INSTALL=True /bin/bash -ux /home/packer/install-dependencies.sh"
       ]
     },
     {

--- a/vhdbuilder/packer/vhd-image-builder-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-gen2.json
@@ -10,7 +10,8 @@
     "build_id": "{{env `BUILD_ID`}}",
     "commit": "{{env `GIT_VERSION`}}",
     "feature_flags": "{{env `FEATURE_FLAGS`}}",
-    "ubuntu_sku": "{{env `UBUNTU_SKU`}}"
+    "ubuntu_sku": "{{env `UBUNTU_SKU`}}",
+    "sgx_driver_install": "{{env `GEN2_SGX_DRIVER_INSTALL`}}"
   },
   "builders": [
     {
@@ -235,7 +236,7 @@
     {
       "type": "shell",
       "inline": [
-        "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} /bin/bash -ux /home/packer/install-dependencies.sh"
+        "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} GEN2_SGX_DRIVER_INSTALL={{user `sgx_driver_install`}} /bin/bash -ux /home/packer/install-dependencies.sh"
       ]
     },
     {


### PR DESCRIPTION
This change enables us to bake the sgx device plugin to the GEN2 VHDs