### PR TITLE
fix: inconsistency in data-root

### DIFF
--- a/parts/linux/cloud-init/nodecustomdata.yml
+++ b/parts/linux/cloud-init/nodecustomdata.yml
@@ -178,7 +178,7 @@ write_files:
              "runtimeArgs": []
         }
       }{{end}}{{if HasDataDir}},
-      "root": "{{GetDataDir}}"{{- end}}
+      "data-root": "{{GetDataDir}}"{{- end}}
     }
 {{end}}
 

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -3174,7 +3174,7 @@ write_files:
              "runtimeArgs": []
         }
       }{{end}}{{if HasDataDir}},
-      "root": "{{GetDataDir}}"{{- end}}
+      "data-root": "{{GetDataDir}}"{{- end}}
     }
 {{end}}
 


### PR DESCRIPTION
https://github.com/Azure/aks-engine/blob/b6ea0dc5755d1d4566f9dc412d73d22f175a3d10/pkg/api/common/types.go#L38

Due to the difference in implementation between agentbaker and aks-engine, I failed to convert this properly when updating the templates. This causes node provisioning to fail.

How can I test this better? I guess I should use the test VHD pipeline to try to provision a cluster based off my branch? What's the best practice?