### PR TITLE
fixing extra quote and missing ports for custom clouds

### DIFF
--- a/parts/linux/cloud-init/nodecustomdata.yml
+++ b/parts/linux/cloud-init/nodecustomdata.yml
@@ -359,7 +359,7 @@ write_files:
     KUBELET_NODE_LABELS={{GetAgentKubernetesLabelsDeprecated . "',variables('labelResourceGroup'),'"}}
 {{end}}
 {{- if IsAKSCustomCloud}}
-    AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/{{GetTargetEnvironment}}.json"
+    AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/{{GetTargetEnvironment}}.json
 {{end}}
     #EOF
 

--- a/pkg/agent/variables.go
+++ b/pkg/agent/variables.go
@@ -111,7 +111,7 @@ func getOutBoundCmd(cs *api.ContainerService) string {
 	if cs.GetCloudSpecConfig().CloudName == api.AzureChinaCloud {
 		registry = `gcr.azk8s.cn 443`
 	} else if cs.IsAKSCustomCloud() {
-		registry = cs.Properties.CustomCloudEnv.McrURL
+		registry = cs.Properties.CustomCloudEnv.McrURL + " 443"
 	} else {
 		registry = `mcr.microsoft.com 443`
 	}

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -3442,7 +3442,7 @@ write_files:
     KUBELET_NODE_LABELS={{GetAgentKubernetesLabelsDeprecated . "',variables('labelResourceGroup'),'"}}
 {{end}}
 {{- if IsAKSCustomCloud}}
-    AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/{{GetTargetEnvironment}}.json"
+    AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/{{GetTargetEnvironment}}.json
 {{end}}
     #EOF
 


### PR DESCRIPTION
There is an extra double quote for AZURE_ENVIRONMENT_FILE env variable in /etc/default/kubelet. 
Also, the outbound connection test command needs to include port 443 for MCR.