### PR TITLE
[wip] enable settings kube-reserved cgroup

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -234,7 +234,14 @@ func (gc *generateCmd) run() error {
 
 	customDataStr := templateGenerator.GetNodeBootstrappingPayload(gc.containerService, gc.containerService.Properties.AgentPoolProfiles[0])
 
-	cseCmdStr := templateGenerator.GetNodeBootstrappingCmd(gc.containerService, gc.containerService.Properties.AgentPoolProfiles[0], "<tenantid>", "<subid>", "rgname", "msiid")
+	cseCmdStr := templateGenerator.GetNodeBootstrappingCmd(gc.containerService, gc.containerService.Properties.AgentPoolProfiles[0],
+		"<tenantid>",
+		"<subid>",
+		"rgname",
+		"msiid",
+		gc.containerService.Properties.AgentPoolProfiles[0].IsNSeriesSKU(),
+		gc.containerService.Properties.AgentPoolProfiles[0].IsNSeriesSKU(),
+	)
 
 	writer := &engine.ArtifactWriter{
 		Translator: &i18n.Translator{

--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,4 @@ require (
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // TODO(ace): CHANGE THIS BEFORE MERGING
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-replace github.com/Azure/aks-engine => github.com/alexeldeib/aks-engine v0.0.0-20200624024745-b2b288b92757
+replace github.com/Azure/aks-engine => github.com/alexeldeib/aks-engine v0.47.1-0.20200629193946-f5a3cf9de56f

--- a/go.mod
+++ b/go.mod
@@ -23,3 +23,8 @@ require (
 	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect
 	gopkg.in/ini.v1 v1.57.0
 )
+
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// TODO(ace): CHANGE THIS BEFORE MERGING
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+replace github.com/Azure/aks-engine => github.com/alexeldeib/aks-engine v0.0.0-20200624024745-b2b288b92757

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/Azure/aks-engine v0.47.0-aks-gomod-80 h1:smjVBUJJXeVuQcoR9F3m+LtWOLYmqAOPOyIobsCaGz0=
-github.com/Azure/aks-engine v0.47.0-aks-gomod-80/go.mod h1:vYBa1EBBoQRP3uYh+Lr5NOxF4WwaDRbyKjQ/Ljm5ZME=
 github.com/Azure/azure-sdk-for-go v36.2.0+incompatible h1:09cv2WoH0g6jl6m2iT+R9qcIPZKhXEL0sbmLhxP895s=
 github.com/Azure/azure-sdk-for-go v36.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
@@ -35,8 +33,8 @@ github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alexeldeib/aks-engine v0.0.0-20200624024745-b2b288b92757 h1:IW7ZtSzTYbvFworeAgdNHcka76LuSenhSVWBYpmob5w=
-github.com/alexeldeib/aks-engine v0.0.0-20200624024745-b2b288b92757/go.mod h1:vYBa1EBBoQRP3uYh+Lr5NOxF4WwaDRbyKjQ/Ljm5ZME=
+github.com/alexeldeib/aks-engine v0.47.1-0.20200629193946-f5a3cf9de56f h1:K3ZwICR8OqGOtWKu4F5AHvMLu7qw1ujs4ERS7yUMmkg=
+github.com/alexeldeib/aks-engine v0.47.1-0.20200629193946-f5a3cf9de56f/go.mod h1:vYBa1EBBoQRP3uYh+Lr5NOxF4WwaDRbyKjQ/Ljm5ZME=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alexeldeib/aks-engine v0.0.0-20200624024745-b2b288b92757 h1:IW7ZtSzTYbvFworeAgdNHcka76LuSenhSVWBYpmob5w=
+github.com/alexeldeib/aks-engine v0.0.0-20200624024745-b2b288b92757/go.mod h1:vYBa1EBBoQRP3uYh+Lr5NOxF4WwaDRbyKjQ/Ljm5ZME=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -230,8 +230,8 @@ ensureDocker() {
         wait_for_file 1200 1 $DOCKER_MOUNT_FLAGS_SYSTEMD_FILE || exit $ERR_FILE_WATCH_TIMEOUT
     fi
     {{- if HasKubeReservedCgroup}}
-    DOCKER_SLICE_FILE=/etc/systemd/system/docker.service.d/kubereserved-slice.conf
-    wait_for_file 1200 1 $DOCKER_SLICE_FILE || exit $ERR_FILE_WATCH_TIMEOUT
+    DOCKER_SLICE_CONF_FILE=/etc/systemd/system/docker.service.d/kubereserved-slice.conf
+    wait_for_file 1200 1 $DOCKER_SLICE_CONF_FILE || exit $ERR_FILE_WATCH_TIMEOUT
     {{- end}}
     DOCKER_JSON_FILE=/etc/docker/daemon.json
     for i in $(seq 1 1200); do
@@ -278,8 +278,8 @@ ensureKubelet() {
     {{- if HasKubeReservedCgroup}}
     KUBERESERVED_SLICE_FILE=/etc/systemd/system/{{- GetKubeReservedCgroup -}}.slice
     wait_for_file 1200 1 $KUBERESERVED_SLICE_FILE || exit $ERR_KUBERESERVED_SLICE_SETUP_FAIL
-    KUBELET_SLICE_FILE=/etc/systemd/system/kubelet.service.d/kubereserved-slice.conf
-    wait_for_file 1200 1 $KUBELET_SLICE_FILE || exit $ERR_KUBELET_SLICE_SETUP_FAIL
+    KUBELET_SLICE_CONFIG_FILE=/etc/systemd/system/kubelet.service.d/kubereserved-slice.conf
+    wait_for_file 1200 1 $KUBELET_SLICE_CONFIG_FILE || exit $ERR_KUBELET_SLICE_SETUP_FAIL
     {{- end}}
     systemctlEnableAndStart kubelet || exit $ERR_KUBELET_START_FAIL
     {{if HasCiliumNetworkPolicy}}

--- a/parts/linux/cloud-init/nodecustomdata.yml
+++ b/parts/linux/cloud-init/nodecustomdata.yml
@@ -58,6 +58,46 @@ write_files:
     {{GetVariableProperty "cloudInitData" "initAKSCustomCloud"}}
 {{end}}
 
+{{- if HasKubeReservedCgroup}}
+- path: /etc/systemd/system/{{- GetKubeReservedCgroup -}}.slice
+  permissions: "0644"
+  owner: root
+  content: |
+    [Unit]
+    Description=Limited resources slice for Kubernetes services
+    Documentation=man:systemd.special(7)
+    DefaultDependencies=no
+    Before=slices.target
+    Requires=-.slice
+    After=-.slice
+    #EOF
+    
+- path: /etc/systemd/system/kubelet.service.d/kubereserved-slice.conf
+  permissions: "0644"
+  owner: root
+  content: |
+    [Service]
+    Slice={{- GetKubeReservedCgroup -}}.slice
+    #EOF
+  {{if NeedsContainerd}}
+- path: /etc/systemd/system/containerd.service.d/kubereserved-slice.conf
+  permissions: "0644"
+  owner: root
+  content: |
+    [Service]
+    Slice={{- GetKubeReservedCgroup -}}.slice
+    #EOF
+  {{else}}
+- path: /etc/systemd/system/docker.service.d/kubereserved-slice.conf
+  permissions: "0644"
+  owner: root
+  content: |
+    [Service]
+    Slice={{- GetKubeReservedCgroup -}}.slice
+    #EOF
+  {{end}}
+{{end}}
+
 - path: /etc/systemd/system/kubelet.service
   permissions: "0644"
   encoding: gzip

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -528,16 +528,16 @@ func getContainerServiceFuncMap(cs *api.ContainerService, profile *api.AgentPool
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.ContainerRuntimeConfig[common.ContainerDataDirKey]
 		},
 		"HasKubeReservedCgroup": func() bool {
-			kc := cs.Properties.OrchestratorProfile.KubernetesConfig
-			return kc != nil && kc.KubeReservedCgroup != ""
-		},
-
-		"GetKubeReservedCgroup": func() string {
-			kc := cs.Properties.OrchestratorProfile.KubernetesConfig
-			if kc == nil {
-				return ""
+			if profile.KubernetesConfig != nil && profile.KubernetesConfig.KubeReservedCgroup != "" {
+				return true
 			}
-			return kc.KubeReservedCgroup
+			return cs.Properties.OrchestratorProfile.KubernetesConfig != nil && cs.Properties.OrchestratorProfile.KubernetesConfig.KubeReservedCgroup != ""
+		},
+		"GetKubeReservedCgroup": func() string {
+			if profile.KubernetesConfig != nil && profile.KubernetesConfig.KubeReservedCgroup != "" {
+				return profile.KubernetesConfig.KubeReservedCgroup
+			}
+			return cs.Properties.OrchestratorProfile.KubernetesConfig.KubeReservedCgroup
 		},
 		"HasNSeriesSKU": func() bool {
 			return cs.Properties.HasNSeriesSKU()

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -527,6 +527,18 @@ func getContainerServiceFuncMap(cs *api.ContainerService, profile *api.AgentPool
 		"GetDataDir": func() string {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.ContainerRuntimeConfig[common.ContainerDataDirKey]
 		},
+		"HasKubeReservedCgroup": func() bool {
+			kc := cs.Properties.OrchestratorProfile.KubernetesConfig
+			return kc != nil && kc.KubeReservedCgroup != ""
+		},
+
+		"GetKubeReservedCgroup": func() string {
+			kc := cs.Properties.OrchestratorProfile.KubernetesConfig
+			if kc == nil {
+				return ""
+			}
+			return kc.KubeReservedCgroup
+		},
 		"HasNSeriesSKU": func() bool {
 			return cs.Properties.HasNSeriesSKU()
 		},

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -679,8 +679,8 @@ ensureDocker() {
         wait_for_file 1200 1 $DOCKER_MOUNT_FLAGS_SYSTEMD_FILE || exit $ERR_FILE_WATCH_TIMEOUT
     fi
     {{- if HasKubeReservedCgroup}}
-    DOCKER_SLICE_FILE=/etc/systemd/system/docker.service.d/kubereserved-slice.conf
-    wait_for_file 1200 1 $DOCKER_SLICE_FILE || exit $ERR_FILE_WATCH_TIMEOUT
+    DOCKER_SLICE_CONF_FILE=/etc/systemd/system/docker.service.d/kubereserved-slice.conf
+    wait_for_file 1200 1 $DOCKER_SLICE_CONF_FILE || exit $ERR_FILE_WATCH_TIMEOUT
     {{- end}}
     DOCKER_JSON_FILE=/etc/docker/daemon.json
     for i in $(seq 1 1200); do
@@ -727,8 +727,8 @@ ensureKubelet() {
     {{- if HasKubeReservedCgroup}}
     KUBERESERVED_SLICE_FILE=/etc/systemd/system/{{- GetKubeReservedCgroup -}}.slice
     wait_for_file 1200 1 $KUBERESERVED_SLICE_FILE || exit $ERR_KUBERESERVED_SLICE_SETUP_FAIL
-    KUBELET_SLICE_FILE=/etc/systemd/system/kubelet.service.d/kubereserved-slice.conf
-    wait_for_file 1200 1 $KUBELET_SLICE_FILE || exit $ERR_KUBELET_SLICE_SETUP_FAIL
+    KUBELET_SLICE_CONFIG_FILE=/etc/systemd/system/kubelet.service.d/kubereserved-slice.conf
+    wait_for_file 1200 1 $KUBELET_SLICE_CONFIG_FILE || exit $ERR_KUBELET_SLICE_SETUP_FAIL
     {{- end}}
     systemctlEnableAndStart kubelet || exit $ERR_KUBELET_START_FAIL
     {{if HasCiliumNetworkPolicy}}

--- a/vendor/github.com/Azure/aks-engine/pkg/api/azenvtypes.go
+++ b/vendor/github.com/Azure/aks-engine/pkg/api/azenvtypes.go
@@ -196,7 +196,7 @@ var (
 		ImageOffer:     "aks-windows",
 		ImageSku:       "2019-datacenter-core-smalldisk-2006",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "17763.1282.200610",
+		ImageVersion:   "17763.1282.200625",
 	}
 
 	// WindowsServer2019OSImageConfig is the 'vanilla' Windows Server 2019 image
@@ -204,7 +204,7 @@ var (
 		ImageOffer:     "WindowsServer",
 		ImageSku:       "2019-Datacenter-Core-with-Containers-smalldisk",
 		ImagePublisher: "MicrosoftWindowsServer",
-		ImageVersion:   "17763.1217.2005081535",
+		ImageVersion:   "17763.1282.2006061953",
 	}
 
 	// ACC1604OSImageConfig is the ACC image based on Ubuntu 16.04.

--- a/vendor/github.com/Azure/aks-engine/pkg/api/converterfromapi.go
+++ b/vendor/github.com/Azure/aks-engine/pkg/api/converterfromapi.go
@@ -327,6 +327,7 @@ func convertKubernetesConfigToVLabs(apiCfg *KubernetesConfig, vlabsCfg *vlabs.Ku
 	vlabsCfg.PrivateAzureRegistryServer = apiCfg.PrivateAzureRegistryServer
 	vlabsCfg.OutboundRuleIdleTimeoutInMinutes = apiCfg.OutboundRuleIdleTimeoutInMinutes
 	vlabsCfg.CloudProviderDisableOutboundSNAT = apiCfg.CloudProviderDisableOutboundSNAT
+	vlabsCfg.KubeReservedCgroup = apiCfg.KubeReservedCgroup
 	convertAddonsToVlabs(apiCfg, vlabsCfg)
 	convertKubeletConfigToVlabs(apiCfg, vlabsCfg)
 	convertControllerManagerConfigToVlabs(apiCfg, vlabsCfg)

--- a/vendor/github.com/Azure/aks-engine/pkg/api/convertertoapi.go
+++ b/vendor/github.com/Azure/aks-engine/pkg/api/convertertoapi.go
@@ -341,6 +341,7 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	api.PrivateAzureRegistryServer = vlabs.PrivateAzureRegistryServer
 	api.OutboundRuleIdleTimeoutInMinutes = vlabs.OutboundRuleIdleTimeoutInMinutes
 	api.CloudProviderDisableOutboundSNAT = vlabs.CloudProviderDisableOutboundSNAT
+	api.KubeReservedCgroup = vlabs.KubeReservedCgroup
 	convertAddonsToAPI(vlabs, api)
 	convertKubeletConfigToAPI(vlabs, api)
 	convertControllerManagerConfigToAPI(vlabs, api)

--- a/vendor/github.com/Azure/aks-engine/pkg/api/k8s_versions.go
+++ b/vendor/github.com/Azure/aks-engine/pkg/api/k8s_versions.go
@@ -182,6 +182,18 @@ func getKubeConfigs() map[string]map[string]string {
 
 func getVersionOverrides(v string) map[string]string {
 	switch v {
+	case "1.18.4":
+		return map[string]string{"windowszip": "v1.18.4-hotfix.20200624/windowszip/v1.18.4-hotfix.20200624-1int.zip"}
+	case "1.18.2":
+		return map[string]string{"windowszip": "v1.18.2-hotfix.20200624/windowszip/v1.18.2-hotfix.20200624-1int.zip"}
+	case "1.17.7":
+		return map[string]string{"windowszip": "v1.17.7-hotfix.20200624/windowszip/v1.17.7-hotfix.20200624-1int.zip"}
+	case "1.16.11":
+		return map[string]string{"windowszip": "v1.16.11-hotfix.20200617/windowszip/v1.16.11-hotfix.20200617-1int.zip"}
+	case "1.16.10":
+		return map[string]string{"windowszip": "v1.16.10-hotfix.20200623/windowszip/v1.16.10-hotfix.20200623-1int.zip"}
+	case "1.15.12":
+		return map[string]string{"windowszip": "v1.15.12-hotfix.20200623/windowszip/v1.15.12-hotfix.20200623-1int.zip"}
 	case "1.8.11":
 		return map[string]string{"kube-dns": "k8s-dns-kube-dns-amd64:1.14.9"}
 	case "1.8.9":

--- a/vendor/github.com/Azure/aks-engine/pkg/api/types.go
+++ b/vendor/github.com/Azure/aks-engine/pkg/api/types.go
@@ -449,6 +449,7 @@ type KubernetesConfig struct {
 	APIServerConfig                   map[string]string `json:"apiServerConfig,omitempty"`
 	SchedulerConfig                   map[string]string `json:"schedulerConfig,omitempty"`
 	PodSecurityPolicyConfig           map[string]string `json:"podSecurityPolicyConfig,omitempty"` // Deprecated
+	KubeReservedCgroup                string            `json:"kubeReservedCgroup,omitempty"`
 	CloudProviderBackoffMode          string            `json:"cloudProviderBackoffMode"`
 	CloudProviderBackoff              *bool             `json:"cloudProviderBackoff,omitempty"`
 	CloudProviderBackoffRetries       int               `json:"cloudProviderBackoffRetries,omitempty"`

--- a/vendor/github.com/Azure/aks-engine/pkg/api/vlabs/types.go
+++ b/vendor/github.com/Azure/aks-engine/pkg/api/vlabs/types.go
@@ -352,6 +352,7 @@ type KubernetesConfig struct {
 	APIServerConfig                   map[string]string `json:"apiServerConfig,omitempty"`
 	SchedulerConfig                   map[string]string `json:"schedulerConfig,omitempty"`
 	PodSecurityPolicyConfig           map[string]string `json:"podSecurityPolicyConfig,omitempty"` // Deprecated
+	KubeReservedCgroup                string            `json:"kubeReservedCgroup,omitempty"`
 	CloudProviderBackoffMode          string            `json:"cloudProviderBackoffMode"`
 	CloudProviderBackoff              *bool             `json:"cloudProviderBackoff,omitempty"`
 	CloudProviderBackoffRetries       int               `json:"cloudProviderBackoffRetries,omitempty"`

--- a/vendor/github.com/Azure/aks-engine/pkg/engine/template_generator.go
+++ b/vendor/github.com/Azure/aks-engine/pkg/engine/template_generator.go
@@ -295,6 +295,18 @@ func getContainerServiceFuncMap(cs *api.ContainerService) template.FuncMap {
 			}
 			return kc.GetOrderedKubeletConfigStringForPowershell()
 		},
+		"HasKubeReservedCgroup": func() bool {
+			kc := cs.Properties.OrchestratorProfile.KubernetesConfig
+			return kc != nil && kc.KubeReservedCgroup != ""
+		},
+
+		"GetKubeReservedCgroup": func() string {
+			kc := cs.Properties.OrchestratorProfile.KubernetesConfig
+			if kc == nil {
+				return ""
+			}
+			return kc.KubeReservedCgroup
+		},
 		"GetK8sRuntimeConfigKeyVals": func(config map[string]string) string {
 			return common.GetOrderedEscapedKeyValsString(config)
 		},

--- a/vendor/github.com/Azure/aks-engine/pkg/engine/templates_generated.go
+++ b/vendor/github.com/Azure/aks-engine/pkg/engine/templates_generated.go
@@ -41645,7 +41645,7 @@ function Write-KubeClusterConfig {
     $Global:ClusterConfiguration | Add-Member -MemberType NoteProperty -Name Cri -Value @{
         Name   = $global:ContainerRuntime;
         Images = @{
-            "Pause" = "mcr.microsoft.com/oss/kubernetes/pause:1.3.1"
+            "Pause" = "mcr.microsoft.com/oss/kubernetes/pause:1.4.0"
         }
     }
 
@@ -43676,7 +43676,7 @@ New-InfraContainer {
     $clusterConfig = ConvertFrom-Json ((Get-Content $global:KubeClusterConfigPath -ErrorAction Stop) | Out-String)
     $defaultPauseImage = $clusterConfig.Cri.Images.Pause
 
-    $pauseImageVersions = @("1803", "1809", "1903", "1909")
+    $pauseImageVersions = @("1809", "1903", "1909", "2004")
 
     if ($pauseImageVersions -icontains $windowsVersion) {
         $imageList = docker images $defaultPauseImage --format "{{.Repository}}:{{.Tag}}"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/Azure/aks-engine v0.47.0-aks-gomod-80
+# github.com/Azure/aks-engine v0.47.0-aks-gomod-80 => github.com/alexeldeib/aks-engine v0.47.1-0.20200629193946-f5a3cf9de56f
 github.com/Azure/aks-engine/pkg/api
 github.com/Azure/aks-engine/pkg/api/agentPoolOnlyApi/v20170831
 github.com/Azure/aks-engine/pkg/api/agentPoolOnlyApi/v20180331


### PR DESCRIPTION
it's best practice to run kubelet + docker in a separate cgroup for kube-reserved processes. this enforces isolation from other system daemons under resource pressure. This PR makes doing so possible on top of https://github.com/Azure/aks-engine/pull/3530 which itself is a cherry-pick of https://github.com/Azure/aks-engine/pull/3201 to AKS.