### PR TITLE
Move bpf/bcc installation out of cse

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 source /home/packer/provision_installs.sh
 source /home/packer/provision_source.sh
+source /home/packer/tool_installs.sh
 source /home/packer/packer_source.sh
 
 VHD_LOGS_FILEPATH=/opt/azure/vhd-install.complete

--- a/vhdbuilder/packer/vhd-image-builder-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-gen2.json
@@ -79,6 +79,11 @@
     },
     {
       "type": "file",
+      "source": "vhdbuilder/scripts/linux/tool_installs.sh",
+      "destination": "/home/packer/tool_installs.sh"
+    },
+    {
+      "type": "file",
       "source": "vhdbuilder/packer/install-dependencies.sh",
       "destination": "/home/packer/install-dependencies.sh"
     },

--- a/vhdbuilder/packer/vhd-image-builder-sig.json
+++ b/vhdbuilder/packer/vhd-image-builder-sig.json
@@ -82,6 +82,11 @@
     },
     {
       "type": "file",
+      "source": "vhdbuilder/scripts/linux/tool_installs.sh",
+      "destination": "/home/packer/tool_installs.sh"
+    },
+    {
+      "type": "file",
       "source": "vhdbuilder/packer/install-dependencies.sh",
       "destination": "/home/packer/install-dependencies.sh"
     },

--- a/vhdbuilder/packer/vhd-image-builder.json
+++ b/vhdbuilder/packer/vhd-image-builder.json
@@ -73,6 +73,11 @@
     },
     {
       "type": "file",
+      "source": "vhdbuilder/scripts/linux/tool_installs.sh",
+      "destination": "/home/packer/tool_installs.sh"
+    },
+    {
+      "type": "file",
       "source": "vhdbuilder/packer/install-dependencies.sh",
       "destination": "/home/packer/install-dependencies.sh"
     },

--- a/vhdbuilder/scripts/linux/tool_installs.sh
+++ b/vhdbuilder/scripts/linux/tool_installs.sh
@@ -1,0 +1,54 @@
+
+#!/bin/bash
+
+{{/* BCC/BPF-related error codes */}}
+ERR_IOVISOR_KEY_DOWNLOAD_TIMEOUT=168 {{/* Timeout waiting to download IOVisor repo key */}}
+ERR_IOVISOR_APT_KEY_TIMEOUT=169 {{/* Timeout waiting for IOVisor apt-key */}}
+ERR_BCC_INSTALL_TIMEOUT=170 {{/* Timeout waiting for bcc install */}}
+ERR_BPFTRACE_BIN_DOWNLOAD_FAIL=171 {{/* Failed to download bpftrace binary */}}
+ERR_BPFTRACE_TOOLS_DOWNLOAD_FAIL=172 {{/* Failed to download bpftrace default programs */}}
+
+BPFTRACE_DOWNLOADS_DIR="/opt/bpftrace/downloads"
+UBUNTU_CODENAME=$(lsb_release -c -s)
+
+installBcc() {
+    echo "Installing BCC tools..."
+    IOVISOR_KEY_TMP=/tmp/iovisor-release.key
+    IOVISOR_URL=https://repo.iovisor.org/GPG-KEY
+    retrycmd_if_failure_no_stats 120 5 25 curl -fsSL $IOVISOR_URL > $IOVISOR_KEY_TMP || exit $ERR_IOVISOR_KEY_DOWNLOAD_TIMEOUT
+    wait_for_apt_locks
+    retrycmd_if_failure 30 5 30 apt-key add $IOVISOR_KEY_TMP || exit $ERR_IOVISOR_APT_KEY_TIMEOUT
+    echo "deb https://repo.iovisor.org/apt/${UBUNTU_CODENAME} ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/iovisor.list
+    apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT
+    apt_get_install 120 5 25 bcc-tools libbcc-examples linux-headers-$(uname -r) || exit $ERR_BCC_INSTALL_TIMEOUT
+    apt-key del "$(gpg --with-colons $IOVISOR_KEY_TMP 2>/dev/null | head -n 1 | cut -d':' -f5)"
+    rm -f /etc/apt/sources.list.d/iovisor.list
+}
+
+installBpftrace() {
+    local version="v0.9.4"
+    local bpftrace_bin="bpftrace"
+    local bpftrace_tools="bpftrace-tools.tar"
+    local bpftrace_url="https://upstreamartifacts.azureedge.net/$bpftrace_bin/$version"
+    local bpftrace_filepath="/usr/local/bin/$bpftrace_bin"
+    local tools_filepath="/usr/local/share/$bpftrace_bin"
+    if [[ -f "$bpftrace_filepath" ]]; then
+        installed_version="$($bpftrace_bin -V | cut -d' ' -f2)"
+        if [[ "$version" == "$installed_version" ]]; then
+            return
+        fi
+        rm "$bpftrace_filepath"
+        if [[ -d "$tools_filepath" ]]; then
+            rm -r  "$tools_filepath"
+        fi
+    fi
+    mkdir -p "$tools_filepath"
+    install_dir="$BPFTRACE_DOWNLOADS_DIR/$version"
+    mkdir -p "$install_dir"
+    download_path="$install_dir/$bpftrace_tools"
+    retrycmd_if_failure 30 5 60 curl -fSL -o "$bpftrace_filepath" "$bpftrace_url/$bpftrace_bin" || exit $ERR_BPFTRACE_BIN_DOWNLOAD_FAIL
+    retrycmd_if_failure 30 5 60 curl -fSL -o "$download_path" "$bpftrace_url/$bpftrace_tools" || exit $ERR_BPFTRACE_TOOLS_DOWNLOAD_FAIL
+    tar -xvf "$download_path" -C "$tools_filepath"
+    chmod +x "$bpftrace_filepath"
+    chmod -R +x "$tools_filepath/tools"
+}


### PR DESCRIPTION
1.  it is only used in VHD baking, not part of cse
2. we want to keep cse_install.sh as small as possible to avoid exceeding cloud-init content size limit