### PR TITLE
Port aks-engine's ContainerService struct into our code base.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/api/vlabs"
 	"github.com/Azure/aks-engine/pkg/armhelpers"
@@ -292,7 +293,7 @@ func getCompletionCmd(root *cobra.Command) *cobra.Command {
 	return completionCmd
 }
 
-func writeCustomCloudProfile(cs *api.ContainerService) error {
+func writeCustomCloudProfile(cs *datamodel.ContainerService) error {
 
 	tmpFile, err := ioutil.TempFile("", "azurestackcloud.json")
 	tmpFileName := tmpFile.Name()

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/api/common"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -16,7 +17,7 @@ import (
 
 var _ = Describe("Assert generated customData and cseCmd", func() {
 	DescribeTable("Generated customData and CSE", func(folder, k8sVersion string, configUpdator func(*NodeBootstrappingConfiguration)) {
-		cs := &api.ContainerService{
+		cs := &datamodel.ContainerService{
 			Location: "southcentralus",
 			Type:     "Microsoft.ContainerService/ManagedClusters",
 			Properties: &api.Properties{

--- a/pkg/agent/datamodel/addons.go
+++ b/pkg/agent/datamodel/addons.go
@@ -1,0 +1,1066 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/aks-engine/pkg/api/common"
+	"github.com/Azure/aks-engine/pkg/helpers"
+	"github.com/Azure/go-autorest/autorest/to"
+	log "github.com/sirupsen/logrus"
+)
+
+func (cs *ContainerService) setAddonsConfig(isUpgrade bool) {
+	o := cs.Properties.OrchestratorProfile
+	clusterDNSPrefix := "aks-engine-cluster"
+	if cs != nil && cs.Properties != nil && cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.DNSPrefix != "" {
+		clusterDNSPrefix = cs.Properties.MasterProfile.DNSPrefix
+	}
+	cloudSpecConfig := cs.GetCloudSpecConfig()
+	k8sComponents := api.K8sComponentsByVersionMap[o.OrchestratorVersion]
+	specConfig := cloudSpecConfig.KubernetesSpecConfig
+	omsagentImage := "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod01072020"
+	var workspaceDomain string
+	if cs.Properties.IsAzureStackCloud() {
+		dependenciesLocation := string(cs.Properties.CustomCloudProfile.DependenciesLocation)
+		workspaceDomain = helpers.GetLogAnalyticsWorkspaceDomain(dependenciesLocation)
+		if strings.EqualFold(dependenciesLocation, "china") {
+			omsagentImage = "dockerhub.azk8s.cn/microsoft/oms:ciprod01072020"
+		}
+	} else {
+		workspaceDomain = helpers.GetLogAnalyticsWorkspaceDomain(cloudSpecConfig.CloudName)
+		if strings.EqualFold(cloudSpecConfig.CloudName, "AzureChinaCloud") {
+			omsagentImage = "dockerhub.azk8s.cn/microsoft/oms:ciprod01072020"
+		}
+	}
+	workspaceDomain = base64.StdEncoding.EncodeToString([]byte(workspaceDomain))
+	defaultsHeapsterAddonsConfig := api.KubernetesAddon{
+		Name:    common.HeapsterAddonName,
+		Enabled: to.BoolPtr(api.DefaultHeapsterAddonEnabled),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.HeapsterAddonName,
+				Image:          specConfig.KubernetesImageBase + k8sComponents["heapster"],
+				CPURequests:    "88m",
+				MemoryRequests: "204Mi",
+				CPULimits:      "88m",
+				MemoryLimits:   "204Mi",
+			},
+			{
+				Name:           "heapster-nanny",
+				Image:          specConfig.KubernetesImageBase + k8sComponents["addonresizer"],
+				CPURequests:    "88m",
+				MemoryRequests: "204Mi",
+				CPULimits:      "88m",
+				MemoryLimits:   "204Mi",
+			},
+		},
+	}
+
+	defaultTillerAddonsConfig := api.KubernetesAddon{
+		Name:    common.TillerAddonName,
+		Enabled: to.BoolPtr(api.DefaultTillerAddonEnabled),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.TillerAddonName,
+				CPURequests:    "50m",
+				MemoryRequests: "150Mi",
+				CPULimits:      "50m",
+				MemoryLimits:   "150Mi",
+				Image:          specConfig.TillerImageBase + k8sComponents[common.TillerAddonName],
+			},
+		},
+		Config: map[string]string{
+			"max-history": strconv.Itoa(api.DefaultTillerMaxHistory),
+		},
+	}
+
+	defaultACIConnectorAddonsConfig := api.KubernetesAddon{
+		Name:    common.ACIConnectorAddonName,
+		Enabled: to.BoolPtr(api.DefaultACIConnectorAddonEnabled && !cs.Properties.IsAzureStackCloud()),
+		Config: map[string]string{
+			"region":   "westus",
+			"nodeName": "aci-connector",
+			"os":       "Linux",
+			"taint":    "azure.com/aci",
+		},
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.ACIConnectorAddonName,
+				CPURequests:    "50m",
+				MemoryRequests: "150Mi",
+				CPULimits:      "50m",
+				MemoryLimits:   "150Mi",
+				Image:          specConfig.ACIConnectorImageBase + k8sComponents[common.ACIConnectorAddonName],
+			},
+		},
+	}
+
+	defaultClusterAutoscalerAddonsConfig := api.KubernetesAddon{
+		Name:    common.ClusterAutoscalerAddonName,
+		Enabled: to.BoolPtr(api.DefaultClusterAutoscalerAddonEnabled && !cs.Properties.IsAzureStackCloud()),
+		Mode:    api.AddonModeEnsureExists,
+		Config: map[string]string{
+			"scan-interval":                         "1m",
+			"expendable-pods-priority-cutoff":       "-10",
+			"ignore-daemonsets-utilization":         "false",
+			"ignore-mirror-pods-utilization":        "false",
+			"max-autoprovisioned-node-group-count":  "15",
+			"max-empty-bulk-delete":                 "10",
+			"max-failing-time":                      "15m0s",
+			"max-graceful-termination-sec":          "600",
+			"max-inactivity":                        "10m0s",
+			"max-node-provision-time":               "15m0s",
+			"max-nodes-total":                       "0",
+			"max-total-unready-percentage":          "45",
+			"memory-total":                          "0:6400000",
+			"min-replica-count":                     "0",
+			"new-pod-scale-up-delay":                "0s",
+			"node-autoprovisioning-enabled":         "false",
+			"ok-total-unready-count":                "3",
+			"scale-down-candidates-pool-min-count":  "50",
+			"scale-down-candidates-pool-ratio":      "0.1",
+			"scale-down-delay-after-add":            "10m0s",
+			"scale-down-delay-after-delete":         "1m",
+			"scale-down-delay-after-failure":        "3m0s",
+			"scale-down-enabled":                    "true",
+			"scale-down-non-empty-candidates-count": "30",
+			"scale-down-unneeded-time":              "10m0s",
+			"scale-down-unready-time":               "20m0s",
+			"scale-down-utilization-threshold":      "0.5",
+			"skip-nodes-with-local-storage":         "false",
+			"skip-nodes-with-system-pods":           "true",
+			"stderrthreshold":                       "2",
+			"unremovable-node-recheck-timeout":      "5m0s",
+			"v":                                     "3",
+			"write-status-configmap":                "true",
+			"balance-similar-node-groups":           "true",
+		},
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.ClusterAutoscalerAddonName,
+				CPURequests:    "100m",
+				MemoryRequests: "300Mi",
+				CPULimits:      "100m",
+				MemoryLimits:   "300Mi",
+				Image:          specConfig.KubernetesImageBase + k8sComponents[common.ClusterAutoscalerAddonName],
+			},
+		},
+		Pools: makeDefaultClusterAutoscalerAddonPoolsConfig(cs),
+	}
+
+	defaultBlobfuseFlexVolumeAddonsConfig := api.KubernetesAddon{
+		Name:    common.BlobfuseFlexVolumeAddonName,
+		Enabled: to.BoolPtr(api.DefaultBlobfuseFlexVolumeAddonEnabled && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.8.0") && !cs.Properties.HasCoreOS() && !cs.Properties.IsAzureStackCloud()),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.BlobfuseFlexVolumeAddonName,
+				CPURequests:    "50m",
+				MemoryRequests: "100Mi",
+				CPULimits:      "50m",
+				MemoryLimits:   "100Mi",
+				Image:          k8sComponents[common.BlobfuseFlexVolumeAddonName],
+			},
+		},
+	}
+
+	defaultSMBFlexVolumeAddonsConfig := api.KubernetesAddon{
+		Name:    common.SMBFlexVolumeAddonName,
+		Enabled: to.BoolPtr(api.DefaultSMBFlexVolumeAddonEnabled && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.8.0") && !cs.Properties.HasCoreOS() && !cs.Properties.IsAzureStackCloud()),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.SMBFlexVolumeAddonName,
+				CPURequests:    "50m",
+				MemoryRequests: "100Mi",
+				CPULimits:      "50m",
+				MemoryLimits:   "100Mi",
+				Image:          k8sComponents[common.SMBFlexVolumeAddonName],
+			},
+		},
+	}
+
+	defaultKeyVaultFlexVolumeAddonsConfig := api.KubernetesAddon{
+		Name:    common.KeyVaultFlexVolumeAddonName,
+		Enabled: to.BoolPtr(api.DefaultKeyVaultFlexVolumeAddonEnabled && !cs.Properties.HasCoreOS() && !cs.Properties.IsAzureStackCloud()),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.KeyVaultFlexVolumeAddonName,
+				CPURequests:    "50m",
+				MemoryRequests: "100Mi",
+				CPULimits:      "50m",
+				MemoryLimits:   "100Mi",
+				Image:          k8sComponents[common.KeyVaultFlexVolumeAddonName],
+			},
+		},
+	}
+
+	defaultDashboardAddonsConfig := api.KubernetesAddon{
+		Name:    common.DashboardAddonName,
+		Enabled: to.BoolPtr(api.DefaultDashboardAddonEnabled),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.DashboardAddonName,
+				CPURequests:    "300m",
+				MemoryRequests: "150Mi",
+				CPULimits:      "300m",
+				MemoryLimits:   "150Mi",
+				Image:          specConfig.KubernetesImageBase + k8sComponents[common.DashboardAddonName],
+			},
+		},
+	}
+
+	defaultReschedulerAddonsConfig := api.KubernetesAddon{
+		Name:    common.ReschedulerAddonName,
+		Enabled: to.BoolPtr(api.DefaultReschedulerAddonEnabled && !cs.Properties.IsAzureStackCloud()),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.ReschedulerAddonName,
+				CPURequests:    "10m",
+				MemoryRequests: "100Mi",
+				CPULimits:      "10m",
+				MemoryLimits:   "100Mi",
+				Image:          specConfig.KubernetesImageBase + k8sComponents[common.ReschedulerAddonName],
+			},
+		},
+	}
+
+	defaultMetricsServerAddonsConfig := api.KubernetesAddon{
+		Name:    common.MetricsServerAddonName,
+		Enabled: to.BoolPtr(api.DefaultMetricsServerAddonEnabled),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:  common.MetricsServerAddonName,
+				Image: specConfig.KubernetesImageBase + k8sComponents[common.MetricsServerAddonName],
+			},
+		},
+	}
+
+	defaultNVIDIADevicePluginAddonsConfig := api.KubernetesAddon{
+		Name:    common.NVIDIADevicePluginAddonName,
+		Enabled: to.BoolPtr(cs.Properties.IsNvidiaDevicePluginCapable() && !cs.Properties.HasCoreOS() && !cs.Properties.IsAzureStackCloud()),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name: common.NVIDIADevicePluginAddonName,
+				// from https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/device-plugins/nvidia-gpu/daemonset.yaml#L44
+				CPURequests:    "50m",
+				MemoryRequests: "100Mi",
+				CPULimits:      "50m",
+				MemoryLimits:   "100Mi",
+				Image:          specConfig.NVIDIAImageBase + k8sComponents[common.NVIDIADevicePluginAddonName],
+			},
+		},
+	}
+
+	defaultContainerMonitoringAddonsConfig := api.KubernetesAddon{
+		Name:    common.ContainerMonitoringAddonName,
+		Enabled: to.BoolPtr(api.DefaultContainerMonitoringAddonEnabled && !cs.Properties.IsAzureStackCloud()),
+		Config: map[string]string{
+			"omsAgentVersion":       "1.10.0.1",
+			"dockerProviderVersion": "8.0.0-2",
+			"schema-versions":       "v1",
+			"clusterName":           clusterDNSPrefix,
+			"workspaceDomain":       workspaceDomain,
+		},
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           "omsagent",
+				CPURequests:    "150m",
+				MemoryRequests: "250Mi",
+				CPULimits:      "1",
+				MemoryLimits:   "750Mi",
+				Image:          omsagentImage,
+			},
+		},
+	}
+
+	defaultIPMasqAgentAddonsConfig := api.KubernetesAddon{
+		Name: common.IPMASQAgentAddonName,
+		Enabled: to.BoolPtr(api.DefaultIPMasqAgentAddonEnabled &&
+			(o.KubernetesConfig.NetworkPlugin != api.NetworkPluginCilium &&
+				o.KubernetesConfig.NetworkPlugin != api.NetworkPluginAntrea)),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.IPMASQAgentAddonName,
+				CPURequests:    "50m",
+				MemoryRequests: "50Mi",
+				CPULimits:      "50m",
+				MemoryLimits:   "250Mi",
+				Image:          specConfig.KubernetesImageBase + k8sComponents[common.IPMASQAgentAddonName],
+			},
+		},
+		Config: map[string]string{
+			"non-masquerade-cidr":           cs.Properties.GetNonMasqueradeCIDR(),
+			"non-masq-cni-cidr":             cs.Properties.GetAzureCNICidr(),
+			"secondary-non-masquerade-cidr": cs.Properties.GetSecondaryNonMasqueradeCIDR(),
+			"enable-ipv6": strconv.FormatBool(cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6DualStack") ||
+				cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6Only")),
+		},
+	}
+
+	defaultAzureCNINetworkMonitorAddonsConfig := api.KubernetesAddon{
+		Name:    common.AzureCNINetworkMonitorAddonName,
+		Enabled: to.BoolPtr(o.IsAzureCNI() && o.KubernetesConfig.NetworkPolicy != api.NetworkPolicyCalico),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:  common.AzureCNINetworkMonitorAddonName,
+				Image: specConfig.AzureCNIImageBase + k8sComponents[common.AzureCNINetworkMonitorAddonName],
+			},
+		},
+	}
+
+	defaultAzureNetworkPolicyAddonsConfig := api.KubernetesAddon{
+		Name:    common.AzureNetworkPolicyAddonName,
+		Enabled: to.BoolPtr(o.KubernetesConfig.NetworkPlugin == api.NetworkPluginAzure && o.KubernetesConfig.NetworkPolicy == api.NetworkPolicyAzure),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.AzureNetworkPolicyAddonName,
+				Image:          k8sComponents[common.AzureNetworkPolicyAddonName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "100m",
+				MemoryLimits:   "200Mi",
+			},
+		},
+	}
+
+	defaultCloudNodeManagerAddonsConfig := api.KubernetesAddon{
+		Name:    common.CloudNodeManagerAddonName,
+		Enabled: to.BoolPtr(common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") && to.Bool(o.KubernetesConfig.UseCloudControllerManager)),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:  common.CloudNodeManagerAddonName,
+				Image: specConfig.MCRKubernetesImageBase + k8sComponents[common.CloudNodeManagerAddonName],
+			},
+		},
+	}
+
+	defaultDNSAutoScalerAddonsConfig := api.KubernetesAddon{
+		Name: common.DNSAutoscalerAddonName,
+		// TODO enable this when it has been smoke tested
+		Enabled: to.BoolPtr(api.DefaultDNSAutoscalerAddonEnabled),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.DNSAutoscalerAddonName,
+				Image:          specConfig.KubernetesImageBase + k8sComponents[common.DNSAutoscalerAddonName],
+				CPURequests:    "20m",
+				MemoryRequests: "100Mi",
+			},
+		},
+	}
+
+	defaultsCalicoDaemonSetAddonsConfig := api.KubernetesAddon{
+		Name:    common.CalicoAddonName,
+		Enabled: to.BoolPtr(o.KubernetesConfig.NetworkPolicy == api.NetworkPolicyCalico),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:  "calico-typha",
+				Image: specConfig.CalicoImageBase + k8sComponents["calico-typha"],
+			},
+			{
+				Name:  "calico-cni",
+				Image: specConfig.CalicoImageBase + k8sComponents["calico-cni"],
+			},
+			{
+				Name:  "calico-node",
+				Image: specConfig.CalicoImageBase + k8sComponents["calico-node"],
+			},
+			{
+				Name:  "calico-pod2daemon",
+				Image: specConfig.CalicoImageBase + k8sComponents["calico-pod2daemon"],
+			},
+			{
+				Name:  "calico-cluster-proportional-autoscaler",
+				Image: specConfig.KubernetesImageBase + k8sComponents["calico-cluster-proportional-autoscaler"],
+			},
+		},
+	}
+
+	defaultsCiliumAddonsConfig := api.KubernetesAddon{
+		Name:    common.CiliumAddonName,
+		Enabled: to.BoolPtr(o.KubernetesConfig.NetworkPolicy == api.NetworkPolicyCilium),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:  common.CiliumAgentContainerName,
+				Image: k8sComponents[common.CiliumAgentContainerName],
+			},
+			{
+				Name:  common.CiliumCleanStateContainerName,
+				Image: k8sComponents[common.CiliumCleanStateContainerName],
+			},
+			{
+				Name:  common.CiliumOperatorContainerName,
+				Image: k8sComponents[common.CiliumOperatorContainerName],
+			},
+			{
+				Name:  common.CiliumEtcdOperatorContainerName,
+				Image: k8sComponents[common.CiliumEtcdOperatorContainerName],
+			},
+		},
+	}
+
+	defaultsAntreaDaemonSetAddonsConfig := api.KubernetesAddon{
+		Name:    common.AntreaAddonName,
+		Enabled: to.BoolPtr(o.KubernetesConfig.NetworkPlugin == api.NetworkPluginAntrea),
+		Config: map[string]string{
+			"serviceCidr": o.KubernetesConfig.ServiceCIDR,
+		},
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:  common.AntreaControllerContainerName,
+				Image: k8sComponents[common.AntreaControllerContainerName],
+			},
+			{
+				Name:  common.AntreaAgentContainerName,
+				Image: k8sComponents[common.AntreaAgentContainerName],
+			},
+			{
+				Name:  common.AntreaOVSContainerName,
+				Image: k8sComponents[common.AntreaOVSContainerName],
+			},
+			{
+				Name:  common.AntreaInstallCNIContainerName,
+				Image: k8sComponents["antrea"+common.AntreaInstallCNIContainerName],
+			},
+		},
+	}
+
+	defaultsAADPodIdentityAddonsConfig := api.KubernetesAddon{
+		Name:    common.AADPodIdentityAddonName,
+		Enabled: to.BoolPtr(api.DefaultAADPodIdentityAddonEnabled && !cs.Properties.IsAzureStackCloud()),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.NMIContainerName,
+				Image:          k8sComponents[common.NMIContainerName],
+				CPURequests:    "100m",
+				MemoryRequests: "300Mi",
+				CPULimits:      "100m",
+				MemoryLimits:   "300Mi",
+			},
+			{
+				Name:           common.MICContainerName,
+				Image:          k8sComponents[common.MICContainerName],
+				CPURequests:    "100m",
+				MemoryRequests: "300Mi",
+				CPULimits:      "100m",
+				MemoryLimits:   "300Mi",
+			},
+		},
+	}
+
+	defaultsAzurePolicyAddonsConfig := api.KubernetesAddon{
+		Name:    common.AzurePolicyAddonName,
+		Enabled: to.BoolPtr(api.DefaultAzurePolicyAddonEnabled && !cs.Properties.IsAzureStackCloud()),
+		Config: map[string]string{
+			"auditInterval":             "30",
+			"constraintViolationsLimit": "20",
+		},
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.AzurePolicyAddonName,
+				Image:          k8sComponents[common.AzurePolicyAddonName],
+				CPURequests:    "30m",
+				MemoryRequests: "50Mi",
+				CPULimits:      "100m",
+				MemoryLimits:   "200Mi",
+			},
+			{
+				Name:           common.GatekeeperContainerName,
+				Image:          k8sComponents[common.GatekeeperContainerName],
+				CPURequests:    "100m",
+				MemoryRequests: "256Mi",
+				CPULimits:      "100m",
+				MemoryLimits:   "512Mi",
+			},
+		},
+	}
+
+	defaultNodeProblemDetectorConfig := api.KubernetesAddon{
+		Name:    common.NodeProblemDetectorAddonName,
+		Enabled: to.BoolPtr(api.DefaultNodeProblemDetectorAddonEnabled),
+		Config: map[string]string{
+			"customPluginMonitor": "/config/kernel-monitor-counter.json,/config/systemd-monitor-counter.json",
+			"systemLogMonitor":    "/config/kernel-monitor.json,/config/docker-monitor.json,/config/systemd-monitor.json",
+			"systemStatsMonitor":  "/config/system-stats-monitor.json",
+			"versionLabel":        "v0.8.0",
+		},
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.NodeProblemDetectorAddonName,
+				Image:          k8sComponents[common.NodeProblemDetectorAddonName],
+				CPURequests:    "20m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "100Mi",
+			},
+		},
+	}
+
+	defaultAppGwAddonsConfig := api.KubernetesAddon{
+		Name:    common.AppGwIngressAddonName,
+		Enabled: to.BoolPtr(api.DefaultAppGwIngressAddonEnabled),
+		Config: map[string]string{
+			"appgw-subnet":     "",
+			"appgw-sku":        "WAF_v2",
+			"appgw-private-ip": "",
+		},
+	}
+
+	defaultAzureDiskCSIDriverAddonsConfig := api.KubernetesAddon{
+		Name:    common.AzureDiskCSIDriverAddonName,
+		Enabled: to.BoolPtr(api.DefaultAzureDiskCSIDriverAddonEnabled && to.Bool(o.KubernetesConfig.UseCloudControllerManager)),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.CSIProvisionerContainerName,
+				Image:          specConfig.MCRKubernetesImageBase + k8sComponents[common.CSIProvisionerContainerName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "200Mi",
+			},
+			{
+				Name:           common.CSIAttacherContainerName,
+				Image:          specConfig.MCRKubernetesImageBase + k8sComponents[common.CSIAttacherContainerName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "200Mi",
+			},
+			{
+				Name:           common.CSIClusterDriverRegistrarContainerName,
+				Image:          specConfig.MCRKubernetesImageBase + k8sComponents[common.CSIClusterDriverRegistrarContainerName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "200Mi",
+			},
+			{
+				Name:           common.CSILivenessProbeContainerName,
+				Image:          specConfig.MCRKubernetesImageBase + k8sComponents[common.CSILivenessProbeContainerName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "200Mi",
+			},
+			{
+				Name:           common.CSINodeDriverRegistrarContainerName,
+				Image:          specConfig.MCRKubernetesImageBase + k8sComponents[common.CSINodeDriverRegistrarContainerName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "200Mi",
+			},
+			{
+				Name:           common.CSISnapshotterContainerName,
+				Image:          specConfig.MCRKubernetesImageBase + k8sComponents[common.CSISnapshotterContainerName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "200Mi",
+			},
+			{
+				Name:           common.CSIResizerContainerName,
+				Image:          specConfig.MCRKubernetesImageBase + k8sComponents[common.CSIResizerContainerName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "200Mi",
+			},
+			{
+				Name:           common.CSIAzureDiskContainerName,
+				Image:          specConfig.MCRKubernetesImageBase + k8sComponents[common.CSIAzureDiskContainerName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "200Mi",
+			},
+		},
+	}
+
+	defaultAzureFileCSIDriverAddonsConfig := api.KubernetesAddon{
+		Name:    common.AzureFileCSIDriverAddonName,
+		Enabled: to.BoolPtr(api.DefaultAzureFileCSIDriverAddonEnabled && to.Bool(o.KubernetesConfig.UseCloudControllerManager)),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           common.CSIProvisionerContainerName,
+				Image:          specConfig.MCRKubernetesImageBase + k8sComponents[common.CSIProvisionerContainerName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "200Mi",
+			},
+			{
+				Name:           common.CSIAttacherContainerName,
+				Image:          specConfig.MCRKubernetesImageBase + k8sComponents[common.CSIAttacherContainerName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "200Mi",
+			},
+			{
+				Name:           common.CSIClusterDriverRegistrarContainerName,
+				Image:          specConfig.MCRKubernetesImageBase + k8sComponents[common.CSIClusterDriverRegistrarContainerName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "200Mi",
+			},
+			{
+				Name:           common.CSILivenessProbeContainerName,
+				Image:          specConfig.MCRKubernetesImageBase + k8sComponents[common.CSILivenessProbeContainerName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "200Mi",
+			},
+			{
+				Name:           common.CSINodeDriverRegistrarContainerName,
+				Image:          specConfig.MCRKubernetesImageBase + k8sComponents[common.CSINodeDriverRegistrarContainerName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "200Mi",
+			},
+			{
+				Name:           common.CSIAzureFileContainerName,
+				Image:          specConfig.MCRKubernetesImageBase + k8sComponents[common.CSIAzureFileContainerName],
+				CPURequests:    "10m",
+				MemoryRequests: "20Mi",
+				CPULimits:      "200m",
+				MemoryLimits:   "200Mi",
+			},
+		},
+	}
+
+	defaultKubeDNSAddonsConfig := api.KubernetesAddon{
+		Name:    common.KubeDNSAddonName,
+		Enabled: to.BoolPtr(api.DefaultKubeDNSAddonEnabled),
+		Config: map[string]string{
+			"domain":    o.KubernetesConfig.KubeletConfig["--cluster-domain"],
+			"clusterIP": o.KubernetesConfig.DNSServiceIP,
+		},
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:  "kubedns",
+				Image: specConfig.KubernetesImageBase + k8sComponents["kube-dns"],
+			},
+			{
+				Name:  "dnsmasq",
+				Image: specConfig.KubernetesImageBase + k8sComponents["dnsmasq"],
+			},
+			{
+				Name:  "sidecar",
+				Image: specConfig.KubernetesImageBase + k8sComponents["k8s-dns-sidecar"],
+			},
+		},
+	}
+
+	defaultCorednsAddonsConfig := api.KubernetesAddon{
+		Name:    common.CoreDNSAddonName,
+		Enabled: to.BoolPtr(api.DefaultCoreDNSAddonEnabled),
+		Config: map[string]string{
+			"domain":    o.KubernetesConfig.KubeletConfig["--cluster-domain"],
+			"clusterIP": o.KubernetesConfig.DNSServiceIP,
+		},
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:  common.CoreDNSAddonName,
+				Image: specConfig.KubernetesImageBase + k8sComponents[common.CoreDNSAddonName],
+			},
+		},
+	}
+
+	// set host network to true for single stack IPv6 as the the nameserver is currently
+	// IPv4 only. By setting it to host network, we can leverage the host routes to successfully
+	// resolve dns.
+	if cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6Only") {
+		defaultCorednsAddonsConfig.Config["use-host-network"] = "true"
+	}
+
+	// If we have any explicit coredns or kube-dns configuration in the addons array
+	if getAddonsIndexByName(o.KubernetesConfig.Addons, common.KubeDNSAddonName) != -1 || getAddonsIndexByName(o.KubernetesConfig.Addons, common.CoreDNSAddonName) != -1 {
+		// Ensure we don't we don't prepare an addons spec w/ both kube-dns and coredns enabled
+		if o.KubernetesConfig.IsAddonEnabled(common.KubeDNSAddonName) {
+			defaultCorednsAddonsConfig.Enabled = to.BoolPtr(false)
+		}
+	}
+
+	defaultKubeProxyAddonsConfig := api.KubernetesAddon{
+		Name:    common.KubeProxyAddonName,
+		Enabled: to.BoolPtr(api.DefaultKubeProxyAddonEnabled),
+		Config: map[string]string{
+			"cluster-cidr": o.KubernetesConfig.ClusterSubnet,
+			"proxy-mode":   string(o.KubernetesConfig.ProxyMode),
+			"featureGates": cs.Properties.GetKubeProxyFeatureGates(),
+		},
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:  common.KubeProxyAddonName,
+				Image: specConfig.KubernetesImageBase + k8sComponents[common.KubeProxyAddonName],
+			},
+		},
+	}
+
+	// set bind address, healthz and metric bind address to :: explicitly for
+	// single stack IPv6 cluster as it is single stack IPv6 on dual stack host
+	if cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6Only") {
+		defaultKubeProxyAddonsConfig.Config["bind-address"] = "::"
+		defaultKubeProxyAddonsConfig.Config["healthz-bind-address"] = "::"
+		defaultKubeProxyAddonsConfig.Config["metrics-bind-address"] = "::1"
+	}
+
+	defaultPodSecurityPolicyAddonsConfig := api.KubernetesAddon{
+		Name:    common.PodSecurityPolicyAddonName,
+		Enabled: to.BoolPtr(common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.15.0") || to.Bool(o.KubernetesConfig.EnablePodSecurityPolicy)),
+	}
+
+	defaultAuditPolicyAddonsConfig := api.KubernetesAddon{
+		Name:    common.AuditPolicyAddonName,
+		Enabled: to.BoolPtr(true),
+	}
+
+	defaultAzureCloudProviderAddonsConfig := api.KubernetesAddon{
+		Name:    common.AzureCloudProviderAddonName,
+		Enabled: to.BoolPtr(true),
+	}
+
+	defaultAADDefaultAdminGroupAddonsConfig := api.KubernetesAddon{
+		Name:    common.AADAdminGroupAddonName,
+		Enabled: to.BoolPtr(cs.Properties.HasAADAdminGroupID()),
+		Config: map[string]string{
+			"adminGroupID": cs.Properties.GetAADAdminGroupID(),
+		},
+	}
+
+	defaultFlannelAddonsConfig := api.KubernetesAddon{
+		Name:    common.FlannelAddonName,
+		Enabled: to.BoolPtr(o.KubernetesConfig.NetworkPlugin == api.NetworkPluginFlannel),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:  common.KubeFlannelContainerName,
+				Image: k8sComponents[common.KubeFlannelContainerName],
+			},
+			{
+				Name:  common.FlannelInstallCNIContainerName,
+				Image: k8sComponents["flannel"+common.FlannelInstallCNIContainerName],
+			},
+		},
+	}
+
+	defaultScheduledMaintenanceAddonsConfig := api.KubernetesAddon{
+		Name:    common.ScheduledMaintenanceAddonName,
+		Enabled: to.BoolPtr(false),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:  common.KubeRBACProxyContainerName,
+				Image: k8sComponents[common.KubeRBACProxyContainerName],
+			},
+			{
+				Name:  common.ScheduledMaintenanceManagerContainerName,
+				Image: k8sComponents[common.ScheduledMaintenanceManagerContainerName],
+			},
+		},
+	}
+
+	// Allow folks to simply enable kube-dns at cluster creation time without also requiring that coredns be explicitly disabled
+	if !isUpgrade && o.KubernetesConfig.IsAddonEnabled(common.KubeDNSAddonName) {
+		defaultCorednsAddonsConfig.Enabled = to.BoolPtr(false)
+	}
+
+	defaultAddons := []api.KubernetesAddon{
+		defaultsHeapsterAddonsConfig,
+		defaultTillerAddonsConfig,
+		defaultACIConnectorAddonsConfig,
+		defaultClusterAutoscalerAddonsConfig,
+		defaultBlobfuseFlexVolumeAddonsConfig,
+		defaultSMBFlexVolumeAddonsConfig,
+		defaultKeyVaultFlexVolumeAddonsConfig,
+		defaultDashboardAddonsConfig,
+		defaultReschedulerAddonsConfig,
+		defaultMetricsServerAddonsConfig,
+		defaultNVIDIADevicePluginAddonsConfig,
+		defaultContainerMonitoringAddonsConfig,
+		defaultAzureCNINetworkMonitorAddonsConfig,
+		defaultAzureNetworkPolicyAddonsConfig,
+		defaultCloudNodeManagerAddonsConfig,
+		defaultIPMasqAgentAddonsConfig,
+		defaultDNSAutoScalerAddonsConfig,
+		defaultsCalicoDaemonSetAddonsConfig,
+		defaultsCiliumAddonsConfig,
+		defaultsAADPodIdentityAddonsConfig,
+		defaultAppGwAddonsConfig,
+		defaultAzureDiskCSIDriverAddonsConfig,
+		defaultAzureFileCSIDriverAddonsConfig,
+		defaultsAzurePolicyAddonsConfig,
+		defaultNodeProblemDetectorConfig,
+		defaultKubeDNSAddonsConfig,
+		defaultCorednsAddonsConfig,
+		defaultKubeProxyAddonsConfig,
+		defaultPodSecurityPolicyAddonsConfig,
+		defaultAuditPolicyAddonsConfig,
+		defaultAzureCloudProviderAddonsConfig,
+		defaultAADDefaultAdminGroupAddonsConfig,
+		defaultsAntreaDaemonSetAddonsConfig,
+		defaultFlannelAddonsConfig,
+		defaultScheduledMaintenanceAddonsConfig,
+	}
+	// Add default addons specification, if no user-provided spec exists
+	if o.KubernetesConfig.Addons == nil {
+		o.KubernetesConfig.Addons = defaultAddons
+	} else {
+		for _, addon := range defaultAddons {
+			o.KubernetesConfig.Addons = appendAddonIfNotPresent(o.KubernetesConfig.Addons, addon)
+		}
+	}
+
+	// Ensure cloud-node-manager and CSI components are enabled on appropriate upgrades
+	if isUpgrade && to.Bool(o.KubernetesConfig.UseCloudControllerManager) &&
+		common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") {
+		componentry := map[string]api.KubernetesAddon{
+			common.AzureDiskCSIDriverAddonName: defaultAzureDiskCSIDriverAddonsConfig,
+			common.AzureFileCSIDriverAddonName: defaultAzureFileCSIDriverAddonsConfig,
+			common.CloudNodeManagerAddonName:   defaultCloudNodeManagerAddonsConfig,
+		}
+		for name, config := range componentry {
+			if i := getAddonsIndexByName(o.KubernetesConfig.Addons, name); i > -1 {
+				if !to.Bool(o.KubernetesConfig.Addons[i].Enabled) {
+					o.KubernetesConfig.Addons[i] = config
+				}
+			}
+		}
+	}
+
+	// Back-compat for older addon specs of cluster-autoscaler
+	if isUpgrade {
+		i := getAddonsIndexByName(o.KubernetesConfig.Addons, common.ClusterAutoscalerAddonName)
+		if i > -1 && to.Bool(o.KubernetesConfig.Addons[i].Enabled) {
+			if o.KubernetesConfig.Addons[i].Pools == nil {
+				log.Warnf("This cluster upgrade operation will enable the per-pool cluster-autoscaler addon.\n")
+				var pools []api.AddonNodePoolsConfig
+				for i, p := range cs.Properties.AgentPoolProfiles {
+					pool := api.AddonNodePoolsConfig{
+						Name: p.Name,
+						Config: map[string]string{
+							"min-nodes": strconv.Itoa(p.Count),
+							"max-nodes": strconv.Itoa(p.Count),
+						},
+					}
+					if i == 0 {
+						originalMinNodes := o.KubernetesConfig.Addons[i].Config["min-nodes"]
+						originalMaxNodes := o.KubernetesConfig.Addons[i].Config["max-nodes"]
+						if originalMinNodes != "" {
+							pool.Config["min-nodes"] = originalMinNodes
+							delete(o.KubernetesConfig.Addons[i].Config, "min-nodes")
+						}
+						if originalMaxNodes != "" {
+							pool.Config["max-nodes"] = originalMaxNodes
+							delete(o.KubernetesConfig.Addons[i].Config, "max-nodes")
+						}
+					}
+					log.Warnf("cluster-autoscaler will configure pool \"%s\" with min-nodes=%s, and max-nodes=%s.\n", pool.Name, pool.Config["min-nodes"], pool.Config["max-nodes"])
+					pools = append(pools, pool)
+				}
+				o.KubernetesConfig.Addons[i].Pools = pools
+				log.Warnf("You may modify the pool configurations via `kubectl edit deployment cluster-autoscaler -n kube-system`.\n")
+				log.Warnf("Look for the `--nodes=` configuration flags (see below) in the deployment spec:\n")
+				log.Warnf("\n%s", GetClusterAutoscalerNodesConfig(o.KubernetesConfig.Addons[i], cs))
+			}
+		}
+	}
+
+	// Back-compat for pre-1.12 clusters built before kube-dns and coredns were converted to user-configurable addons
+	// Migrate to coredns unless coredns is explicitly set to false
+	if isUpgrade && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.12.0") {
+		// If we don't have coredns in our addons array at all, this means we're in a legacy scenario and we want to migrate from kube-dns to coredns
+		if i := getAddonsIndexByName(o.KubernetesConfig.Addons, common.CoreDNSAddonName); i == -1 {
+			o.KubernetesConfig.Addons[i].Enabled = to.BoolPtr(true)
+			// Ensure we don't we don't prepare an addons spec w/ both kube-dns and coredns enabled
+			if j := getAddonsIndexByName(o.KubernetesConfig.Addons, common.KubeDNSAddonName); j > -1 {
+				o.KubernetesConfig.Addons[j].Enabled = to.BoolPtr(false)
+			}
+		}
+	}
+
+	for _, addon := range defaultAddons {
+		synthesizeAddonsConfig(o.KubernetesConfig.Addons, addon, isUpgrade)
+	}
+
+	if len(o.KubernetesConfig.PodSecurityPolicyConfig) > 0 && isUpgrade {
+		if base64Data, ok := o.KubernetesConfig.PodSecurityPolicyConfig["data"]; ok {
+			if i := getAddonsIndexByName(o.KubernetesConfig.Addons, common.PodSecurityPolicyAddonName); i > -1 {
+				if o.KubernetesConfig.Addons[i].Data == "" {
+					o.KubernetesConfig.Addons[i].Data = base64Data
+				}
+			}
+		}
+	}
+
+	// Specific back-compat business logic for calico addon
+	// Ensure addon is set to Enabled w/ proper containers config no matter what if NetworkPolicy == calico
+	i := getAddonsIndexByName(o.KubernetesConfig.Addons, common.CalicoAddonName)
+	if isUpgrade && o.KubernetesConfig.NetworkPolicy == api.NetworkPolicyCalico && i > -1 && o.KubernetesConfig.Addons[i].Enabled != to.BoolPtr(true) {
+		j := getAddonsIndexByName(defaultAddons, common.CalicoAddonName)
+		// Ensure calico is statically set to enabled
+		o.KubernetesConfig.Addons[i].Enabled = to.BoolPtr(true)
+		// Assume addon configuration was pruned due to an inherited enabled=false, so re-apply default values
+		o.KubernetesConfig.Addons[i] = assignDefaultAddonVals(o.KubernetesConfig.Addons[i], defaultAddons[j], isUpgrade)
+	}
+
+	// Support back-compat configuration for Azure NetworkPolicy, which no longer ships with a "telemetry" container starting w/ 1.16.0
+	if isUpgrade && o.KubernetesConfig.NetworkPolicy == api.NetworkPolicyAzure && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") {
+		i = getAddonsIndexByName(o.KubernetesConfig.Addons, common.AzureNetworkPolicyAddonName)
+		var hasTelemetryContainerConfig bool
+		var prunedContainersConfig []api.KubernetesContainerSpec
+		if i > -1 {
+			for _, c := range o.KubernetesConfig.Addons[i].Containers {
+				if c.Name == common.AzureVnetTelemetryContainerName {
+					hasTelemetryContainerConfig = true
+				} else {
+					prunedContainersConfig = append(prunedContainersConfig, c)
+				}
+			}
+			if hasTelemetryContainerConfig {
+				o.KubernetesConfig.Addons[i].Containers = prunedContainersConfig
+			}
+		}
+	}
+
+	// Specific back-compat business logic for deprecated "kube-proxy-daemonset" addon
+	if i := getAddonsIndexByName(o.KubernetesConfig.Addons, "kube-proxy-daemonset"); i > -1 {
+		if to.Bool(o.KubernetesConfig.Addons[i].Enabled) {
+			if j := getAddonsIndexByName(o.KubernetesConfig.Addons, common.KubeProxyAddonName); j > -1 {
+				// Copy data from deprecated addon spec to the current "kube-proxy" addon
+				o.KubernetesConfig.Addons[j] = api.KubernetesAddon{
+					Name:    common.KubeProxyAddonName,
+					Enabled: to.BoolPtr(true),
+					Data:    o.KubernetesConfig.Addons[i].Data,
+				}
+			}
+		}
+		// Remove deprecated "kube-proxy-daemonset addon"
+		o.KubernetesConfig.Addons = append(o.KubernetesConfig.Addons[:i], o.KubernetesConfig.Addons[i+1:]...)
+	}
+
+	// Enable pod-security-policy addon during upgrade to 1.15 or greater scenarios, unless explicitly disabled
+	if isUpgrade && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.15.0") && !o.KubernetesConfig.IsAddonDisabled(common.PodSecurityPolicyAddonName) {
+		if i := getAddonsIndexByName(o.KubernetesConfig.Addons, common.PodSecurityPolicyAddonName); i > -1 {
+			o.KubernetesConfig.Addons[i].Enabled = to.BoolPtr(true)
+		}
+	}
+}
+
+func appendAddonIfNotPresent(addons []api.KubernetesAddon, addon api.KubernetesAddon) []api.KubernetesAddon {
+	i := getAddonsIndexByName(addons, addon.Name)
+	if i < 0 {
+		return append(addons, addon)
+	}
+	return addons
+}
+
+func getAddonsIndexByName(addons []api.KubernetesAddon, name string) int {
+	for i := range addons {
+		if addons[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// assignDefaultAddonVals will assign default values to addon from defaults, for each property in addon that has a zero value
+func assignDefaultAddonVals(addon, defaults api.KubernetesAddon, isUpgrade bool) api.KubernetesAddon {
+	if addon.Enabled == nil {
+		addon.Enabled = defaults.Enabled
+	}
+	if !to.Bool(addon.Enabled) {
+		return api.KubernetesAddon{
+			Name:    addon.Name,
+			Enabled: addon.Enabled,
+		}
+	}
+	if addon.Data != "" {
+		return api.KubernetesAddon{
+			Name:    addon.Name,
+			Enabled: addon.Enabled,
+			Data:    addon.Data,
+		}
+	}
+	if addon.Mode == "" {
+		addon.Mode = defaults.Mode
+	}
+	for i := range defaults.Containers {
+		c := addon.GetAddonContainersIndexByName(defaults.Containers[i].Name)
+		if c < 0 {
+			addon.Containers = append(addon.Containers, defaults.Containers[i])
+		} else {
+			if addon.Containers[c].Image == "" || isUpgrade {
+				addon.Containers[c].Image = defaults.Containers[i].Image
+			}
+			if addon.Containers[c].CPURequests == "" {
+				addon.Containers[c].CPURequests = defaults.Containers[i].CPURequests
+			}
+			if addon.Containers[c].MemoryRequests == "" {
+				addon.Containers[c].MemoryRequests = defaults.Containers[i].MemoryRequests
+			}
+			if addon.Containers[c].CPULimits == "" {
+				addon.Containers[c].CPULimits = defaults.Containers[i].CPULimits
+			}
+			if addon.Containers[c].MemoryLimits == "" {
+				addon.Containers[c].MemoryLimits = defaults.Containers[i].MemoryLimits
+			}
+		}
+	}
+	// For pools-specific configuration, we only take the defaults if we have zero user-provided pools configuration
+	if len(addon.Pools) == 0 {
+		for i := range defaults.Pools {
+			addon.Pools = append(addon.Pools, defaults.Pools[i])
+		}
+	}
+	for key, val := range defaults.Config {
+		if addon.Config == nil {
+			addon.Config = make(map[string]string)
+		}
+		if v, ok := addon.Config[key]; !ok || v == "" {
+			addon.Config[key] = val
+		}
+	}
+	return addon
+}
+
+func synthesizeAddonsConfig(addons []api.KubernetesAddon, addon api.KubernetesAddon, isUpgrade bool) {
+	i := getAddonsIndexByName(addons, addon.Name)
+	if i >= 0 {
+		addons[i] = assignDefaultAddonVals(addons[i], addon, isUpgrade)
+	}
+}
+
+func makeDefaultClusterAutoscalerAddonPoolsConfig(cs *ContainerService) []api.AddonNodePoolsConfig {
+	var ret []api.AddonNodePoolsConfig
+	for _, pool := range cs.Properties.AgentPoolProfiles {
+		ret = append(ret, api.AddonNodePoolsConfig{
+			Name: pool.Name,
+			Config: map[string]string{
+				"min-nodes": strconv.Itoa(pool.Count),
+				"max-nodes": strconv.Itoa(pool.Count),
+			},
+		})
+	}
+	return ret
+}
+
+// GetClusterAutoscalerNodesConfig returns the cluster-autoscaler runtime configuration flag for a nodepool
+func GetClusterAutoscalerNodesConfig(addon api.KubernetesAddon, cs *ContainerService) string {
+	var ret string
+	for _, pool := range addon.Pools {
+		nodepoolName := cs.Properties.GetAgentVMPrefix(cs.Properties.GetAgentPoolByName(pool.Name), cs.Properties.GetAgentPoolIndexByName(pool.Name))
+		ret += fmt.Sprintf("        - --nodes=%s:%s:%s\n", pool.Config["min-nodes"], pool.Config["max-nodes"], nodepoolName)
+	}
+	if ret != "" {
+		ret = strings.TrimRight(ret, "\n")
+	}
+	return ret
+}

--- a/pkg/agent/datamodel/addons_test.go
+++ b/pkg/agent/datamodel/addons_test.go
@@ -1,0 +1,4093 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/aks-engine/pkg/api/common"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+func TestAppendAddonIfNotPresent(t *testing.T) {
+	names := []string{"AddonA", "AddonB", "AddonC", "AddonD", "AddonE"}
+	addons := []api.KubernetesAddon{}
+
+	for i, name := range names {
+		addon := api.KubernetesAddon{Name: name}
+		addons = appendAddonIfNotPresent(addons, addon)
+		if len(addons) != i+1 {
+			t.Errorf("incorrect length by appendAddonIfNotPresent, expect: '%d', actual: '%d'", i+1, len(addons))
+		}
+	}
+
+	for _, name := range names {
+		addon := api.KubernetesAddon{Name: name}
+		addons = appendAddonIfNotPresent(addons, addon)
+		if len(addons) != len(names) {
+			t.Errorf("incorrect length by appendAddonIfNotPresent, expect: '%d', actual: '%d'", len(names), len(addons))
+		}
+	}
+}
+
+func TestGetAddonsIndexByName(t *testing.T) {
+	includedNames := []string{"AddonA", "AddonB", "AddonC", "AddonD", "AddonE"}
+	notIncludedNames := []string{"AddonF", "AddonG", "AddonH"}
+	addons := []api.KubernetesAddon{}
+
+	for _, name := range includedNames {
+		addons = append(addons, api.KubernetesAddon{Name: name})
+	}
+
+	for i, addon := range addons {
+		j := getAddonsIndexByName(addons, addon.Name)
+		if j != i {
+			t.Errorf("incorrect index by getAddonsIndexByName, expect: '%d', actual: '%d'", i, j)
+		}
+	}
+
+	for _, name := range notIncludedNames {
+		j := getAddonsIndexByName(addons, name)
+		if j != -1 {
+			t.Errorf("incorrect index by getAddonsIndexByName, expect: '%d', actual: '%d'", -1, j)
+		}
+	}
+}
+
+func TestPodSecurityPolicyConfigUpgrade(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.8.0")
+	o := mockCS.Properties.OrchestratorProfile
+
+	isUpgrade := true
+	base64DataPSP := "cHNwQ3VzdG9tRGF0YQ=="
+	o.OrchestratorType = api.Kubernetes
+	o.KubernetesConfig.Addons = []api.KubernetesAddon{
+		{
+			Name:    common.PodSecurityPolicyAddonName,
+			Enabled: to.BoolPtr(true),
+			Data:    base64DataPSP,
+		},
+	}
+
+	mockCS.setAddonsConfig(isUpgrade)
+
+	i := getAddonsIndexByName(o.KubernetesConfig.Addons, common.PodSecurityPolicyAddonName)
+	if i < 0 {
+		t.Errorf("expected a positive index for the addon %s, instead got %d from getAddonsIndexByName", common.PodSecurityPolicyAddonName, i)
+	}
+
+	if o.KubernetesConfig.Addons[i].Name != common.PodSecurityPolicyAddonName {
+		t.Errorf("expected addon %s name to be present, instead got %s", common.PodSecurityPolicyAddonName, o.KubernetesConfig.Addons[i].Name)
+	}
+
+	if o.KubernetesConfig.Addons[i].Data != base64DataPSP {
+		t.Errorf("expected %s data to be present, instead got %s", base64DataPSP, o.KubernetesConfig.Addons[i].Data)
+	}
+}
+
+func TestDisabledAddons(t *testing.T) {
+	defaultAddon := api.KubernetesAddon{
+		Name:    "mockAddon",
+		Enabled: to.BoolPtr(false),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           "mockAddon",
+				CPURequests:    "50m",
+				MemoryRequests: "50Mi",
+				CPULimits:      "50m",
+				MemoryLimits:   "250Mi",
+				Image:          "mockImage",
+			},
+		},
+		Config: map[string]string{
+			"fake-config-1": "someValue1",
+			"fake-config-2": "someValue2",
+		},
+	}
+
+	cases := []struct {
+		name                string
+		myAddon             api.KubernetesAddon
+		isUpgrade           bool
+		expectedResultAddon api.KubernetesAddon
+	}{
+		{
+			name: "default addon enabled",
+			myAddon: api.KubernetesAddon{
+				Name:    "mockAddon",
+				Enabled: to.BoolPtr(true),
+			},
+			isUpgrade: false,
+			expectedResultAddon: api.KubernetesAddon{
+				Name:    "mockAddon",
+				Enabled: to.BoolPtr(true),
+				Containers: []api.KubernetesContainerSpec{
+					{
+						Name:           "mockAddon",
+						CPURequests:    "50m",
+						MemoryRequests: "50Mi",
+						CPULimits:      "50m",
+						MemoryLimits:   "250Mi",
+						Image:          "mockImage",
+					},
+				},
+				Config: map[string]string{
+					"fake-config-1": "someValue1",
+					"fake-config-2": "someValue2",
+				},
+			},
+		},
+		{
+			name: "addon disabled, isUpgrade=false",
+			myAddon: api.KubernetesAddon{
+				Name: "mockAddon",
+			},
+			isUpgrade: false,
+			expectedResultAddon: api.KubernetesAddon{
+				Name:    "mockAddon",
+				Enabled: to.BoolPtr(false),
+			},
+		},
+		{
+			name: "addon disabled, isUpgrade=true",
+			myAddon: api.KubernetesAddon{
+				Name:    "mockAddon",
+				Enabled: to.BoolPtr(false),
+			},
+			isUpgrade: true,
+			expectedResultAddon: api.KubernetesAddon{
+				Name:    "mockAddon",
+				Enabled: to.BoolPtr(false),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			result := assignDefaultAddonVals(c.myAddon, defaultAddon, c.isUpgrade)
+			if !reflect.DeepEqual(result, c.expectedResultAddon) {
+				t.Fatalf("expected result addon %v to be equal to %v", result, c.expectedResultAddon)
+			}
+		})
+	}
+
+}
+
+func TestSetAddonsConfig(t *testing.T) {
+	specConfig := api.AzureCloudSpecEnvMap["AzurePublicCloud"].KubernetesSpecConfig
+	azureStackCloudSpec := api.AzureEnvironmentSpecConfig{
+		CloudName: "AzureStackCloud",
+		KubernetesSpecConfig: api.KubernetesSpecConfig{
+			KubernetesImageBase:              "KubernetesImageBase",
+			TillerImageBase:                  "TillerImageBase",
+			ACIConnectorImageBase:            "ACIConnectorImageBase",
+			NVIDIAImageBase:                  "NVIDIAImageBase",
+			AzureCNIImageBase:                "AzureCNIImageBase",
+			CalicoImageBase:                  "CalicoImageBase",
+			EtcdDownloadURLBase:              "EtcdDownloadURLBase",
+			KubeBinariesSASURLBase:           "KubeBinariesSASURLBase",
+			WindowsTelemetryGUID:             "WindowsTelemetryGUID",
+			CNIPluginsDownloadURL:            "CNIPluginsDownloadURL",
+			VnetCNILinuxPluginsDownloadURL:   "VnetCNILinuxPluginsDownloadURL",
+			VnetCNIWindowsPluginsDownloadURL: "VnetCNIWindowsPluginsDownloadURL",
+			ContainerdDownloadURLBase:        "ContainerdDownloadURLBase",
+		},
+		EndpointConfig: api.AzureEndpointConfig{
+			ResourceManagerVMDNSSuffix: "ResourceManagerVMDNSSuffix",
+		},
+	}
+	api.AzureCloudSpecEnvMap[api.AzureStackCloud] = azureStackCloudSpec
+	tests := []struct {
+		name           string
+		cs             *ContainerService
+		isUpgrade      bool
+		expectedAddons []api.KubernetesAddon
+	}{
+		{
+			name: "default addons",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+						},
+					},
+				},
+			},
+			isUpgrade:      false,
+			expectedAddons: getDefaultAddons("1.15.4"),
+		},
+		{
+			name: "tiller addon is enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.TillerAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.TillerAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.TillerAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "150Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "150Mi",
+							Image:          specConfig.TillerImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.TillerAddonName],
+						},
+					},
+					Config: map[string]string{
+						"max-history": strconv.Itoa(0),
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "ACI Connector addon enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.ACIConnectorAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.ACIConnectorAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"region":   "westus",
+						"nodeName": "aci-connector",
+						"os":       "Linux",
+						"taint":    "azure.com/aci",
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.ACIConnectorAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "150Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "150Mi",
+							Image:          specConfig.ACIConnectorImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.ACIConnectorAddonName],
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "cluster-autoscaler addon enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.ClusterAutoscalerAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:  "pool1",
+							Count: 1,
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.ClusterAutoscalerAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"scan-interval":                         "1m",
+						"expendable-pods-priority-cutoff":       "-10",
+						"ignore-daemonsets-utilization":         "false",
+						"ignore-mirror-pods-utilization":        "false",
+						"max-autoprovisioned-node-group-count":  "15",
+						"max-empty-bulk-delete":                 "10",
+						"max-failing-time":                      "15m0s",
+						"max-graceful-termination-sec":          "600",
+						"max-inactivity":                        "10m0s",
+						"max-node-provision-time":               "15m0s",
+						"max-nodes-total":                       "0",
+						"max-total-unready-percentage":          "45",
+						"memory-total":                          "0:6400000",
+						"min-replica-count":                     "0",
+						"new-pod-scale-up-delay":                "0s",
+						"node-autoprovisioning-enabled":         "false",
+						"ok-total-unready-count":                "3",
+						"scale-down-candidates-pool-min-count":  "50",
+						"scale-down-candidates-pool-ratio":      "0.1",
+						"scale-down-delay-after-add":            "10m0s",
+						"scale-down-delay-after-delete":         "1m",
+						"scale-down-delay-after-failure":        "3m0s",
+						"scale-down-enabled":                    "true",
+						"scale-down-non-empty-candidates-count": "30",
+						"scale-down-unneeded-time":              "10m0s",
+						"scale-down-unready-time":               "20m0s",
+						"scale-down-utilization-threshold":      "0.5",
+						"skip-nodes-with-local-storage":         "false",
+						"skip-nodes-with-system-pods":           "true",
+						"stderrthreshold":                       "2",
+						"unremovable-node-recheck-timeout":      "5m0s",
+						"v":                                     "3",
+						"write-status-configmap":                "true",
+						"balance-similar-node-groups":           "true",
+					},
+					Pools: []api.AddonNodePoolsConfig{
+						{
+							Name: "pool1",
+							Config: map[string]string{
+								"min-nodes": "1",
+								"max-nodes": "1",
+							},
+						},
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.ClusterAutoscalerAddonName,
+							CPURequests:    "100m",
+							MemoryRequests: "300Mi",
+							CPULimits:      "100m",
+							MemoryLimits:   "300Mi",
+							Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.ClusterAutoscalerAddonName],
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "cluster-autoscaler addon enabled - update",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.ClusterAutoscalerAddonName,
+									Enabled: to.BoolPtr(true),
+									Config: map[string]string{
+										"min-nodes": "1",
+										"max-nodes": "3",
+									},
+								},
+							},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:  "pool1",
+							Count: 1,
+						},
+					},
+				},
+			},
+			isUpgrade: true,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.ClusterAutoscalerAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"scan-interval":                         "1m",
+						"expendable-pods-priority-cutoff":       "-10",
+						"ignore-daemonsets-utilization":         "false",
+						"ignore-mirror-pods-utilization":        "false",
+						"max-autoprovisioned-node-group-count":  "15",
+						"max-empty-bulk-delete":                 "10",
+						"max-failing-time":                      "15m0s",
+						"max-graceful-termination-sec":          "600",
+						"max-inactivity":                        "10m0s",
+						"max-node-provision-time":               "15m0s",
+						"max-nodes-total":                       "0",
+						"max-total-unready-percentage":          "45",
+						"memory-total":                          "0:6400000",
+						"min-replica-count":                     "0",
+						"new-pod-scale-up-delay":                "0s",
+						"node-autoprovisioning-enabled":         "false",
+						"ok-total-unready-count":                "3",
+						"scale-down-candidates-pool-min-count":  "50",
+						"scale-down-candidates-pool-ratio":      "0.1",
+						"scale-down-delay-after-add":            "10m0s",
+						"scale-down-delay-after-delete":         "1m",
+						"scale-down-delay-after-failure":        "3m0s",
+						"scale-down-enabled":                    "true",
+						"scale-down-non-empty-candidates-count": "30",
+						"scale-down-unneeded-time":              "10m0s",
+						"scale-down-unready-time":               "20m0s",
+						"scale-down-utilization-threshold":      "0.5",
+						"skip-nodes-with-local-storage":         "false",
+						"skip-nodes-with-system-pods":           "true",
+						"stderrthreshold":                       "2",
+						"unremovable-node-recheck-timeout":      "5m0s",
+						"v":                                     "3",
+						"write-status-configmap":                "true",
+						"balance-similar-node-groups":           "true",
+					},
+					Pools: []api.AddonNodePoolsConfig{
+						{
+							Name: "pool1",
+							Config: map[string]string{
+								"min-nodes": "1",
+								"max-nodes": "3",
+							},
+						},
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.ClusterAutoscalerAddonName,
+							CPURequests:    "100m",
+							MemoryRequests: "300Mi",
+							CPULimits:      "100m",
+							MemoryLimits:   "300Mi",
+							Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.ClusterAutoscalerAddonName],
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "cluster-autoscaler addon enabled on cluster with multiple pools",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.ClusterAutoscalerAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:  "pool1",
+							Count: 5,
+						},
+						{
+							Name:  "pool2",
+							Count: 10,
+						},
+						{
+							Name:  "pool3",
+							Count: 1,
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.ClusterAutoscalerAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"scan-interval":                         "1m",
+						"expendable-pods-priority-cutoff":       "-10",
+						"ignore-daemonsets-utilization":         "false",
+						"ignore-mirror-pods-utilization":        "false",
+						"max-autoprovisioned-node-group-count":  "15",
+						"max-empty-bulk-delete":                 "10",
+						"max-failing-time":                      "15m0s",
+						"max-graceful-termination-sec":          "600",
+						"max-inactivity":                        "10m0s",
+						"max-node-provision-time":               "15m0s",
+						"max-nodes-total":                       "0",
+						"max-total-unready-percentage":          "45",
+						"memory-total":                          "0:6400000",
+						"min-replica-count":                     "0",
+						"new-pod-scale-up-delay":                "0s",
+						"node-autoprovisioning-enabled":         "false",
+						"ok-total-unready-count":                "3",
+						"scale-down-candidates-pool-min-count":  "50",
+						"scale-down-candidates-pool-ratio":      "0.1",
+						"scale-down-delay-after-add":            "10m0s",
+						"scale-down-delay-after-delete":         "1m",
+						"scale-down-delay-after-failure":        "3m0s",
+						"scale-down-enabled":                    "true",
+						"scale-down-non-empty-candidates-count": "30",
+						"scale-down-unneeded-time":              "10m0s",
+						"scale-down-unready-time":               "20m0s",
+						"scale-down-utilization-threshold":      "0.5",
+						"skip-nodes-with-local-storage":         "false",
+						"skip-nodes-with-system-pods":           "true",
+						"stderrthreshold":                       "2",
+						"unremovable-node-recheck-timeout":      "5m0s",
+						"v":                                     "3",
+						"write-status-configmap":                "true",
+						"balance-similar-node-groups":           "true",
+					},
+					Pools: []api.AddonNodePoolsConfig{
+						{
+							Name: "pool1",
+							Config: map[string]string{
+								"min-nodes": "5",
+								"max-nodes": "5",
+							},
+						},
+						{
+							Name: "pool2",
+							Config: map[string]string{
+								"min-nodes": "10",
+								"max-nodes": "10",
+							},
+						},
+						{
+							Name: "pool3",
+							Config: map[string]string{
+								"min-nodes": "1",
+								"max-nodes": "1",
+							},
+						},
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.ClusterAutoscalerAddonName,
+							CPURequests:    "100m",
+							MemoryRequests: "300Mi",
+							CPULimits:      "100m",
+							MemoryLimits:   "300Mi",
+							Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.ClusterAutoscalerAddonName],
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "cluster-autoscaler addon enabled on cluster with multiple pools - update",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.ClusterAutoscalerAddonName,
+									Enabled: to.BoolPtr(true),
+									Config: map[string]string{
+										"min-nodes": "5",
+										"max-nodes": "100",
+									},
+								},
+							},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:  "pool1",
+							Count: 5,
+						},
+						{
+							Name:  "pool2",
+							Count: 10,
+						},
+						{
+							Name:  "pool3",
+							Count: 1,
+						},
+					},
+				},
+			},
+			isUpgrade: true,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.ClusterAutoscalerAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"scan-interval":                         "1m",
+						"expendable-pods-priority-cutoff":       "-10",
+						"ignore-daemonsets-utilization":         "false",
+						"ignore-mirror-pods-utilization":        "false",
+						"max-autoprovisioned-node-group-count":  "15",
+						"max-empty-bulk-delete":                 "10",
+						"max-failing-time":                      "15m0s",
+						"max-graceful-termination-sec":          "600",
+						"max-inactivity":                        "10m0s",
+						"max-node-provision-time":               "15m0s",
+						"max-nodes-total":                       "0",
+						"max-total-unready-percentage":          "45",
+						"memory-total":                          "0:6400000",
+						"min-replica-count":                     "0",
+						"new-pod-scale-up-delay":                "0s",
+						"node-autoprovisioning-enabled":         "false",
+						"ok-total-unready-count":                "3",
+						"scale-down-candidates-pool-min-count":  "50",
+						"scale-down-candidates-pool-ratio":      "0.1",
+						"scale-down-delay-after-add":            "10m0s",
+						"scale-down-delay-after-delete":         "1m",
+						"scale-down-delay-after-failure":        "3m0s",
+						"scale-down-enabled":                    "true",
+						"scale-down-non-empty-candidates-count": "30",
+						"scale-down-unneeded-time":              "10m0s",
+						"scale-down-unready-time":               "20m0s",
+						"scale-down-utilization-threshold":      "0.5",
+						"skip-nodes-with-local-storage":         "false",
+						"skip-nodes-with-system-pods":           "true",
+						"stderrthreshold":                       "2",
+						"unremovable-node-recheck-timeout":      "5m0s",
+						"v":                                     "3",
+						"write-status-configmap":                "true",
+						"balance-similar-node-groups":           "true",
+					},
+					Pools: []api.AddonNodePoolsConfig{
+						{
+							Name: "pool1",
+							Config: map[string]string{
+								"min-nodes": "5",
+								"max-nodes": "100",
+							},
+						},
+						{
+							Name: "pool2",
+							Config: map[string]string{
+								"min-nodes": "10",
+								"max-nodes": "10",
+							},
+						},
+						{
+							Name: "pool3",
+							Config: map[string]string{
+								"min-nodes": "1",
+								"max-nodes": "1",
+							},
+						},
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.ClusterAutoscalerAddonName,
+							CPURequests:    "100m",
+							MemoryRequests: "300Mi",
+							CPULimits:      "100m",
+							MemoryLimits:   "300Mi",
+							Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.ClusterAutoscalerAddonName],
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "cluster-autoscaler addon enabled with configuration",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.ClusterAutoscalerAddonName,
+									Enabled: to.BoolPtr(true),
+									Config: map[string]string{
+										"scan-interval":                         "30s",
+										"expendable-pods-priority-cutoff":       "-20",
+										"ignore-daemonsets-utilization":         "true",
+										"ignore-mirror-pods-utilization":        "true",
+										"max-autoprovisioned-node-group-count":  "25",
+										"max-empty-bulk-delete":                 "12",
+										"max-failing-time":                      "15m10s",
+										"max-graceful-termination-sec":          "700",
+										"max-inactivity":                        "11m0s",
+										"max-node-provision-time":               "16m0s",
+										"max-nodes-total":                       "1",
+										"max-total-unready-percentage":          "46",
+										"memory-total":                          "0:12800000",
+										"min-replica-count":                     "1",
+										"new-pod-scale-up-delay":                "10s",
+										"node-autoprovisioning-enabled":         "true",
+										"ok-total-unready-count":                "4",
+										"scale-down-candidates-pool-min-count":  "51",
+										"scale-down-candidates-pool-ratio":      "0.3",
+										"scale-down-delay-after-add":            "20m0s",
+										"scale-down-delay-after-delete":         "20s",
+										"scale-down-delay-after-failure":        "4m0s",
+										"scale-down-enabled":                    "false",
+										"scale-down-non-empty-candidates-count": "50",
+										"scale-down-unneeded-time":              "11m0s",
+										"scale-down-unready-time":               "23m0s",
+										"scale-down-utilization-threshold":      "0.8",
+										"skip-nodes-with-local-storage":         "true",
+										"skip-nodes-with-system-pods":           "false",
+										"stderrthreshold":                       "7",
+										"unremovable-node-recheck-timeout":      "9m0s",
+										"v":                                     "6",
+										"write-status-configmap":                "false",
+										"balance-similar-node-groups":           "false",
+									},
+									Pools: []api.AddonNodePoolsConfig{
+										{
+											Name: "pool1",
+											Config: map[string]string{
+												"min-nodes": "1",
+												"max-nodes": "100",
+											},
+										},
+										{
+											Name: "pool2",
+											Config: map[string]string{
+												"min-nodes": "3",
+												"max-nodes": "10",
+											},
+										},
+										{
+											Name: "pool3",
+											Config: map[string]string{
+												"min-nodes": "1",
+												"max-nodes": "6",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:  "pool1",
+							Count: 5,
+						},
+						{
+							Name:  "pool2",
+							Count: 10,
+						},
+						{
+							Name:  "pool3",
+							Count: 1,
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.ClusterAutoscalerAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"scan-interval":                         "30s",
+						"expendable-pods-priority-cutoff":       "-20",
+						"ignore-daemonsets-utilization":         "true",
+						"ignore-mirror-pods-utilization":        "true",
+						"max-autoprovisioned-node-group-count":  "25",
+						"max-empty-bulk-delete":                 "12",
+						"max-failing-time":                      "15m10s",
+						"max-graceful-termination-sec":          "700",
+						"max-inactivity":                        "11m0s",
+						"max-node-provision-time":               "16m0s",
+						"max-nodes-total":                       "1",
+						"max-total-unready-percentage":          "46",
+						"memory-total":                          "0:12800000",
+						"min-replica-count":                     "1",
+						"new-pod-scale-up-delay":                "10s",
+						"node-autoprovisioning-enabled":         "true",
+						"ok-total-unready-count":                "4",
+						"scale-down-candidates-pool-min-count":  "51",
+						"scale-down-candidates-pool-ratio":      "0.3",
+						"scale-down-delay-after-add":            "20m0s",
+						"scale-down-delay-after-delete":         "20s",
+						"scale-down-delay-after-failure":        "4m0s",
+						"scale-down-enabled":                    "false",
+						"scale-down-non-empty-candidates-count": "50",
+						"scale-down-unneeded-time":              "11m0s",
+						"scale-down-unready-time":               "23m0s",
+						"scale-down-utilization-threshold":      "0.8",
+						"skip-nodes-with-local-storage":         "true",
+						"skip-nodes-with-system-pods":           "false",
+						"stderrthreshold":                       "7",
+						"unremovable-node-recheck-timeout":      "9m0s",
+						"v":                                     "6",
+						"write-status-configmap":                "false",
+						"balance-similar-node-groups":           "false",
+					},
+					Pools: []api.AddonNodePoolsConfig{
+						{
+							Name: "pool1",
+							Config: map[string]string{
+								"min-nodes": "1",
+								"max-nodes": "100",
+							},
+						},
+						{
+							Name: "pool2",
+							Config: map[string]string{
+								"min-nodes": "3",
+								"max-nodes": "10",
+							},
+						},
+						{
+							Name: "pool3",
+							Config: map[string]string{
+								"min-nodes": "1",
+								"max-nodes": "6",
+							},
+						},
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.ClusterAutoscalerAddonName,
+							CPURequests:    "100m",
+							MemoryRequests: "300Mi",
+							CPULimits:      "100m",
+							MemoryLimits:   "300Mi",
+							Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.ClusterAutoscalerAddonName],
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "cluster-autoscaler addon enabled with configuration - update",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.ClusterAutoscalerAddonName,
+									Enabled: to.BoolPtr(true),
+									Config: map[string]string{
+										"scan-interval":                         "30s",
+										"expendable-pods-priority-cutoff":       "-20",
+										"ignore-daemonsets-utilization":         "true",
+										"ignore-mirror-pods-utilization":        "true",
+										"max-autoprovisioned-node-group-count":  "25",
+										"max-empty-bulk-delete":                 "12",
+										"max-failing-time":                      "15m10s",
+										"max-graceful-termination-sec":          "700",
+										"max-inactivity":                        "11m0s",
+										"max-node-provision-time":               "16m0s",
+										"max-nodes-total":                       "1",
+										"max-total-unready-percentage":          "46",
+										"memory-total":                          "0:12800000",
+										"min-replica-count":                     "1",
+										"new-pod-scale-up-delay":                "10s",
+										"node-autoprovisioning-enabled":         "true",
+										"ok-total-unready-count":                "4",
+										"scale-down-candidates-pool-min-count":  "51",
+										"scale-down-candidates-pool-ratio":      "0.3",
+										"scale-down-delay-after-add":            "20m0s",
+										"scale-down-delay-after-delete":         "20s",
+										"scale-down-delay-after-failure":        "4m0s",
+										"scale-down-enabled":                    "false",
+										"scale-down-non-empty-candidates-count": "50",
+										"scale-down-unneeded-time":              "11m0s",
+										"scale-down-unready-time":               "23m0s",
+										"scale-down-utilization-threshold":      "0.8",
+										"skip-nodes-with-local-storage":         "true",
+										"skip-nodes-with-system-pods":           "false",
+										"stderrthreshold":                       "7",
+										"unremovable-node-recheck-timeout":      "9m0s",
+										"v":                                     "6",
+										"write-status-configmap":                "false",
+										"balance-similar-node-groups":           "false",
+									},
+									Pools: []api.AddonNodePoolsConfig{
+										{
+											Name: "pool1",
+											Config: map[string]string{
+												"min-nodes": "1",
+												"max-nodes": "100",
+											},
+										},
+										{
+											Name: "pool2",
+											Config: map[string]string{
+												"min-nodes": "3",
+												"max-nodes": "10",
+											},
+										},
+										{
+											Name: "pool3",
+											Config: map[string]string{
+												"min-nodes": "1",
+												"max-nodes": "6",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:  "pool1",
+							Count: 5,
+						},
+						{
+							Name:  "pool2",
+							Count: 10,
+						},
+						{
+							Name:  "pool3",
+							Count: 1,
+						},
+					},
+				},
+			},
+			isUpgrade: true,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.ClusterAutoscalerAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"scan-interval":                         "30s",
+						"expendable-pods-priority-cutoff":       "-20",
+						"ignore-daemonsets-utilization":         "true",
+						"ignore-mirror-pods-utilization":        "true",
+						"max-autoprovisioned-node-group-count":  "25",
+						"max-empty-bulk-delete":                 "12",
+						"max-failing-time":                      "15m10s",
+						"max-graceful-termination-sec":          "700",
+						"max-inactivity":                        "11m0s",
+						"max-node-provision-time":               "16m0s",
+						"max-nodes-total":                       "1",
+						"max-total-unready-percentage":          "46",
+						"memory-total":                          "0:12800000",
+						"min-replica-count":                     "1",
+						"new-pod-scale-up-delay":                "10s",
+						"node-autoprovisioning-enabled":         "true",
+						"ok-total-unready-count":                "4",
+						"scale-down-candidates-pool-min-count":  "51",
+						"scale-down-candidates-pool-ratio":      "0.3",
+						"scale-down-delay-after-add":            "20m0s",
+						"scale-down-delay-after-delete":         "20s",
+						"scale-down-delay-after-failure":        "4m0s",
+						"scale-down-enabled":                    "false",
+						"scale-down-non-empty-candidates-count": "50",
+						"scale-down-unneeded-time":              "11m0s",
+						"scale-down-unready-time":               "23m0s",
+						"scale-down-utilization-threshold":      "0.8",
+						"skip-nodes-with-local-storage":         "true",
+						"skip-nodes-with-system-pods":           "false",
+						"stderrthreshold":                       "7",
+						"unremovable-node-recheck-timeout":      "9m0s",
+						"v":                                     "6",
+						"write-status-configmap":                "false",
+						"balance-similar-node-groups":           "false",
+					},
+					Pools: []api.AddonNodePoolsConfig{
+						{
+							Name: "pool1",
+							Config: map[string]string{
+								"min-nodes": "1",
+								"max-nodes": "100",
+							},
+						},
+						{
+							Name: "pool2",
+							Config: map[string]string{
+								"min-nodes": "3",
+								"max-nodes": "10",
+							},
+						},
+						{
+							Name: "pool3",
+							Config: map[string]string{
+								"min-nodes": "1",
+								"max-nodes": "6",
+							},
+						},
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.ClusterAutoscalerAddonName,
+							CPURequests:    "100m",
+							MemoryRequests: "300Mi",
+							CPULimits:      "100m",
+							MemoryLimits:   "300Mi",
+							Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.ClusterAutoscalerAddonName],
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "cluster-autoscaler addon enabled with mixed configuration plus defaults",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.ClusterAutoscalerAddonName,
+									Enabled: to.BoolPtr(true),
+									Config: map[string]string{
+										"scan-interval":                        "30s",
+										"expendable-pods-priority-cutoff":      "-20",
+										"ignore-daemonsets-utilization":        "true",
+										"ignore-mirror-pods-utilization":       "true",
+										"max-autoprovisioned-node-group-count": "25",
+										"max-empty-bulk-delete":                "12",
+										"max-failing-time":                     "15m10s",
+										"max-graceful-termination-sec":         "700",
+										"max-inactivity":                       "11m0s",
+										"max-node-provision-time":              "16m0s",
+										"max-nodes-total":                      "1",
+										"max-total-unready-percentage":         "46",
+									},
+									Pools: []api.AddonNodePoolsConfig{
+										{
+											Name: "pool1",
+											Config: map[string]string{
+												"min-nodes": "1",
+												"max-nodes": "100",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:  "pool1",
+							Count: 5,
+						},
+						{
+							Name:  "pool2",
+							Count: 10,
+						},
+						{
+							Name:  "pool3",
+							Count: 1,
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.ClusterAutoscalerAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"scan-interval":                         "30s",
+						"expendable-pods-priority-cutoff":       "-20",
+						"ignore-daemonsets-utilization":         "true",
+						"ignore-mirror-pods-utilization":        "true",
+						"max-autoprovisioned-node-group-count":  "25",
+						"max-empty-bulk-delete":                 "12",
+						"max-failing-time":                      "15m10s",
+						"max-graceful-termination-sec":          "700",
+						"max-inactivity":                        "11m0s",
+						"max-node-provision-time":               "16m0s",
+						"max-nodes-total":                       "1",
+						"max-total-unready-percentage":          "46",
+						"memory-total":                          "0:6400000",
+						"min-replica-count":                     "0",
+						"new-pod-scale-up-delay":                "0s",
+						"node-autoprovisioning-enabled":         "false",
+						"ok-total-unready-count":                "3",
+						"scale-down-candidates-pool-min-count":  "50",
+						"scale-down-candidates-pool-ratio":      "0.1",
+						"scale-down-delay-after-add":            "10m0s",
+						"scale-down-delay-after-delete":         "1m",
+						"scale-down-delay-after-failure":        "3m0s",
+						"scale-down-enabled":                    "true",
+						"scale-down-non-empty-candidates-count": "30",
+						"scale-down-unneeded-time":              "10m0s",
+						"scale-down-unready-time":               "20m0s",
+						"scale-down-utilization-threshold":      "0.5",
+						"skip-nodes-with-local-storage":         "false",
+						"skip-nodes-with-system-pods":           "true",
+						"stderrthreshold":                       "2",
+						"unremovable-node-recheck-timeout":      "5m0s",
+						"v":                                     "3",
+						"write-status-configmap":                "true",
+						"balance-similar-node-groups":           "true",
+					},
+					Pools: []api.AddonNodePoolsConfig{
+						{
+							Name: "pool1",
+							Config: map[string]string{
+								"min-nodes": "1",
+								"max-nodes": "100",
+							},
+						},
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.ClusterAutoscalerAddonName,
+							CPURequests:    "100m",
+							MemoryRequests: "300Mi",
+							CPULimits:      "100m",
+							MemoryLimits:   "300Mi",
+							Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.ClusterAutoscalerAddonName],
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "cluster-autoscaler addon enabled with mixed configuration plus defaults - update",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.ClusterAutoscalerAddonName,
+									Enabled: to.BoolPtr(true),
+									Config: map[string]string{
+										"scan-interval":                        "30s",
+										"expendable-pods-priority-cutoff":      "-20",
+										"ignore-daemonsets-utilization":        "true",
+										"ignore-mirror-pods-utilization":       "true",
+										"max-autoprovisioned-node-group-count": "25",
+										"max-empty-bulk-delete":                "12",
+										"max-failing-time":                     "15m10s",
+										"max-graceful-termination-sec":         "700",
+										"max-inactivity":                       "11m0s",
+										"max-node-provision-time":              "16m0s",
+										"max-nodes-total":                      "1",
+										"max-total-unready-percentage":         "46",
+									},
+									Pools: []api.AddonNodePoolsConfig{
+										{
+											Name: "pool1",
+											Config: map[string]string{
+												"min-nodes": "1",
+												"max-nodes": "100",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:  "pool1",
+							Count: 5,
+						},
+						{
+							Name:  "pool2",
+							Count: 10,
+						},
+						{
+							Name:  "pool3",
+							Count: 1,
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.ClusterAutoscalerAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"scan-interval":                         "30s",
+						"expendable-pods-priority-cutoff":       "-20",
+						"ignore-daemonsets-utilization":         "true",
+						"ignore-mirror-pods-utilization":        "true",
+						"max-autoprovisioned-node-group-count":  "25",
+						"max-empty-bulk-delete":                 "12",
+						"max-failing-time":                      "15m10s",
+						"max-graceful-termination-sec":          "700",
+						"max-inactivity":                        "11m0s",
+						"max-node-provision-time":               "16m0s",
+						"max-nodes-total":                       "1",
+						"max-total-unready-percentage":          "46",
+						"memory-total":                          "0:6400000",
+						"min-replica-count":                     "0",
+						"new-pod-scale-up-delay":                "0s",
+						"node-autoprovisioning-enabled":         "false",
+						"ok-total-unready-count":                "3",
+						"scale-down-candidates-pool-min-count":  "50",
+						"scale-down-candidates-pool-ratio":      "0.1",
+						"scale-down-delay-after-add":            "10m0s",
+						"scale-down-delay-after-delete":         "1m",
+						"scale-down-delay-after-failure":        "3m0s",
+						"scale-down-enabled":                    "true",
+						"scale-down-non-empty-candidates-count": "30",
+						"scale-down-unneeded-time":              "10m0s",
+						"scale-down-unready-time":               "20m0s",
+						"scale-down-utilization-threshold":      "0.5",
+						"skip-nodes-with-local-storage":         "false",
+						"skip-nodes-with-system-pods":           "true",
+						"stderrthreshold":                       "2",
+						"unremovable-node-recheck-timeout":      "5m0s",
+						"v":                                     "3",
+						"write-status-configmap":                "true",
+						"balance-similar-node-groups":           "true",
+					},
+					Pools: []api.AddonNodePoolsConfig{
+						{
+							Name: "pool1",
+							Config: map[string]string{
+								"min-nodes": "1",
+								"max-nodes": "100",
+							},
+						},
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.ClusterAutoscalerAddonName,
+							CPURequests:    "100m",
+							MemoryRequests: "300Mi",
+							CPULimits:      "100m",
+							MemoryLimits:   "300Mi",
+							Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.ClusterAutoscalerAddonName],
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "smb-flexvolume addon enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.SMBFlexVolumeAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.SMBFlexVolumeAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.SMBFlexVolumeAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "100Mi",
+							Image:          api.K8sComponentsByVersionMap["1.15.4"][common.SMBFlexVolumeAddonName],
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "rescheduler addon enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.ReschedulerAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.ReschedulerAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.ReschedulerAddonName,
+							CPURequests:    "10m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "10m",
+							MemoryLimits:   "100Mi",
+							Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.ReschedulerAddonName],
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "nvidia addon enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							VMSize: "Standard_NC6",
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.NVIDIADevicePluginAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.NVIDIADevicePluginAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "100Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "100Mi",
+							Image:          specConfig.NVIDIAImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.NVIDIADevicePluginAddonName],
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "container-monitoring addon enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.ContainerMonitoringAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.ContainerMonitoringAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"omsAgentVersion":       "1.10.0.1",
+						"dockerProviderVersion": "8.0.0-2",
+						"schema-versions":       "v1",
+						"clusterName":           "aks-engine-cluster",
+						"workspaceDomain":       "b3BpbnNpZ2h0cy5henVyZS5jb20=",
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           "omsagent",
+							CPURequests:    "150m",
+							MemoryRequests: "250Mi",
+							CPULimits:      "1",
+							MemoryLimits:   "750Mi",
+							Image:          "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod01072020",
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "Azure Network Policy addon enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							NetworkPolicy: api.NetworkPolicyAzure,
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.AzureNetworkPolicyAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.AzureNetworkPolicyAddonName,
+							Image:          api.K8sComponentsByVersionMap["1.15.4"][common.AzureNetworkPolicyAddonName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "100m",
+							MemoryLimits:   "200Mi",
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "Azure Network Policy addon enabled - 1.16 upgrade",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.16.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							NetworkPolicy: api.NetworkPolicyAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.AzureNetworkPolicyAddonName,
+									Enabled: to.BoolPtr(true),
+									Containers: []api.KubernetesContainerSpec{
+										{
+											Name:  common.AzureNetworkPolicyAddonName,
+											Image: api.K8sComponentsByVersionMap["1.16.0"][common.AzureNetworkPolicyAddonName],
+										},
+										{
+											Name:  common.AzureVnetTelemetryContainerName,
+											Image: api.K8sComponentsByVersionMap["1.16.0"][common.AzureVnetTelemetryContainerName],
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: true,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.AzureNetworkPolicyAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.AzureNetworkPolicyAddonName,
+							Image:          api.K8sComponentsByVersionMap["1.16.0"][common.AzureNetworkPolicyAddonName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "100m",
+							MemoryLimits:   "200Mi",
+						},
+					},
+				},
+			}, "1.16.0"),
+		},
+		{
+			name: "dns-autoscaler addon enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.DNSAutoscalerAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.DNSAutoscalerAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.DNSAutoscalerAddonName,
+							Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.DNSAutoscalerAddonName],
+							CPURequests:    "20m",
+							MemoryRequests: "100Mi",
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "calico addon enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							NetworkPolicy: api.NetworkPolicyCalico,
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: omitFromAddons([]string{common.AzureCNINetworkMonitorAddonName}, concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.CalicoAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:  "calico-typha",
+							Image: specConfig.CalicoImageBase + api.K8sComponentsByVersionMap["1.15.4"]["calico-typha"],
+						},
+						{
+							Name:  "calico-cni",
+							Image: specConfig.CalicoImageBase + api.K8sComponentsByVersionMap["1.15.4"]["calico-cni"],
+						},
+						{
+							Name:  "calico-node",
+							Image: specConfig.CalicoImageBase + api.K8sComponentsByVersionMap["1.15.4"]["calico-node"],
+						},
+						{
+							Name:  "calico-pod2daemon",
+							Image: specConfig.CalicoImageBase + api.K8sComponentsByVersionMap["1.15.4"]["calico-pod2daemon"],
+						},
+						{
+							Name:  "calico-cluster-proportional-autoscaler",
+							Image: specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"]["calico-cluster-proportional-autoscaler"],
+						},
+					},
+				},
+			}, "1.15.4")),
+		},
+		{
+			name: "calico addon back-compat",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							NetworkPolicy: api.NetworkPolicyCalico,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.CalicoAddonName,
+									Enabled: to.BoolPtr(false),
+									Containers: []api.KubernetesContainerSpec{
+										{
+											Name:  "calico-typha",
+											Image: specConfig.CalicoImageBase + "typha:old", // confirm that upgrade will change this to default image
+										},
+										{
+											Name:  "calico-cni",
+											Image: specConfig.CalicoImageBase + "cni:v3.8.0",
+										},
+										{
+											Name:  "calico-node",
+											Image: specConfig.CalicoImageBase + "node:v3.8.0",
+										},
+										{
+											Name:  "calico-pod2daemon",
+											Image: specConfig.CalicoImageBase + "pod2daemon-flexvol:v3.8.0",
+										},
+										{
+											Name:  "calico-cluster-proportional-autoscaler",
+											Image: specConfig.KubernetesImageBase + "cluster-proportional-autoscaler-amd64:1.1.2-r2",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: true,
+			expectedAddons: omitFromAddons([]string{common.AzureCNINetworkMonitorAddonName}, concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.CalicoAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:  "calico-typha",
+							Image: specConfig.CalicoImageBase + api.K8sComponentsByVersionMap["1.15.4"]["calico-typha"],
+						},
+						{
+							Name:  "calico-cni",
+							Image: specConfig.CalicoImageBase + api.K8sComponentsByVersionMap["1.15.4"]["calico-cni"],
+						},
+						{
+							Name:  "calico-node",
+							Image: specConfig.CalicoImageBase + api.K8sComponentsByVersionMap["1.15.4"]["calico-node"],
+						},
+						{
+							Name:  "calico-pod2daemon",
+							Image: specConfig.CalicoImageBase + api.K8sComponentsByVersionMap["1.15.4"]["calico-pod2daemon"],
+						},
+						{
+							Name:  "calico-cluster-proportional-autoscaler",
+							Image: specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"]["calico-cluster-proportional-autoscaler"],
+						},
+					},
+				},
+			}, "1.15.4")),
+		},
+		{
+			name: "aad-pod-identity enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.AADPodIdentityAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.AADPodIdentityAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.NMIContainerName,
+							Image:          api.K8sComponentsByVersionMap["1.15.4"][common.NMIContainerName],
+							CPURequests:    "100m",
+							MemoryRequests: "300Mi",
+							CPULimits:      "100m",
+							MemoryLimits:   "300Mi",
+						},
+						{
+							Name:           common.MICContainerName,
+							Image:          api.K8sComponentsByVersionMap["1.15.4"][common.MICContainerName],
+							CPURequests:    "100m",
+							MemoryRequests: "300Mi",
+							CPULimits:      "100m",
+							MemoryLimits:   "300Mi",
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "azure-policy addon enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.AzurePolicyAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.AzurePolicyAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"auditInterval":             "30",
+						"constraintViolationsLimit": "20",
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.AzurePolicyAddonName,
+							Image:          api.K8sComponentsByVersionMap["1.15.4"][common.AzurePolicyAddonName],
+							CPURequests:    "30m",
+							MemoryRequests: "50Mi",
+							CPULimits:      "100m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.GatekeeperContainerName,
+							Image:          api.K8sComponentsByVersionMap["1.15.4"][common.GatekeeperContainerName],
+							CPURequests:    "100m",
+							MemoryRequests: "256Mi",
+							CPULimits:      "100m",
+							MemoryLimits:   "512Mi",
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "cilium networkPolicy",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPolicy: api.NetworkPolicyCilium,
+							NetworkPlugin: api.NetworkPluginCilium,
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: omitFromAddons([]string{common.IPMASQAgentAddonName, common.AzureCNINetworkMonitorAddonName}, concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.CiliumAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:  common.CiliumAgentContainerName,
+							Image: api.K8sComponentsByVersionMap["1.15.4"][common.CiliumAgentContainerName],
+						},
+						{
+							Name:  common.CiliumCleanStateContainerName,
+							Image: api.K8sComponentsByVersionMap["1.15.4"][common.CiliumCleanStateContainerName],
+						},
+						{
+							Name:  common.CiliumOperatorContainerName,
+							Image: api.K8sComponentsByVersionMap["1.15.4"][common.CiliumOperatorContainerName],
+						},
+						{
+							Name:  common.CiliumEtcdOperatorContainerName,
+							Image: api.K8sComponentsByVersionMap["1.15.4"][common.CiliumEtcdOperatorContainerName],
+						},
+					},
+				},
+			}, "1.15.4")),
+		},
+		{
+			name: "Azure Stack addons",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							VMSize: "Standard_NC6", // to validate that Azure Stack cluster config does not get nvidia addon
+						},
+					},
+					CustomCloudProfile: &api.CustomCloudProfile{
+						Environment: &azure.Environment{
+							Name: "AzureStackCloud",
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: []api.KubernetesAddon{
+				{
+					Name:    common.DashboardAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.DashboardAddonName,
+							CPURequests:    "300m",
+							MemoryRequests: "150Mi",
+							CPULimits:      "300m",
+							MemoryLimits:   "150Mi",
+							Image:          "KubernetesImageBase" + api.K8sComponentsByVersionMap["1.14.0"][common.DashboardAddonName],
+						},
+					},
+				},
+				{
+					Name:    common.MetricsServerAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:  common.MetricsServerAddonName,
+							Image: "KubernetesImageBase" + api.K8sComponentsByVersionMap["1.14.0"][common.MetricsServerAddonName],
+						},
+					},
+				},
+				{
+					Name:    common.IPMASQAgentAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.IPMASQAgentAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "50Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "250Mi",
+							Image:          "KubernetesImageBase" + api.K8sComponentsByVersionMap["1.14.0"][common.IPMASQAgentAddonName],
+						},
+					},
+					Config: map[string]string{
+						"non-masquerade-cidr": api.DefaultVNETCIDR,
+						"non-masq-cni-cidr":   api.DefaultCNICIDR,
+						"enable-ipv6":         "false",
+					},
+				},
+				{
+					Name:    common.AzureCNINetworkMonitorAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:  common.AzureCNINetworkMonitorAddonName,
+							Image: "AzureCNIImageBase" + api.K8sComponentsByVersionMap["1.14.0"][common.AzureCNINetworkMonitorAddonName],
+						},
+					},
+				},
+				{
+					Name:    common.CoreDNSAddonName,
+					Enabled: to.BoolPtr(api.DefaultCoreDNSAddonEnabled),
+					Config: map[string]string{
+						"domain":    "cluster.local",
+						"clusterIP": api.DefaultKubernetesDNSServiceIP,
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:  common.CoreDNSAddonName,
+							Image: "KubernetesImageBase" + api.K8sComponentsByVersionMap["1.14.0"][common.CoreDNSAddonName],
+						},
+					},
+				},
+				{
+					Name:    common.KubeProxyAddonName,
+					Enabled: to.BoolPtr(api.DefaultKubeProxyAddonEnabled),
+					Config: map[string]string{
+						"cluster-cidr": api.DefaultKubernetesSubnet,
+						"proxy-mode":   string(api.KubeProxyModeIPTables),
+						"featureGates": "{}",
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:  common.KubeProxyAddonName,
+							Image: "KubernetesImageBase" + api.K8sComponentsByVersionMap["1.14.0"][common.KubeProxyAddonName],
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "CoreOS addons",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Distro: api.CoreOS,
+							VMSize: "Standard_NC6", // to validate that CoreOS distro does not get nvidia addon
+						},
+					},
+				},
+			},
+			isUpgrade:      false,
+			expectedAddons: omitFromAddons([]string{common.BlobfuseFlexVolumeAddonName, common.KeyVaultFlexVolumeAddonName}, getDefaultAddons("1.15.4")),
+		},
+		{
+			name: "azure disk and azure file csi driver enabled for k8s >= 1.13.0 and UseCloudControllerManager is true",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet:             api.DefaultKubernetesSubnet,
+							ProxyMode:                 api.KubeProxyModeIPTables,
+							NetworkPlugin:             api.NetworkPluginAzure,
+							UseCloudControllerManager: to.BoolPtr(true),
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.AzureFileCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.CSIProvisionerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.CSIProvisionerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAttacherContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.CSIAttacherContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIClusterDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.CSIClusterDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSILivenessProbeContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.CSILivenessProbeContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSINodeDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.CSINodeDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAzureFileContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.CSIAzureFileContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+					},
+				},
+				{
+					Name:    common.AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.CSIProvisionerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.CSIProvisionerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAttacherContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.CSIAttacherContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIClusterDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.CSIClusterDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSILivenessProbeContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.CSILivenessProbeContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSINodeDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.CSINodeDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSISnapshotterContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSISnapshotterContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIResizerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIResizerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAzureDiskContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.CSIAzureDiskContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "azure cloud-node-manager enabled for k8s == 1.16 and useCloudControllerManager is true",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.16.1",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet:             api.DefaultKubernetesSubnet,
+							ProxyMode:                 api.KubeProxyModeIPTables,
+							NetworkPlugin:             api.NetworkPluginAzure,
+							UseCloudControllerManager: to.BoolPtr(true),
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.AzureFileCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.CSIProvisionerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIProvisionerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAttacherContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIAttacherContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIClusterDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIClusterDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSILivenessProbeContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSILivenessProbeContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSINodeDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSINodeDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAzureFileContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIAzureFileContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+					},
+				},
+				{
+					Name:    common.AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.CSIProvisionerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIProvisionerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAttacherContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIAttacherContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIClusterDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIClusterDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSILivenessProbeContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSILivenessProbeContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSINodeDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSINodeDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSISnapshotterContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSISnapshotterContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIResizerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIResizerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAzureDiskContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIAzureDiskContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+					},
+				},
+				{
+					Name:    common.CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(true),
+				},
+			}, "1.16.1"),
+		},
+		{
+			name: "azure cloud-node-manager enabled for k8s == 1.17.0 and useCloudControllerManager is true",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.17.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet:             api.DefaultKubernetesSubnet,
+							ProxyMode:                 api.KubeProxyModeIPTables,
+							NetworkPlugin:             api.NetworkPluginAzure,
+							UseCloudControllerManager: to.BoolPtr(true),
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.AzureFileCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.CSIProvisionerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIProvisionerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAttacherContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIAttacherContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIClusterDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIClusterDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSILivenessProbeContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSILivenessProbeContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSINodeDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSINodeDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAzureFileContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIAzureFileContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+					},
+				},
+				{
+					Name:    common.AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.CSIProvisionerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIProvisionerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAttacherContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIAttacherContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIClusterDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIClusterDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSILivenessProbeContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSILivenessProbeContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSINodeDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSINodeDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSISnapshotterContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSISnapshotterContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIResizerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIResizerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAzureDiskContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIAzureDiskContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+					},
+				},
+				{
+					Name:    common.CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(true),
+				},
+			}, "1.17.0"),
+		},
+		{
+			name: "azure cloud-node-manager enabled for k8s >= 1.17.0 - upgrade",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.17.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet:             api.DefaultKubernetesSubnet,
+							ProxyMode:                 api.KubeProxyModeIPTables,
+							NetworkPlugin:             api.NetworkPluginAzure,
+							UseCloudControllerManager: to.BoolPtr(true),
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.AzureDiskCSIDriverAddonName,
+									Enabled: to.BoolPtr(false),
+								},
+								{
+									Name:    common.AzureFileCSIDriverAddonName,
+									Enabled: to.BoolPtr(false),
+								},
+								{
+									Name:    common.CloudNodeManagerAddonName,
+									Enabled: to.BoolPtr(false),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: true,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.AzureFileCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.CSIProvisionerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIProvisionerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAttacherContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIAttacherContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIClusterDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIClusterDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSILivenessProbeContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSILivenessProbeContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSINodeDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSINodeDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAzureFileContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIAzureFileContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+					},
+				},
+				{
+					Name:    common.AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.CSIProvisionerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIProvisionerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAttacherContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIAttacherContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIClusterDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIClusterDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSILivenessProbeContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSILivenessProbeContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSINodeDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSINodeDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSISnapshotterContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSISnapshotterContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIResizerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIResizerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAzureDiskContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIAzureDiskContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+					},
+				},
+				{
+					Name:    common.CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(true),
+				},
+			}, "1.17.0"),
+		},
+		{
+			name: "azure cloud-node-manager enabled for k8s == 1.16.1 upgrade",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.16.1",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet:             api.DefaultKubernetesSubnet,
+							ProxyMode:                 api.KubeProxyModeIPTables,
+							NetworkPlugin:             api.NetworkPluginAzure,
+							UseCloudControllerManager: to.BoolPtr(true),
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.AzureDiskCSIDriverAddonName,
+									Enabled: to.BoolPtr(false),
+								},
+								{
+									Name:    common.AzureFileCSIDriverAddonName,
+									Enabled: to.BoolPtr(false),
+								},
+								{
+									Name:    common.CloudNodeManagerAddonName,
+									Enabled: to.BoolPtr(false),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: true,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.AzureFileCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.CSIProvisionerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIProvisionerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAttacherContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIAttacherContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIClusterDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIClusterDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSILivenessProbeContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSILivenessProbeContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSINodeDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSINodeDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAzureFileContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIAzureFileContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+					},
+				},
+				{
+					Name:    common.AzureDiskCSIDriverAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.CSIProvisionerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIProvisionerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAttacherContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIAttacherContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIClusterDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIClusterDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSILivenessProbeContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSILivenessProbeContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSINodeDriverRegistrarContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSINodeDriverRegistrarContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSISnapshotterContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSISnapshotterContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIResizerContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.17.0"][common.CSIResizerContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+						{
+							Name:           common.CSIAzureDiskContainerName,
+							Image:          specConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap["1.16.1"][common.CSIAzureDiskContainerName],
+							CPURequests:    "10m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "200Mi",
+						},
+					},
+				},
+				{
+					Name:    common.CloudNodeManagerAddonName,
+					Enabled: to.BoolPtr(true),
+				},
+			}, "1.16.1"),
+		},
+		{
+			name: "upgrade w/ no kube-dns or coredns specified", // back-compat support for clusters configured prior to user-configurable coredns and kube-dns addons
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.13.11",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons:        []api.KubernetesAddon{},
+						},
+					},
+				},
+			},
+			isUpgrade:      true,
+			expectedAddons: getDefaultAddons("1.13.11"),
+		},
+		{
+			name: "upgrade w/ manual kube-dns enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.13.11",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.KubeDNSAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: true,
+			expectedAddons: omitFromAddons([]string{common.CoreDNSAddonName}, concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.KubeDNSAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"domain":    "cluster.local",
+						"clusterIP": api.DefaultKubernetesDNSServiceIP,
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:  "kubedns",
+							Image: specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.13.11"][common.KubeDNSAddonName],
+						},
+						{
+							Name:  "dnsmasq",
+							Image: specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.13.11"]["dnsmasq"],
+						},
+						{
+							Name:  "sidecar",
+							Image: specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.13.11"]["k8s-dns-sidecar"],
+						},
+					},
+				},
+			}, "1.13.11")),
+		},
+		{
+			name: "upgrade w/ manual coredns enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.13.11",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.CoreDNSAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:      true,
+			expectedAddons: getDefaultAddons("1.13.11"),
+		},
+		{
+			name: "kube-dns enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.KubeDNSAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: omitFromAddons([]string{common.CoreDNSAddonName}, concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.KubeDNSAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"domain":    "cluster.local",
+						"clusterIP": api.DefaultKubernetesDNSServiceIP,
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:  "kubedns",
+							Image: specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.KubeDNSAddonName],
+						},
+						{
+							Name:  "dnsmasq",
+							Image: specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"]["dnsmasq"],
+						},
+						{
+							Name:  "sidecar",
+							Image: specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"]["k8s-dns-sidecar"],
+						},
+					},
+				},
+			}, "1.15.4")),
+		},
+		{
+			name: "coredns enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.CoreDNSAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:      false,
+			expectedAddons: getDefaultAddons("1.15.4"),
+		},
+		{
+			name: "kube-proxy w/ user configuration",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.KubeProxyAddonName,
+									Enabled: to.BoolPtr(true),
+									Config: map[string]string{
+										"cluster-cidr": "foo",
+										"proxy-mode":   "bar",
+										"featureGates": "baz",
+									},
+									Containers: []api.KubernetesContainerSpec{
+										{
+											Name:  common.KubeProxyAddonName,
+											Image: "bam",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: overwriteDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.KubeProxyAddonName,
+					Enabled: to.BoolPtr(api.DefaultKubeProxyAddonEnabled),
+					Config: map[string]string{
+						"cluster-cidr": "foo",
+						"proxy-mode":   "bar",
+						"featureGates": "baz",
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:  common.KubeProxyAddonName,
+							Image: "bam",
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "kube-proxy disabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.KubeProxyAddonName,
+									Enabled: to.BoolPtr(false),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:      false,
+			expectedAddons: omitFromAddons([]string{common.KubeProxyAddonName}, getDefaultAddons("1.15.4")),
+		},
+		{
+			name: "node-problem-detector addon enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.NodeProblemDetectorAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.NodeProblemDetectorAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"customPluginMonitor": "/config/kernel-monitor-counter.json,/config/systemd-monitor-counter.json",
+						"systemLogMonitor":    "/config/kernel-monitor.json,/config/docker-monitor.json,/config/systemd-monitor.json",
+						"systemStatsMonitor":  "/config/system-stats-monitor.json",
+						"versionLabel":        "v0.8.0",
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.NodeProblemDetectorAddonName,
+							Image:          api.K8sComponentsByVersionMap["1.15.4"][common.NodeProblemDetectorAddonName],
+							CPURequests:    "20m",
+							MemoryRequests: "20Mi",
+							CPULimits:      "200m",
+							MemoryLimits:   "100Mi",
+						},
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "pod-security-policy upgrade to 1.15",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+						},
+					},
+				},
+			},
+			isUpgrade:      true,
+			expectedAddons: getDefaultAddons("1.15.4"),
+		},
+		{
+			name: "pod-security-policy disabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.PodSecurityPolicyAddonName,
+									Enabled: to.BoolPtr(false),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:      false,
+			expectedAddons: omitFromAddons([]string{common.PodSecurityPolicyAddonName}, getDefaultAddons("1.15.4")),
+		},
+		{
+			name: "pod-security-policy disabled during upgrade",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.PodSecurityPolicyAddonName,
+									Enabled: to.BoolPtr(false),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:      true,
+			expectedAddons: omitFromAddons([]string{common.PodSecurityPolicyAddonName}, getDefaultAddons("1.15.4")),
+		},
+		{
+			name: "audit-policy disabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.AuditPolicyAddonName,
+									Enabled: to.BoolPtr(false),
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:      false,
+			expectedAddons: omitFromAddons([]string{common.AuditPolicyAddonName}, getDefaultAddons("1.15.4")),
+		},
+		{
+			name: "aad-default-aad-admin-group addon enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+						},
+					},
+					AADProfile: &api.AADProfile{
+						AdminGroupID: "7d04bcd3-3c48-49ab-a064-c0b7d69896da",
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.AADAdminGroupAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"adminGroupID": "7d04bcd3-3c48-49ab-a064-c0b7d69896da",
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "antrea addon enabled",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP: api.DefaultKubernetesDNSServiceIP,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+							},
+							ClusterSubnet: api.DefaultKubernetesSubnet,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							NetworkPlugin: api.NetworkPluginAzure,
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: concatenateDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.AntreaAddonName,
+					Enabled: to.BoolPtr(true),
+					Config: map[string]string{
+						"serviceCidr": api.DefaultKubernetesServiceCIDR,
+					},
+				},
+			}, "1.15.4"),
+		},
+		{
+			name: "addons with IPv6 single stack",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					FeatureFlags: &api.FeatureFlags{
+						EnableIPv6Only: true,
+					},
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.18.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP:  api.DefaultKubernetesDNSServiceIPv6,
+							NetworkPlugin: api.NetworkPluginKubenet,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+								"--node-ip":        "::",
+							},
+							ClusterSubnet: api.DefaultKubernetesClusterSubnetIPv6,
+							ProxyMode:     api.KubeProxyModeIPTables,
+							APIServerConfig: map[string]string{
+								"--bind-address": "::",
+							},
+							ControllerManagerConfig: map[string]string{
+								"--bind-address": "::",
+							},
+							SchedulerConfig: map[string]string{
+								"--bind-address": "::",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: omitFromAddons([]string{common.AzureCNINetworkMonitorAddonName}, overwriteDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.CoreDNSAddonName,
+					Enabled: to.BoolPtr(api.DefaultCoreDNSAddonEnabled),
+					Config: map[string]string{
+						"domain":           "cluster.local",
+						"clusterIP":        api.DefaultKubernetesDNSServiceIPv6,
+						"use-host-network": "true",
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:  common.CoreDNSAddonName,
+							Image: specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.18.0"][common.CoreDNSAddonName],
+						},
+					},
+				},
+				{
+					Name:    common.IPMASQAgentAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.IPMASQAgentAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "50Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "250Mi",
+							Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.18.0"][common.IPMASQAgentAddonName],
+						},
+					},
+					Config: map[string]string{
+						"non-masquerade-cidr":           api.DefaultKubernetesClusterSubnetIPv6,
+						"enable-ipv6":                   "true",
+						"non-masq-cni-cidr":             "",
+						"secondary-non-masquerade-cidr": "",
+					},
+				},
+				{
+					Name:    common.KubeProxyAddonName,
+					Enabled: to.BoolPtr(api.DefaultKubeProxyAddonEnabled),
+					Config: map[string]string{
+						"cluster-cidr":         api.DefaultKubernetesClusterSubnetIPv6,
+						"proxy-mode":           string(api.KubeProxyModeIPTables),
+						"featureGates":         "{}",
+						"bind-address":         "::",
+						"healthz-bind-address": "::",
+						"metrics-bind-address": "::1",
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:  common.KubeProxyAddonName,
+							Image: specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.18.0"][common.KubeProxyAddonName],
+						},
+					},
+				},
+			}, "1.18.0")),
+		},
+		{
+			name: "addons with dual stack",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					FeatureFlags: &api.FeatureFlags{
+						EnableIPv6DualStack: true,
+					},
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorVersion: "1.18.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							DNSServiceIP:  api.DefaultKubernetesDNSServiceIP,
+							NetworkPlugin: api.NetworkPluginKubenet,
+							KubeletConfig: map[string]string{
+								"--cluster-domain": "cluster.local",
+								"--feature-gates":  "IPv6DualStack=true",
+							},
+							ClusterSubnet: api.DefaultKubernetesClusterSubnet + "," + api.DefaultKubernetesClusterSubnetIPv6,
+							ServiceCIDR:   api.DefaultKubernetesServiceCIDR + "," + api.DefaultKubernetesServiceCIDRIPv6,
+							ProxyMode:     api.KubeProxyModeIPVS,
+							APIServerConfig: map[string]string{
+								"--feature-gates": "IPv6DualStack=true",
+							},
+							ControllerManagerConfig: map[string]string{
+								"--feature-gates": "IPv6DualStack=true",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade: false,
+			expectedAddons: omitFromAddons([]string{common.AzureCNINetworkMonitorAddonName}, overwriteDefaultAddons([]api.KubernetesAddon{
+				{
+					Name:    common.IPMASQAgentAddonName,
+					Enabled: to.BoolPtr(true),
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:           common.IPMASQAgentAddonName,
+							CPURequests:    "50m",
+							MemoryRequests: "50Mi",
+							CPULimits:      "50m",
+							MemoryLimits:   "250Mi",
+							Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.18.0"][common.IPMASQAgentAddonName],
+						},
+					},
+					Config: map[string]string{
+						"non-masquerade-cidr":           api.DefaultKubernetesClusterSubnet,
+						"enable-ipv6":                   "true",
+						"non-masq-cni-cidr":             "",
+						"secondary-non-masquerade-cidr": api.DefaultKubernetesClusterSubnetIPv6,
+					},
+				},
+				{
+					Name:    common.KubeProxyAddonName,
+					Enabled: to.BoolPtr(api.DefaultKubeProxyAddonEnabled),
+					Config: map[string]string{
+						"cluster-cidr": api.DefaultKubernetesClusterSubnet + "," + api.DefaultKubernetesClusterSubnetIPv6,
+						"proxy-mode":   string(api.KubeProxyModeIPVS),
+						"featureGates": "IPv6DualStack: true",
+					},
+					Containers: []api.KubernetesContainerSpec{
+						{
+							Name:  common.KubeProxyAddonName,
+							Image: specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.18.0"][common.KubeProxyAddonName],
+						},
+					},
+				},
+			}, "1.18.0")),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			test.cs.setAddonsConfig(test.isUpgrade)
+			for _, addonName := range []string{
+				common.HeapsterAddonName,
+				common.TillerAddonName,
+				common.ACIConnectorAddonName,
+				common.ClusterAutoscalerAddonName,
+				common.BlobfuseFlexVolumeAddonName,
+				common.SMBFlexVolumeAddonName,
+				common.KeyVaultFlexVolumeAddonName,
+				common.DashboardAddonName,
+				common.ReschedulerAddonName,
+				common.MetricsServerAddonName,
+				common.NVIDIADevicePluginAddonName,
+				common.ContainerMonitoringAddonName,
+				common.IPMASQAgentAddonName,
+				common.AzureCNINetworkMonitorAddonName,
+				common.AzureNetworkPolicyAddonName,
+				common.DNSAutoscalerAddonName,
+				common.CalicoAddonName,
+				common.AADPodIdentityAddonName,
+				common.AzurePolicyAddonName,
+				common.AzureFileCSIDriverAddonName,
+				common.AzureDiskCSIDriverAddonName,
+				common.CloudNodeManagerAddonName,
+				common.CoreDNSAddonName,
+				common.KubeDNSAddonName,
+				common.KubeProxyAddonName,
+				common.NodeProblemDetectorAddonName,
+				common.PodSecurityPolicyAddonName,
+				common.AADAdminGroupAddonName,
+			} {
+				addon := test.cs.Properties.OrchestratorProfile.KubernetesConfig.Addons[getAddonsIndexByName(test.cs.Properties.OrchestratorProfile.KubernetesConfig.Addons, addonName)]
+				if addon.IsEnabled() {
+					if i := getAddonsIndexByName(test.expectedAddons, addonName); i == -1 {
+						t.Fatalf("got addon %s that we weren't expecting", addon.Name)
+					}
+					expectedAddon := test.expectedAddons[getAddonsIndexByName(test.expectedAddons, addonName)]
+					if to.Bool(addon.Enabled) != to.Bool(expectedAddon.Enabled) {
+						t.Fatalf("expected addon %s to have Enabled value %t, instead got %t", expectedAddon.Name, to.Bool(expectedAddon.Enabled), to.Bool(addon.Enabled))
+					}
+					if expectedAddon.Containers != nil {
+						if len(expectedAddon.Containers) != len(addon.Containers) {
+							t.Fatalf("expected addon %s to have %d containers , got %d", expectedAddon.Name, len(expectedAddon.Containers), len(addon.Containers))
+						}
+						for i, container := range expectedAddon.Containers {
+							if container.Name != addon.Containers[i].Name {
+								t.Fatalf("expected addon %s to have container Name %s at at Containers index %d, got %s", expectedAddon.Name, container.Name, i, addon.Containers[i].Name)
+							}
+							if container.Image != addon.Containers[i].Image {
+								t.Fatalf("expected addon %s to have container Image %s at at Containers index %d, got %s", expectedAddon.Name, container.Image, i, addon.Containers[i].Image)
+							}
+							if container.CPURequests != addon.Containers[i].CPURequests {
+								t.Fatalf("expected addon %s to have container CPURequests %s at at Containers index %d, got %s", expectedAddon.Name, container.CPURequests, i, addon.Containers[i].CPURequests)
+							}
+							if container.MemoryRequests != addon.Containers[i].MemoryRequests {
+								t.Fatalf("expected addon %s to have container MemoryRequests %s at at Containers index %d, got %s", expectedAddon.Name, container.MemoryRequests, i, addon.Containers[i].MemoryRequests)
+							}
+							if container.CPULimits != addon.Containers[i].CPULimits {
+								t.Fatalf("expected addon %s to have container CPULimits %s at at Containers index %d, got %s", expectedAddon.Name, container.CPULimits, i, addon.Containers[i].CPULimits)
+							}
+							if container.MemoryLimits != addon.Containers[i].MemoryLimits {
+								t.Fatalf("expected addon %s to have container MemoryLimits %s at at Containers index %d, got %s", expectedAddon.Name, container.MemoryLimits, i, addon.Containers[i].MemoryLimits)
+							}
+						}
+					}
+					if expectedAddon.Config != nil {
+						for key, val := range expectedAddon.Config {
+							if val != addon.Config[key] {
+								t.Fatalf("expected addon %s to have config %s=%s, got %s=%s", expectedAddon.Name, key, val, key, addon.Config[key])
+							}
+						}
+					}
+					if addon.Config != nil {
+						for key, val := range addon.Config {
+							if val != expectedAddon.Config[key] {
+								t.Fatalf("expected addon %s to have config %s=%s, got %s=%s", addon.Name, key, val, key, expectedAddon.Config[key])
+							}
+						}
+					}
+					if expectedAddon.Pools != nil {
+						if len(expectedAddon.Pools) != len(addon.Pools) {
+							t.Fatalf("expected addon %s to have %d pools , got %d", expectedAddon.Name, len(expectedAddon.Pools), len(addon.Pools))
+						}
+						for i, expectedPool := range expectedAddon.Pools {
+							if expectedPool.Name != addon.Pools[i].Name {
+								t.Fatalf("expected addon %s to have pool Name %s at Pools index %d, got %s", expectedAddon.Name, expectedPool.Name, i, addon.Pools[i].Name)
+							}
+							if expectedPool.Config != nil {
+								for key, val := range expectedPool.Config {
+									if val != addon.Pools[i].Config[key] {
+										t.Fatalf("expected addon %s to have pool config %s=%s for pool name %s, got %s=%s", expectedAddon.Name, key, val, expectedPool.Name, key, addon.Pools[i].Config[key])
+									}
+								}
+							}
+						}
+					}
+				} else {
+					if i := getAddonsIndexByName(test.expectedAddons, addonName); i > -1 {
+						if to.Bool(test.expectedAddons[i].Enabled) {
+							t.Fatalf("expected addon %s to be enabled, instead it was disabled", addonName)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+func TestMakeDefaultClusterAutoscalerAddonPoolsConfig(t *testing.T) {
+	cases := []struct {
+		name                     string
+		cs                       *ContainerService
+		expectedAddonPoolsConfig []api.AddonNodePoolsConfig
+	}{
+		{
+			name: "1 pool",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:  "pool1",
+							Count: 3,
+						},
+					},
+				},
+			},
+			expectedAddonPoolsConfig: []api.AddonNodePoolsConfig{
+				{
+					Name: "pool1",
+					Config: map[string]string{
+						"min-nodes": "3",
+						"max-nodes": "3",
+					},
+				},
+			},
+		},
+		{
+			name: "5 pools",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:  "pool1",
+							Count: 3,
+						},
+						{
+							Name:  "pool2",
+							Count: 10,
+						},
+						{
+							Name:  "pool3",
+							Count: 1,
+						},
+						{
+							Name:  "pool4",
+							Count: 33,
+						},
+						{
+							Name:  "pool5",
+							Count: 5,
+						},
+					},
+				},
+			},
+			expectedAddonPoolsConfig: []api.AddonNodePoolsConfig{
+				{
+					Name: "pool1",
+					Config: map[string]string{
+						"min-nodes": "3",
+						"max-nodes": "3",
+					},
+				},
+				{
+					Name: "pool2",
+					Config: map[string]string{
+						"min-nodes": "10",
+						"max-nodes": "10",
+					},
+				},
+				{
+					Name: "pool3",
+					Config: map[string]string{
+						"min-nodes": "1",
+						"max-nodes": "1",
+					},
+				},
+				{
+					Name: "pool4",
+					Config: map[string]string{
+						"min-nodes": "33",
+						"max-nodes": "33",
+					},
+				},
+				{
+					Name: "pool5",
+					Config: map[string]string{
+						"min-nodes": "5",
+						"max-nodes": "5",
+					},
+				},
+			},
+		},
+		{
+			name: "0 pools",
+			cs: &ContainerService{
+				Properties: &api.Properties{},
+			},
+			expectedAddonPoolsConfig: []api.AddonNodePoolsConfig{},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			result := makeDefaultClusterAutoscalerAddonPoolsConfig(c.cs)
+			if c.expectedAddonPoolsConfig != nil {
+				if len(c.expectedAddonPoolsConfig) != len(result) {
+					t.Fatalf("expected to have %d pools, got %d", len(result), len(c.expectedAddonPoolsConfig))
+				}
+				for i, pool := range c.expectedAddonPoolsConfig {
+					if pool.Name != result[i].Name {
+						t.Fatalf("expected to have pool Name %s at Pools index %d, got %s", pool.Name, i, result[i].Name)
+					}
+					if pool.Config != nil {
+						for key, val := range pool.Config {
+							if val != result[i].Config[key] {
+								t.Fatalf("expected to have pool config %s=%s for pool name %s, got %s=%s", key, val, pool.Name, key, result[i].Config[key])
+							}
+						}
+					}
+				}
+			} else {
+				if result != nil {
+					t.Fatalf("expected a nil slice, got %#v", result)
+				}
+			}
+		})
+	}
+}
+
+func TestGetClusterAutoscalerNodesConfig(t *testing.T) {
+	specConfig := api.AzureCloudSpecEnvMap["AzurePublicCloud"].KubernetesSpecConfig
+	cases := []struct {
+		name                string
+		addon               api.KubernetesAddon
+		cs                  *ContainerService
+		expectedNodesConfig string
+	}{
+		{
+			name: "1 pool",
+			addon: api.KubernetesAddon{
+				Name:    common.ClusterAutoscalerAddonName,
+				Enabled: to.BoolPtr(true),
+				Mode:    api.AddonModeEnsureExists,
+				Config: map[string]string{
+					"scan-interval": "1m",
+					"v":             "3",
+				},
+				Containers: []api.KubernetesContainerSpec{
+					{
+						Name:           common.ClusterAutoscalerAddonName,
+						CPURequests:    "100m",
+						MemoryRequests: "300Mi",
+						CPULimits:      "100m",
+						MemoryLimits:   "300Mi",
+						Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.ClusterAutoscalerAddonName],
+					},
+				},
+				Pools: []api.AddonNodePoolsConfig{
+					{
+						Name: "pool1",
+						Config: map[string]string{
+							"min-nodes": "1",
+							"max-nodes": "10",
+						},
+					},
+				},
+			},
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.ClusterAutoscalerAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+							UseManagedIdentity: true,
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:                "pool1",
+							Count:               1,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+					},
+				},
+			},
+			expectedNodesConfig: "        - --nodes=1:10:k8s-pool1-49584119-vmss",
+		},
+		{
+			name: "multiple pools",
+			addon: api.KubernetesAddon{
+				Name:    common.ClusterAutoscalerAddonName,
+				Enabled: to.BoolPtr(true),
+				Mode:    api.AddonModeEnsureExists,
+				Config: map[string]string{
+					"scan-interval": "1m",
+					"v":             "3",
+				},
+				Containers: []api.KubernetesContainerSpec{
+					{
+						Name:           common.ClusterAutoscalerAddonName,
+						CPURequests:    "100m",
+						MemoryRequests: "300Mi",
+						CPULimits:      "100m",
+						MemoryLimits:   "300Mi",
+						Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.ClusterAutoscalerAddonName],
+					},
+				},
+				Pools: []api.AddonNodePoolsConfig{
+					{
+						Name: "pool1",
+						Config: map[string]string{
+							"min-nodes": "1",
+							"max-nodes": "10",
+						},
+					},
+					{
+						Name: "pool2",
+						Config: map[string]string{
+							"min-nodes": "1",
+							"max-nodes": "10",
+						},
+					},
+				},
+			},
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.ClusterAutoscalerAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+							UseManagedIdentity: true,
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:                "pool1",
+							Count:               1,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+						{
+							Name:                "pool2",
+							Count:               1,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+					},
+				},
+			},
+			expectedNodesConfig: "        - --nodes=1:10:k8s-pool1-49584119-vmss\n        - --nodes=1:10:k8s-pool2-49584119-vmss",
+		},
+		{
+			name: "no pools",
+			addon: api.KubernetesAddon{
+				Name:    common.ClusterAutoscalerAddonName,
+				Enabled: to.BoolPtr(true),
+				Mode:    api.AddonModeEnsureExists,
+				Config: map[string]string{
+					"scan-interval": "1m",
+					"v":             "3",
+				},
+				Containers: []api.KubernetesContainerSpec{
+					{
+						Name:           common.ClusterAutoscalerAddonName,
+						CPURequests:    "100m",
+						MemoryRequests: "300Mi",
+						CPULimits:      "100m",
+						MemoryLimits:   "300Mi",
+						Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap["1.15.4"][common.ClusterAutoscalerAddonName],
+					},
+				},
+			},
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.4",
+						KubernetesConfig: &api.KubernetesConfig{
+							NetworkPlugin: api.NetworkPluginAzure,
+							Addons: []api.KubernetesAddon{
+								{
+									Name:    common.ClusterAutoscalerAddonName,
+									Enabled: to.BoolPtr(true),
+								},
+							},
+							UseManagedIdentity: true,
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:                "pool1",
+							Count:               1,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+						{
+							Name:                "pool2",
+							Count:               1,
+							AvailabilityProfile: api.VirtualMachineScaleSets,
+						},
+					},
+				},
+			},
+			expectedNodesConfig: "",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			result := GetClusterAutoscalerNodesConfig(c.addon, c.cs)
+			if c.expectedNodesConfig != result {
+				t.Errorf("expected GetClusterAutoscalerNodesConfig to return %s, instead got %s", c.expectedNodesConfig, result)
+			}
+		})
+	}
+}
+
+func concatenateDefaultAddons(addons []api.KubernetesAddon, version string) []api.KubernetesAddon {
+	defaults := getDefaultAddons(version)
+	defaults = append(defaults, addons...)
+	return defaults
+}
+
+func overwriteDefaultAddons(addons []api.KubernetesAddon, version string) []api.KubernetesAddon {
+	overrideAddons := make(map[string]api.KubernetesAddon)
+	for _, addonOverride := range addons {
+		overrideAddons[addonOverride.Name] = addonOverride
+	}
+
+	var ret []api.KubernetesAddon
+	defaults := getDefaultAddons(version)
+
+	for _, addon := range defaults {
+		if _, exists := overrideAddons[addon.Name]; exists {
+			ret = append(ret, overrideAddons[addon.Name])
+			continue
+		}
+		ret = append(ret, addon)
+	}
+
+	return ret
+}
+
+func omitFromAddons(addons []string, completeSet []api.KubernetesAddon) []api.KubernetesAddon {
+	var ret []api.KubernetesAddon
+	for _, addon := range completeSet {
+		if !isInStrSlice(addon.Name, addons) {
+			ret = append(ret, addon)
+		}
+	}
+	return ret
+}
+
+func isInStrSlice(name string, names []string) bool {
+	for _, n := range names {
+		if name == n {
+			return true
+		}
+	}
+	return false
+}
+
+func getDefaultAddons(version string) []api.KubernetesAddon {
+	specConfig := api.AzureCloudSpecEnvMap["AzurePublicCloud"].KubernetesSpecConfig
+	addons := []api.KubernetesAddon{
+		{
+			Name:    common.BlobfuseFlexVolumeAddonName,
+			Enabled: to.BoolPtr(true),
+			Containers: []api.KubernetesContainerSpec{
+				{
+					Name:           common.BlobfuseFlexVolumeAddonName,
+					CPURequests:    "50m",
+					MemoryRequests: "100Mi",
+					CPULimits:      "50m",
+					MemoryLimits:   "100Mi",
+					Image:          api.K8sComponentsByVersionMap[version][common.BlobfuseFlexVolumeAddonName],
+				},
+			},
+		},
+		{
+			Name:    common.KeyVaultFlexVolumeAddonName,
+			Enabled: to.BoolPtr(true),
+			Containers: []api.KubernetesContainerSpec{
+				{
+					Name:           common.KeyVaultFlexVolumeAddonName,
+					CPURequests:    "50m",
+					MemoryRequests: "100Mi",
+					CPULimits:      "50m",
+					MemoryLimits:   "100Mi",
+					Image:          api.K8sComponentsByVersionMap[version][common.KeyVaultFlexVolumeAddonName],
+				},
+			},
+		},
+		{
+			Name:    common.DashboardAddonName,
+			Enabled: to.BoolPtr(true),
+			Containers: []api.KubernetesContainerSpec{
+				{
+					Name:           common.DashboardAddonName,
+					CPURequests:    "300m",
+					MemoryRequests: "150Mi",
+					CPULimits:      "300m",
+					MemoryLimits:   "150Mi",
+					Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap[version][common.DashboardAddonName],
+				},
+			},
+		},
+		{
+			Name:    common.MetricsServerAddonName,
+			Enabled: to.BoolPtr(true),
+			Containers: []api.KubernetesContainerSpec{
+				{
+					Name:  common.MetricsServerAddonName,
+					Image: specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap[version][common.MetricsServerAddonName],
+				},
+			},
+		},
+		{
+			Name:    common.IPMASQAgentAddonName,
+			Enabled: to.BoolPtr(true),
+			Containers: []api.KubernetesContainerSpec{
+				{
+					Name:           common.IPMASQAgentAddonName,
+					CPURequests:    "50m",
+					MemoryRequests: "50Mi",
+					CPULimits:      "50m",
+					MemoryLimits:   "250Mi",
+					Image:          specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap[version][common.IPMASQAgentAddonName],
+				},
+			},
+			Config: map[string]string{
+				"non-masquerade-cidr": api.DefaultVNETCIDR,
+				"non-masq-cni-cidr":   api.DefaultCNICIDR,
+				"enable-ipv6":         "false",
+			},
+		},
+		{
+			Name:    common.AzureCNINetworkMonitorAddonName,
+			Enabled: to.BoolPtr(true),
+			Containers: []api.KubernetesContainerSpec{
+				{
+					Name:  common.AzureCNINetworkMonitorAddonName,
+					Image: specConfig.AzureCNIImageBase + api.K8sComponentsByVersionMap[version][common.AzureCNINetworkMonitorAddonName],
+				},
+			},
+		},
+		{
+			Name:    common.AuditPolicyAddonName,
+			Enabled: to.BoolPtr(true),
+		},
+		{
+			Name:    common.AzureCloudProviderAddonName,
+			Enabled: to.BoolPtr(true),
+		},
+		{
+			Name:    common.CoreDNSAddonName,
+			Enabled: to.BoolPtr(api.DefaultCoreDNSAddonEnabled),
+			Config: map[string]string{
+				"domain":    "cluster.local",
+				"clusterIP": api.DefaultKubernetesDNSServiceIP,
+			},
+			Containers: []api.KubernetesContainerSpec{
+				{
+					Name:  common.CoreDNSAddonName,
+					Image: specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap[version][common.CoreDNSAddonName],
+				},
+			},
+		},
+		{
+			Name:    common.KubeProxyAddonName,
+			Enabled: to.BoolPtr(api.DefaultKubeProxyAddonEnabled),
+			Config: map[string]string{
+				"cluster-cidr": api.DefaultKubernetesSubnet,
+				"proxy-mode":   string(api.KubeProxyModeIPTables),
+				"featureGates": "{}",
+			},
+			Containers: []api.KubernetesContainerSpec{
+				{
+					Name:  common.KubeProxyAddonName,
+					Image: specConfig.KubernetesImageBase + api.K8sComponentsByVersionMap[version][common.KubeProxyAddonName],
+				},
+			},
+		},
+	}
+
+	if common.IsKubernetesVersionGe(version, "1.15.0") {
+		addons = append(addons, api.KubernetesAddon{
+			Name:    common.PodSecurityPolicyAddonName,
+			Enabled: to.BoolPtr(true),
+		})
+	}
+
+	return addons
+}

--- a/pkg/agent/datamodel/defaults-apiserver.go
+++ b/pkg/agent/datamodel/defaults-apiserver.go
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/aks-engine/pkg/api/common"
+	"github.com/Azure/aks-engine/pkg/helpers"
+)
+
+func (cs *ContainerService) setAPIServerConfig() {
+	o := cs.Properties.OrchestratorProfile
+	staticAPIServerConfig := map[string]string{
+		"--bind-address":                "0.0.0.0",
+		"--advertise-address":           "<advertiseAddr>",
+		"--allow-privileged":            "true",
+		"--anonymous-auth":              "false",
+		"--audit-log-path":              "/var/log/kubeaudit/audit.log",
+		"--insecure-port":               "8080",
+		"--secure-port":                 "443",
+		"--service-account-lookup":      "true",
+		"--etcd-certfile":               "/etc/kubernetes/certs/etcdclient.crt",
+		"--etcd-keyfile":                "/etc/kubernetes/certs/etcdclient.key",
+		"--tls-cert-file":               "/etc/kubernetes/certs/apiserver.crt",
+		"--tls-private-key-file":        "/etc/kubernetes/certs/apiserver.key",
+		"--client-ca-file":              "/etc/kubernetes/certs/ca.crt",
+		"--repair-malformed-updates":    "false",
+		"--service-account-key-file":    "/etc/kubernetes/certs/apiserver.key",
+		"--kubelet-client-certificate":  "/etc/kubernetes/certs/client.crt",
+		"--kubelet-client-key":          "/etc/kubernetes/certs/client.key",
+		"--service-cluster-ip-range":    o.KubernetesConfig.ServiceCIDR,
+		"--storage-backend":             o.GetAPIServerEtcdAPIVersion(),
+		"--enable-bootstrap-token-auth": "true",
+		"--v":                           "4",
+	}
+
+	if cs.Properties.MasterProfile != nil {
+		if cs.Properties.MasterProfile.HasCosmosEtcd() {
+			// Configuration for cosmos etcd
+			staticAPIServerConfig["--etcd-servers"] = fmt.Sprintf("https://%s:%s", cs.Properties.MasterProfile.GetCosmosEndPointURI(), strconv.Itoa(api.DefaultMasterEtcdClientPort))
+		} else {
+			// Configuration for local etcd
+			staticAPIServerConfig["--etcd-cafile"] = "/etc/kubernetes/certs/ca.crt"
+			staticAPIServerConfig["--etcd-servers"] = fmt.Sprintf("https://127.0.0.1:%s", strconv.Itoa(api.DefaultMasterEtcdClientPort))
+		}
+	}
+
+	// Default apiserver config
+	defaultAPIServerConfig := map[string]string{
+		"--audit-log-maxage":    "30",
+		"--audit-log-maxbackup": "10",
+		"--audit-log-maxsize":   "100",
+		"--profiling":           api.DefaultKubernetesAPIServerEnableProfiling,
+		"--tls-cipher-suites":   api.TLSStrongCipherSuitesAPIServer,
+	}
+
+	// Data Encryption at REST configuration conditions
+	if to.Bool(o.KubernetesConfig.EnableDataEncryptionAtRest) || to.Bool(o.KubernetesConfig.EnableEncryptionWithExternalKms) {
+		staticAPIServerConfig["--experimental-encryption-provider-config"] = "/etc/kubernetes/encryption-config.yaml"
+	}
+
+	// Aggregated API configuration
+	if o.KubernetesConfig.EnableAggregatedAPIs {
+		defaultAPIServerConfig["--requestheader-client-ca-file"] = "/etc/kubernetes/certs/proxy-ca.crt"
+		defaultAPIServerConfig["--proxy-client-cert-file"] = "/etc/kubernetes/certs/proxy.crt"
+		defaultAPIServerConfig["--proxy-client-key-file"] = "/etc/kubernetes/certs/proxy.key"
+		defaultAPIServerConfig["--requestheader-allowed-names"] = ""
+		defaultAPIServerConfig["--requestheader-extra-headers-prefix"] = "X-Remote-Extra-"
+		defaultAPIServerConfig["--requestheader-group-headers"] = "X-Remote-Group"
+		defaultAPIServerConfig["--requestheader-username-headers"] = "X-Remote-User"
+	}
+
+	// Enable cloudprovider if we're not using cloud controller manager
+	if !to.Bool(o.KubernetesConfig.UseCloudControllerManager) {
+		staticAPIServerConfig["--cloud-provider"] = "azure"
+		staticAPIServerConfig["--cloud-config"] = "/etc/kubernetes/azure.json"
+	}
+
+	// AAD configuration
+	if cs.Properties.HasAadProfile() {
+		defaultAPIServerConfig["--oidc-username-claim"] = "oid"
+		defaultAPIServerConfig["--oidc-groups-claim"] = "groups"
+		defaultAPIServerConfig["--oidc-client-id"] = "spn:" + cs.Properties.AADProfile.ServerAppID
+		issuerHost := "sts.windows.net"
+		if helpers.GetTargetEnv(cs.Location, cs.Properties.GetCustomCloudName()) == "AzureChinaCloud" {
+			issuerHost = "sts.chinacloudapi.cn"
+		}
+		defaultAPIServerConfig["--oidc-issuer-url"] = "https://" + issuerHost + "/" + cs.Properties.AADProfile.TenantID + "/"
+	}
+
+	// Audit Policy configuration
+	defaultAPIServerConfig["--audit-policy-file"] = "/etc/kubernetes/addons/audit-policy.yaml"
+
+	// RBAC configuration
+	if to.Bool(o.KubernetesConfig.EnableRbac) {
+		if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.7.0") {
+			defaultAPIServerConfig["--authorization-mode"] = "Node,RBAC"
+		} else {
+			defaultAPIServerConfig["--authorization-mode"] = "RBAC"
+		}
+	}
+
+	// Set default admission controllers
+	admissionControlKey, admissionControlValues := getDefaultAdmissionControls(cs)
+	defaultAPIServerConfig[admissionControlKey] = admissionControlValues
+
+	// Enable VolumeSnapshotDataSource feature gate for Azure Disk CSI Driver
+	// which is disabled from 1.13 to 1.16 by default
+	if !common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.17.0") {
+		addDefaultFeatureGates(defaultAPIServerConfig, o.OrchestratorVersion, "1.13.0", "VolumeSnapshotDataSource=true")
+	}
+
+	// If no user-configurable apiserver config values exists, use the defaults
+	if o.KubernetesConfig.APIServerConfig == nil {
+		o.KubernetesConfig.APIServerConfig = defaultAPIServerConfig
+	} else {
+		for key, val := range defaultAPIServerConfig {
+			// If we don't have a user-configurable apiserver config for each option
+			if _, ok := o.KubernetesConfig.APIServerConfig[key]; !ok {
+				// then assign the default value
+				o.KubernetesConfig.APIServerConfig[key] = val
+			} else {
+				// Manual override of "--audit-policy-file" for back-compat
+				if key == "--audit-policy-file" {
+					if o.KubernetesConfig.APIServerConfig[key] == "/etc/kubernetes/manifests/audit-policy.yaml" {
+						o.KubernetesConfig.APIServerConfig[key] = val
+					}
+				}
+			}
+		}
+	}
+
+	// We don't support user-configurable values for the following,
+	// so any of the value assignments below will override user-provided values
+	for key, val := range staticAPIServerConfig {
+		o.KubernetesConfig.APIServerConfig[key] = val
+	}
+
+	// Remove flags for secure communication to kubelet, if configured
+	if !to.Bool(o.KubernetesConfig.EnableSecureKubelet) {
+		for _, key := range []string{"--kubelet-client-certificate", "--kubelet-client-key"} {
+			delete(o.KubernetesConfig.APIServerConfig, key)
+		}
+	}
+
+	// Enforce flags removal that don't work with specific versions, to accommodate upgrade
+	// Remove flags that are not compatible with 1.10
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.10.0") {
+		for _, key := range []string{"--admission-control"} {
+			delete(o.KubernetesConfig.APIServerConfig, key)
+		}
+	}
+	// Enforce flags removal that don't work with specific versions, to accommodate upgrade
+	// Remove flags that are not compatible with 1.14
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.14.0-alpha.1") {
+		for _, key := range []string{"--repair-malformed-updates"} {
+			delete(o.KubernetesConfig.APIServerConfig, key)
+		}
+	}
+	// Set bind address to prefer IPv6 address for single stack IPv6 cluster
+	// Remove --advertise-address so that --bind-address will be used
+	if cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6Only") {
+		o.KubernetesConfig.APIServerConfig["--bind-address"] = "::"
+		for _, key := range []string{"--advertise-address"} {
+			delete(o.KubernetesConfig.APIServerConfig, key)
+		}
+	}
+}
+
+func getDefaultAdmissionControls(cs *ContainerService) (string, string) {
+	o := cs.Properties.OrchestratorProfile
+	admissionControlKey := "--enable-admission-plugins"
+	admissionControlValues := "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,ValidatingAdmissionWebhook,ResourceQuota,ExtendedResourceToleration"
+
+	// Pod Security Policy configuration
+	if o.KubernetesConfig.IsAddonEnabled(common.PodSecurityPolicyAddonName) {
+		admissionControlValues += ",PodSecurityPolicy"
+	}
+
+	return admissionControlKey, admissionControlValues
+}

--- a/pkg/agent/datamodel/defaults-apiserver_test.go
+++ b/pkg/agent/datamodel/defaults-apiserver_test.go
@@ -1,0 +1,528 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/aks-engine/pkg/api/common"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+const defaultTestClusterVer = "1.7.12"
+
+func TestAPIServerConfigEnableDataEncryptionAtRest(t *testing.T) {
+	// Test EnableDataEncryptionAtRest = true
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableDataEncryptionAtRest = to.BoolPtr(true)
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--experimental-encryption-provider-config"] != "/etc/kubernetes/encryption-config.yaml" {
+		t.Fatalf("got unexpected '--experimental-encryption-provider-config' API server config value for EnableDataEncryptionAtRest=true: %s",
+			a["--experimental-encryption-provider-config"])
+	}
+
+	// Test EnableDataEncryptionAtRest = false
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableDataEncryptionAtRest = to.BoolPtr(false)
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if _, ok := a["--experimental-encryption-provider-config"]; ok {
+		t.Fatalf("got unexpected '--experimental-encryption-provider-config' API server config value for EnableDataEncryptionAtRest=false: %s",
+			a["--experimental-encryption-provider-config"])
+	}
+}
+
+func TestAPIServerConfigEnableEncryptionWithExternalKms(t *testing.T) {
+	// Test EnableEncryptionWithExternalKms = true
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableEncryptionWithExternalKms = to.BoolPtr(true)
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--experimental-encryption-provider-config"] != "/etc/kubernetes/encryption-config.yaml" {
+		t.Fatalf("got unexpected '--experimental-encryption-provider-config' API server config value for EnableEncryptionWithExternalKms=true: %s",
+			a["--experimental-encryption-provider-config"])
+	}
+
+	// Test EnableEncryptionWithExternalKms = false
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableEncryptionWithExternalKms = to.BoolPtr(false)
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if _, ok := a["--experimental-encryption-provider-config"]; ok {
+		t.Fatalf("got unexpected '--experimental-encryption-provider-config' API server config value for EnableEncryptionWithExternalKms=false: %s",
+			a["--experimental-encryption-provider-config"])
+	}
+}
+
+func TestAPIServerConfigEnableAggregatedAPIs(t *testing.T) {
+	// Test EnableAggregatedAPIs = true
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs = true
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--requestheader-client-ca-file"] != "/etc/kubernetes/certs/proxy-ca.crt" {
+		t.Fatalf("got unexpected '--requestheader-client-ca-file' API server config value for EnableAggregatedAPIs=true: %s",
+			a["--requestheader-client-ca-file"])
+	}
+	if a["--proxy-client-cert-file"] != "/etc/kubernetes/certs/proxy.crt" {
+		t.Fatalf("got unexpected '--proxy-client-cert-file' API server config value for EnableAggregatedAPIs=true: %s",
+			a["--proxy-client-cert-file"])
+	}
+	if a["--proxy-client-key-file"] != "/etc/kubernetes/certs/proxy.key" {
+		t.Fatalf("got unexpected '--proxy-client-key-file' API server config value for EnableAggregatedAPIs=true: %s",
+			a["--proxy-client-key-file"])
+	}
+	if a["--requestheader-allowed-names"] != "" {
+		t.Fatalf("got unexpected '--requestheader-allowed-names' API server config value for EnableAggregatedAPIs=true: %s",
+			a["--requestheader-allowed-names"])
+	}
+	if a["--requestheader-extra-headers-prefix"] != "X-Remote-Extra-" {
+		t.Fatalf("got unexpected '--requestheader-extra-headers-prefix' API server config value for EnableAggregatedAPIs=true: %s",
+			a["--requestheader-extra-headers-prefix"])
+	}
+	if a["--requestheader-group-headers"] != "X-Remote-Group" {
+		t.Fatalf("got unexpected '--requestheader-group-headers' API server config value for EnableAggregatedAPIs=true: %s",
+			a["--requestheader-group-headers"])
+	}
+	if a["--requestheader-username-headers"] != "X-Remote-User" {
+		t.Fatalf("got unexpected '--requestheader-username-headers' API server config value for EnableAggregatedAPIs=true: %s",
+			a["--requestheader-username-headers"])
+	}
+
+	// Test EnableAggregatedAPIs = false
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs = false
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	for _, key := range []string{"--requestheader-client-ca-file", "--proxy-client-cert-file", "--proxy-client-key-file",
+		"--requestheader-allowed-names", "--requestheader-extra-headers-prefix", "--requestheader-group-headers",
+		"--requestheader-username-headers"} {
+		if _, ok := a[key]; ok {
+			t.Fatalf("got unexpected '%s' API server config value for EnableAggregatedAPIs=false: %s",
+				key, a[key])
+		}
+	}
+}
+
+func TestAPIServerConfigUseCloudControllerManager(t *testing.T) {
+	// Test UseCloudControllerManager = true
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(true)
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if _, ok := a["--cloud-provider"]; ok {
+		t.Fatalf("got unexpected '--cloud-provider' API server config value for UseCloudControllerManager=false: %s",
+			a["--cloud-provider"])
+	}
+	if _, ok := a["--cloud-config"]; ok {
+		t.Fatalf("got unexpected '--cloud-config' API server config value for UseCloudControllerManager=false: %s",
+			a["--cloud-config"])
+	}
+
+	// Test UseCloudControllerManager = false
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(false)
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--cloud-provider"] != "azure" {
+		t.Fatalf("got unexpected '--cloud-provider' API server config value for UseCloudControllerManager=true: %s",
+			a["--cloud-provider"])
+	}
+	if a["--cloud-config"] != "/etc/kubernetes/azure.json" {
+		t.Fatalf("got unexpected '--cloud-config' API server config value for UseCloudControllerManager=true: %s",
+			a["--cloud-config"])
+	}
+}
+
+func TestAPIServerConfigHasAadProfile(t *testing.T) {
+	// Test HasAadProfile = true
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.AADProfile = &api.AADProfile{
+		ServerAppID: "test-id",
+		TenantID:    "test-tenant",
+	}
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--oidc-username-claim"] != "oid" {
+		t.Fatalf("got unexpected '--oidc-username-claim' API server config value for HasAadProfile=true: %s",
+			a["--oidc-username-claim"])
+	}
+	if a["--oidc-groups-claim"] != "groups" {
+		t.Fatalf("got unexpected '--oidc-groups-claim' API server config value for HasAadProfile=true: %s",
+			a["--oidc-groups-claim"])
+	}
+	if a["--oidc-client-id"] != "spn:"+cs.Properties.AADProfile.ServerAppID {
+		t.Fatalf("got unexpected '--oidc-client-id' API server config value for HasAadProfile=true: %s",
+			a["--oidc-client-id"])
+	}
+	if a["--oidc-issuer-url"] != "https://sts.windows.net/"+cs.Properties.AADProfile.TenantID+"/" {
+		t.Fatalf("got unexpected '--oidc-issuer-url' API server config value for HasAadProfile=true: %s",
+			a["--oidc-issuer-url"])
+	}
+
+	// Test OIDC user overrides
+	cs = CreateMockContainerService("testcluster", "1.7.12", 3, 2, false)
+	cs.Properties.AADProfile = &api.AADProfile{
+		ServerAppID: "test-id",
+		TenantID:    "test-tenant",
+	}
+	usernameClaimOverride := "custom-username-claim"
+	groupsClaimOverride := "custom-groups-claim"
+	clientIDOverride := "custom-client-id"
+	issuerURLOverride := "custom-issuer-url"
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = map[string]string{
+		"--oidc-username-claim": usernameClaimOverride,
+		"--oidc-groups-claim":   groupsClaimOverride,
+		"--oidc-client-id":      clientIDOverride,
+		"--oidc-issuer-url":     issuerURLOverride,
+	}
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--oidc-username-claim"] != usernameClaimOverride {
+		t.Fatalf("got unexpected '--oidc-username-claim' API server config value when user override provided: %s, expected: %s",
+			a["--oidc-username-claim"], usernameClaimOverride)
+	}
+	if a["--oidc-groups-claim"] != groupsClaimOverride {
+		t.Fatalf("got unexpected '--oidc-groups-claim' API server config value when user override provided: %s, expected: %s",
+			a["--oidc-groups-claim"], groupsClaimOverride)
+	}
+	if a["--oidc-client-id"] != clientIDOverride {
+		t.Fatalf("got unexpected '--oidc-client-id' API server config value when user override provided: %s, expected: %s",
+			a["--oidc-client-id"], clientIDOverride)
+	}
+	if a["--oidc-issuer-url"] != issuerURLOverride {
+		t.Fatalf("got unexpected '--oidc-issuer-url' API server config value when user override provided: %s, expected: %s",
+			a["--oidc-issuer-url"], issuerURLOverride)
+	}
+
+	// Test China Cloud settings
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.AADProfile = &api.AADProfile{
+		ServerAppID: "test-id",
+		TenantID:    "test-tenant",
+	}
+	cs.Location = "chinaeast"
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--oidc-issuer-url"] != "https://sts.chinacloudapi.cn/"+cs.Properties.AADProfile.TenantID+"/" {
+		t.Fatalf("got unexpected '--oidc-issuer-url' API server config value for HasAadProfile=true using China cloud: %s",
+			a["--oidc-issuer-url"])
+	}
+
+	cs.Location = "chinaeast2"
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--oidc-issuer-url"] != "https://sts.chinacloudapi.cn/"+cs.Properties.AADProfile.TenantID+"/" {
+		t.Fatalf("got unexpected '--oidc-issuer-url' API server config value for HasAadProfile=true using China cloud: %s",
+			a["--oidc-issuer-url"])
+	}
+
+	cs.Location = "chinanorth"
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--oidc-issuer-url"] != "https://sts.chinacloudapi.cn/"+cs.Properties.AADProfile.TenantID+"/" {
+		t.Fatalf("got unexpected '--oidc-issuer-url' API server config value for HasAadProfile=true using China cloud: %s",
+			a["--oidc-issuer-url"])
+	}
+
+	cs.Location = "chinanorth2"
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--oidc-issuer-url"] != "https://sts.chinacloudapi.cn/"+cs.Properties.AADProfile.TenantID+"/" {
+		t.Fatalf("got unexpected '--oidc-issuer-url' API server config value for HasAadProfile=true using China cloud: %s",
+			a["--oidc-issuer-url"])
+	}
+
+	// Test HasAadProfile = false
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	for _, key := range []string{"--oidc-username-claim", "--oidc-groups-claim", "--oidc-client-id", "--oidc-issuer-url"} {
+		if _, ok := a[key]; ok {
+			t.Fatalf("got unexpected '%s' API server config value for HasAadProfile=false: %s",
+				key, a[key])
+		}
+	}
+}
+
+func TestAPIServerConfigEnableRbac(t *testing.T) {
+	// Test EnableRbac = true
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(true)
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--authorization-mode"] != "Node,RBAC" {
+		t.Fatalf("got unexpected '--authorization-mode' API server config value for EnableRbac=true: %s",
+			a["--authorization-mode"])
+	}
+
+	// Test EnableRbac = true with 1.6 cluster
+	cs = CreateMockContainerService("testcluster", "1.6.11", 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(true)
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--authorization-mode"] != "RBAC" {
+		t.Fatalf("got unexpected '--authorization-mode' API server config value for 1.6 cluster with EnableRbac=true: %s",
+			a["--authorization-mode"])
+	}
+
+	// Test EnableRbac = false
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(false)
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if _, ok := a["--authorization-mode"]; ok {
+		t.Fatalf("got unexpected '--authorization-mode' API server config value for EnableRbac=false: %s",
+			a["--authorization-mode"])
+	}
+
+	// Test EnableRbac = false with 1.6 cluster
+	cs = CreateMockContainerService("testcluster", "1.6.11", 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(false)
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if _, ok := a["--authorization-mode"]; ok {
+		t.Fatalf("got unexpected '--authorization-mode' API server config value for 1.6 cluster with EnableRbac=false: %s",
+			a["--authorization-mode"])
+	}
+}
+
+func TestAPIServerConfigDisableRbac(t *testing.T) {
+	// Test EnableRbac = false
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(false)
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--authorization-mode"] != "" {
+		t.Fatalf("got unexpected '--authorization-mode' API server config value for EnableRbac=false: %s",
+			a["--authorization-mode"])
+	}
+}
+
+func TestAPIServerConfigEnableSecureKubelet(t *testing.T) {
+	// Test EnableSecureKubelet = true
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(true)
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--kubelet-client-certificate"] != "/etc/kubernetes/certs/client.crt" {
+		t.Fatalf("got unexpected '--kubelet-client-certificate' API server config value for EnableSecureKubelet=true: %s",
+			a["--kubelet-client-certificate"])
+	}
+	if a["--kubelet-client-key"] != "/etc/kubernetes/certs/client.key" {
+		t.Fatalf("got unexpected '--kubelet-client-key' API server config value for EnableSecureKubelet=true: %s",
+			a["--kubelet-client-key"])
+	}
+
+	// Test EnableSecureKubelet = false
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(false)
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	for _, key := range []string{"--kubelet-client-certificate", "--kubelet-client-key"} {
+		if _, ok := a[key]; ok {
+			t.Fatalf("got unexpected '%s' API server config value for EnableSecureKubelet=false: %s",
+				key, a[key])
+		}
+	}
+}
+
+func TestAPIServerConfigDefaultAdmissionControls(t *testing.T) {
+	version := "1.15.4"
+	enableAdmissionPluginsKey := "--enable-admission-plugins"
+	admissonControlKey := "--admission-control"
+	cs := CreateMockContainerService("testcluster", version, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = map[string]string{}
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig[admissonControlKey] = "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,AlwaysPullImages,ExtendedResourceToleration"
+	cs.Properties.OrchestratorProfile.KubernetesConfig.Addons = []api.KubernetesAddon{
+		{
+			Name:    common.PodSecurityPolicyAddonName,
+			Enabled: to.BoolPtr(true),
+		},
+	}
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+
+	if _, found := a[enableAdmissionPluginsKey]; !found {
+		t.Fatalf("Admission control key '%s' not set in API server config for version %s", enableAdmissionPluginsKey, version)
+	}
+
+	// --admission-control was deprecated in v1.10
+	if _, found := a[admissonControlKey]; found {
+		t.Fatalf("Deprecated admission control key '%s' set in API server config for version %s", admissonControlKey, version)
+	}
+
+	// PodSecurityPolicy should be enabled in admission control
+	admissionControlVal := a[enableAdmissionPluginsKey]
+	if !strings.Contains(admissionControlVal, ",PodSecurityPolicy") {
+		t.Fatalf("Admission control value '%s' expected to contain PodSecurityPolicy", admissionControlVal)
+	}
+}
+
+func TestAPIServerConfigEnableProfiling(t *testing.T) {
+	// Test
+	// "apiServerConfig": {
+	// 	"--profiling": "true"
+	// },
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = map[string]string{
+		"--profiling": "true",
+	}
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--profiling"] != "true" {
+		t.Fatalf("got unexpected '--profiling' API server config value for \"--profiling\": \"true\": %s",
+			a["--profiling"])
+	}
+
+	// Test default
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--profiling"] != api.DefaultKubernetesAPIServerEnableProfiling {
+		t.Fatalf("got unexpected default value for '--profiling' API server config: %s",
+			a["--profiling"])
+	}
+}
+
+func TestAPIServerConfigRepairMalformedUpdates(t *testing.T) {
+	// Test default
+	cs := CreateMockContainerService("testcluster", "1.13.0", 3, 2, false)
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--repair-malformed-updates"] != "false" {
+		t.Fatalf("got unexpected default value for '--repair-malformed-updates' API server config: %s",
+			a["--repair-malformed-updates"])
+	}
+
+	// Validate that 1.14.0 doesn't include --repair-malformed-updates at all
+	cs = CreateMockContainerService("testcluster", "1.14.0", 3, 2, false)
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if _, ok := a["--repair-malformed-updates"]; ok {
+		t.Fatalf("got a value for the deprecated '--repair-malformed-updates' API server config: %s",
+			a["--repair-malformed-updates"])
+	}
+}
+
+func TestAPIServerAuditPolicyBackCompatOverride(t *testing.T) {
+	// Validate that we statically override "--audit-policy-file" values of "/etc/kubernetes/manifests/audit-policy.yaml" for back-compat
+	auditPolicyKey := "--audit-policy-file"
+	cs := CreateMockContainerService("testcluster", "1.10.8", 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = map[string]string{}
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig[auditPolicyKey] = "/etc/kubernetes/manifests/audit-policy.yaml"
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a[auditPolicyKey] != "/etc/kubernetes/addons/audit-policy.yaml" {
+		t.Fatalf("got unexpected default value for '%s' API server config: %s",
+			auditPolicyKey, a[auditPolicyKey])
+	}
+}
+
+func TestAPIServerWeakCipherSuites(t *testing.T) {
+	// Test allowed versions
+	for _, version := range []string{"1.13.0", "1.14.0"} {
+		cs := CreateMockContainerService("testcluster", version, 3, 2, false)
+		cs.setAPIServerConfig()
+		a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+		if a["--tls-cipher-suites"] != api.TLSStrongCipherSuitesAPIServer {
+			t.Fatalf("got unexpected default value for '--tls-cipher-suites' API server config for Kubernetes version %s: %s",
+				version, a["--tls-cipher-suites"])
+		}
+	}
+
+	allSuites := "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_RC4_128_SHA"
+	// Test user-override
+	for _, version := range []string{"1.13.0", "1.14.0"} {
+		cs := CreateMockContainerService("testcluster", version, 3, 2, false)
+		cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = map[string]string{
+			"--tls-cipher-suites": allSuites,
+		}
+		cs.setAPIServerConfig()
+		a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+		if a["--tls-cipher-suites"] != allSuites {
+			t.Fatalf("got unexpected default value for '--tls-cipher-suites' API server config for Kubernetes version %s: %s",
+				version, a["--tls-cipher-suites"])
+		}
+	}
+}
+
+func TestAPIServerCosmosEtcd(t *testing.T) {
+	// Test default
+	cs := CreateMockContainerService("testcluster", "1.15.4", 3, 2, false)
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--etcd-cafile"] != "/etc/kubernetes/certs/ca.crt" {
+		t.Fatalf("got unexpected default value for '--etcd-cafile' API server config: %s",
+			a["--etcd-cafile"])
+	}
+	if a["--etcd-servers"] != fmt.Sprintf("https://127.0.0.1:%s", strconv.Itoa(api.DefaultMasterEtcdClientPort)) {
+		t.Fatalf("got unexpected default value for '--etcd-servers' API server config: %s",
+			a["--etcd-servers"])
+	}
+
+	// Validate that 1.14.0 doesn't include --repair-malformed-updates at all
+	cs = CreateMockContainerService("testcluster", "1.14.0", 3, 2, false)
+	cs.Properties.MasterProfile.CosmosEtcd = to.BoolPtr(true)
+	cs.Properties.MasterProfile.DNSPrefix = "my-cosmos"
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--etcd-servers"] != fmt.Sprintf("https://%s:%s", cs.Properties.MasterProfile.GetCosmosEndPointURI(), strconv.Itoa(api.DefaultMasterEtcdClientPort)) {
+		t.Fatalf("got unexpected default value for '--etcd-servers' API server config: %s",
+			a["--etcd-servers"])
+	}
+}
+
+func TestAPIServerFeatureGates(t *testing.T) {
+	// Test k8s < 1.13
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--feature-gates"] != "" {
+		t.Fatalf("got unexpected '--feature-gates' API server config value for k8s v%s: %s",
+			defaultTestClusterVer, a["--feature-gates"])
+	}
+
+	// Test 1.13 <= k8s <= 1.16
+	cs = CreateMockContainerService("testcluster", "1.14.0", 3, 2, false)
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--feature-gates"] != "VolumeSnapshotDataSource=true" {
+		t.Fatalf("got unexpected '--feature-gates' API server config value for k8s v%s: %s",
+			"1.14.0", a["--feature-gates"])
+	}
+
+	// Test k8s >= 1.17
+	cs = CreateMockContainerService("testcluster", "1.17.0", 3, 2, false)
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--feature-gates"] != "" {
+		t.Fatalf("got unexpected '--feature-gates' API server config value for k8s v%s: %s",
+			"1.17.0", a["--feature-gates"])
+	}
+}
+
+func TestAPIServerIPv6Only(t *testing.T) {
+	cs := CreateMockContainerService("testcluster", "1.18.0", 3, 2, false)
+	cs.Properties.FeatureFlags = &api.FeatureFlags{EnableIPv6Only: true}
+	cs.setAPIServerConfig()
+
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	// bind address should be :: for single stack IPv6 cluster
+	if a["--bind-address"] != "::" {
+		t.Fatalf("got unexpected default value for '--bind-address' API server config: %s",
+			a["--bind-address"])
+	}
+	for _, key := range []string{"--advertise-address"} {
+		if _, ok := a[key]; ok {
+			t.Fatalf("got unexpected '%s' API server config value for '--advertise-address' %s",
+				key, a[key])
+		}
+	}
+}

--- a/pkg/agent/datamodel/defaults-cloud-controller-manager.go
+++ b/pkg/agent/datamodel/defaults-cloud-controller-manager.go
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"strconv"
+
+	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/aks-engine/pkg/api/common"
+)
+
+func (cs *ContainerService) setCloudControllerManagerConfig() {
+	o := cs.Properties.OrchestratorProfile
+	staticCloudControllerManagerConfig := map[string]string{
+		"--allocate-node-cidrs":         strconv.FormatBool(!o.IsAzureCNI()),
+		"--configure-cloud-routes":      strconv.FormatBool(o.RequireRouteTable()),
+		"--cloud-provider":              "azure",
+		"--cloud-config":                "/etc/kubernetes/azure.json",
+		"--cluster-cidr":                o.KubernetesConfig.ClusterSubnet,
+		"--kubeconfig":                  "/var/lib/kubelet/kubeconfig",
+		"--leader-elect":                "true",
+		"--route-reconciliation-period": "10s",
+		"--v":                           "2",
+	}
+
+	// Add new arguments for Azure cloud-controller-manager component.
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") {
+		staticCloudControllerManagerConfig["--controllers"] = "*"
+	}
+
+	// Set --cluster-name based on appropriate DNS prefix
+	if cs.Properties.MasterProfile != nil {
+		staticCloudControllerManagerConfig["--cluster-name"] = cs.Properties.MasterProfile.DNSPrefix
+	} else if cs.Properties.HostedMasterProfile != nil {
+		staticCloudControllerManagerConfig["--cluster-name"] = cs.Properties.HostedMasterProfile.DNSPrefix
+	}
+
+	// Default cloud-controller-manager config
+	defaultCloudControllerManagerConfig := map[string]string{
+		"--route-reconciliation-period": api.DefaultKubernetesCtrlMgrRouteReconciliationPeriod,
+	}
+
+	// If no user-configurable cloud-controller-manager config values exists, use the defaults
+	if o.KubernetesConfig.CloudControllerManagerConfig == nil {
+		o.KubernetesConfig.CloudControllerManagerConfig = defaultCloudControllerManagerConfig
+	} else {
+		for key, val := range defaultCloudControllerManagerConfig {
+			// If we don't have a user-configurable cloud-controller-manager config for each option
+			if _, ok := o.KubernetesConfig.CloudControllerManagerConfig[key]; !ok {
+				// then assign the default value
+				o.KubernetesConfig.CloudControllerManagerConfig[key] = val
+			}
+		}
+	}
+
+	// We don't support user-configurable values for the following,
+	// so any of the value assignments below will override user-provided values
+	for key, val := range staticCloudControllerManagerConfig {
+		o.KubernetesConfig.CloudControllerManagerConfig[key] = val
+	}
+
+	// TODO add RBAC support
+	/*if *o.KubernetesConfig.EnableRbac {
+		o.KubernetesConfig.CloudControllerManagerConfig["--use-service-account-credentials"] = "true"
+	}*/
+}

--- a/pkg/agent/datamodel/defaults-cloud-controller-manager_test.go
+++ b/pkg/agent/datamodel/defaults-cloud-controller-manager_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"testing"
+)
+
+func TestCloudControllerManagerConfig(t *testing.T) {
+	k8sVersion := "1.16.1"
+	cs := CreateMockContainerService("testcluster", k8sVersion, 3, 2, false)
+	cs.setCloudControllerManagerConfig()
+	cm := cs.Properties.OrchestratorProfile.KubernetesConfig.CloudControllerManagerConfig
+	if cm["--controllers"] != "*" {
+		t.Fatalf("got unexpected '--controllers' Cloud Controller Manager config value for Kubernetes %s: %s",
+			k8sVersion, cm["--controllers"])
+	}
+
+	k8sVersion = "1.15.4"
+	cs = CreateMockContainerService("testcluster", k8sVersion, 3, 2, false)
+	cs.setCloudControllerManagerConfig()
+	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.CloudControllerManagerConfig
+	if val, ok := cm["--controllers"]; ok {
+		t.Fatalf("got unexpected '--controllers' Cloud Controller Manager config value for Kubernetes %s: %s",
+			k8sVersion, val)
+	}
+}

--- a/pkg/agent/datamodel/defaults-controller-manager_test.go
+++ b/pkg/agent/datamodel/defaults-controller-manager_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"testing"
+
+	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+func TestControllerManagerConfigEnableRbac(t *testing.T) {
+	// Test EnableRbac = true
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(true)
+	cs.setControllerManagerConfig()
+	cm := cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--use-service-account-credentials"] != "true" {
+		t.Fatalf("got unexpected '--use-service-account-credentials' Controller Manager config value for EnableRbac=true: %s",
+			cm["--use-service-account-credentials"])
+	}
+
+	// Test default
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(false)
+	cs.setControllerManagerConfig()
+	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--use-service-account-credentials"] != api.DefaultKubernetesCtrlMgrUseSvcAccountCreds {
+		t.Fatalf("got unexpected '--use-service-account-credentials' Controller Manager config value for EnableRbac=false: %s",
+			cm["--use-service-account-credentials"])
+	}
+}
+
+func TestControllerManagerConfigCloudProvider(t *testing.T) {
+	// Test UseCloudControllerManager = true
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(true)
+	cs.setControllerManagerConfig()
+	cm := cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--cloud-provider"] != "external" {
+		t.Fatalf("got unexpected '--cloud-provider' Controller Manager config value for UseCloudControllerManager=true: %s",
+			cm["--cloud-provider"])
+	}
+
+	// Test UseCloudControllerManager = false
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(false)
+	cs.setControllerManagerConfig()
+	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--cloud-provider"] != "azure" {
+		t.Fatalf("got unexpected '--cloud-provider' Controller Manager config value for UseCloudControllerManager=false: %s",
+			cm["--cloud-provider"])
+	}
+}
+
+func TestControllerManagerConfigEnableProfiling(t *testing.T) {
+	// Test
+	// "controllerManagerConfig": {
+	// 	"--profiling": "true"
+	// },
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig = map[string]string{
+		"--profiling": "true",
+	}
+	cs.setControllerManagerConfig()
+	cm := cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--profiling"] != "true" {
+		t.Fatalf("got unexpected '--profiling' Controller Manager config value for \"--profiling\": \"true\": %s",
+			cm["--profiling"])
+	}
+
+	// Test default
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setControllerManagerConfig()
+	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--profiling"] != api.DefaultKubernetesCtrMgrEnableProfiling {
+		t.Fatalf("got unexpected default value for '--profiling' Controller Manager config: %s",
+			cm["--profiling"])
+	}
+}
+
+func TestControllerManagerConfigDefaultFeatureGates(t *testing.T) {
+	// test defaultTestClusterVer
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setControllerManagerConfig()
+	cm := cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--feature-gates"] != "" {
+		t.Fatalf("got unexpected '--feature-gates' Controller Manager config value for \"--feature-gates\": \"\": %s",
+			cm["--feature-gates"])
+	}
+
+	// test 1.9.0
+	cs = CreateMockContainerService("testcluster", "1.9.0", 3, 2, false)
+	cs.setControllerManagerConfig()
+	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--feature-gates"] != "ServiceNodeExclusion=true" {
+		t.Fatalf("got unexpected '--feature-gates' Controller Manager config value for \"--feature-gates\": \"ServiceNodeExclusion=true\": %s",
+			cm["--feature-gates"])
+	}
+
+	// test 1.10.0
+	cs = CreateMockContainerService("testcluster", "1.10.0", 3, 2, false)
+	cs.setControllerManagerConfig()
+	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--feature-gates"] != "LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true" {
+		t.Fatalf("got unexpected '--feature-gates' Controller Manager config value for \"--feature-gates\": \"LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true\": %s",
+			cm["--feature-gates"])
+	}
+
+	// test 1.14
+	cs = CreateMockContainerService("testcluster", "1.14.1", 3, 2, false)
+	cs.setControllerManagerConfig()
+	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--feature-gates"] != "LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true" {
+		t.Fatalf("got unexpected '--feature-gates' Controller Manager config value for \"--feature-gates\": \"LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true\": %s",
+			cm["--feature-gates"])
+	}
+
+	// test user-overrides
+	cs = CreateMockContainerService("testcluster", "1.14.1", 3, 2, false)
+	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	cm["--feature-gates"] = "TaintBasedEvictions=true"
+	cs.setControllerManagerConfig()
+	if cm["--feature-gates"] != "LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true,TaintBasedEvictions=true" {
+		t.Fatalf("got unexpected '--feature-gates' Controller Manager config value for \"--feature-gates\": \"LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true\": %s",
+			cm["--feature-gates"])
+	}
+}
+
+func TestControllerManagerConfigHostedMasterProfile(t *testing.T) {
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.MasterProfile = nil
+	cs.Properties.HostedMasterProfile = &api.HostedMasterProfile{
+		DNSPrefix: "foodns",
+	}
+	cs.setControllerManagerConfig()
+	cm := cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--cluster-name"] != "foodns" {
+		t.Fatalf("expected controller-manager to have cluster-name foodns when using HostedMasterProfile")
+	}
+}

--- a/pkg/agent/datamodel/defaults-custom-cloud-profile.go
+++ b/pkg/agent/datamodel/defaults-custom-cloud-profile.go
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/aks-engine/pkg/helpers"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+func (cs *ContainerService) setCustomCloudProfileDefaults(params api.CustomCloudProfileDefaultsParams) error {
+	p := cs.Properties
+	if p.IsAzureStackCloud() {
+		p.CustomCloudProfile.AuthenticationMethod = helpers.EnsureString(p.CustomCloudProfile.AuthenticationMethod, api.ClientSecretAuthMethod)
+		p.CustomCloudProfile.IdentitySystem = helpers.EnsureString(p.CustomCloudProfile.IdentitySystem, api.AzureADIdentitySystem)
+		p.CustomCloudProfile.DependenciesLocation = api.DependenciesLocation(helpers.EnsureString(string(p.CustomCloudProfile.DependenciesLocation), api.AzureStackDependenciesLocationPublic))
+		err := cs.SetCustomCloudProfileEnvironment()
+		if err != nil {
+			return fmt.Errorf("Failed to set environment - %s", err)
+		}
+		err = p.SetAzureStackCloudSpec(api.AzureStackCloudSpecParams(params))
+		if err != nil {
+			return fmt.Errorf("Failed to set cloud spec - %s", err)
+		}
+	}
+	return nil
+}
+
+// SetCustomCloudProfileEnvironment retrieves the endpoints from Azure Stack metadata endpoint and sets the values for azure.Environment
+func (cs *ContainerService) SetCustomCloudProfileEnvironment() error {
+	p := cs.Properties
+	if p.IsAzureStackCloud() {
+		if p.CustomCloudProfile.Environment == nil {
+			p.CustomCloudProfile.Environment = &azure.Environment{}
+		}
+
+		env := p.CustomCloudProfile.Environment
+		if env.Name == "" || env.ResourceManagerEndpoint == "" || env.ServiceManagementEndpoint == "" || env.ActiveDirectoryEndpoint == "" || env.GraphEndpoint == "" || env.ResourceManagerVMDNSSuffix == "" {
+			env.Name = api.AzureStackCloud
+			if !strings.HasPrefix(p.CustomCloudProfile.PortalURL, fmt.Sprintf("https://portal.%s.", cs.Location)) {
+				return fmt.Errorf("portalURL needs to start with https://portal.%s. ", cs.Location)
+			}
+			azsFQDNSuffix := strings.Replace(p.CustomCloudProfile.PortalURL, fmt.Sprintf("https://portal.%s.", cs.Location), "", -1)
+			azsFQDNSuffix = strings.TrimSuffix(azsFQDNSuffix, "/")
+			env.ResourceManagerEndpoint = fmt.Sprintf("https://management.%s.%s/", cs.Location, azsFQDNSuffix)
+			metadataURL := fmt.Sprintf("%s/metadata/endpoints?api-version=1.0", strings.TrimSuffix(env.ResourceManagerEndpoint, "/"))
+
+			// Retrieve the metadata
+			httpClient := &http.Client{
+				Timeout: 30 * time.Second,
+			}
+			endpointsresp, err := httpClient.Get(metadataURL)
+			if err != nil || endpointsresp.StatusCode != 200 {
+				return fmt.Errorf("%s . apimodel invalid: failed to retrieve Azure Stack endpoints from %s", err, metadataURL)
+			}
+
+			body, err := ioutil.ReadAll(endpointsresp.Body)
+			if err != nil {
+				return fmt.Errorf("%s . apimodel invalid: failed to read the response from %s", err, metadataURL)
+			}
+
+			endpoints := api.AzureStackMetadataEndpoints{}
+			err = json.Unmarshal(body, &endpoints)
+			if err != nil {
+				return fmt.Errorf("%s . apimodel invalid: failed to parse the response from %s", err, metadataURL)
+			}
+
+			if endpoints.GraphEndpoint == "" || endpoints.Authentication == nil || endpoints.Authentication.LoginEndpoint == "" || len(endpoints.Authentication.Audiences) == 0 || endpoints.Authentication.Audiences[0] == "" {
+				return fmt.Errorf("%s . apimodel invalid: invalid response from %s", err, metadataURL)
+			}
+
+			env.GraphEndpoint = endpoints.GraphEndpoint
+			env.ServiceManagementEndpoint = endpoints.Authentication.Audiences[0]
+			env.GalleryEndpoint = endpoints.GalleryEndpoint
+			env.ActiveDirectoryEndpoint = endpoints.Authentication.LoginEndpoint
+			if p.CustomCloudProfile.IdentitySystem == api.ADFSIdentitySystem {
+				env.ActiveDirectoryEndpoint = strings.TrimSuffix(env.ActiveDirectoryEndpoint, "/")
+				env.ActiveDirectoryEndpoint = strings.TrimSuffix(env.ActiveDirectoryEndpoint, "adfs")
+			}
+
+			env.ManagementPortalURL = endpoints.PortalEndpoint
+			env.ResourceManagerVMDNSSuffix = fmt.Sprintf("cloudapp.%s", azsFQDNSuffix)
+			env.StorageEndpointSuffix = fmt.Sprintf("%s.%s", cs.Location, azsFQDNSuffix)
+			env.KeyVaultDNSSuffix = fmt.Sprintf("vault.%s.%s", cs.Location, azsFQDNSuffix)
+		}
+	}
+	return nil
+}

--- a/pkg/agent/datamodel/defaults-kubelet.go
+++ b/pkg/agent/datamodel/defaults-kubelet.go
@@ -1,0 +1,290 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/aks-engine/pkg/api/common"
+)
+
+func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
+	o := cs.Properties.OrchestratorProfile
+	staticLinuxKubeletConfig := map[string]string{
+		"--address":                     "0.0.0.0",
+		"--allow-privileged":            "true",
+		"--anonymous-auth":              "false",
+		"--authorization-mode":          "Webhook",
+		"--client-ca-file":              "/etc/kubernetes/certs/ca.crt",
+		"--pod-manifest-path":           "/etc/kubernetes/manifests",
+		"--cluster-dns":                 o.KubernetesConfig.DNSServiceIP,
+		"--cgroups-per-qos":             "true",
+		"--kubeconfig":                  "/var/lib/kubelet/kubeconfig",
+		"--keep-terminated-pod-volumes": "false",
+		"--tls-cert-file":               "/etc/kubernetes/certs/kubeletserver.crt",
+		"--tls-private-key-file":        "/etc/kubernetes/certs/kubeletserver.key",
+	}
+
+	for key := range staticLinuxKubeletConfig {
+		switch key {
+		case "--anonymous-auth", "--client-ca-file":
+			if !to.Bool(o.KubernetesConfig.EnableSecureKubelet) { // Don't add if EnableSecureKubelet is disabled
+				staticLinuxKubeletConfig[key] = ""
+			}
+		}
+	}
+
+	// Start with copy of Linux config
+	staticWindowsKubeletConfig := make(map[string]string)
+	for key, val := range staticLinuxKubeletConfig {
+		switch key {
+		case "--pod-manifest-path", "--tls-cert-file", "--tls-private-key-file": // Don't add Linux-specific config
+			staticWindowsKubeletConfig[key] = ""
+		case "--anonymous-auth":
+			if !to.Bool(o.KubernetesConfig.EnableSecureKubelet) { // Don't add if EnableSecureKubelet is disabled
+				staticWindowsKubeletConfig[key] = ""
+			} else {
+				staticWindowsKubeletConfig[key] = val
+			}
+		case "--client-ca-file":
+			if !to.Bool(o.KubernetesConfig.EnableSecureKubelet) { // Don't add if EnableSecureKubelet is disabled
+				staticWindowsKubeletConfig[key] = ""
+			} else {
+				staticWindowsKubeletConfig[key] = "c:\\k\\ca.crt"
+			}
+		default:
+			staticWindowsKubeletConfig[key] = val
+		}
+	}
+
+	// Add Windows-specific overrides
+	// Eventually paths should not be hardcoded here. They should be relative to $global:KubeDir in the PowerShell script
+	staticWindowsKubeletConfig["--azure-container-registry-config"] = "c:\\k\\azure.json"
+	staticWindowsKubeletConfig["--pod-infra-container-image"] = "kubletwin/pause"
+	staticWindowsKubeletConfig["--kubeconfig"] = "c:\\k\\config"
+	staticWindowsKubeletConfig["--cloud-config"] = "c:\\k\\azure.json"
+	staticWindowsKubeletConfig["--cgroups-per-qos"] = "false"
+	staticWindowsKubeletConfig["--enforce-node-allocatable"] = "\"\"\"\""
+	staticWindowsKubeletConfig["--system-reserved"] = "memory=2Gi"
+	staticWindowsKubeletConfig["--hairpin-mode"] = "promiscuous-bridge"
+	staticWindowsKubeletConfig["--image-pull-progress-deadline"] = "20m"
+	staticWindowsKubeletConfig["--resolv-conf"] = "\"\"\"\""
+	staticWindowsKubeletConfig["--eviction-hard"] = "\"\"\"\""
+
+	// Default Kubelet config
+	defaultKubeletConfig := map[string]string{
+		"--cluster-domain":                    "cluster.local",
+		"--network-plugin":                    "cni",
+		"--pod-infra-container-image":         o.KubernetesConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap[o.OrchestratorVersion]["pause"],
+		"--max-pods":                          strconv.Itoa(api.DefaultKubernetesMaxPods),
+		"--eviction-hard":                     api.DefaultKubernetesHardEvictionThreshold,
+		"--node-status-update-frequency":      api.K8sComponentsByVersionMap[o.OrchestratorVersion]["nodestatusfreq"],
+		"--image-gc-high-threshold":           strconv.Itoa(api.DefaultKubernetesGCHighThreshold),
+		"--image-gc-low-threshold":            strconv.Itoa(api.DefaultKubernetesGCLowThreshold),
+		"--non-masquerade-cidr":               api.DefaultNonMasqueradeCIDR,
+		"--cloud-provider":                    "azure",
+		"--cloud-config":                      "/etc/kubernetes/azure.json",
+		"--azure-container-registry-config":   "/etc/kubernetes/azure.json",
+		"--event-qps":                         api.DefaultKubeletEventQPS,
+		"--cadvisor-port":                     api.DefaultKubeletCadvisorPort,
+		"--pod-max-pids":                      strconv.Itoa(api.DefaultKubeletPodMaxPIDs),
+		"--image-pull-progress-deadline":      "30m",
+		"--enforce-node-allocatable":          "pods",
+		"--streaming-connection-idle-timeout": "4h",
+		"--tls-cipher-suites":                 api.TLSStrongCipherSuitesKubelet,
+	}
+
+	// Set --non-masquerade-cidr if ip-masq-agent is disabled on AKS or
+	// explicitly disabled in kubernetes config
+	if cs.Properties.IsIPMasqAgentDisabled() {
+		defaultKubeletConfig["--non-masquerade-cidr"] = cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet
+	}
+
+	// Apply Azure CNI-specific --max-pods value
+	if o.KubernetesConfig.NetworkPlugin == api.NetworkPluginAzure {
+		defaultKubeletConfig["--max-pods"] = strconv.Itoa(api.DefaultKubernetesMaxPodsVNETIntegrated)
+	}
+
+	minVersionRotateCerts := "1.11.9"
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, minVersionRotateCerts) {
+		defaultKubeletConfig["--rotate-certificates"] = "true"
+	}
+
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.16.0") {
+		// for enabling metrics-server v0.3.0+
+		defaultKubeletConfig["--authentication-token-webhook"] = "true"
+		if !cs.Properties.IsHostedMasterProfile() { // Skip for AKS until it supports metrics-server v0.3
+			defaultKubeletConfig["--read-only-port"] = "0" // we only have metrics-server v0.3 support in 1.16.0 and above
+		}
+	}
+
+	// If no user-configurable kubelet config values exists, use the defaults
+	setMissingKubeletValues(o.KubernetesConfig, defaultKubeletConfig)
+	addDefaultFeatureGates(o.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, minVersionRotateCerts, "RotateKubeletServerCertificate=true")
+
+	// Override default cloud-provider?
+	if to.Bool(o.KubernetesConfig.UseCloudControllerManager) {
+		staticLinuxKubeletConfig["--cloud-provider"] = "external"
+	}
+
+	// Override default --network-plugin?
+	if o.KubernetesConfig.NetworkPlugin == api.NetworkPluginKubenet {
+		if o.KubernetesConfig.NetworkPolicy != api.NetworkPolicyCalico {
+			o.KubernetesConfig.KubeletConfig["--network-plugin"] = api.NetworkPluginKubenet
+		}
+	}
+
+	// We don't support user-configurable values for the following,
+	// so any of the value assignments below will override user-provided values
+	for key, val := range staticLinuxKubeletConfig {
+		o.KubernetesConfig.KubeletConfig[key] = val
+	}
+
+	if isUpgrade && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.14.0") {
+		hasSupportPodPidsLimitFeatureGate := strings.Contains(o.KubernetesConfig.KubeletConfig["--feature-gates"], "SupportPodPidsLimit=true")
+		podMaxPids, err := strconv.Atoi(o.KubernetesConfig.KubeletConfig["--pod-max-pids"])
+		if err != nil {
+			o.KubernetesConfig.KubeletConfig["--pod-max-pids"] = strconv.Itoa(-1)
+		} else {
+			// If we don't have an explicit SupportPodPidsLimit=true, disable --pod-max-pids by setting to -1
+			// To prevent older clusters from inheriting SupportPodPidsLimit=true implicitly starting w/ 1.14.0
+			if !hasSupportPodPidsLimitFeatureGate || podMaxPids <= 0 {
+				o.KubernetesConfig.KubeletConfig["--pod-max-pids"] = strconv.Itoa(-1)
+			}
+		}
+	}
+
+	removeKubeletFlags(o.KubernetesConfig.KubeletConfig, o.OrchestratorVersion)
+
+	// Master-specific kubelet config changes go here
+	if cs.Properties.MasterProfile != nil {
+		if cs.Properties.MasterProfile.KubernetesConfig == nil {
+			cs.Properties.MasterProfile.KubernetesConfig = &api.KubernetesConfig{}
+			cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig = make(map[string]string)
+		}
+		setMissingKubeletValues(cs.Properties.MasterProfile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
+		addDefaultFeatureGates(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, "", "")
+
+		if isUpgrade && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.14.0") {
+			hasSupportPodPidsLimitFeatureGate := strings.Contains(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--feature-gates"], "SupportPodPidsLimit=true")
+			podMaxPids, err := strconv.Atoi(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--pod-max-pids"])
+			if err != nil {
+				cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--pod-max-pids"] = strconv.Itoa(-1)
+			} else {
+				// If we don't have an explicit SupportPodPidsLimit=true, disable --pod-max-pids by setting to -1
+				// To prevent older clusters from inheriting SupportPodPidsLimit=true implicitly starting w/ 1.14.0
+				if !hasSupportPodPidsLimitFeatureGate || podMaxPids <= 0 {
+					cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--pod-max-pids"] = strconv.Itoa(-1)
+				}
+			}
+		}
+		// "--protect-kernel-defaults" is only true for VHD based VMs since the base Ubuntu distros don't have a /etc/sysctl.d/60-CIS.conf file.
+		if cs.Properties.MasterProfile.IsVHDDistro() {
+			if _, ok := cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--protect-kernel-defaults"]; !ok {
+				cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--protect-kernel-defaults"] = "true"
+			}
+		}
+		// Override the --resolv-conf kubelet config value for Ubuntu 18.04 after the distro value is set.
+		if cs.Properties.MasterProfile.IsUbuntu1804() {
+			cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--resolv-conf"] = "/run/systemd/resolve/resolv.conf"
+		}
+
+		removeKubeletFlags(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig, o.OrchestratorVersion)
+	}
+
+	// Agent-specific kubelet config changes go here
+	for _, profile := range cs.Properties.AgentPoolProfiles {
+		if profile.KubernetesConfig == nil {
+			profile.KubernetesConfig = &api.KubernetesConfig{}
+			profile.KubernetesConfig.KubeletConfig = make(map[string]string)
+		}
+
+		if profile.OSType == api.Windows {
+			for key, val := range staticWindowsKubeletConfig {
+				profile.KubernetesConfig.KubeletConfig[key] = val
+			}
+		} else {
+			for key, val := range staticLinuxKubeletConfig {
+				profile.KubernetesConfig.KubeletConfig[key] = val
+			}
+		}
+
+		setMissingKubeletValues(profile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
+
+		if isUpgrade && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.14.0") {
+			hasSupportPodPidsLimitFeatureGate := strings.Contains(profile.KubernetesConfig.KubeletConfig["--feature-gates"], "SupportPodPidsLimit=true")
+			podMaxPids, err := strconv.Atoi(profile.KubernetesConfig.KubeletConfig["--pod-max-pids"])
+			if err != nil {
+				profile.KubernetesConfig.KubeletConfig["--pod-max-pids"] = strconv.Itoa(-1)
+			} else {
+				// If we don't have an explicit SupportPodPidsLimit=true, disable --pod-max-pids by setting to -1
+				// To prevent older clusters from inheriting SupportPodPidsLimit=true implicitly starting w/ 1.14.0
+				if !hasSupportPodPidsLimitFeatureGate || podMaxPids <= 0 {
+					profile.KubernetesConfig.KubeletConfig["--pod-max-pids"] = strconv.Itoa(-1)
+				}
+			}
+		}
+
+		// "--protect-kernel-defaults" is only true for VHD based VMs since the base Ubuntu distros don't have a /etc/sysctl.d/60-CIS.conf file.
+		if profile.IsVHDDistro() {
+			if _, ok := profile.KubernetesConfig.KubeletConfig["--protect-kernel-defaults"]; !ok {
+				profile.KubernetesConfig.KubeletConfig["--protect-kernel-defaults"] = "true"
+			}
+		}
+		// Override the --resolv-conf kubelet config value for Ubuntu 18.04 after the distro value is set.
+		if profile.IsUbuntu1804() {
+			profile.KubernetesConfig.KubeletConfig["--resolv-conf"] = "/run/systemd/resolve/resolv.conf"
+		}
+
+		removeKubeletFlags(profile.KubernetesConfig.KubeletConfig, o.OrchestratorVersion)
+	}
+}
+
+func removeKubeletFlags(k map[string]string, v string) {
+	// Get rid of values not supported until v1.10
+	if !common.IsKubernetesVersionGe(v, "1.10.0") {
+		for _, key := range []string{"--pod-max-pids"} {
+			delete(k, key)
+		}
+	}
+
+	// Get rid of values not supported in v1.12 and up
+	if common.IsKubernetesVersionGe(v, "1.12.0") {
+		for _, key := range []string{"--cadvisor-port"} {
+			delete(k, key)
+		}
+	}
+
+	// Get rid of values not supported in v1.15 and up
+	if common.IsKubernetesVersionGe(v, "1.15.0-beta.1") {
+		for _, key := range []string{"--allow-privileged"} {
+			delete(k, key)
+		}
+	}
+
+	// Get rid of keys with empty string values
+	for key, val := range k {
+		if val == "" {
+			delete(k, key)
+		}
+	}
+}
+
+func setMissingKubeletValues(p *api.KubernetesConfig, d map[string]string) {
+	if p.KubeletConfig == nil {
+		p.KubeletConfig = d
+	} else {
+		for key, val := range d {
+			// If we don't have a user-configurable value for each option
+			if _, ok := p.KubeletConfig[key]; !ok {
+				// then assign the default value
+				p.KubeletConfig[key] = val
+			}
+		}
+	}
+}

--- a/pkg/agent/datamodel/defaults-kubelet_test.go
+++ b/pkg/agent/datamodel/defaults-kubelet_test.go
@@ -1,0 +1,2027 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/aks-engine/pkg/api/common"
+	"github.com/Azure/aks-engine/pkg/helpers"
+)
+
+func TestKubeletConfigDefaults(t *testing.T) {
+	cs := CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(api.Kubernetes, common.KubernetesDefaultRelease, "", false, false), 3, 2, false)
+	winProfile := &api.AgentPoolProfile{}
+	winProfile.Count = 1
+	winProfile.Name = "agentpool2"
+	winProfile.VMSize = "Standard_D2_v2"
+	winProfile.OSType = api.Windows
+	cs.Properties.AgentPoolProfiles = append(cs.Properties.AgentPoolProfiles, winProfile)
+	cs.setKubeletConfig(false)
+	kubeletConfig := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	expected := map[string]string{
+		"--address":                           "0.0.0.0",
+		"--allow-privileged":                  "true", // validate that we delete this key for >= 1.15 clusters
+		"--anonymous-auth":                    "false",
+		"--authorization-mode":                "Webhook",
+		"--azure-container-registry-config":   "/etc/kubernetes/azure.json",
+		"--cadvisor-port":                     "", // Validate that we delete this key for >= 1.12 clusters
+		"--cgroups-per-qos":                   "true",
+		"--client-ca-file":                    "/etc/kubernetes/certs/ca.crt",
+		"--cloud-provider":                    "azure",
+		"--cloud-config":                      "/etc/kubernetes/azure.json",
+		"--cluster-dns":                       api.DefaultKubernetesDNSServiceIP,
+		"--cluster-domain":                    "cluster.local",
+		"--enforce-node-allocatable":          "pods",
+		"--event-qps":                         api.DefaultKubeletEventQPS,
+		"--eviction-hard":                     api.DefaultKubernetesHardEvictionThreshold,
+		"--image-gc-high-threshold":           strconv.Itoa(api.DefaultKubernetesGCHighThreshold),
+		"--image-gc-low-threshold":            strconv.Itoa(api.DefaultKubernetesGCLowThreshold),
+		"--image-pull-progress-deadline":      "30m",
+		"--keep-terminated-pod-volumes":       "false",
+		"--kubeconfig":                        "/var/lib/kubelet/kubeconfig",
+		"--max-pods":                          strconv.Itoa(api.DefaultKubernetesMaxPods),
+		"--network-plugin":                    api.NetworkPluginKubenet,
+		"--node-status-update-frequency":      api.K8sComponentsByVersionMap[cs.Properties.OrchestratorProfile.OrchestratorVersion]["nodestatusfreq"],
+		"--non-masquerade-cidr":               api.DefaultNonMasqueradeCIDR,
+		"--pod-manifest-path":                 "/etc/kubernetes/manifests",
+		"--pod-infra-container-image":         cs.Properties.OrchestratorProfile.KubernetesConfig.MCRKubernetesImageBase + api.K8sComponentsByVersionMap[cs.Properties.OrchestratorProfile.OrchestratorVersion]["pause"],
+		"--pod-max-pids":                      strconv.Itoa(api.DefaultKubeletPodMaxPIDs),
+		"--protect-kernel-defaults":           "true",
+		"--rotate-certificates":               "true",
+		"--streaming-connection-idle-timeout": "4h",
+		"--feature-gates":                     "RotateKubeletServerCertificate=true",
+		"--tls-cipher-suites":                 api.TLSStrongCipherSuitesKubelet,
+		"--tls-cert-file":                     "/etc/kubernetes/certs/kubeletserver.crt",
+		"--tls-private-key-file":              "/etc/kubernetes/certs/kubeletserver.key",
+	}
+	for key, val := range kubeletConfig {
+		if expected[key] != val {
+			t.Fatalf("got unexpected kubelet config value for %s: %s, expected %s",
+				key, val, expected[key])
+		}
+	}
+	masterKubeletConfig := cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
+	for key, val := range masterKubeletConfig {
+		if expected[key] != val {
+			t.Fatalf("got unexpected masterProfile kubelet config value for %s: %s, expected %s",
+				key, val, expected[key])
+		}
+	}
+	linuxProfileKubeletConfig := cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	for key, val := range linuxProfileKubeletConfig {
+		if expected[key] != val {
+			t.Fatalf("got unexpected Linux agent profile kubelet config value for %s: %s, expected %s",
+				key, val, expected[key])
+		}
+	}
+
+	windowsProfileKubeletConfig := cs.Properties.AgentPoolProfiles[1].KubernetesConfig.KubeletConfig
+	expected["--azure-container-registry-config"] = "c:\\k\\azure.json"
+	expected["--pod-infra-container-image"] = "kubletwin/pause"
+	expected["--kubeconfig"] = "c:\\k\\config"
+	expected["--cloud-config"] = "c:\\k\\azure.json"
+	expected["--cgroups-per-qos"] = "false"
+	expected["--enforce-node-allocatable"] = "\"\"\"\""
+	expected["--system-reserved"] = "memory=2Gi"
+	expected["--client-ca-file"] = "c:\\k\\ca.crt"
+	expected["--hairpin-mode"] = "promiscuous-bridge"
+	expected["--image-pull-progress-deadline"] = "20m"
+	expected["--resolv-conf"] = "\"\"\"\""
+	expected["--eviction-hard"] = "\"\"\"\""
+	delete(expected, "--pod-manifest-path")
+	delete(expected, "--protect-kernel-defaults")
+	delete(expected, "--tls-cert-file")
+	delete(expected, "--tls-private-key-file")
+	for key, val := range windowsProfileKubeletConfig {
+		if expected[key] != val {
+			t.Fatalf("got unexpected Windows agent profile kubelet config value for %s: %s, expected %s",
+				key, val, expected[key])
+		}
+	}
+
+	cs = CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(api.Kubernetes, common.KubernetesDefaultRelease, "", false, false), 3, 2, false)
+	// check when ip-masq-agent is explicitly disabled in kubernetes config
+	cs.Properties.OrchestratorProfile.KubernetesConfig.Addons = []api.KubernetesAddon{
+		{
+			Name:    common.IPMASQAgentAddonName,
+			Enabled: to.BoolPtr(false),
+		},
+	}
+
+	cs.setKubeletConfig(false)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+
+	for key, val := range map[string]string{"--non-masquerade-cidr": api.DefaultKubernetesSubnet} {
+		if k[key] != val {
+			t.Fatalf("got unexpected kubelet config value for %s: %s, expected %s",
+				key, k[key], val)
+		}
+	}
+
+	cs = CreateMockContainerService("testcluster", "1.8.6", 3, 2, false)
+	// TODO test all default overrides
+	overrideVal := "/etc/override"
+	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig = map[string]string{
+		"--azure-container-registry-config": overrideVal,
+	}
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	for key, val := range map[string]string{"--azure-container-registry-config": overrideVal} {
+		if k[key] != val {
+			t.Fatalf("got unexpected kubelet config value for %s: %s, expected %s",
+				key, k[key], val)
+		}
+	}
+
+	cs = CreateMockContainerService("testcluster", "1.16.0", 3, 2, false)
+	cs.setKubeletConfig(false)
+	kubeletConfig = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	expectedKeys := []string{
+		"--authentication-token-webhook",
+	}
+	for _, key := range expectedKeys {
+		if _, ok := kubeletConfig[key]; !ok {
+			t.Fatalf("could not find expected kubelet config value for %s", key)
+		}
+	}
+}
+
+func TestKubeletConfigDefaultsRemovals(t *testing.T) {
+	cs := CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(api.Kubernetes, "1.13", "", false, false), 3, 2, false)
+	poolProfile := &api.AgentPoolProfile{}
+	poolProfile.Count = 1
+	poolProfile.Name = "agentpool2"
+	poolProfile.VMSize = "Standard_D2_v2"
+	poolProfile.OSType = api.Linux
+	cs.Properties.AgentPoolProfiles = append(cs.Properties.AgentPoolProfiles, poolProfile)
+	cs.setKubeletConfig(false)
+	kubeletConfig := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	unexpected := []string{
+		"--cadvisor-port",
+	}
+	for _, key := range unexpected {
+		if _, ok := kubeletConfig[key]; ok {
+			t.Fatalf("got unexpected kubelet config value for %s, expected it not to be present",
+				key)
+		}
+	}
+	cs = CreateMockContainerService("testcluster", "1.15.0-beta.1", 3, 2, false)
+	cs.Properties.AgentPoolProfiles = append(cs.Properties.AgentPoolProfiles, poolProfile)
+	cs.setKubeletConfig(false)
+	kubeletConfig = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	unexpected = []string{
+		"--allow-privileged",
+		"--cadvisor-port",
+	}
+	for _, key := range unexpected {
+		if _, ok := kubeletConfig[key]; ok {
+			t.Fatalf("got unexpected kubelet config value for %s, expected it not to be present",
+				key)
+		}
+	}
+}
+
+func TestKubeletConfigUseCloudControllerManager(t *testing.T) {
+	// Test UseCloudControllerManager = true
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(true)
+	cs.setKubeletConfig(false)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--cloud-provider"] != "external" {
+		t.Fatalf("got unexpected '--cloud-provider' kubelet config value for UseCloudControllerManager=true: %s",
+			k["--cloud-provider"])
+	}
+
+	// Test UseCloudControllerManager = false
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = to.BoolPtr(false)
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--cloud-provider"] != "azure" {
+		t.Fatalf("got unexpected '--cloud-provider' kubelet config value for UseCloudControllerManager=false: %s",
+			k["--cloud-provider"])
+	}
+
+}
+
+func TestKubeletConfigCloudConfig(t *testing.T) {
+	// Test default value and custom value for --cloud-config
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setKubeletConfig(false)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--cloud-config"] != "/etc/kubernetes/azure.json" {
+		t.Fatalf("got unexpected '--cloud-config' kubelet config default value: %s",
+			k["--cloud-config"])
+	}
+
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--cloud-config"] = "custom.json"
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--cloud-config"] != "custom.json" {
+		t.Fatalf("got unexpected '--cloud-config' kubelet config default value: %s",
+			k["--cloud-config"])
+	}
+}
+
+func TestKubeletConfigAzureContainerRegistryConfig(t *testing.T) {
+	// Test default value and custom value for --azure-container-registry-config
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setKubeletConfig(false)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--azure-container-registry-config"] != "/etc/kubernetes/azure.json" {
+		t.Fatalf("got unexpected '--azure-container-registry-config' kubelet config default value: %s",
+			k["--azure-container-registry-config"])
+	}
+
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--azure-container-registry-config"] = "custom.json"
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--azure-container-registry-config"] != "custom.json" {
+		t.Fatalf("got unexpected '--azure-container-registry-config' kubelet config default value: %s",
+			k["--azure-container-registry-config"])
+	}
+}
+
+func TestKubeletConfigNetworkPlugin(t *testing.T) {
+	// Test NetworkPlugin = "kubenet"
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginKubenet
+	cs.setKubeletConfig(false)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--network-plugin"] != api.NetworkPluginKubenet {
+		t.Fatalf("got unexpected '--network-plugin' kubelet config value for NetworkPlugin=kubenet: %s",
+			k["--network-plugin"])
+	}
+
+	// Test NetworkPlugin = "azure"
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginAzure
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--network-plugin"] != "cni" {
+		t.Fatalf("got unexpected '--network-plugin' kubelet config value for NetworkPlugin=azure: %s",
+			k["--network-plugin"])
+	}
+
+}
+
+func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
+	// Test EnableSecureKubelet = true
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(true)
+	cs.setKubeletConfig(false)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	ka := cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	for _, kubernetesConfig := range []map[string]string{k, ka} {
+		if kubernetesConfig["--anonymous-auth"] != "false" {
+			t.Fatalf("got unexpected '--anonymous-auth' kubelet config value for EnableSecureKubelet=true: %s",
+				kubernetesConfig["--anonymous-auth"])
+		}
+		if kubernetesConfig["--authorization-mode"] != "Webhook" {
+			t.Fatalf("got unexpected '--authorization-mode' kubelet config value for EnableSecureKubelet=true: %s",
+				kubernetesConfig["--authorization-mode"])
+		}
+		if kubernetesConfig["--client-ca-file"] != "/etc/kubernetes/certs/ca.crt" {
+			t.Fatalf("got unexpected '--client-ca-file' kubelet config value for EnableSecureKubelet=true: %s",
+				kubernetesConfig["--client-ca-file"])
+		}
+	}
+
+	// Test EnableSecureKubelet = false
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(false)
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	ka = cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	for _, kubernetesConfig := range []map[string]string{k, ka} {
+		for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
+			if _, ok := kubernetesConfig[key]; ok {
+				t.Fatalf("got unexpected '%s' kubelet config value for EnableSecureKubelet=false: %s",
+					key, kubernetesConfig[key])
+			}
+		}
+	}
+
+	// Test default (EnableSecureKubelet = false) for Windows
+	cs = CreateMockContainerService("testcluster", "1.10.13", 3, 1, false)
+	p := GetK8sDefaultProperties(true)
+	cs.Properties = p
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(false)
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	ka = cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	for _, kubernetesConfig := range []map[string]string{k, ka} {
+		for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
+			if _, ok := kubernetesConfig[key]; ok {
+				t.Fatalf("got unexpected '%s' kubelet config value for EnableSecureKubelet=false: %s",
+					key, kubernetesConfig[key])
+			}
+		}
+	}
+
+	// Test explicit EnableSecureKubelet = false for Windows
+	cs = CreateMockContainerService("testcluster", "1.10.13", 3, 1, false)
+	p = GetK8sDefaultProperties(true)
+	cs.Properties = p
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(false)
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	ka = cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	for _, kubernetesConfig := range []map[string]string{k, ka} {
+		for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
+			if _, ok := kubernetesConfig[key]; ok {
+				t.Fatalf("got unexpected '%s' kubelet config value for EnableSecureKubelet=false: %s",
+					key, kubernetesConfig[key])
+			}
+		}
+	}
+
+	// Test EnableSecureKubelet = true for Windows
+	cs = CreateMockContainerService("testcluster", "1.10.13", 3, 1, false)
+	p = GetK8sDefaultProperties(true)
+	cs.Properties = p
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(true)
+	cs.setKubeletConfig(false)
+	kubernetesConfig := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	kubernetesConfigWindowsAgentPool := cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	if kubernetesConfig["--anonymous-auth"] != "false" {
+		t.Fatalf("got unexpected '--anonymous-auth' kubelet config value for EnableSecureKubelet=true: %s",
+			kubernetesConfig["--anonymous-auth"])
+	}
+	if kubernetesConfig["--client-ca-file"] != "/etc/kubernetes/certs/ca.crt" {
+		t.Fatalf("got unexpected '--client-ca-file' kubelet config value for EnableSecureKubelet=true: %s",
+			kubernetesConfig["--client-ca-file"])
+	}
+	if kubernetesConfigWindowsAgentPool["--anonymous-auth"] != "false" {
+		t.Fatalf("got unexpected '--anonymous-auth' kubelet config value for EnableSecureKubelet=true: %s",
+			kubernetesConfig["--anonymous-auth"])
+	}
+	if kubernetesConfigWindowsAgentPool["--client-ca-file"] != "c:\\k\\ca.crt" {
+		t.Fatalf("got unexpected '--client-ca-file' kubelet config value for EnableSecureKubelet=true: %s",
+			kubernetesConfig["--client-ca-file"])
+	}
+}
+
+func TestKubeletMaxPods(t *testing.T) {
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginAzure
+	cs.setKubeletConfig(false)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--max-pods"] != strconv.Itoa(api.DefaultKubernetesMaxPodsVNETIntegrated) {
+		t.Fatalf("got unexpected '--max-pods' kubelet config value for NetworkPolicy=%s: %s",
+			api.NetworkPluginAzure, k["--max-pods"])
+	}
+
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginKubenet
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--max-pods"] != strconv.Itoa(api.DefaultKubernetesMaxPods) {
+		t.Fatalf("got unexpected '--max-pods' kubelet config value for NetworkPolicy=%s: %s",
+			api.NetworkPluginKubenet, k["--max-pods"])
+	}
+
+	// Test that user-overrides for --max-pods work as intended
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginKubenet
+	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--max-pods"] = "99"
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--max-pods"] != "99" {
+		t.Fatalf("got unexpected '--max-pods' kubelet config value for NetworkPolicy=%s: %s",
+			api.NetworkPluginKubenet, k["--max-pods"])
+	}
+
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginAzure
+	cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--max-pods"] = "99"
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--max-pods"] != "99" {
+		t.Fatalf("got unexpected '--max-pods' kubelet config value for NetworkPolicy=%s: %s",
+			api.NetworkPluginKubenet, k["--max-pods"])
+	}
+}
+
+func TestKubeletCalico(t *testing.T) {
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = api.NetworkPolicyCalico
+	cs.setKubeletConfig(false)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--network-plugin"] != "cni" {
+		t.Fatalf("got unexpected '--network-plugin' kubelet config value for NetworkPolicy=%s: %s",
+			api.NetworkPolicyCalico, k["--network-plugin"])
+	}
+}
+
+func TestKubeletHostedMasterIPMasqAgentDisabled(t *testing.T) {
+	subnet := "172.16.0.0/16"
+	// MasterIPMasqAgent disabled, --non-masquerade-cidr should be subnet
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.HostedMasterProfile = &api.HostedMasterProfile{
+		IPMasqAgent: false,
+	}
+	cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = subnet
+	cs.Properties.OrchestratorProfile.KubernetesConfig.Addons = []api.KubernetesAddon{
+		{
+			Name:    common.IPMASQAgentAddonName,
+			Enabled: to.BoolPtr(true),
+		},
+	}
+
+	cs.setKubeletConfig(false)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--non-masquerade-cidr"] != subnet {
+		t.Fatalf("got unexpected '--non-masquerade-cidr' kubelet config value %s, the expected value is %s",
+			k["--non-masquerade-cidr"], subnet)
+	}
+
+	// MasterIPMasqAgent enabled, --non-masquerade-cidr should be 0.0.0.0/0
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.HostedMasterProfile = &api.HostedMasterProfile{
+		IPMasqAgent: true,
+	}
+	cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = subnet
+	cs.Properties.OrchestratorProfile.KubernetesConfig.Addons = []api.KubernetesAddon{
+		{
+			Name:    common.IPMASQAgentAddonName,
+			Enabled: to.BoolPtr(true),
+		},
+	}
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--non-masquerade-cidr"] != api.DefaultNonMasqueradeCIDR {
+		t.Fatalf("got unexpected '--non-masquerade-cidr' kubelet config value %s, the expected value is %s",
+			k["--non-masquerade-cidr"], api.DefaultNonMasqueradeCIDR)
+	}
+
+	// no HostedMasterProfile, --non-masquerade-cidr should be 0.0.0.0/0
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = subnet
+	cs.Properties.OrchestratorProfile.KubernetesConfig.Addons = []api.KubernetesAddon{
+		{
+			Name:    common.IPMASQAgentAddonName,
+			Enabled: to.BoolPtr(true),
+		},
+	}
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--non-masquerade-cidr"] != api.DefaultNonMasqueradeCIDR {
+		t.Fatalf("got unexpected '--non-masquerade-cidr' kubelet config value %s, the expected value is %s",
+			k["--non-masquerade-cidr"], api.DefaultNonMasqueradeCIDR)
+	}
+}
+
+func TestKubeletIPMasqAgentEnabledOrDisabled(t *testing.T) {
+	subnet := "172.16.0.0/16"
+	// MasterIPMasqAgent disabled, --non-masquerade-cidr should be subnet
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	b := false
+	cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{
+		Addons: []api.KubernetesAddon{
+			{
+				Name:    common.IPMASQAgentAddonName,
+				Enabled: &b,
+			},
+		},
+	}
+	cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = subnet
+	cs.setKubeletConfig(false)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--non-masquerade-cidr"] != subnet {
+		t.Fatalf("got unexpected '--non-masquerade-cidr' kubelet config value %s, the expected value is %s",
+			k["--non-masquerade-cidr"], subnet)
+	}
+
+	// MasterIPMasqAgent enabled, --non-masquerade-cidr should be 0.0.0.0/0
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	b = true
+	cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{
+		Addons: []api.KubernetesAddon{
+			{
+				Name:    common.IPMASQAgentAddonName,
+				Enabled: &b,
+			},
+		},
+	}
+	cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = subnet
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--non-masquerade-cidr"] != api.DefaultNonMasqueradeCIDR {
+		t.Fatalf("got unexpected '--non-masquerade-cidr' kubelet config value %s, the expected value is %s",
+			k["--non-masquerade-cidr"], api.DefaultNonMasqueradeCIDR)
+	}
+
+	// No ip-masq-agent addon configuration specified, --non-masquerade-cidr should be 0.0.0.0/0
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--non-masquerade-cidr"] != api.DefaultNonMasqueradeCIDR {
+		t.Fatalf("got unexpected '--non-masquerade-cidr' kubelet config value %s, the expected value is %s",
+			k["--non-masquerade-cidr"], api.DefaultNonMasqueradeCIDR)
+	}
+}
+
+func TestEnforceNodeAllocatable(t *testing.T) {
+	// Validate default
+	cs := CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
+	cs.setKubeletConfig(false)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--enforce-node-allocatable"] != "pods" {
+		t.Fatalf("got unexpected '--enforce-node-allocatable' kubelet config value %s, the expected value is %s",
+			k["--enforce-node-allocatable"], "pods")
+	}
+
+	// Validate that --enforce-node-allocatable is overridable
+	cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{
+		KubeletConfig: map[string]string{
+			"--enforce-node-allocatable": "kube-reserved/system-reserved",
+		},
+	}
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--enforce-node-allocatable"] != "kube-reserved/system-reserved" {
+		t.Fatalf("got unexpected '--enforce-node-allocatable' kubelet config value %s, the expected value is %s",
+			k["--enforce-node-allocatable"], "kube-reserved/system-reserved")
+	}
+}
+
+func TestProtectKernelDefaults(t *testing.T) {
+	// Validate default
+	cs := CreateMockContainerService("testcluster", "1.12.7", 3, 2, false)
+	cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	km := cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
+	if km["--protect-kernel-defaults"] != "true" {
+		t.Fatalf("got unexpected '--protect-kernel-defaults' kubelet config value %s, the expected value is %s",
+			km["--protect-kernel-defaults"], "true")
+	}
+	ka := cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	if ka["--protect-kernel-defaults"] != "true" {
+		t.Fatalf("got unexpected '--protect-kernel-defaults' kubelet config value %s, the expected value is %s",
+			ka["--protect-kernel-defaults"], "true")
+	}
+
+	// Validate that --protect-kernel-defaults is "true" by default for relevant distros
+	for _, distro := range api.DistroValues {
+		switch distro {
+		case api.AKSUbuntu1604, api.AKSUbuntu1804:
+			cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
+			cs.Properties.MasterProfile.Distro = distro
+			cs.Properties.AgentPoolProfiles[0].Distro = distro
+			cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+				IsScale:    false,
+				IsUpgrade:  false,
+				PkiKeySize: helpers.DefaultPkiKeySize,
+			})
+			km = cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
+			if km["--protect-kernel-defaults"] != "true" {
+				t.Fatalf("got unexpected '--protect-kernel-defaults' kubelet config value %s, the expected value is %s",
+					km["--protect-kernel-defaults"], "true")
+			}
+			ka = cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+			if ka["--protect-kernel-defaults"] != "true" {
+				t.Fatalf("got unexpected '--protect-kernel-defaults' kubelet config value %s, the expected value is %s",
+					ka["--protect-kernel-defaults"], "true")
+			}
+
+		// Validate that --protect-kernel-defaults is not enabled for relevant distros
+		case api.Ubuntu, api.Ubuntu1804, api.Ubuntu1804Gen2, api.ACC1604, api.CoreOS:
+			cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
+			cs.Properties.MasterProfile.Distro = distro
+			cs.Properties.AgentPoolProfiles[0].Distro = distro
+			cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+				IsScale:    false,
+				IsUpgrade:  false,
+				PkiKeySize: helpers.DefaultPkiKeySize,
+			})
+			km = cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
+			if _, ok := km["--protect-kernel-defaults"]; ok {
+				t.Fatalf("got unexpected '--protect-kernel-defaults' kubelet config value %s",
+					km["--protect-kernel-defaults"])
+			}
+			ka = cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+			if _, ok := ka["--protect-kernel-defaults"]; ok {
+				t.Fatalf("got unexpected '--protect-kernel-defaults' kubelet config value %s",
+					ka["--protect-kernel-defaults"])
+			}
+		}
+	}
+
+	// Validate that --protect-kernel-defaults is not enabled for Windows
+	cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
+	cs.Properties.MasterProfile.Distro = api.AKSUbuntu1604
+	cs.Properties.AgentPoolProfiles[0].OSType = api.Windows
+	cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	km = cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
+	if km["--protect-kernel-defaults"] != "true" {
+		t.Fatalf("got unexpected '--protect-kernel-defaults' kubelet config value %s, the expected value is %s",
+			km["--protect-kernel-defaults"], "true")
+	}
+	ka = cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	if _, ok := ka["--protect-kernel-defaults"]; ok {
+		t.Fatalf("got unexpected '--protect-kernel-defaults' kubelet config value %s",
+			ka["--protect-kernel-defaults"])
+	}
+
+	// Validate that --protect-kernel-defaults is overridable
+	for _, distro := range api.DistroValues {
+		switch distro {
+		case api.Ubuntu, api.Ubuntu1804, api.Ubuntu1804Gen2, api.AKSUbuntu1604, api.AKSUbuntu1804:
+			cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
+			cs.Properties.MasterProfile.Distro = "ubuntu"
+			cs.Properties.AgentPoolProfiles[0].Distro = "ubuntu"
+			cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{
+				KubeletConfig: map[string]string{
+					"--protect-kernel-defaults": "false",
+				},
+			}
+			cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+				IsScale:    false,
+				IsUpgrade:  false,
+				PkiKeySize: helpers.DefaultPkiKeySize,
+			})
+			km = cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
+			if km["--protect-kernel-defaults"] != "false" {
+				t.Fatalf("got unexpected '--protect-kernel-defaults' kubelet config value %s, the expected value is %s",
+					km["--protect-kernel-defaults"], "false")
+			}
+			ka = cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+			if ka["--protect-kernel-defaults"] != "false" {
+				t.Fatalf("got unexpected '--protect-kernel-defaults' kubelet config value %s, the expected value is %s",
+					ka["--protect-kernel-defaults"], "false")
+			}
+		}
+	}
+}
+
+func TestStaticWindowsConfig(t *testing.T) {
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 1, false)
+	p := GetK8sDefaultProperties(true)
+	cs.Properties = p
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(true)
+
+	// Start with copy of Linux config
+	staticLinuxKubeletConfig := map[string]string{
+		"--address":                     "0.0.0.0",
+		"--allow-privileged":            "true",
+		"--anonymous-auth":              "false",
+		"--authorization-mode":          "Webhook",
+		"--client-ca-file":              "/etc/kubernetes/certs/ca.crt",
+		"--pod-manifest-path":           "/etc/kubernetes/manifests",
+		"--cluster-dns":                 cs.Properties.OrchestratorProfile.KubernetesConfig.DNSServiceIP,
+		"--cgroups-per-qos":             "true",
+		"--kubeconfig":                  "/var/lib/kubelet/kubeconfig",
+		"--keep-terminated-pod-volumes": "false",
+	}
+	expected := make(map[string]string)
+	for key, val := range staticLinuxKubeletConfig {
+		if key != "--pod-manifest-path" {
+			expected[key] = val
+		}
+	}
+
+	// Add Windows-specific overrides
+	// Eventually paths should not be hardcoded here. They should be relative to $global:KubeDir in the PowerShell script
+	expected["--azure-container-registry-config"] = "c:\\k\\azure.json"
+	expected["--pod-infra-container-image"] = "kubletwin/pause"
+	expected["--kubeconfig"] = "c:\\k\\config"
+	expected["--cloud-config"] = "c:\\k\\azure.json"
+	expected["--cgroups-per-qos"] = "false"
+	expected["--enforce-node-allocatable"] = "\"\"\"\""
+	expected["--system-reserved"] = "memory=2Gi"
+	expected["--client-ca-file"] = "c:\\k\\ca.crt"
+	expected["--hairpin-mode"] = "promiscuous-bridge"
+	expected["--image-pull-progress-deadline"] = "20m"
+	expected["--resolv-conf"] = "\"\"\"\""
+	expected["--eviction-hard"] = "\"\"\"\""
+
+	cs.setKubeletConfig(false)
+	for _, profile := range cs.Properties.AgentPoolProfiles {
+		if profile.OSType == api.Windows {
+			for key, val := range expected {
+				if val != profile.KubernetesConfig.KubeletConfig[key] {
+					t.Fatalf("got unexpected '%s' kubelet config value, expected %s, got %s",
+						key, val, profile.KubernetesConfig.KubeletConfig[key])
+				}
+			}
+		}
+	}
+}
+
+func TestKubeletRotateCertificates(t *testing.T) {
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setKubeletConfig(false)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--rotate-certificates"] != "" {
+		t.Fatalf("got unexpected '--rotate-certificates' kubelet config value for k8s version %s: %s",
+			defaultTestClusterVer, k["--rotate-certificates"])
+	}
+
+	// Test 1.14
+	cs = CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(api.Kubernetes, "1.14", "", false, false), 3, 2, false)
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--rotate-certificates"] != "true" {
+		t.Fatalf("got unexpected '--rotate-certificates' kubelet config value for k8s version %s: %s",
+			defaultTestClusterVer, k["--rotate-certificates"])
+	}
+
+	// Test 1.16
+	cs = CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(api.Kubernetes, "1.16", "", false, false), 3, 2, false)
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--rotate-certificates"] != "true" {
+		t.Fatalf("got unexpected '--rotate-certificates' kubelet config value for k8s version %s: %s",
+			defaultTestClusterVer, k["--rotate-certificates"])
+	}
+
+	// Test user-override
+	cs = CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(api.Kubernetes, "1.14", "", false, false), 3, 2, false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	k["--rotate-certificates"] = "false"
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--rotate-certificates"] != "false" {
+		t.Fatalf("got unexpected '--rotate-certificates' kubelet config value despite override value %s: %s",
+			"false", k["--rotate-certificates"])
+	}
+}
+func TestKubeletConfigDefaultFeatureGates(t *testing.T) {
+	// test 1.7
+	cs := CreateMockContainerService("testcluster", "1.7.12", 3, 2, false)
+	cs.setKubeletConfig(false)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--feature-gates"] != "" {
+		t.Fatalf("got unexpected '--feature-gates' kubelet config value for \"--feature-gates\": \"\": %s",
+			k["--feature-gates"])
+	}
+
+	// test 1.14
+	cs = CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(api.Kubernetes, "1.14", "", false, false), 3, 2, false)
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--feature-gates"] != "RotateKubeletServerCertificate=true" {
+		t.Fatalf("got unexpected '--feature-gates' kubelet config value for \"--feature-gates\": \"\": %s",
+			k["--feature-gates"])
+	}
+
+	// test 1.16
+	cs = CreateMockContainerService("testcluster", common.RationalizeReleaseAndVersion(api.Kubernetes, "1.16", "", false, false), 3, 2, false)
+	cs.setKubeletConfig(false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--feature-gates"] != "RotateKubeletServerCertificate=true" {
+		t.Fatalf("got unexpected '--feature-gates' kubelet config value for \"--feature-gates\": \"\": %s",
+			k["--feature-gates"])
+	}
+
+	// test user-overrides
+	cs = CreateMockContainerService("testcluster", "1.14.1", 3, 2, false)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	k["--feature-gates"] = "DynamicKubeletConfig=true"
+	cs.setKubeletConfig(false)
+	if k["--feature-gates"] != "DynamicKubeletConfig=true,RotateKubeletServerCertificate=true" {
+		t.Fatalf("got unexpected '--feature-gates' kubelet config value for \"--feature-gates\": \"\": %s",
+			k["--feature-gates"])
+	}
+}
+
+func TestKubeletStrongCipherSuites(t *testing.T) {
+	// Test allowed versions
+	for _, version := range []string{"1.13.0", "1.14.0"} {
+		cs := CreateMockContainerService("testcluster", version, 3, 2, false)
+		cs.setKubeletConfig(false)
+		k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+		if k["--tls-cipher-suites"] != api.TLSStrongCipherSuitesKubelet {
+			t.Fatalf("got unexpected default value for '--tls-cipher-suites' kubelet config for Kubernetes version %s: %s",
+				version, k["--tls-cipher-suites"])
+		}
+	}
+
+	allSuites := "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_RC4_128_SHA"
+	// Test user-override
+	for _, version := range []string{"1.13.0", "1.14.0"} {
+		cs := CreateMockContainerService("testcluster", version, 3, 2, false)
+		cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig = map[string]string{
+			"--tls-cipher-suites": allSuites,
+		}
+		cs.setKubeletConfig(false)
+		k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+		if k["--tls-cipher-suites"] != allSuites {
+			t.Fatalf("got unexpected default value for '--tls-cipher-suites' API server config for Kubernetes version %s: %s",
+				version, k["--tls-cipher-suites"])
+		}
+	}
+}
+
+func TestSupportPodPidsLimitFeatureGate(t *testing.T) {
+	cases := []struct {
+		name                                   string
+		cs                                     *ContainerService
+		isUpgrade                              bool
+		expectedPodMaxPids                     string
+		expectedSupportPodPidsLimitFeatureGate bool
+	}{
+		{
+			name: "no --pod-max-pids defined",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig:    &api.KubernetesConfig{},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined, no SupportPodPidsLimit defined",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids": "100",
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=false",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--feature-gates": "SupportPodPidsLimit=false",
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=true",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined, SupportPodPidsLimit=false",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "100",
+								"--feature-gates": "SupportPodPidsLimit=false",
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined, SupportPodPidsLimit=true",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "100",
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "no --pod-max-pids defined, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig:    &api.KubernetesConfig{},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids": "100",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=false, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--feature-gates": "SupportPodPidsLimit=false",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined, no SupportPodPidsLimit defined, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids": "-100",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined, SupportPodPidsLimit=false, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "100",
+								"--feature-gates": "SupportPodPidsLimit=false",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "100",
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined as 100a, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "100a",
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			c.cs.setKubeletConfig(c.isUpgrade)
+			podMaxPids := c.cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--pod-max-pids"]
+			if podMaxPids != c.expectedPodMaxPids {
+				t.Fatalf("expected --pod-max-pids be equal to %s, got %s", c.expectedPodMaxPids, podMaxPids)
+			}
+			featureGates := c.cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--feature-gates"]
+			hasSupportPodPidsLimitFeatureGate := strings.Contains(featureGates, "SupportPodPidsLimit=true")
+			if hasSupportPodPidsLimitFeatureGate != c.expectedSupportPodPidsLimitFeatureGate {
+				t.Fatalf("expected SupportPodPidsLimit=true presence in --feature gates to be %t, got %t", c.expectedSupportPodPidsLimitFeatureGate, hasSupportPodPidsLimitFeatureGate)
+			}
+		})
+	}
+
+}
+
+func TestSupportPodPidsLimitFeatureGateInMasterProfile(t *testing.T) {
+	cases := []struct {
+		name                                   string
+		cs                                     *ContainerService
+		isUpgrade                              bool
+		expectedPodMaxPids                     string
+		expectedSupportPodPidsLimitFeatureGate bool
+	}{
+		{
+			name: "no --pod-max-pids defined",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined, no SupportPodPidsLimit defined",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids": "100",
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=false",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--feature-gates": "SupportPodPidsLimit=false",
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=true",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined, SupportPodPidsLimit=false",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "100",
+								"--feature-gates": "SupportPodPidsLimit=false",
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined, SupportPodPidsLimit=true",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "100",
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "no --pod-max-pids defined, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=false, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--feature-gates": "SupportPodPidsLimit=false",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined as 100, no SupportPodPidsLimit defined, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids": "100",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined as -100, no SupportPodPidsLimit defined, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids": "-100",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined, SupportPodPidsLimit=false, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "100",
+								"--feature-gates": "SupportPodPidsLimit=false",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined as 100, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "100",
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined as 0, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "0",
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined as -1, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "-1",
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined as 100a, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--pod-max-pids":  "100a",
+								"--feature-gates": "SupportPodPidsLimit=true",
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			c.cs.setKubeletConfig(c.isUpgrade)
+			podMaxPids := c.cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--pod-max-pids"]
+			if podMaxPids != c.expectedPodMaxPids {
+				t.Fatalf("expected --pod-max-pids be equal to %s, got %s", c.expectedPodMaxPids, podMaxPids)
+			}
+			featureGates := c.cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--feature-gates"]
+			hasSupportPodPidsLimitFeatureGate := strings.Contains(featureGates, "SupportPodPidsLimit=true")
+			if hasSupportPodPidsLimitFeatureGate != c.expectedSupportPodPidsLimitFeatureGate {
+				t.Fatalf("expected SupportPodPidsLimit=true presence in --feature gates to be %t, got %t", c.expectedSupportPodPidsLimitFeatureGate, hasSupportPodPidsLimitFeatureGate)
+			}
+		})
+	}
+
+}
+
+func TestSupportPodPidsLimitFeatureGateInAgentPool(t *testing.T) {
+	cases := []struct {
+		name                                   string
+		cs                                     *ContainerService
+		isUpgrade                              bool
+		expectedPodMaxPids                     string
+		expectedSupportPodPidsLimitFeatureGate bool
+	}{
+		{
+			name: "no --pod-max-pids defined",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{},
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined, no SupportPodPidsLimit defined",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--pod-max-pids": "100",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=false",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--feature-gates": "SupportPodPidsLimit=false",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=true",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--feature-gates": "SupportPodPidsLimit=true",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined, SupportPodPidsLimit=false",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--pod-max-pids":  "100",
+									"--feature-gates": "SupportPodPidsLimit=false",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined, SupportPodPidsLimit=true",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--pod-max-pids":  "100",
+									"--feature-gates": "SupportPodPidsLimit=true",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "no --pod-max-pids defined, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=false, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--feature-gates": "SupportPodPidsLimit=false",
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "no --pod-max-pids defined, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--feature-gates": "SupportPodPidsLimit=true",
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined as 100, no SupportPodPidsLimit defined, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--pod-max-pids": "100",
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined as -100, no SupportPodPidsLimit defined, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--pod-max-pids": "-100",
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined, SupportPodPidsLimit=false, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--pod-max-pids":  "100",
+									"--feature-gates": "SupportPodPidsLimit=false",
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: false,
+		},
+		{
+			name: "--pod-max-pids defined as 100, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--pod-max-pids":  "100",
+									"--feature-gates": "SupportPodPidsLimit=true",
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "100",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined as 0, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--feature-gates": "SupportPodPidsLimit=true",
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined as -1, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--pod-max-pids":  "-1",
+									"--feature-gates": "SupportPodPidsLimit=true",
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+		{
+			name: "--pod-max-pids defined as 100a, SupportPodPidsLimit=true, upgrade scenario",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--pod-max-pids":  "100a",
+									"--feature-gates": "SupportPodPidsLimit=true",
+								},
+							},
+						},
+					},
+				},
+			},
+			isUpgrade:                              true,
+			expectedPodMaxPids:                     "-1",
+			expectedSupportPodPidsLimitFeatureGate: true,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			c.cs.setKubeletConfig(c.isUpgrade)
+			podMaxPids := c.cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig["--pod-max-pids"]
+			if podMaxPids != c.expectedPodMaxPids {
+				t.Fatalf("expected --pod-max-pids be equal to %s, got %s", c.expectedPodMaxPids, podMaxPids)
+			}
+			featureGates := c.cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig["--feature-gates"]
+			hasSupportPodPidsLimitFeatureGate := strings.Contains(featureGates, "SupportPodPidsLimit=true")
+			if hasSupportPodPidsLimitFeatureGate != c.expectedSupportPodPidsLimitFeatureGate {
+				t.Fatalf("expected SupportPodPidsLimit=true presence in --feature gates to be %t, got %t", c.expectedSupportPodPidsLimitFeatureGate, hasSupportPodPidsLimitFeatureGate)
+			}
+		})
+	}
+
+}
+func TestReadOnlyPort(t *testing.T) {
+	cases := []struct {
+		name                 string
+		cs                   *ContainerService
+		expectedReadOnlyPort string
+	}{
+		{
+			name: "default pre-1.16",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.0",
+						KubernetesConfig:    &api.KubernetesConfig{},
+					},
+				},
+			},
+			expectedReadOnlyPort: "",
+		},
+		{
+			name: "default 1.16",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.16.0",
+						KubernetesConfig:    &api.KubernetesConfig{},
+					},
+				},
+			},
+			expectedReadOnlyPort: "0",
+		},
+		{
+			name: "AKS 1.16",
+			cs: &ContainerService{
+				Properties: &api.Properties{
+					HostedMasterProfile: &api.HostedMasterProfile{
+						FQDN: "foo",
+					},
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.16.0",
+						KubernetesConfig:    &api.KubernetesConfig{},
+					},
+				},
+			},
+			expectedReadOnlyPort: "",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			c.cs.setKubeletConfig(false)
+			readOnlyPort := c.cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig["--read-only-port"]
+			if readOnlyPort != c.expectedReadOnlyPort {
+				t.Fatalf("expected --read-only-port be equal to %s, got %s", c.expectedReadOnlyPort, readOnlyPort)
+			}
+		})
+	}
+}

--- a/pkg/agent/datamodel/defaults-scheduler.go
+++ b/pkg/agent/datamodel/defaults-scheduler.go
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import "github.com/Azure/aks-engine/pkg/api"
+
+// staticSchedulerConfig is not user-overridable
+var staticSchedulerConfig = map[string]string{
+	"--kubeconfig":   "/var/lib/kubelet/kubeconfig",
+	"--leader-elect": "true",
+}
+
+// defaultSchedulerConfig provides targeted defaults, but is user-overridable
+var defaultSchedulerConfig = map[string]string{
+	"--v":         "2",
+	"--profiling": api.DefaultKubernetesSchedulerEnableProfiling,
+}
+
+func (cs *ContainerService) setSchedulerConfig() {
+	o := cs.Properties.OrchestratorProfile
+
+	// If no user-configurable scheduler config values exists, make an empty map, and fill in with defaults
+	if o.KubernetesConfig.SchedulerConfig == nil {
+		o.KubernetesConfig.SchedulerConfig = make(map[string]string)
+	}
+
+	for key, val := range defaultSchedulerConfig {
+		// If we don't have a user-configurable scheduler config for each option
+		if _, ok := o.KubernetesConfig.SchedulerConfig[key]; !ok {
+			// then assign the default value
+			o.KubernetesConfig.SchedulerConfig[key] = val
+		}
+	}
+
+	// We don't support user-configurable values for the following,
+	// so any of the value assignments below will override user-provided values
+	for key, val := range staticSchedulerConfig {
+		o.KubernetesConfig.SchedulerConfig[key] = val
+	}
+}

--- a/pkg/agent/datamodel/defaults-scheduler_test.go
+++ b/pkg/agent/datamodel/defaults-scheduler_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"github.com/Azure/aks-engine/pkg/api"
+	"testing"
+)
+
+func TestSchedulerDefaultConfig(t *testing.T) {
+	cs := CreateMockContainerService("testcluster", "1.9.6", 3, 2, false)
+	cs.setSchedulerConfig()
+	s := cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig
+	for key, val := range staticSchedulerConfig {
+		if val != s[key] {
+			t.Fatalf("got unexpected kube-scheduler static config value for %s. Expected %s, got %s",
+				key, val, s[key])
+		}
+	}
+	for key, val := range defaultSchedulerConfig {
+		if val != s[key] {
+			t.Fatalf("got unexpected kube-scheduler default config value for %s. Expected %s, got %s",
+				key, val, s[key])
+		}
+	}
+}
+
+func TestSchedulerUserConfig(t *testing.T) {
+	cs := CreateMockContainerService("testcluster", "1.9.6", 3, 2, true)
+	assignmentMap := map[string]string{
+		"--scheduler-name": "my-custom-name",
+		"--feature-gates":  "APIListChunking=true,APIResponseCompression=true,Accelerators=true,AdvancedAuditing=true",
+	}
+	cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig = assignmentMap
+	cs.setSchedulerConfig()
+	for key, val := range assignmentMap {
+		if val != cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig[key] {
+			t.Fatalf("got unexpected kube-scheduler config value for %s. Expected %s, got %s",
+				key, val, cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig[key])
+		}
+	}
+}
+
+func TestSchedulerStaticConfig(t *testing.T) {
+	cs := CreateMockContainerService("testcluster", "1.9.6", 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig = map[string]string{
+		"--kubeconfig":   "user-override",
+		"--leader-elect": "user-override",
+		"--profiling":    "user-override",
+	}
+	cs.setSchedulerConfig()
+	for key, val := range staticSchedulerConfig {
+		if val != cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig[key] {
+			t.Fatalf("kube-scheduler static config did not override user values for %s. Expected %s, got %s",
+				key, val, cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig)
+		}
+	}
+}
+
+func TestSchedulerConfigEnableProfiling(t *testing.T) {
+	// Test
+	// "schedulerConfig": {
+	// 	"--profiling": "true"
+	// },
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig = map[string]string{
+		"--profiling": "true",
+	}
+	cs.setSchedulerConfig()
+	s := cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig
+	if s["--profiling"] != "true" {
+		t.Fatalf("got unexpected '--profiling' Scheduler config value for \"--profiling\": \"true\": %s",
+			s["--profiling"])
+	}
+
+	// Test default
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setSchedulerConfig()
+	s = cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig
+	if s["--profiling"] != api.DefaultKubernetesSchedulerEnableProfiling {
+		t.Fatalf("got unexpected default value for '--profiling' Scheduler config: %s",
+			s["--profiling"])
+	}
+}

--- a/pkg/agent/datamodel/defaults.go
+++ b/pkg/agent/datamodel/defaults.go
@@ -1,0 +1,1086 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/aks-engine/pkg/api/common"
+	"github.com/Azure/aks-engine/pkg/helpers"
+	"github.com/blang/semver"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// SetPropertiesDefaults for the container Properties, returns true if certs are generated
+func (cs *ContainerService) SetPropertiesDefaults(params api.PropertiesDefaultsParams) (bool, error) {
+	// Set custom cloud profile defaults if this cluster configuration has custom cloud profile
+	if cs.Properties.CustomCloudProfile != nil {
+		err := cs.setCustomCloudProfileDefaults(api.CustomCloudProfileDefaultsParams{
+			IsUpgrade: params.IsUpgrade,
+			IsScale:   params.IsScale,
+		})
+		if err != nil {
+			return false, err
+		}
+	}
+
+	// Set master profile defaults if this cluster configuration includes master node(s)
+	if cs.Properties.MasterProfile != nil {
+		cs.setMasterProfileDefaults(params.IsUpgrade)
+	}
+
+	// move load balancer sku defaults logic from setOrchestratorDefaults() to here to serve LB checking at setAgentProfileDefaults()
+	cs.setLoadBalancerSkuDefaults()
+
+	cs.setAgentProfileDefaults(params.IsUpgrade, params.IsScale)
+
+	cs.setStorageDefaults()
+	cs.setOrchestratorDefaults(params.IsUpgrade, params.IsScale)
+	cs.setExtensionDefaults()
+
+	// Set hosted master profile defaults if this cluster configuration has a hosted control plane
+	if cs.Properties.HostedMasterProfile != nil {
+		cs.setHostedMasterProfileDefaults()
+	}
+
+	if cs.Properties.WindowsProfile != nil {
+		cs.setWindowsProfileDefaults(params.IsUpgrade, params.IsScale)
+	}
+
+	cs.setTelemetryProfileDefaults()
+
+	certsGenerated, _, e := cs.SetDefaultCerts(api.DefaultCertParams{
+		PkiKeySize: params.PkiKeySize,
+	})
+	if e != nil {
+		return false, e
+	}
+	return certsGenerated, nil
+}
+
+// setOrchestratorDefaults for orchestrators
+func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
+	isUpdate := isUpgrade || isScale
+	a := cs.Properties
+
+	cloudSpecConfig := cs.GetCloudSpecConfig()
+	if a.OrchestratorProfile == nil {
+		return
+	}
+	o := a.OrchestratorProfile
+	if o.OrchestratorVersion == "" {
+		o.OrchestratorVersion = common.GetValidPatchVersion(
+			o.OrchestratorType,
+			o.OrchestratorVersion, isUpdate, a.HasWindows())
+	}
+
+	switch o.OrchestratorType {
+	case api.Kubernetes:
+		if o.KubernetesConfig == nil {
+			o.KubernetesConfig = &api.KubernetesConfig{}
+		}
+		// For backwards compatibility with original, overloaded "NetworkPolicy" config vector
+		// we translate deprecated NetworkPolicy usage to the NetworkConfig equivalent
+		// and set a default network policy enforcement configuration
+		switch o.KubernetesConfig.NetworkPolicy {
+		case api.NetworkPolicyAzure:
+			if o.KubernetesConfig.NetworkPlugin == "" {
+				o.KubernetesConfig.NetworkPlugin = api.NetworkPluginAzure
+				o.KubernetesConfig.NetworkPolicy = api.DefaultNetworkPolicy
+			}
+		case api.NetworkPolicyNone:
+			o.KubernetesConfig.NetworkPlugin = api.NetworkPluginKubenet
+			o.KubernetesConfig.NetworkPolicy = api.DefaultNetworkPolicy
+		case api.NetworkPolicyCalico:
+			if o.KubernetesConfig.NetworkPlugin == "" {
+				// If not specified, then set the network plugin to be kubenet
+				// for backwards compatibility. Otherwise, use what is specified.
+				o.KubernetesConfig.NetworkPlugin = api.NetworkPluginKubenet
+			}
+		case api.NetworkPolicyCilium:
+			o.KubernetesConfig.NetworkPlugin = api.NetworkPluginCilium
+		case api.NetworkPolicyAntrea:
+			o.KubernetesConfig.NetworkPlugin = api.NetworkPluginAntrea
+		}
+
+		if o.KubernetesConfig.KubernetesImageBase == "" {
+			o.KubernetesConfig.KubernetesImageBase = cloudSpecConfig.KubernetesSpecConfig.KubernetesImageBase
+		}
+
+		if o.KubernetesConfig.MCRKubernetesImageBase == "" {
+			o.KubernetesConfig.MCRKubernetesImageBase = cloudSpecConfig.KubernetesSpecConfig.MCRKubernetesImageBase
+		}
+
+		if o.KubernetesConfig.EtcdVersion == "" {
+			o.KubernetesConfig.EtcdVersion = api.DefaultEtcdVersion
+		} else if isUpgrade {
+			if o.KubernetesConfig.EtcdVersion != api.DefaultEtcdVersion {
+				// Override (i.e., upgrade) the etcd version if the default is newer in an upgrade scenario
+				if common.GetMinVersion([]string{o.KubernetesConfig.EtcdVersion, api.DefaultEtcdVersion}, true) == o.KubernetesConfig.EtcdVersion {
+					log.Warnf("etcd will be upgraded to version %s\n", api.DefaultEtcdVersion)
+					o.KubernetesConfig.EtcdVersion = api.DefaultEtcdVersion
+				}
+			}
+
+		}
+
+		if a.HasWindows() {
+			if o.KubernetesConfig.NetworkPlugin == "" {
+				o.KubernetesConfig.NetworkPlugin = api.DefaultNetworkPluginWindows
+			}
+		} else {
+			if o.KubernetesConfig.NetworkPlugin == "" {
+				if o.KubernetesConfig.IsAddonEnabled(common.FlannelAddonName) {
+					o.KubernetesConfig.NetworkPlugin = api.NetworkPluginFlannel
+				} else {
+					o.KubernetesConfig.NetworkPlugin = api.DefaultNetworkPlugin
+				}
+			}
+		}
+		if o.KubernetesConfig.ContainerRuntime == "" {
+			o.KubernetesConfig.ContainerRuntime = api.DefaultContainerRuntime
+		}
+		switch o.KubernetesConfig.ContainerRuntime {
+		case api.Docker:
+			if o.KubernetesConfig.MobyVersion == "" || isUpdate {
+				if o.KubernetesConfig.MobyVersion != api.DefaultMobyVersion {
+					if isUpgrade {
+						log.Warnf("Moby will be upgraded to version %s\n", api.DefaultMobyVersion)
+					} else if isScale {
+						log.Warnf("Any new nodes will have Moby version %s\n", api.DefaultMobyVersion)
+					}
+				}
+				o.KubernetesConfig.MobyVersion = api.DefaultMobyVersion
+			}
+		case api.Containerd, api.KataContainers:
+			if o.KubernetesConfig.ContainerdVersion == "" || isUpdate {
+				if o.KubernetesConfig.ContainerdVersion != api.DefaultContainerdVersion {
+					if isUpgrade {
+						log.Warnf("containerd will be upgraded to version %s\n", api.DefaultContainerdVersion)
+					} else if isScale {
+						log.Warnf("Any new nodes will have containerd version %s\n", api.DefaultContainerdVersion)
+					}
+				}
+				o.KubernetesConfig.ContainerdVersion = api.DefaultContainerdVersion
+			}
+		}
+		if o.KubernetesConfig.ClusterSubnet == "" {
+			if o.IsAzureCNI() {
+				// When Azure CNI is enabled, all masters, agents and pods share the same large subnet.
+				// Except when master is VMSS, then masters and agents have separate subnets within the same large subnet.
+				o.KubernetesConfig.ClusterSubnet = api.DefaultKubernetesSubnet
+			} else {
+				o.KubernetesConfig.ClusterSubnet = api.DefaultKubernetesClusterSubnet
+				// ipv6 only cluster
+				if cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6Only") {
+					o.KubernetesConfig.ClusterSubnet = api.DefaultKubernetesClusterSubnetIPv6
+				}
+				// ipv4 and ipv6 subnet for dual stack
+				if cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6DualStack") {
+					o.KubernetesConfig.ClusterSubnet = strings.Join([]string{api.DefaultKubernetesClusterSubnet, cs.getDefaultKubernetesClusterSubnetIPv6()}, ",")
+				}
+			}
+		} else {
+			// ensure 2 subnets exists if ipv6 dual stack feature is enabled
+			if cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6DualStack") && !o.IsAzureCNI() {
+				clusterSubnets := strings.Split(o.KubernetesConfig.ClusterSubnet, ",")
+				if len(clusterSubnets) == 1 {
+					// if error exists, then it'll be caught by validate
+					ip, _, err := net.ParseCIDR(clusterSubnets[0])
+					if err == nil {
+						if ip.To4() != nil {
+							// the first cidr block is ipv4, so append ipv6
+							clusterSubnets = append(clusterSubnets, cs.getDefaultKubernetesClusterSubnetIPv6())
+						} else {
+							// first cidr has to be ipv4
+							clusterSubnets = append([]string{api.DefaultKubernetesClusterSubnet}, clusterSubnets...)
+						}
+						// only set the cluster subnet if no error has been encountered
+						o.KubernetesConfig.ClusterSubnet = strings.Join(clusterSubnets, ",")
+					}
+				}
+			}
+		}
+		if o.KubernetesConfig.GCHighThreshold == 0 {
+			o.KubernetesConfig.GCHighThreshold = api.DefaultKubernetesGCHighThreshold
+		}
+		if o.KubernetesConfig.GCLowThreshold == 0 {
+			o.KubernetesConfig.GCLowThreshold = api.DefaultKubernetesGCLowThreshold
+		}
+		if o.KubernetesConfig.DNSServiceIP == "" {
+			o.KubernetesConfig.DNSServiceIP = api.DefaultKubernetesDNSServiceIP
+			if cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6Only") {
+				o.KubernetesConfig.DNSServiceIP = api.DefaultKubernetesDNSServiceIPv6
+			}
+		}
+		if o.KubernetesConfig.DockerBridgeSubnet == "" {
+			o.KubernetesConfig.DockerBridgeSubnet = api.DefaultDockerBridgeSubnet
+		}
+		if o.KubernetesConfig.ServiceCIDR == "" {
+			o.KubernetesConfig.ServiceCIDR = api.DefaultKubernetesServiceCIDR
+			if cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6Only") {
+				o.KubernetesConfig.ServiceCIDR = api.DefaultKubernetesServiceCIDRIPv6
+			}
+		}
+
+		if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.14.0") {
+			o.KubernetesConfig.CloudProviderBackoffMode = api.CloudProviderBackoffModeV2
+			if o.KubernetesConfig.CloudProviderBackoff == nil {
+				o.KubernetesConfig.CloudProviderBackoff = to.BoolPtr(true)
+			}
+		} else {
+			o.KubernetesConfig.CloudProviderBackoffMode = "v1"
+			if o.KubernetesConfig.CloudProviderBackoff == nil {
+				o.KubernetesConfig.CloudProviderBackoff = to.BoolPtr(false)
+			}
+		}
+
+		// Enforce sane cloudprovider backoff defaults.
+		o.KubernetesConfig.SetCloudProviderBackoffDefaults()
+
+		if o.KubernetesConfig.CloudProviderRateLimit == nil {
+			o.KubernetesConfig.CloudProviderRateLimit = to.BoolPtr(api.DefaultKubernetesCloudProviderRateLimit)
+		}
+		// Enforce sane cloudprovider rate limit defaults.
+		a.SetCloudProviderRateLimitDefaults()
+
+		if o.KubernetesConfig.PrivateCluster == nil {
+			o.KubernetesConfig.PrivateCluster = &api.PrivateCluster{}
+		}
+
+		if o.KubernetesConfig.PrivateCluster.Enabled == nil {
+			o.KubernetesConfig.PrivateCluster.Enabled = to.BoolPtr(api.DefaultPrivateClusterEnabled)
+		}
+
+		if o.KubernetesConfig.PrivateCluster.EnableHostsConfigAgent == nil {
+			o.KubernetesConfig.PrivateCluster.EnableHostsConfigAgent = to.BoolPtr(api.DefaultPrivateClusterHostsConfigAgentEnabled)
+		}
+
+		if "" == a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB {
+			switch {
+			case a.TotalNodes() > 20:
+				if a.IsAzureStackCloud() {
+					// Currently on Azure Stack max size of managed disk size is 1023GB.
+					a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = api.MaxAzureStackManagedDiskSize
+				} else {
+					a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = api.DefaultEtcdDiskSizeGT20Nodes
+				}
+			case a.TotalNodes() > 10:
+				if a.IsAzureStackCloud() {
+					// Currently on Azure Stack max size of managed disk size is 1023GB.
+					a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = api.MaxAzureStackManagedDiskSize
+				} else {
+					a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = api.DefaultEtcdDiskSizeGT10Nodes
+				}
+			case a.TotalNodes() > 3:
+				a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = api.DefaultEtcdDiskSizeGT3Nodes
+			default:
+				a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = api.DefaultEtcdDiskSize
+			}
+		}
+
+		if to.Bool(o.KubernetesConfig.EnableDataEncryptionAtRest) {
+			if "" == a.OrchestratorProfile.KubernetesConfig.EtcdEncryptionKey {
+				a.OrchestratorProfile.KubernetesConfig.EtcdEncryptionKey = generateEtcdEncryptionKey()
+			}
+		}
+
+		if a.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision() && a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB == 0 {
+			a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB = api.DefaultJumpboxDiskSize
+		}
+
+		if a.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision() && a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Username == "" {
+			a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Username = api.DefaultJumpboxUsername
+		}
+
+		if a.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision() && a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.StorageProfile == "" {
+			a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.StorageProfile = api.ManagedDisks
+		}
+
+		if a.OrchestratorProfile.KubernetesConfig.EnableRbac == nil {
+			a.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(api.DefaultRBACEnabled)
+		}
+
+		// Upgrade scenario:
+		// We need to force set EnableRbac to true for upgrades to 1.15.0 and greater if it was previously set to false (AKS Engine only)
+		if !a.OrchestratorProfile.KubernetesConfig.IsRBACEnabled() && common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.15.0") && isUpgrade && !cs.Properties.IsHostedMasterProfile() {
+			log.Warnf("RBAC will be enabled during upgrade to version %s\n", o.OrchestratorVersion)
+			a.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(true)
+		}
+
+		if a.OrchestratorProfile.KubernetesConfig.IsRBACEnabled() {
+			a.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs = true
+		} else if isUpdate && a.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs {
+			// Upgrade scenario:
+			// We need to force set EnableAggregatedAPIs to false if RBAC was previously disabled
+			a.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs = false
+		}
+
+		if a.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet == nil {
+			a.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = to.BoolPtr(api.DefaultSecureKubeletEnabled)
+		}
+
+		if a.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata == nil {
+			if a.IsAzureStackCloud() {
+				a.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata = to.BoolPtr(api.DefaultAzureStackUseInstanceMetadata)
+			} else {
+				a.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata = to.BoolPtr(api.DefaultUseInstanceMetadata)
+			}
+		}
+
+		if a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == api.StandardLoadBalancerSku && a.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB == nil {
+			a.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB = to.BoolPtr(api.DefaultExcludeMasterFromStandardLB)
+		}
+
+		if a.OrchestratorProfile.IsAzureCNI() {
+			if a.HasWindows() {
+				a.OrchestratorProfile.KubernetesConfig.AzureCNIVersion = api.AzureCniPluginVerWindows
+			} else {
+				a.OrchestratorProfile.KubernetesConfig.AzureCNIVersion = api.AzureCniPluginVerLinux
+			}
+		}
+
+		if a.OrchestratorProfile.KubernetesConfig.MaximumLoadBalancerRuleCount == 0 {
+			a.OrchestratorProfile.KubernetesConfig.MaximumLoadBalancerRuleCount = api.DefaultMaximumLoadBalancerRuleCount
+		}
+		if a.OrchestratorProfile.KubernetesConfig.ProxyMode == "" {
+			a.OrchestratorProfile.KubernetesConfig.ProxyMode = api.DefaultKubeProxyMode
+		}
+		if a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == api.StandardLoadBalancerSku &&
+			a.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes == 0 {
+			a.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes = api.DefaultOutboundRuleIdleTimeoutInMinutes
+		}
+
+		if o.KubernetesConfig.LoadBalancerSku == api.StandardLoadBalancerSku {
+			if o.KubernetesConfig.CloudProviderDisableOutboundSNAT == nil {
+				o.KubernetesConfig.CloudProviderDisableOutboundSNAT = to.BoolPtr(false)
+			}
+		} else {
+			// CloudProviderDisableOutboundSNAT is only valid in the context of Standard LB, statically set to false if not Standard LB
+			o.KubernetesConfig.CloudProviderDisableOutboundSNAT = to.BoolPtr(false)
+		}
+
+		if o.KubernetesConfig.ContainerRuntimeConfig == nil {
+			o.KubernetesConfig.ContainerRuntimeConfig = make(map[string]string)
+		}
+
+		// Master-specific defaults that depend upon OrchestratorProfile defaults
+		if cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == api.StandardLoadBalancerSku {
+			cs.Properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB = to.BoolPtr(api.DefaultExcludeMasterFromStandardLB)
+		}
+		if cs.Properties.MasterProfile != nil {
+			if !cs.Properties.MasterProfile.IsCustomVNET() {
+				if cs.Properties.OrchestratorProfile.IsAzureCNI() {
+					// When VNET integration is enabled, all masters, agents and pods share the same large subnet.
+					cs.Properties.MasterProfile.Subnet = cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet
+					// FirstConsecutiveStaticIP is not reset if it is upgrade and some value already exists
+					if !isUpgrade || len(cs.Properties.MasterProfile.FirstConsecutiveStaticIP) == 0 {
+						if cs.Properties.MasterProfile.IsVirtualMachineScaleSets() {
+							cs.Properties.MasterProfile.FirstConsecutiveStaticIP = api.DefaultFirstConsecutiveKubernetesStaticIPVMSS
+							cs.Properties.MasterProfile.Subnet = api.DefaultKubernetesMasterSubnet
+							cs.Properties.MasterProfile.AgentSubnet = api.DefaultKubernetesAgentSubnetVMSS
+						} else {
+							cs.Properties.MasterProfile.FirstConsecutiveStaticIP = cs.Properties.MasterProfile.GetFirstConsecutiveStaticIPAddress(cs.Properties.MasterProfile.Subnet)
+						}
+					}
+				} else {
+					cs.Properties.MasterProfile.Subnet = api.DefaultKubernetesMasterSubnet
+					cs.Properties.MasterProfile.SubnetIPv6 = api.DefaultKubernetesMasterSubnetIPv6
+					// FirstConsecutiveStaticIP is not reset if it is upgrade and some value already exists
+					if !isUpgrade || len(cs.Properties.MasterProfile.FirstConsecutiveStaticIP) == 0 {
+						if cs.Properties.MasterProfile.IsVirtualMachineScaleSets() {
+							cs.Properties.MasterProfile.FirstConsecutiveStaticIP = api.DefaultFirstConsecutiveKubernetesStaticIPVMSS
+							cs.Properties.MasterProfile.AgentSubnet = api.DefaultKubernetesAgentSubnetVMSS
+						} else {
+							cs.Properties.MasterProfile.FirstConsecutiveStaticIP = api.DefaultFirstConsecutiveKubernetesStaticIP
+						}
+					}
+				}
+			}
+
+			// Distro assignment for masterProfile
+			if cs.Properties.MasterProfile.Distro == "" && cs.Properties.MasterProfile.ImageRef == nil {
+				if cs.Properties.OrchestratorProfile.IsKubernetes() && cs.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage == "" {
+					cs.Properties.MasterProfile.Distro = api.AKSUbuntu1604
+				} else {
+					cs.Properties.MasterProfile.Distro = api.Ubuntu
+				}
+			} else if cs.Properties.OrchestratorProfile.IsKubernetes() && (isUpgrade || isScale) {
+				if cs.Properties.MasterProfile.Distro == api.AKSDockerEngine || cs.Properties.MasterProfile.Distro == api.AKS1604Deprecated {
+					cs.Properties.MasterProfile.Distro = api.AKSUbuntu1604
+				} else if cs.Properties.MasterProfile.Distro == api.AKS1804Deprecated {
+					cs.Properties.MasterProfile.Distro = api.AKSUbuntu1804
+				}
+			}
+			// The AKS Distro is not available in Azure German Cloud.
+			if cloudSpecConfig.CloudName == api.AzureGermanCloud {
+				cs.Properties.MasterProfile.Distro = api.Ubuntu
+			}
+		}
+
+		// Pool-specific defaults that depend upon OrchestratorProfile defaults
+		for _, profile := range cs.Properties.AgentPoolProfiles {
+			if cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == api.StandardLoadBalancerSku {
+				cs.Properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB = to.BoolPtr(api.DefaultExcludeMasterFromStandardLB)
+			}
+			// configure the subnets if not in custom VNET
+			if cs.Properties.MasterProfile != nil && !cs.Properties.MasterProfile.IsCustomVNET() {
+				subnetCounter := 0
+				for _, profile := range cs.Properties.AgentPoolProfiles {
+					if !cs.Properties.MasterProfile.IsVirtualMachineScaleSets() {
+						profile.Subnet = cs.Properties.MasterProfile.Subnet
+					}
+					if cs.Properties.OrchestratorProfile.OrchestratorType == api.Kubernetes {
+						if !cs.Properties.MasterProfile.IsVirtualMachineScaleSets() {
+							profile.Subnet = cs.Properties.MasterProfile.Subnet
+						}
+					} else {
+						profile.Subnet = fmt.Sprintf(api.DefaultAgentSubnetTemplate, subnetCounter)
+					}
+					subnetCounter++
+				}
+			}
+			// Distro assignment for pools
+			if profile.OSType != api.Windows {
+				if profile.Distro == "" && profile.ImageRef == nil {
+					if cs.Properties.OrchestratorProfile.IsKubernetes() && cs.Properties.OrchestratorProfile.KubernetesConfig != nil && cs.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage == "" {
+						if profile.OSDiskSizeGB != 0 && profile.OSDiskSizeGB < api.VHDDiskSizeAKS {
+							profile.Distro = api.Ubuntu
+						} else {
+							profile.Distro = api.AKSUbuntu1604
+						}
+					} else {
+						profile.Distro = api.Ubuntu
+					}
+					// Ensure deprecated distros are overridden
+					// Previous versions of aks-engine required the docker-engine distro for N series vms,
+					// so we need to hard override it in order to produce a working cluster in upgrade/scale contexts.
+				} else if cs.Properties.OrchestratorProfile.IsKubernetes() && (isUpgrade || isScale) {
+					if profile.Distro == api.AKSDockerEngine || profile.Distro == api.AKS1604Deprecated {
+						profile.Distro = api.AKSUbuntu1604
+					} else if profile.Distro == api.AKS1804Deprecated {
+						profile.Distro = api.AKSUbuntu1804
+					}
+				}
+				// The AKS Distro is not available in Azure German Cloud.
+				if cloudSpecConfig.CloudName == api.AzureGermanCloud {
+					profile.Distro = api.Ubuntu
+				}
+			}
+		}
+
+		// Configure kubelet
+		cs.setKubeletConfig(isUpgrade)
+
+		// Configure addons
+		cs.setAddonsConfig(isUpgrade)
+
+		// Master-specific defaults that depend upon kubelet defaults
+		// Set the default number of IP addresses allocated for masters.
+		if cs.Properties.MasterProfile != nil {
+			if cs.Properties.MasterProfile.IPAddressCount == 0 {
+				// Allocate one IP address for the node.
+				cs.Properties.MasterProfile.IPAddressCount = 1
+				// Allocate IP addresses for pods if VNET integration is enabled.
+				if cs.Properties.OrchestratorProfile.IsAzureCNI() {
+					masterMaxPods, _ := strconv.Atoi(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig["--max-pods"])
+					cs.Properties.MasterProfile.IPAddressCount += masterMaxPods
+				}
+			}
+		}
+		// Pool-specific defaults that depend upon kubelet defaults
+		for _, profile := range cs.Properties.AgentPoolProfiles {
+			// Set the default number of IP addresses allocated for agents.
+			if profile.IPAddressCount == 0 {
+				// Allocate one IP address for the node.
+				profile.IPAddressCount = 1
+				// Allocate IP addresses for pods if VNET integration is enabled.
+				if cs.Properties.OrchestratorProfile.IsAzureCNI() {
+					agentPoolMaxPods, _ := strconv.Atoi(profile.KubernetesConfig.KubeletConfig["--max-pods"])
+					profile.IPAddressCount += agentPoolMaxPods
+				}
+			}
+		}
+
+		// Configure controller-manager
+		cs.setControllerManagerConfig()
+		// Configure cloud-controller-manager
+		cs.setCloudControllerManagerConfig()
+		// Configure apiserver
+		cs.setAPIServerConfig()
+		// Configure scheduler
+		cs.setSchedulerConfig()
+
+	case api.DCOS:
+		if o.DcosConfig == nil {
+			o.DcosConfig = &api.DcosConfig{}
+		}
+		dcosSemVer, _ := semver.Make(o.OrchestratorVersion)
+		dcosBootstrapSemVer, _ := semver.Make(common.DCOSVersion1Dot11Dot0)
+		if !dcosSemVer.LT(dcosBootstrapSemVer) {
+			if o.DcosConfig.BootstrapProfile == nil {
+				o.DcosConfig.BootstrapProfile = &api.BootstrapProfile{}
+			}
+			if len(o.DcosConfig.BootstrapProfile.VMSize) == 0 {
+				o.DcosConfig.BootstrapProfile.VMSize = "Standard_D2s_v3"
+			}
+		}
+		if !cs.Properties.MasterProfile.IsCustomVNET() {
+			if cs.Properties.OrchestratorProfile.DcosConfig != nil && cs.Properties.OrchestratorProfile.DcosConfig.BootstrapProfile != nil {
+				if !isUpgrade || len(cs.Properties.OrchestratorProfile.DcosConfig.BootstrapProfile.StaticIP) == 0 {
+					cs.Properties.OrchestratorProfile.DcosConfig.BootstrapProfile.StaticIP = api.DefaultDCOSBootstrapStaticIP
+				}
+			}
+		}
+	}
+}
+
+// SetDefaultCerts generates and sets defaults for the container certificateProfile, returns true if certs are generated
+func (cs *ContainerService) SetDefaultCerts(params api.DefaultCertParams) (bool, []net.IP, error) {
+	p := cs.Properties
+	if p.MasterProfile == nil || p.OrchestratorProfile.OrchestratorType != api.Kubernetes {
+		return false, nil, nil
+	}
+
+	provided := certsAlreadyPresent(p.CertificateProfile, p.MasterProfile.Count)
+
+	if areAllTrue(provided) {
+		return false, nil, nil
+	}
+
+	var azureProdFQDNs []string
+	for _, location := range cs.GetLocations() {
+		azureProdFQDNs = append(azureProdFQDNs, api.FormatProdFQDNByLocation(p.MasterProfile.DNSPrefix, location, p.GetCustomCloudName()))
+	}
+
+	masterExtraFQDNs := append(azureProdFQDNs, p.MasterProfile.SubjectAltNames...)
+	masterExtraFQDNs = append(masterExtraFQDNs, "localhost")
+	firstMasterIP := net.ParseIP(p.MasterProfile.FirstConsecutiveStaticIP).To4()
+	localhostIP := net.ParseIP("127.0.0.1").To4()
+
+	if firstMasterIP == nil {
+		return false, nil, errors.Errorf("MasterProfile.FirstConsecutiveStaticIP '%s' is an invalid IP address", p.MasterProfile.FirstConsecutiveStaticIP)
+	}
+
+	ips := []net.IP{firstMasterIP, localhostIP}
+
+	// Include the Internal load balancer as well
+	if p.MasterProfile.IsVirtualMachineScaleSets() {
+		ips = append(ips, net.IP{firstMasterIP[0], firstMasterIP[1], byte(255), byte(api.DefaultInternalLbStaticIPOffset)})
+	} else {
+		// Add the Internal Loadbalancer IP which is always at p known offset from the firstMasterIP
+		ips = append(ips, net.IP{firstMasterIP[0], firstMasterIP[1], firstMasterIP[2], firstMasterIP[3] + byte(api.DefaultInternalLbStaticIPOffset)})
+	}
+
+	var offsetMultiplier int
+	if p.MasterProfile.IsVirtualMachineScaleSets() {
+		offsetMultiplier = p.MasterProfile.IPAddressCount
+	} else {
+		offsetMultiplier = 1
+	}
+	addr := binary.BigEndian.Uint32(firstMasterIP)
+	for i := 1; i < p.MasterProfile.Count; i++ {
+		newAddr := getNewAddr(addr, i, offsetMultiplier)
+		ip := make(net.IP, 4)
+		binary.BigEndian.PutUint32(ip, newAddr)
+		ips = append(ips, ip)
+	}
+	if p.CertificateProfile == nil {
+		p.CertificateProfile = &api.CertificateProfile{}
+	}
+
+	// use the specified Certificate Authority pair, or generate p new pair
+	var caPair *helpers.PkiKeyCertPair
+	if provided["ca"] {
+		caPair = &helpers.PkiKeyCertPair{CertificatePem: p.CertificateProfile.CaCertificate, PrivateKeyPem: p.CertificateProfile.CaPrivateKey}
+	} else {
+		var err error
+		pkiKeyCertPairParams := helpers.PkiKeyCertPairParams{
+			CommonName: "ca",
+			PkiKeySize: params.PkiKeySize,
+		}
+
+		caPair, err = helpers.CreatePkiKeyCertPair(pkiKeyCertPairParams)
+		if err != nil {
+			return false, ips, err
+		}
+
+		p.CertificateProfile.CaCertificate = caPair.CertificatePem
+		p.CertificateProfile.CaPrivateKey = caPair.PrivateKeyPem
+	}
+
+	serviceCIDR := p.OrchestratorProfile.KubernetesConfig.ServiceCIDR
+
+	// all validation for dual stack done with primary service cidr as that is considered
+	// the default ip family for cluster.
+	if cs.Properties.FeatureFlags.IsFeatureEnabled("EnableIPv6DualStack") {
+		// split service cidrs
+		serviceCIDRs := strings.Split(serviceCIDR, ",")
+		serviceCIDR = serviceCIDRs[0]
+	}
+
+	cidrFirstIP, err := common.CidrStringFirstIP(serviceCIDR)
+	if err != nil {
+		return false, ips, err
+	}
+	ips = append(ips, cidrFirstIP)
+
+	pkiParams := helpers.PkiParams{}
+	pkiParams.CaPair = caPair
+	pkiParams.ClusterDomain = api.DefaultKubernetesClusterDomain
+	pkiParams.ExtraFQDNs = masterExtraFQDNs
+	pkiParams.ExtraIPs = ips
+	pkiParams.MasterCount = p.MasterProfile.Count
+	pkiParams.PkiKeySize = params.PkiKeySize
+	apiServerPair, clientPair, kubeConfigPair, etcdServerPair, etcdClientPair, etcdPeerPairs, err :=
+		helpers.CreatePki(pkiParams)
+	if err != nil {
+		return false, ips, err
+	}
+
+	// If no Certificate Authority pair or no cert/key pair was provided, use generated cert/key pairs signed by provided Certificate Authority pair
+	if !provided["apiserver"] || !provided["ca"] {
+		p.CertificateProfile.APIServerCertificate = apiServerPair.CertificatePem
+		p.CertificateProfile.APIServerPrivateKey = apiServerPair.PrivateKeyPem
+	}
+	if !provided["client"] || !provided["ca"] {
+		p.CertificateProfile.ClientCertificate = clientPair.CertificatePem
+		p.CertificateProfile.ClientPrivateKey = clientPair.PrivateKeyPem
+	}
+	if !provided["kubeconfig"] || !provided["ca"] {
+		p.CertificateProfile.KubeConfigCertificate = kubeConfigPair.CertificatePem
+		p.CertificateProfile.KubeConfigPrivateKey = kubeConfigPair.PrivateKeyPem
+	}
+	if !provided["etcd"] || !provided["ca"] {
+		p.CertificateProfile.EtcdServerCertificate = etcdServerPair.CertificatePem
+		p.CertificateProfile.EtcdServerPrivateKey = etcdServerPair.PrivateKeyPem
+		p.CertificateProfile.EtcdClientCertificate = etcdClientPair.CertificatePem
+		p.CertificateProfile.EtcdClientPrivateKey = etcdClientPair.PrivateKeyPem
+		p.CertificateProfile.EtcdPeerCertificates = make([]string, p.MasterProfile.Count)
+		p.CertificateProfile.EtcdPeerPrivateKeys = make([]string, p.MasterProfile.Count)
+		for i, v := range etcdPeerPairs {
+			p.CertificateProfile.EtcdPeerCertificates[i] = v.CertificatePem
+			p.CertificateProfile.EtcdPeerPrivateKeys[i] = v.PrivateKeyPem
+		}
+	}
+
+	return true, ips, nil
+}
+
+func areAllTrue(m map[string]bool) bool {
+	for _, v := range m {
+		if !v {
+			return false
+		}
+	}
+	return true
+}
+
+// getNewIP returns a new IP derived from an address plus a multiple of an offset
+func getNewAddr(addr uint32, count int, offsetMultiplier int) uint32 {
+	offset := count * offsetMultiplier
+	newAddr := addr + uint32(offset)
+	return newAddr
+}
+
+// certsAlreadyPresent already present returns a map where each key is a type of cert and each value is true if that cert/key pair is user-provided
+func certsAlreadyPresent(c *api.CertificateProfile, m int) map[string]bool {
+	g := map[string]bool{
+		"ca":         false,
+		"apiserver":  false,
+		"kubeconfig": false,
+		"client":     false,
+		"etcd":       false,
+	}
+	if c != nil {
+		etcdPeer := true
+		if len(c.EtcdPeerCertificates) != m || len(c.EtcdPeerPrivateKeys) != m {
+			etcdPeer = false
+		} else {
+			for i, p := range c.EtcdPeerCertificates {
+				if !(len(p) > 0) || !(len(c.EtcdPeerPrivateKeys[i]) > 0) {
+					etcdPeer = false
+				}
+			}
+		}
+		g["ca"] = len(c.CaCertificate) > 0 && len(c.CaPrivateKey) > 0
+		g["apiserver"] = len(c.APIServerCertificate) > 0 && len(c.APIServerPrivateKey) > 0
+		g["kubeconfig"] = len(c.KubeConfigCertificate) > 0 && len(c.KubeConfigPrivateKey) > 0
+		g["client"] = len(c.ClientCertificate) > 0 && len(c.ClientPrivateKey) > 0
+		g["etcd"] = etcdPeer && len(c.EtcdClientCertificate) > 0 && len(c.EtcdClientPrivateKey) > 0 && len(c.EtcdServerCertificate) > 0 && len(c.EtcdServerPrivateKey) > 0
+	}
+	return g
+}
+
+// combine user-provided --feature-gates vals with defaults
+// a minimum k8s version may be declared as required for defaults assignment
+func addDefaultFeatureGates(m map[string]string, version string, minVersion string, defaults string) {
+	if minVersion != "" {
+		if common.IsKubernetesVersionGe(version, minVersion) {
+			m["--feature-gates"] = combineValues(m["--feature-gates"], defaults)
+		} else {
+			m["--feature-gates"] = combineValues(m["--feature-gates"], "")
+		}
+	} else {
+		m["--feature-gates"] = combineValues(m["--feature-gates"], defaults)
+	}
+}
+
+func combineValues(inputs ...string) string {
+	valueMap := make(map[string]string)
+	for _, input := range inputs {
+		applyValueStringToMap(valueMap, input)
+	}
+	return mapToString(valueMap)
+}
+
+func applyValueStringToMap(valueMap map[string]string, input string) {
+	values := strings.Split(input, ",")
+	for index := 0; index < len(values); index++ {
+		// trim spaces (e.g. if the input was "foo=true, bar=true" - we want to drop the space after the comma)
+		value := strings.Trim(values[index], " ")
+		valueParts := strings.Split(value, "=")
+		if len(valueParts) == 2 {
+			valueMap[valueParts[0]] = valueParts[1]
+		}
+	}
+}
+
+func mapToString(valueMap map[string]string) string {
+	// Order by key for consistency
+	keys := []string{}
+	for key := range valueMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var buf bytes.Buffer
+	for _, key := range keys {
+		buf.WriteString(fmt.Sprintf("%s=%s,", key, valueMap[key]))
+	}
+	return strings.TrimSuffix(buf.String(), ",")
+}
+
+func generateEtcdEncryptionKey() string {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// getDefaultKubernetesClusterSubnetIPv6 returns the default IPv6 cluster subnet
+func (cs *ContainerService) getDefaultKubernetesClusterSubnetIPv6() string {
+	o := cs.Properties.OrchestratorProfile
+	// In 1.17+ the default IPv6 mask size is /64 which means the cluster
+	// subnet mask size >= /48
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.17.0") {
+		return api.DefaultKubernetesClusterSubnetIPv6
+	}
+	// In 1.16, the default mask size for IPv6 is /24 which forces the cluster
+	// subnet mask size to be strictly >= /8
+	return "fc00::/8"
+}
+
+func (cs *ContainerService) setMasterProfileDefaults(isUpgrade bool) {
+	p := cs.Properties
+
+	// set default to VMAS for now
+	if p.MasterProfile.AvailabilityProfile == "" {
+		p.MasterProfile.AvailabilityProfile = api.AvailabilitySet
+	}
+
+	if p.MasterProfile.IsVirtualMachineScaleSets() {
+		if p.MasterProfile.SinglePlacementGroup == nil {
+			p.MasterProfile.SinglePlacementGroup = to.BoolPtr(api.DefaultSinglePlacementGroup)
+		}
+	}
+
+	if p.MasterProfile.IsCustomVNET() && p.MasterProfile.IsVirtualMachineScaleSets() {
+		if p.OrchestratorProfile.OrchestratorType == api.Kubernetes {
+			p.MasterProfile.FirstConsecutiveStaticIP = p.MasterProfile.GetFirstConsecutiveStaticIPAddress(p.MasterProfile.VnetCidr)
+		}
+	}
+
+	if !p.OrchestratorProfile.IsKubernetes() {
+		p.MasterProfile.Distro = api.Ubuntu
+		if !p.MasterProfile.IsCustomVNET() {
+			if p.OrchestratorProfile.OrchestratorType == api.DCOS {
+				p.MasterProfile.Subnet = api.DefaultDCOSMasterSubnet
+				// FirstConsecutiveStaticIP is not reset if it is upgrade and some value already exists
+				if !isUpgrade || len(p.MasterProfile.FirstConsecutiveStaticIP) == 0 {
+					p.MasterProfile.FirstConsecutiveStaticIP = api.DefaultDCOSFirstConsecutiveStaticIP
+				}
+			} else if p.HasWindows() {
+				p.MasterProfile.Subnet = api.DefaultSwarmWindowsMasterSubnet
+				// FirstConsecutiveStaticIP is not reset if it is upgrade and some value already exists
+				if !isUpgrade || len(p.MasterProfile.FirstConsecutiveStaticIP) == 0 {
+					p.MasterProfile.FirstConsecutiveStaticIP = api.DefaultSwarmWindowsFirstConsecutiveStaticIP
+				}
+			} else {
+				p.MasterProfile.Subnet = api.DefaultMasterSubnet
+				// FirstConsecutiveStaticIP is not reset if it is upgrade and some value already exists
+				if !isUpgrade || len(p.MasterProfile.FirstConsecutiveStaticIP) == 0 {
+					p.MasterProfile.FirstConsecutiveStaticIP = api.DefaultFirstConsecutiveStaticIP
+				}
+			}
+		}
+	}
+
+	if p.MasterProfile.HTTPSourceAddressPrefix == "" {
+		p.MasterProfile.HTTPSourceAddressPrefix = "*"
+	}
+
+	if nil == p.MasterProfile.CosmosEtcd {
+		p.MasterProfile.CosmosEtcd = to.BoolPtr(api.DefaultUseCosmos)
+	}
+
+	// Update default fault domain value for Azure Stack
+	if p.IsAzureStackCloud() && p.MasterProfile.PlatformFaultDomainCount == nil {
+		p.MasterProfile.PlatformFaultDomainCount = to.IntPtr(api.DefaultAzureStackFaultDomainCount)
+	}
+	if p.MasterProfile.PlatformUpdateDomainCount == nil {
+		p.MasterProfile.PlatformUpdateDomainCount = to.IntPtr(3)
+	}
+}
+
+func (cs *ContainerService) setLoadBalancerSkuDefaults() {
+	p := cs.Properties
+
+	if p.OrchestratorProfile == nil {
+		p.OrchestratorProfile = &api.OrchestratorProfile{}
+	}
+
+	if p.OrchestratorProfile.KubernetesConfig == nil {
+		p.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{}
+	}
+
+	if p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == "" {
+		if p.HasAvailabilityZones() {
+			p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = api.StandardLoadBalancerSku
+		} else {
+			p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = api.DefaultLoadBalancerSku
+		}
+	}
+
+	// normalize sku
+	if strings.EqualFold(p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, api.BasicLoadBalancerSku) {
+		p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = api.BasicLoadBalancerSku
+	} else if strings.EqualFold(p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, api.StandardLoadBalancerSku) {
+		p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = api.StandardLoadBalancerSku
+	}
+}
+
+func (cs *ContainerService) setAgentProfileDefaults(isUpgrade, isScale bool) {
+	p := cs.Properties
+
+	for _, profile := range p.AgentPoolProfiles {
+		if profile.AvailabilityProfile == "" {
+			profile.AvailabilityProfile = api.VirtualMachineScaleSets
+		}
+		if profile.AvailabilityProfile == api.VirtualMachineScaleSets {
+			if profile.ScaleSetEvictionPolicy == "" && (profile.ScaleSetPriority == api.ScaleSetPriorityLow || profile.ScaleSetPriority == api.ScaleSetPrioritySpot) {
+				profile.ScaleSetEvictionPolicy = api.ScaleSetEvictionPolicyDelete
+			}
+
+			if profile.ScaleSetPriority == api.ScaleSetPrioritySpot && profile.SpotMaxPrice == nil {
+				var maximumValueFlag float64 = -1
+				profile.SpotMaxPrice = &maximumValueFlag
+			}
+
+			if profile.VMSSOverProvisioningEnabled == nil {
+				profile.VMSSOverProvisioningEnabled = to.BoolPtr(api.DefaultVMSSOverProvisioningEnabled && !isUpgrade && !isScale)
+			}
+
+			if profile.SinglePlacementGroup == nil {
+				if strings.EqualFold(p.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, api.StandardLoadBalancerSku) {
+					profile.SinglePlacementGroup = to.BoolPtr(false)
+				} else {
+					profile.SinglePlacementGroup = to.BoolPtr(api.DefaultSinglePlacementGroup)
+				}
+			}
+		}
+		// set default OSType to Linux
+		if profile.OSType == "" {
+			profile.OSType = api.Linux
+		}
+
+		// Update default fault domain value for Azure Stack
+		if p.IsAzureStackCloud() && profile.PlatformFaultDomainCount == nil {
+			profile.PlatformFaultDomainCount = to.IntPtr(api.DefaultAzureStackFaultDomainCount)
+		}
+		if profile.PlatformUpdateDomainCount == nil {
+			profile.PlatformUpdateDomainCount = to.IntPtr(3)
+		}
+
+		// Accelerated Networking is supported on most general purpose and compute-optimized instance sizes with 2 or more vCPUs.
+		// These supported series are: D/DSv2 and F/Fs // All the others are not supported
+		// On instances that support hyperthreading, Accelerated Networking is supported on VM instances with 4 or more vCPUs.
+		// Supported series are: D/DSv3, E/ESv3, Fsv2, and Ms/Mms.
+		if profile.AcceleratedNetworkingEnabled == nil {
+			if p.IsAzureStackCloud() {
+				profile.AcceleratedNetworkingEnabled = to.BoolPtr(api.DefaultAzureStackAcceleratedNetworking)
+			} else {
+				profile.AcceleratedNetworkingEnabled = to.BoolPtr(api.DefaultAcceleratedNetworking && !isUpgrade && !isScale && helpers.AcceleratedNetworkingSupported(profile.VMSize))
+			}
+		}
+
+		if profile.AcceleratedNetworkingEnabledWindows == nil {
+			if p.IsAzureStackCloud() {
+				// Here we are using same default variable. We will change once we will start supporting AcceleratedNetworking feature in general.
+				profile.AcceleratedNetworkingEnabledWindows = to.BoolPtr(api.DefaultAzureStackAcceleratedNetworking)
+			} else {
+				profile.AcceleratedNetworkingEnabledWindows = to.BoolPtr(api.DefaultAcceleratedNetworkingWindowsEnabled && !isUpgrade && !isScale && helpers.AcceleratedNetworkingSupported(profile.VMSize))
+			}
+		}
+
+		if profile.AuditDEnabled == nil {
+			profile.AuditDEnabled = to.BoolPtr(api.DefaultAuditDEnabled && !isUpgrade && !isScale)
+		}
+
+		if profile.PreserveNodesProperties == nil {
+			profile.PreserveNodesProperties = to.BoolPtr(api.DefaultPreserveNodesProperties)
+		}
+
+		if profile.EnableVMSSNodePublicIP == nil {
+			profile.EnableVMSSNodePublicIP = to.BoolPtr(api.DefaultEnableVMSSNodePublicIP)
+		}
+
+		if !p.OrchestratorProfile.IsKubernetes() {
+			profile.Distro = api.Ubuntu
+		}
+	}
+}
+
+// setStorageDefaults for agents
+func (cs *ContainerService) setStorageDefaults() {
+	p := cs.Properties
+	if p.MasterProfile != nil && len(p.MasterProfile.StorageProfile) == 0 {
+		if p.OrchestratorProfile.OrchestratorType == api.Kubernetes {
+			p.MasterProfile.StorageProfile = api.ManagedDisks
+		} else {
+			p.MasterProfile.StorageProfile = api.StorageAccount
+		}
+	}
+	for _, profile := range p.AgentPoolProfiles {
+		if len(profile.StorageProfile) == 0 {
+			if p.OrchestratorProfile.OrchestratorType == api.Kubernetes {
+				profile.StorageProfile = api.ManagedDisks
+			} else {
+				profile.StorageProfile = api.StorageAccount
+			}
+		}
+	}
+}
+
+func (cs *ContainerService) setExtensionDefaults() {
+	p := cs.Properties
+	if p.ExtensionProfiles == nil {
+		return
+	}
+	for _, extension := range p.ExtensionProfiles {
+		if extension.RootURL == "" {
+			extension.RootURL = api.DefaultExtensionsRootURL
+		}
+	}
+}
+
+func (cs *ContainerService) setHostedMasterProfileDefaults() {
+	cs.Properties.HostedMasterProfile.Subnet = api.DefaultKubernetesMasterSubnet
+}
+
+// setWindowsProfileDefaults sets default WindowsProfile values
+func (cs *ContainerService) setWindowsProfileDefaults(isUpgrade, isScale bool) {
+	p := cs.Properties
+	windowsProfile := p.WindowsProfile
+	if !isUpgrade && !isScale {
+		if windowsProfile.SSHEnabled == nil {
+			windowsProfile.SSHEnabled = to.BoolPtr(api.DefaultWindowsSSHEnabled)
+		}
+
+		// This allows caller to use the latest ImageVersion and WindowsSku for adding a new Windows pool to an existing cluster.
+		// We must assure that same WindowsPublisher and WindowsOffer are used in an existing cluster.
+		if windowsProfile.WindowsPublisher == api.AKSWindowsServer2019OSImageConfig.ImagePublisher && windowsProfile.WindowsOffer == api.AKSWindowsServer2019OSImageConfig.ImageOffer {
+			if windowsProfile.WindowsSku == "" {
+				windowsProfile.WindowsSku = api.AKSWindowsServer2019OSImageConfig.ImageSku
+			}
+			if windowsProfile.ImageVersion == "" {
+				if windowsProfile.WindowsSku == api.AKSWindowsServer2019OSImageConfig.ImageSku {
+					windowsProfile.ImageVersion = api.AKSWindowsServer2019OSImageConfig.ImageVersion
+				} else {
+					windowsProfile.ImageVersion = "latest"
+				}
+			}
+		} else if windowsProfile.WindowsPublisher == api.WindowsServer2019OSImageConfig.ImagePublisher && windowsProfile.WindowsOffer == api.WindowsServer2019OSImageConfig.ImageOffer {
+			if windowsProfile.WindowsSku == "" {
+				windowsProfile.WindowsSku = api.WindowsServer2019OSImageConfig.ImageSku
+			}
+			if windowsProfile.ImageVersion == "" {
+				if windowsProfile.WindowsSku == api.WindowsServer2019OSImageConfig.ImageSku {
+					windowsProfile.ImageVersion = api.WindowsServer2019OSImageConfig.ImageVersion
+				} else {
+					windowsProfile.ImageVersion = "latest"
+				}
+			}
+		} else {
+			if windowsProfile.WindowsPublisher == "" {
+				windowsProfile.WindowsPublisher = api.AKSWindowsServer2019OSImageConfig.ImagePublisher
+			}
+			if windowsProfile.WindowsOffer == "" {
+				windowsProfile.WindowsOffer = api.AKSWindowsServer2019OSImageConfig.ImageOffer
+			}
+			if windowsProfile.WindowsSku == "" {
+				windowsProfile.WindowsSku = api.AKSWindowsServer2019OSImageConfig.ImageSku
+			}
+
+			if windowsProfile.ImageVersion == "" {
+				// default versions are specific to a publisher/offer/sku
+				if windowsProfile.WindowsPublisher == api.AKSWindowsServer2019OSImageConfig.ImagePublisher && windowsProfile.WindowsOffer == api.AKSWindowsServer2019OSImageConfig.ImageOffer && windowsProfile.WindowsSku == api.AKSWindowsServer2019OSImageConfig.ImageSku {
+					windowsProfile.ImageVersion = api.AKSWindowsServer2019OSImageConfig.ImageVersion
+				} else {
+					windowsProfile.ImageVersion = "latest"
+				}
+			}
+		}
+	} else if isUpgrade {
+		// Image reference publisher and offer only can be set when you create the scale set so we keep the old values.
+		// Reference: https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-upgrade-scale-set#create-time-properties
+		if windowsProfile.WindowsPublisher == api.AKSWindowsServer2019OSImageConfig.ImagePublisher && windowsProfile.WindowsOffer == api.AKSWindowsServer2019OSImageConfig.ImageOffer {
+			if windowsProfile.ImageVersion == "" {
+				windowsProfile.ImageVersion = api.AKSWindowsServer2019OSImageConfig.ImageVersion
+			}
+			if windowsProfile.WindowsSku == "" {
+				windowsProfile.WindowsSku = api.AKSWindowsServer2019OSImageConfig.ImageSku
+			}
+		} else if windowsProfile.WindowsPublisher == api.WindowsServer2019OSImageConfig.ImagePublisher && windowsProfile.WindowsOffer == api.WindowsServer2019OSImageConfig.ImageOffer {
+			if windowsProfile.ImageVersion == "" {
+				windowsProfile.ImageVersion = api.WindowsServer2019OSImageConfig.ImageVersion
+			}
+			if windowsProfile.WindowsSku == "" {
+				windowsProfile.WindowsSku = api.WindowsServer2019OSImageConfig.ImageSku
+			}
+		}
+	}
+	// Scale: Keep the same version to match other nodes because we have no way to rollback
+}
+
+func (cs *ContainerService) setTelemetryProfileDefaults() {
+	p := cs.Properties
+	if p.TelemetryProfile == nil {
+		p.TelemetryProfile = &api.TelemetryProfile{}
+	}
+
+	if len(p.TelemetryProfile.ApplicationInsightsKey) == 0 {
+		p.TelemetryProfile.ApplicationInsightsKey = api.DefaultApplicationInsightsKey
+	}
+}

--- a/pkg/agent/datamodel/defaults_test.go
+++ b/pkg/agent/datamodel/defaults_test.go
@@ -1,0 +1,4784 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/aks-engine/pkg/api/common"
+	"github.com/Azure/aks-engine/pkg/helpers"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/pkg/errors"
+)
+
+func TestCertsAlreadyPresent(t *testing.T) {
+	var cert *api.CertificateProfile
+
+	result := certsAlreadyPresent(nil, 1)
+	expected := map[string]bool{
+		"ca":         false,
+		"apiserver":  false,
+		"client":     false,
+		"kubeconfig": false,
+		"etcd":       false,
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("certsAlreadyPresent() did not return false for all certs for a non-existent CertificateProfile")
+	}
+	cert = &api.CertificateProfile{}
+	result = certsAlreadyPresent(cert, 1)
+	expected = map[string]bool{
+		"ca":         false,
+		"apiserver":  false,
+		"client":     false,
+		"kubeconfig": false,
+		"etcd":       false,
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("certsAlreadyPresent() did not return false for all certs for empty CertificateProfile")
+	}
+	cert = &api.CertificateProfile{
+		APIServerCertificate: "a",
+	}
+	result = certsAlreadyPresent(cert, 1)
+	expected = map[string]bool{
+		"ca":         false,
+		"apiserver":  false,
+		"client":     false,
+		"kubeconfig": false,
+		"etcd":       false,
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("certsAlreadyPresent() did not return false for all certs for 1 cert in CertificateProfile")
+	}
+
+	cert = &api.CertificateProfile{
+		APIServerCertificate:  "a",
+		CaCertificate:         "c",
+		CaPrivateKey:          "d",
+		ClientCertificate:     "e",
+		ClientPrivateKey:      "f",
+		KubeConfigCertificate: "g",
+		KubeConfigPrivateKey:  "h",
+		EtcdClientCertificate: "i",
+		EtcdClientPrivateKey:  "j",
+		EtcdServerCertificate: "k",
+		EtcdServerPrivateKey:  "l",
+	}
+	result = certsAlreadyPresent(cert, 3)
+	expected = map[string]bool{
+		"ca":         true,
+		"apiserver":  false,
+		"client":     true,
+		"kubeconfig": true,
+		"etcd":       false,
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("certsAlreadyPresent() did not return expected result for some certs in CertificateProfile")
+	}
+	cert = &api.CertificateProfile{
+		APIServerCertificate:  "a",
+		APIServerPrivateKey:   "b",
+		CaCertificate:         "c",
+		CaPrivateKey:          "d",
+		ClientCertificate:     "e",
+		ClientPrivateKey:      "f",
+		KubeConfigCertificate: "g",
+		KubeConfigPrivateKey:  "h",
+		EtcdClientCertificate: "i",
+		EtcdClientPrivateKey:  "j",
+		EtcdServerCertificate: "k",
+		EtcdServerPrivateKey:  "l",
+		EtcdPeerCertificates:  []string{"0", "1", "2"},
+		EtcdPeerPrivateKeys:   []string{"0", "1", "2"},
+	}
+	result = certsAlreadyPresent(cert, 3)
+	expected = map[string]bool{
+		"ca":         true,
+		"apiserver":  true,
+		"client":     true,
+		"kubeconfig": true,
+		"etcd":       true,
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("certsAlreadyPresent() did not return expected result for all certs in CertificateProfile")
+	}
+}
+
+func TestSetMissingKubeletValues(t *testing.T) {
+	config := &api.KubernetesConfig{}
+	defaultKubeletConfig := map[string]string{
+		"--network-plugin":               "1",
+		"--pod-infra-container-image":    "2",
+		"--max-pods":                     "3",
+		"--eviction-hard":                "4",
+		"--node-status-update-frequency": "5",
+		"--image-gc-high-threshold":      "6",
+		"--image-gc-low-threshold":       "7",
+		"--non-masquerade-cidr":          "8",
+		"--cloud-provider":               "9",
+		"--pod-max-pids":                 "10",
+	}
+	setMissingKubeletValues(config, defaultKubeletConfig)
+	for key, val := range defaultKubeletConfig {
+		if config.KubeletConfig[key] != val {
+			t.Fatalf("setMissingKubeletValue() did not return the expected value %s for key %s, instead returned: %s", val, key, config.KubeletConfig[key])
+		}
+	}
+
+	config = &api.KubernetesConfig{
+		KubeletConfig: map[string]string{
+			"--network-plugin":            "a",
+			"--pod-infra-container-image": "b",
+			"--cloud-provider":            "c",
+		},
+	}
+	expectedResult := map[string]string{
+		"--network-plugin":               "a",
+		"--pod-infra-container-image":    "b",
+		"--max-pods":                     "3",
+		"--eviction-hard":                "4",
+		"--node-status-update-frequency": "5",
+		"--image-gc-high-threshold":      "6",
+		"--image-gc-low-threshold":       "7",
+		"--non-masquerade-cidr":          "8",
+		"--cloud-provider":               "c",
+		"--pod-max-pids":                 "10",
+	}
+	setMissingKubeletValues(config, defaultKubeletConfig)
+	for key, val := range expectedResult {
+		if config.KubeletConfig[key] != val {
+			t.Fatalf("setMissingKubeletValue() did not return the expected value %s for key %s, instead returned: %s", val, key, config.KubeletConfig[key])
+		}
+	}
+	config = &api.KubernetesConfig{
+		KubeletConfig: map[string]string{},
+	}
+	setMissingKubeletValues(config, defaultKubeletConfig)
+	for key, val := range defaultKubeletConfig {
+		if config.KubeletConfig[key] != val {
+			t.Fatalf("setMissingKubeletValue() did not return the expected value %s for key %s, instead returned: %s", val, key, config.KubeletConfig[key])
+		}
+	}
+}
+
+func TestAddonsIndexByName(t *testing.T) {
+	addonName := "testaddon"
+	addons := []api.KubernetesAddon{
+		getMockAddon(addonName),
+	}
+	i := getAddonsIndexByName(addons, addonName)
+	if i != 0 {
+		t.Fatalf("addonsIndexByName() did not return the expected index value 0, instead returned: %d", i)
+	}
+	i = getAddonsIndexByName(addons, "nonExistentAddonName")
+	if i != -1 {
+		t.Fatalf("addonsIndexByName() did not return -1 for a non-existent addon, instead returned: %d", i)
+	}
+}
+
+func TestAssignDefaultAddonImages(t *testing.T) {
+	kubernetesVersion := "1.13.11"
+	k8sComponents := api.K8sComponentsByVersionMap[kubernetesVersion]
+	customImage := "myimage"
+	specConfig := api.AzureCloudSpecEnvMap["AzurePublicCloud"].KubernetesSpecConfig
+	defaultAddonImages := map[string]string{
+		common.TillerAddonName:                 specConfig.TillerImageBase + k8sComponents[common.TillerAddonName],
+		common.ACIConnectorAddonName:           specConfig.ACIConnectorImageBase + k8sComponents[common.ACIConnectorAddonName],
+		common.ClusterAutoscalerAddonName:      specConfig.KubernetesImageBase + k8sComponents[common.ClusterAutoscalerAddonName],
+		common.BlobfuseFlexVolumeAddonName:     k8sComponents[common.BlobfuseFlexVolumeAddonName],
+		common.SMBFlexVolumeAddonName:          k8sComponents[common.SMBFlexVolumeAddonName],
+		common.KeyVaultFlexVolumeAddonName:     k8sComponents[common.KeyVaultFlexVolumeAddonName],
+		common.DashboardAddonName:              specConfig.KubernetesImageBase + k8sComponents[common.DashboardAddonName],
+		common.ReschedulerAddonName:            specConfig.KubernetesImageBase + k8sComponents[common.ReschedulerAddonName],
+		common.MetricsServerAddonName:          specConfig.KubernetesImageBase + k8sComponents[common.MetricsServerAddonName],
+		common.NVIDIADevicePluginAddonName:     specConfig.NVIDIAImageBase + k8sComponents[common.NVIDIADevicePluginAddonName],
+		common.ContainerMonitoringAddonName:    "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod01072020",
+		common.IPMASQAgentAddonName:            specConfig.KubernetesImageBase + k8sComponents[common.IPMASQAgentAddonName],
+		common.AzureCNINetworkMonitorAddonName: specConfig.AzureCNIImageBase + k8sComponents[common.AzureCNINetworkMonitorAddonName],
+		common.DNSAutoscalerAddonName:          specConfig.KubernetesImageBase + k8sComponents[common.DNSAutoscalerAddonName],
+		common.HeapsterAddonName:               specConfig.KubernetesImageBase + k8sComponents[common.HeapsterAddonName],
+		common.CalicoAddonName:                 specConfig.CalicoImageBase + k8sComponents["calico-typha"],
+		common.AzureNetworkPolicyAddonName:     k8sComponents[common.AzureNetworkPolicyAddonName],
+		common.AADPodIdentityAddonName:         k8sComponents[common.NMIContainerName],
+		common.AzurePolicyAddonName:            k8sComponents[common.AzurePolicyAddonName],
+		common.NodeProblemDetectorAddonName:    k8sComponents[common.NodeProblemDetectorAddonName],
+		common.KubeDNSAddonName:                specConfig.KubernetesImageBase + k8sComponents[common.KubeDNSAddonName],
+		common.CoreDNSAddonName:                specConfig.KubernetesImageBase + k8sComponents[common.CoreDNSAddonName],
+		common.KubeProxyAddonName:              specConfig.KubernetesImageBase + k8sComponents[common.KubeProxyAddonName],
+		common.AntreaAddonName:                 k8sComponents[common.AntreaControllerContainerName],
+		common.FlannelAddonName:                k8sComponents[common.KubeFlannelContainerName],
+	}
+
+	customAddonImages := make(map[string]string)
+	for k := range defaultAddonImages {
+		customAddonImages[k] = customImage
+	}
+
+	cases := []struct {
+		name           string
+		myAddons       []api.KubernetesAddon
+		isUpdate       bool
+		expectedImages map[string]string
+	}{
+		{
+			name:           "default",
+			myAddons:       getFakeAddons(defaultAddonImages, ""),
+			isUpdate:       false,
+			expectedImages: defaultAddonImages,
+		},
+		{
+			name:           "create scenario",
+			myAddons:       getFakeAddons(defaultAddonImages, customImage),
+			isUpdate:       false,
+			expectedImages: customAddonImages, // Image should not be overridden in create scenarios.
+		},
+		{
+			name:           "upgrade + scale scenario",
+			myAddons:       getFakeAddons(defaultAddonImages, customImage),
+			isUpdate:       true,
+			expectedImages: defaultAddonImages, // Image should be overridden in update scenarios.
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			mockCS := getMockBaseContainerService(kubernetesVersion)
+			mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+			mockCS.Properties.OrchestratorProfile.KubernetesConfig.Addons = c.myAddons
+			mockCS.setOrchestratorDefaults(c.isUpdate, c.isUpdate)
+			resultAddons := mockCS.Properties.OrchestratorProfile.KubernetesConfig.Addons
+			for _, result := range resultAddons {
+				// TODO test more than just the first container image reference
+				if len(result.Containers) > 0 && result.Containers[0].Image != c.expectedImages[result.Name] {
+					t.Errorf("expected setDefaults to set Image to \"%s\" in addon %s, but got \"%s\"", c.expectedImages[result.Name], result.Name, result.Containers[0].Image)
+				}
+			}
+		})
+	}
+}
+
+func getFakeAddons(defaultAddonMap map[string]string, customImage string) []api.KubernetesAddon {
+	var fakeCustomAddons []api.KubernetesAddon
+	for addonName := range defaultAddonMap {
+		containerName := addonName
+		if addonName == common.ContainerMonitoringAddonName {
+			containerName = "omsagent"
+		}
+		if addonName == common.CalicoAddonName {
+			containerName = "calico-typha"
+		}
+		if addonName == common.AADPodIdentityAddonName {
+			containerName = "nmi"
+		}
+		if addonName == common.KubeDNSAddonName {
+			containerName = "kubedns"
+		}
+		if addonName == common.AntreaAddonName {
+			containerName = common.AntreaControllerContainerName
+		}
+		if addonName == common.FlannelAddonName {
+			containerName = common.KubeFlannelContainerName
+		}
+		customAddon := api.KubernetesAddon{
+			Name:    addonName,
+			Enabled: to.BoolPtr(true),
+			Containers: []api.KubernetesContainerSpec{
+				{
+					Name:           containerName,
+					CPURequests:    "50m",
+					MemoryRequests: "150Mi",
+					CPULimits:      "50m",
+					MemoryLimits:   "150Mi",
+				},
+			},
+		}
+		if customImage != "" {
+			customAddon.Containers[0].Image = customImage
+		}
+		fakeCustomAddons = append(fakeCustomAddons, customAddon)
+	}
+	return fakeCustomAddons
+}
+
+func TestAssignDefaultAddonVals(t *testing.T) {
+	addonName := "testaddon"
+	customImage := "myimage"
+	customCPURequests := "60m"
+	customMemoryRequests := "160Mi"
+	customCPULimits := "40m"
+	customMemoryLimits := "140Mi"
+	// Verify that an addon with all custom values provided remains unmodified during default value assignment
+	customAddon := api.KubernetesAddon{
+		Name:    addonName,
+		Enabled: to.BoolPtr(true),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           addonName,
+				Image:          customImage,
+				CPURequests:    customCPURequests,
+				MemoryRequests: customMemoryRequests,
+				CPULimits:      customCPULimits,
+				MemoryLimits:   customMemoryLimits,
+			},
+		},
+	}
+	addonWithDefaults := getMockAddon(addonName)
+	isUpdate := false
+	modifiedAddon := assignDefaultAddonVals(customAddon, addonWithDefaults, isUpdate)
+	if modifiedAddon.Containers[0].Name != customAddon.Containers[0].Name {
+		t.Fatalf("assignDefaultAddonVals() should not have modified Containers 'Name' value %s to %s,", customAddon.Containers[0].Name, modifiedAddon.Containers[0].Name)
+	}
+	if modifiedAddon.Containers[0].Image != customAddon.Containers[0].Image {
+		t.Fatalf("assignDefaultAddonVals() should not have modified Containers 'Image' value %s to %s,", customAddon.Containers[0].Image, modifiedAddon.Containers[0].Image)
+	}
+	if modifiedAddon.Containers[0].CPURequests != customAddon.Containers[0].CPURequests {
+		t.Fatalf("assignDefaultAddonVals() should not have modified Containers 'CPURequests' value %s to %s,", customAddon.Containers[0].CPURequests, modifiedAddon.Containers[0].CPURequests)
+	}
+	if modifiedAddon.Containers[0].MemoryRequests != customAddon.Containers[0].MemoryRequests {
+		t.Fatalf("assignDefaultAddonVals() should not have modified Containers 'MemoryRequests' value %s to %s,", customAddon.Containers[0].MemoryRequests, modifiedAddon.Containers[0].MemoryRequests)
+	}
+	if modifiedAddon.Containers[0].CPULimits != customAddon.Containers[0].CPULimits {
+		t.Fatalf("assignDefaultAddonVals() should not have modified Containers 'CPULimits' value %s to %s,", customAddon.Containers[0].CPULimits, modifiedAddon.Containers[0].CPULimits)
+	}
+	if modifiedAddon.Containers[0].MemoryLimits != customAddon.Containers[0].MemoryLimits {
+		t.Fatalf("assignDefaultAddonVals() should not have modified Containers 'MemoryLimits' value %s to %s,", customAddon.Containers[0].MemoryLimits, modifiedAddon.Containers[0].MemoryLimits)
+	}
+
+	// Verify that an addon with no custom values provided gets all the appropriate defaults
+	customAddon = api.KubernetesAddon{
+		Name:    addonName,
+		Enabled: to.BoolPtr(true),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name: addonName,
+			},
+		},
+	}
+	isUpdate = false
+	modifiedAddon = assignDefaultAddonVals(customAddon, addonWithDefaults, isUpdate)
+	if modifiedAddon.Containers[0].Image != addonWithDefaults.Containers[0].Image {
+		t.Fatalf("assignDefaultAddonVals() should have assigned a default 'Image' value of %s, instead assigned %s,", addonWithDefaults.Containers[0].Image, modifiedAddon.Containers[0].Image)
+	}
+	if modifiedAddon.Containers[0].CPURequests != addonWithDefaults.Containers[0].CPURequests {
+		t.Fatalf("assignDefaultAddonVals() should have assigned a default 'CPURequests' value of %s, instead assigned %s,", addonWithDefaults.Containers[0].CPURequests, modifiedAddon.Containers[0].CPURequests)
+	}
+	if modifiedAddon.Containers[0].MemoryRequests != addonWithDefaults.Containers[0].MemoryRequests {
+		t.Fatalf("assignDefaultAddonVals() should have assigned a default 'MemoryRequests' value of %s, instead assigned %s,", addonWithDefaults.Containers[0].MemoryRequests, modifiedAddon.Containers[0].MemoryRequests)
+	}
+	if modifiedAddon.Containers[0].CPULimits != addonWithDefaults.Containers[0].CPULimits {
+		t.Fatalf("assignDefaultAddonVals() should have assigned a default 'CPULimits' value of %s, instead assigned %s,", addonWithDefaults.Containers[0].CPULimits, modifiedAddon.Containers[0].CPULimits)
+	}
+	if modifiedAddon.Containers[0].MemoryLimits != addonWithDefaults.Containers[0].MemoryLimits {
+		t.Fatalf("assignDefaultAddonVals() should have assigned a default 'MemoryLimits' value of %s, instead assigned %s,", addonWithDefaults.Containers[0].MemoryLimits, modifiedAddon.Containers[0].MemoryLimits)
+	}
+
+	// More checking to verify default interpolation
+	customAddon = api.KubernetesAddon{
+		Name:    addonName,
+		Enabled: to.BoolPtr(true),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:         addonName,
+				CPURequests:  customCPURequests,
+				MemoryLimits: customMemoryLimits,
+			},
+		},
+	}
+	isUpdate = false
+	modifiedAddon = assignDefaultAddonVals(customAddon, addonWithDefaults, isUpdate)
+	if modifiedAddon.Containers[0].Image != addonWithDefaults.Containers[0].Image {
+		t.Fatalf("assignDefaultAddonVals() should have assigned a default 'Image' value of %s, instead assigned %s,", addonWithDefaults.Containers[0].Image, modifiedAddon.Containers[0].Image)
+	}
+	if modifiedAddon.Containers[0].Name != customAddon.Containers[0].Name {
+		t.Fatalf("assignDefaultAddonVals() should not have modified Containers 'Name' value %s to %s,", customAddon.Containers[0].Name, modifiedAddon.Containers[0].Name)
+	}
+	if modifiedAddon.Containers[0].MemoryRequests != addonWithDefaults.Containers[0].MemoryRequests {
+		t.Fatalf("assignDefaultAddonVals() should have assigned a default 'MemoryRequests' value of %s, instead assigned %s,", addonWithDefaults.Containers[0].MemoryRequests, modifiedAddon.Containers[0].MemoryRequests)
+	}
+	if modifiedAddon.Containers[0].CPULimits != addonWithDefaults.Containers[0].CPULimits {
+		t.Fatalf("assignDefaultAddonVals() should have assigned a default 'CPULimits' value of %s, instead assigned %s,", addonWithDefaults.Containers[0].CPULimits, modifiedAddon.Containers[0].CPULimits)
+	}
+	if modifiedAddon.Containers[0].MemoryLimits != customAddon.Containers[0].MemoryLimits {
+		t.Fatalf("assignDefaultAddonVals() should not have modified Containers 'MemoryLimits' value %s to %s,", customAddon.Containers[0].MemoryLimits, modifiedAddon.Containers[0].MemoryLimits)
+	}
+
+	// Verify that an addon with a custom image value will be overridden during upgrade/scale
+	customAddon = api.KubernetesAddon{
+		Name:    addonName,
+		Enabled: to.BoolPtr(true),
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:  addonName,
+				Image: customImage,
+			},
+		},
+	}
+	isUpdate = true
+	modifiedAddon = assignDefaultAddonVals(customAddon, addonWithDefaults, isUpdate)
+	if modifiedAddon.Containers[0].Image != addonWithDefaults.Containers[0].Image {
+		t.Fatalf("assignDefaultAddonVals() should have assigned a default 'Image' value of %s, instead assigned %s,", addonWithDefaults.Containers[0].Image, modifiedAddon.Containers[0].Image)
+	}
+
+	addonWithDefaults.Config = map[string]string{
+		"os":    "Linux",
+		"taint": "node.kubernetes.io/memory-pressure",
+	}
+	isUpdate = false
+	modifiedAddon = assignDefaultAddonVals(customAddon, addonWithDefaults, isUpdate)
+
+	if modifiedAddon.Config["os"] != "Linux" {
+		t.Error("assignDefaultAddonVals() should have added the default config property")
+	}
+
+	if modifiedAddon.Config["taint"] != "node.kubernetes.io/memory-pressure" {
+		t.Error("assignDefaultAddonVals() should have added the default config property")
+	}
+
+	// Verify that an addon with a nil enabled inherits the default enabled value
+	customAddon = api.KubernetesAddon{
+		Name: addonName,
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:  addonName,
+				Image: customImage,
+			},
+		},
+	}
+	isUpdate = false
+	addonWithDefaults.Enabled = to.BoolPtr(true)
+	modifiedAddon = assignDefaultAddonVals(customAddon, addonWithDefaults, isUpdate)
+	if to.Bool(modifiedAddon.Enabled) != to.Bool(addonWithDefaults.Enabled) {
+		t.Errorf("assignDefaultAddonVals() should have assigned a default 'Enabled' value of %t, instead assigned %t,", to.Bool(addonWithDefaults.Enabled), to.Bool(modifiedAddon.Enabled))
+	}
+
+	customAddon = api.KubernetesAddon{
+		Name: addonName,
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:  addonName,
+				Image: customImage,
+			},
+		},
+	}
+	isUpdate = false
+	addonWithDefaults.Enabled = to.BoolPtr(false)
+	modifiedAddon = assignDefaultAddonVals(customAddon, addonWithDefaults, isUpdate)
+	if to.Bool(modifiedAddon.Enabled) != to.Bool(addonWithDefaults.Enabled) {
+		t.Errorf("assignDefaultAddonVals() should have assigned a default 'Enabled' value of %t, instead assigned %t,", to.Bool(addonWithDefaults.Enabled), to.Bool(modifiedAddon.Enabled))
+	}
+}
+
+func TestAcceleratedNetworking(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.10.8")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled = nil
+	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows = nil
+
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  true,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	// In upgrade scenario, nil AcceleratedNetworkingEnabled should always render as false (i.e., we never turn on this feature on an existing vm that didn't have it before)
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled) {
+		t.Errorf("expected nil acceleratedNetworkingEnabled to be false after upgrade, instead got %t", to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled))
+	}
+	// In upgrade scenario, nil AcceleratedNetworkingEnabledWindows should always render as false (i.e., we never turn on this feature on an existing vm that didn't have it before)
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows) {
+		t.Errorf("expected nil acceleratedNetworkingEnabledWindows to be false after upgrade, instead got %t", to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows))
+	}
+
+	mockCS = getMockBaseContainerService("1.10.8")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled = nil
+	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows = nil
+
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    true,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	// In scale scenario, nil AcceleratedNetworkingEnabled should always render as false (i.e., we never turn on this feature on an existing agent pool / VMSS that didn't have it before)
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled) {
+		t.Errorf("expected nil acceleratedNetworkingEnabled to be false after upgrade, instead got %t", to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled))
+	}
+	// In scale scenario, nil AcceleratedNetworkingEnabledWindows should always render as false (i.e., we never turn on this feature on an existing VM that didn't have it before)
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows) {
+		t.Errorf("expected nil acceleratedNetworkingEnabledWindows to be false after upgrade, instead got %t", to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows))
+	}
+
+	mockCS = getMockBaseContainerService("1.10.8")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled = nil
+	mockCS.Properties.AgentPoolProfiles[0].VMSize = "Standard_D2_v2"
+	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows = nil
+	mockCS.Properties.AgentPoolProfiles[0].VMSize = "Standard_D2_v2"
+
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	// In create scenario, nil AcceleratedNetworkingEnabled should be the defaults
+	acceleratedNetworkingEnabled := api.DefaultAcceleratedNetworking
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled) != acceleratedNetworkingEnabled {
+		t.Errorf("expected default acceleratedNetworkingEnabled to be %t, instead got %t", acceleratedNetworkingEnabled, to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled))
+	}
+	// In create scenario, nil AcceleratedNetworkingEnabledWindows should be the defaults
+	acceleratedNetworkingEnabled = api.DefaultAcceleratedNetworkingWindowsEnabled
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows) != acceleratedNetworkingEnabled {
+		t.Errorf("expected default acceleratedNetworkingEnabledWindows to be %t, instead got %t", acceleratedNetworkingEnabled, to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows))
+	}
+
+	mockCS = getMockBaseContainerService("1.10.8")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled = nil
+	mockCS.Properties.AgentPoolProfiles[0].VMSize = "Standard_D666_v2"
+	mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows = nil
+	mockCS.Properties.AgentPoolProfiles[0].VMSize = "Standard_D666_v2"
+
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	// In non-supported VM SKU scenario, acceleratedNetworkingEnabled should always be false
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled) {
+		t.Errorf("expected acceleratedNetworkingEnabled to be %t for an unsupported VM SKU, instead got %t", false, to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabled))
+	}
+	// In non-supported VM SKU scenario, acceleratedNetworkingEnabledWindows should always be false
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows) {
+		t.Errorf("expected acceleratedNetworkingEnabledWindows to be %t for an unsupported VM SKU, instead got %t", false, to.Bool(mockCS.Properties.AgentPoolProfiles[0].AcceleratedNetworkingEnabledWindows))
+	}
+}
+
+func TestVMSSOverProvisioning(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.10.8")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.Properties.AgentPoolProfiles[0].AvailabilityProfile = api.VirtualMachineScaleSets
+	mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled = nil
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  true,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	// In upgrade scenario, nil AcceleratedNetworkingEnabled should always render as false (i.e., we never turn on this feature on an existing vm that didn't have it before)
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled) {
+		t.Errorf("expected nil VMSSOverProvisioningEnabled to be false after upgrade, instead got %t", to.Bool(mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled))
+	}
+
+	mockCS = getMockBaseContainerService("1.10.8")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.Properties.AgentPoolProfiles[0].AvailabilityProfile = api.VirtualMachineScaleSets
+	mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled = nil
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    true,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	// In scale scenario, nil VMSSOverProvisioningEnabled should always render as false (i.e., we never turn on this feature on an existing agent pool / VMSS that didn't have it before)
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled) {
+		t.Errorf("expected nil VMSSOverProvisioningEnabled to be false after upgrade, instead got %t", to.Bool(mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled))
+	}
+
+	mockCS = getMockBaseContainerService("1.10.8")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.Properties.AgentPoolProfiles[0].AvailabilityProfile = api.VirtualMachineScaleSets
+	mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled = nil
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	// In create scenario, nil VMSSOverProvisioningEnabled should be the defaults
+	vmssOverProvisioningEnabled := api.DefaultVMSSOverProvisioningEnabled
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled) != vmssOverProvisioningEnabled {
+		t.Errorf("expected default VMSSOverProvisioningEnabled to be %t, instead got %t", vmssOverProvisioningEnabled, to.Bool(mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled))
+	}
+
+	mockCS = getMockBaseContainerService("1.10.8")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.Properties.AgentPoolProfiles[0].AvailabilityProfile = api.VirtualMachineScaleSets
+	mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled = to.BoolPtr(true)
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	// In create scenario with explicit true, VMSSOverProvisioningEnabled should be true
+	if !to.Bool(mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled) {
+		t.Errorf("expected VMSSOverProvisioningEnabled to be true, instead got %t", to.Bool(mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled))
+	}
+
+	mockCS = getMockBaseContainerService("1.10.8")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.Properties.AgentPoolProfiles[0].AvailabilityProfile = api.VirtualMachineScaleSets
+	mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled = to.BoolPtr(false)
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	// In create scenario with explicit false, VMSSOverProvisioningEnabled should be false
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled) {
+		t.Errorf("expected VMSSOverProvisioningEnabled to be false, instead got %t", to.Bool(mockCS.Properties.AgentPoolProfiles[0].VMSSOverProvisioningEnabled))
+	}
+}
+
+func TestAuditDEnabled(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.12.7")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	isUpgrade := true
+	mockCS.setAgentProfileDefaults(isUpgrade, false)
+
+	// In upgrade scenario, nil AuditDEnabled should always render as false (i.e., we never turn on this feature on an existing vm that didn't have it before)
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled) {
+		t.Errorf("expected nil AuditDEnabled to be false after upgrade, instead got %t", to.Bool(mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled))
+	}
+
+	mockCS = getMockBaseContainerService("1.12.7")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	isScale := true
+	mockCS.setAgentProfileDefaults(false, isScale)
+
+	// In scale scenario, nil AuditDEnabled should always render as false (i.e., we never turn on this feature on an existing agent pool / vms that didn't have it before)
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled) {
+		t.Errorf("expected nil AuditDEnabled to be false after upgrade, instead got %t", to.Bool(mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled))
+	}
+
+	mockCS = getMockBaseContainerService("1.12.7")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.setAgentProfileDefaults(false, false)
+
+	// In create scenario, nil AuditDEnabled should be the defaults
+	auditDEnabledEnabled := api.DefaultAuditDEnabled
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled) != auditDEnabledEnabled {
+		t.Errorf("expected default AuditDEnabled to be %t, instead got %t", auditDEnabledEnabled, to.Bool(mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled))
+	}
+
+	mockCS = getMockBaseContainerService("1.10.8")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled = to.BoolPtr(true)
+	mockCS.setAgentProfileDefaults(false, false)
+
+	// In create scenario with explicit true, AuditDEnabled should be true
+	if !to.Bool(mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled) {
+		t.Errorf("expected AuditDEnabled to be true, instead got %t", to.Bool(mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled))
+	}
+
+	mockCS = getMockBaseContainerService("1.10.8")
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled = to.BoolPtr(false)
+	mockCS.setAgentProfileDefaults(false, false)
+
+	// In create scenario with explicit false, AuditDEnabled should be false
+	if to.Bool(mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled) {
+		t.Errorf("expected AuditDEnabled to be false, instead got %t", to.Bool(mockCS.Properties.AgentPoolProfiles[0].AuditDEnabled))
+	}
+}
+
+func TestKubeletFeatureGatesEnsureFeatureGatesOnAgentsFor1_6_0(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.6.0")
+	properties := mockCS.Properties
+
+	// No KubernetesConfig.KubeletConfig set for MasterProfile or AgentProfile
+	// so they will inherit the top-level config
+	properties.OrchestratorProfile.KubernetesConfig = getKubernetesConfigWithFeatureGates("TopLevel=true")
+
+	mockCS.setKubeletConfig(false)
+
+	agentFeatureGates := properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig["--feature-gates"]
+	if agentFeatureGates != "TopLevel=true" {
+		t.Fatalf("setKubeletConfig did not add 'TopLevel=true' for agent profile: expected 'TopLevel=true' got '%s'", agentFeatureGates)
+	}
+
+	// Verify that the TopLevel feature gate override has only been applied to the agents
+	masterFeatureFates := properties.MasterProfile.KubernetesConfig.KubeletConfig["--feature-gates"]
+	if masterFeatureFates != "TopLevel=true" {
+		t.Fatalf("setKubeletConfig modified feature gates for master profile: expected 'TopLevel=true' got '%s'", agentFeatureGates)
+	}
+}
+
+func TestKubeletFeatureGatesEnsureMasterAndAgentConfigUsedFor1_6_0(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.6.0")
+	properties := mockCS.Properties
+
+	// Set MasterProfile and AgentProfiles KubernetesConfig.KubeletConfig values
+	// Verify that they are used instead of the top-level config
+	properties.OrchestratorProfile.KubernetesConfig = getKubernetesConfigWithFeatureGates("TopLevel=true")
+	properties.MasterProfile = &api.MasterProfile{KubernetesConfig: getKubernetesConfigWithFeatureGates("MasterLevel=true")}
+	properties.AgentPoolProfiles[0].KubernetesConfig = getKubernetesConfigWithFeatureGates("AgentLevel=true")
+
+	mockCS.setKubeletConfig(false)
+
+	agentFeatureGates := properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig["--feature-gates"]
+	if agentFeatureGates != "AgentLevel=true" {
+		t.Fatalf("setKubeletConfig agent profile: expected 'AgentLevel=true' got '%s'", agentFeatureGates)
+	}
+
+	// Verify that the TopLevel feature gate override has only been applied to the agents
+	masterFeatureFates := properties.MasterProfile.KubernetesConfig.KubeletConfig["--feature-gates"]
+	if masterFeatureFates != "MasterLevel=true" {
+		t.Fatalf("setKubeletConfig master profile: expected 'MasterLevel=true' got '%s'", agentFeatureGates)
+	}
+}
+
+func TestEtcdDiskSize(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.8.10")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.Count = 1
+	mockCS.setOrchestratorDefaults(true, true)
+	if properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB != api.DefaultEtcdDiskSize {
+		t.Fatalf("EtcdDiskSizeGB did not have the expected size, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB, api.DefaultEtcdDiskSize)
+	}
+
+	mockCS = getMockBaseContainerService("1.8.10")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.Count = 5
+	mockCS.setOrchestratorDefaults(true, true)
+	if properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB != api.DefaultEtcdDiskSizeGT3Nodes {
+		t.Fatalf("EtcdDiskSizeGB did not have the expected size, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB, api.DefaultEtcdDiskSizeGT3Nodes)
+	}
+
+	mockCS = getMockBaseContainerService("1.8.10")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.Count = 5
+	properties.AgentPoolProfiles[0].Count = 6
+	mockCS.setOrchestratorDefaults(true, true)
+	if properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB != api.DefaultEtcdDiskSizeGT10Nodes {
+		t.Fatalf("EtcdDiskSizeGB did not have the expected size, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB, api.DefaultEtcdDiskSizeGT10Nodes)
+	}
+
+	mockCS = getMockBaseContainerService("1.8.10")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.Count = 5
+	properties.AgentPoolProfiles[0].Count = 16
+	mockCS.setOrchestratorDefaults(true, true)
+	if properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB != api.DefaultEtcdDiskSizeGT20Nodes {
+		t.Fatalf("EtcdDiskSizeGB did not have the expected size, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB, api.DefaultEtcdDiskSizeGT20Nodes)
+	}
+
+	mockCS = getMockBaseContainerService("1.8.10")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.Count = 5
+	properties.AgentPoolProfiles[0].Count = 50
+	customEtcdDiskSize := "512"
+	properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = customEtcdDiskSize
+	mockCS.setOrchestratorDefaults(true, true)
+	if properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB != customEtcdDiskSize {
+		t.Fatalf("EtcdDiskSizeGB did not have the expected size, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB, customEtcdDiskSize)
+	}
+}
+
+func TestGenerateEtcdEncryptionKey(t *testing.T) {
+	key1 := generateEtcdEncryptionKey()
+	key2 := generateEtcdEncryptionKey()
+	if key1 == key2 {
+		t.Fatalf("generateEtcdEncryptionKey should return a unique key each time, instead returned identical %s and %s", key1, key2)
+	}
+	for _, val := range []string{key1, key2} {
+		_, err := base64.StdEncoding.DecodeString(val)
+		if err != nil {
+			t.Fatalf("generateEtcdEncryptionKey should return a base64 encoded key, instead returned %s", val)
+		}
+	}
+}
+
+func TestNetworkPolicyDefaults(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.8.10")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = api.NetworkPolicyCalico
+	mockCS.setOrchestratorDefaults(true, true)
+	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != api.NetworkPluginKubenet {
+		t.Fatalf("NetworkPlugin did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin, api.NetworkPluginKubenet)
+	}
+
+	mockCS = getMockBaseContainerService("1.8.10")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = api.NetworkPolicyCilium
+	mockCS.setOrchestratorDefaults(true, true)
+	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != api.NetworkPluginCilium {
+		t.Fatalf("NetworkPlugin did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin, api.NetworkPluginCilium)
+	}
+
+	mockCS = getMockBaseContainerService("1.15.7")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = api.NetworkPolicyAntrea
+	mockCS.setOrchestratorDefaults(true, true)
+	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != api.NetworkPluginAntrea {
+		t.Fatalf("NetworkPlugin did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin, api.NetworkPluginAntrea)
+	}
+
+	mockCS = getMockBaseContainerService("1.8.10")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = api.NetworkPolicyAzure
+	mockCS.setOrchestratorDefaults(true, true)
+	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != api.NetworkPluginAzure {
+		t.Fatalf("NetworkPlugin did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin, api.NetworkPluginAzure)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy != "" {
+		t.Fatalf("NetworkPolicy did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy, "")
+	}
+
+	mockCS = getMockBaseContainerService("1.8.10")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = api.NetworkPolicyNone
+	mockCS.setOrchestratorDefaults(true, true)
+	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != api.NetworkPluginKubenet {
+		t.Fatalf("NetworkPlugin did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin, api.NetworkPluginKubenet)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy != "" {
+		t.Fatalf("NetworkPolicy did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy, "")
+	}
+}
+
+func TestNetworkPluginDefaults(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.15.7")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.setOrchestratorDefaults(true, true)
+	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != api.DefaultNetworkPlugin {
+		t.Fatalf("NetworkPlugin did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin, api.DefaultNetworkPlugin)
+	}
+
+	mockCS = getMockBaseContainerService("1.15.7")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.Addons = []api.KubernetesAddon{
+		{
+			Name:    common.FlannelAddonName,
+			Enabled: to.BoolPtr(true),
+		},
+	}
+	mockCS.setOrchestratorDefaults(true, true)
+	if properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin != api.NetworkPluginFlannel {
+		t.Fatalf("NetworkPlugin did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin, api.NetworkPluginFlannel)
+	}
+}
+
+func TestContainerRuntime(t *testing.T) {
+
+	for _, mobyVersion := range []string{"3.0.1", "3.0.3", "3.0.4", "3.0.5", "3.0.6", "3.0.7", "3.0.8", "3.0.10"} {
+		mockCS := getMockBaseContainerService("1.10.13")
+		properties := mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.MobyVersion = mobyVersion
+		mockCS.setOrchestratorDefaults(true, true)
+		if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != api.Docker {
+			t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, api.Docker)
+		}
+		if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != api.DefaultMobyVersion {
+			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, api.DefaultMobyVersion)
+		}
+		if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != "" {
+			t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, "")
+		}
+
+		mockCS = getMockBaseContainerService("1.10.13")
+		properties = mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.MobyVersion = mobyVersion
+		mockCS.setOrchestratorDefaults(false, false)
+		if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != api.Docker {
+			t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, api.Docker)
+		}
+		if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != mobyVersion {
+			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, mobyVersion)
+		}
+		if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != "" {
+			t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, "")
+		}
+	}
+
+	mockCS := getMockBaseContainerService("1.10.13")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.setOrchestratorDefaults(false, false)
+	if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != api.Docker {
+		t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, api.Docker)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != api.DefaultMobyVersion {
+		t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.MobyVersion, api.DefaultMobyVersion)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != "" {
+		t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, "")
+	}
+
+	mockCS = getMockBaseContainerService("1.10.13")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = api.Containerd
+	mockCS.setOrchestratorDefaults(false, false)
+	if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != api.Containerd {
+		t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, api.Containerd)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != "" {
+		t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.MobyVersion, "")
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != api.DefaultContainerdVersion {
+		t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, api.DefaultContainerdVersion)
+	}
+
+	mockCS = getMockBaseContainerService("1.10.13")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = api.KataContainers
+	mockCS.setOrchestratorDefaults(false, false)
+	if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != api.KataContainers {
+		t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, api.KataContainers)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != "" {
+		t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.MobyVersion, "")
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != api.DefaultContainerdVersion {
+		t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, api.DefaultContainerdVersion)
+	}
+
+	for _, containerdVersion := range []string{"1.1.2", "1.1.4", "1.1.5"} {
+
+		mockCS = getMockBaseContainerService("1.10.13")
+		properties = mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = api.Containerd
+		properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion = containerdVersion
+		mockCS.setOrchestratorDefaults(true, true)
+		if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != api.Containerd {
+			t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, api.Containerd)
+		}
+		if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != "" {
+			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, "")
+		}
+		if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != api.DefaultContainerdVersion {
+			t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, api.DefaultContainerdVersion)
+		}
+
+		mockCS = getMockBaseContainerService("1.10.13")
+		properties = mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime = api.Containerd
+		properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion = containerdVersion
+		mockCS.setOrchestratorDefaults(false, false)
+		if properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime != api.Containerd {
+			t.Fatalf("ContainerRuntime did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.ContainerRuntime, api.Containerd)
+		}
+		if properties.OrchestratorProfile.KubernetesConfig.MobyVersion != "" {
+			t.Fatalf("MobyVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.MobyVersion, "")
+		}
+		if properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion != containerdVersion {
+			t.Fatalf("Containerd did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.ContainerdVersion, containerdVersion)
+		}
+	}
+}
+
+func TestEtcdVersion(t *testing.T) {
+	// Default (no value) scenario
+	for _, etcdVersion := range []string{""} {
+		// Upgrade scenario should always upgrade to newer, default etcd version
+		// This sort of artificial (upgrade scenario should always have value), but strictly speaking this is what we want to do
+		mockCS := getMockBaseContainerService("1.10.13")
+		properties := mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
+		mockCS.setOrchestratorDefaults(true, false)
+		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != api.DefaultEtcdVersion {
+			t.Fatalf("EtcdVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.EtcdVersion, api.DefaultEtcdVersion)
+		}
+
+		// Create scenario should always accept the provided value
+		mockCS = getMockBaseContainerService("1.10.13")
+		properties = mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
+		mockCS.setOrchestratorDefaults(false, false)
+		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != api.DefaultEtcdVersion {
+			t.Fatalf("EtcdVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.EtcdVersion, api.DefaultEtcdVersion)
+		}
+
+		// Scale scenario should always accept the provided value
+		// This sort of artificial (upgrade scenario should always have value), but strictly speaking this is what we want to do
+		mockCS = getMockBaseContainerService("1.10.13")
+		properties = mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
+		mockCS.setOrchestratorDefaults(false, true)
+		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != api.DefaultEtcdVersion {
+			t.Fatalf("EtcdVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.EtcdVersion, api.DefaultEtcdVersion)
+		}
+	}
+
+	// These versions are all less than or equal to default
+	for _, etcdVersion := range []string{"2.2.5", "3.2.24", api.DefaultEtcdVersion} {
+		// Upgrade scenario should always upgrade to newer, default etcd version
+		mockCS := getMockBaseContainerService("1.10.13")
+		properties := mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
+		mockCS.setOrchestratorDefaults(true, false)
+		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != api.DefaultEtcdVersion {
+			t.Fatalf("EtcdVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.EtcdVersion, api.DefaultEtcdVersion)
+		}
+
+		// Create scenario should always accept the provided value
+		mockCS = getMockBaseContainerService("1.10.13")
+		properties = mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
+		mockCS.setOrchestratorDefaults(false, false)
+		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != etcdVersion {
+			t.Fatalf("EtcdVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.EtcdVersion, etcdVersion)
+		}
+
+		// Scale scenario should always accept the provided value
+		mockCS = getMockBaseContainerService("1.10.13")
+		properties = mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
+		mockCS.setOrchestratorDefaults(false, true)
+		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != etcdVersion {
+			t.Fatalf("EtcdVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.EtcdVersion, etcdVersion)
+		}
+	}
+
+	// These versions are all greater than default
+	for _, etcdVersion := range []string{"3.4.0", "99.99"} {
+		// Upgrade scenario should always keep the user-configured etcd version if it is greater than default
+		mockCS := getMockBaseContainerService("1.10.13")
+		properties := mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
+		mockCS.setOrchestratorDefaults(true, false)
+		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != etcdVersion {
+			t.Fatalf("EtcdVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.EtcdVersion, etcdVersion)
+		}
+
+		// Create scenario should always accept the provided value
+		mockCS = getMockBaseContainerService("1.10.13")
+		properties = mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
+		mockCS.setOrchestratorDefaults(false, false)
+		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != etcdVersion {
+			t.Fatalf("EtcdVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.EtcdVersion, etcdVersion)
+		}
+
+		// Scale scenario should always accept the provided value
+		mockCS = getMockBaseContainerService("1.10.13")
+		properties = mockCS.Properties
+		properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		properties.OrchestratorProfile.KubernetesConfig.EtcdVersion = etcdVersion
+		mockCS.setOrchestratorDefaults(false, true)
+		if properties.OrchestratorProfile.KubernetesConfig.EtcdVersion != etcdVersion {
+			t.Fatalf("EtcdVersion did not have the expected value, got %s, expected %s",
+				properties.OrchestratorProfile.KubernetesConfig.EtcdVersion, etcdVersion)
+		}
+	}
+}
+
+func TestStorageProfile(t *testing.T) {
+	// Test ManagedDisks default configuration
+	mockCS := getMockBaseContainerService("1.13.12")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.Count = 1
+	properties.OrchestratorProfile.KubernetesConfig.PrivateCluster = &api.PrivateCluster{
+		Enabled:        to.BoolPtr(true),
+		JumpboxProfile: &api.PrivateJumpboxProfile{},
+	}
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if properties.MasterProfile.StorageProfile != api.ManagedDisks {
+		t.Fatalf("MasterProfile.StorageProfile did not have the expected configuration, got %s, expected %s",
+			properties.MasterProfile.StorageProfile, api.ManagedDisks)
+	}
+	if !properties.MasterProfile.IsManagedDisks() {
+		t.Fatalf("MasterProfile.StorageProfile did not have the expected configuration, got %t, expected %t",
+			false, true)
+	}
+	if properties.AgentPoolProfiles[0].StorageProfile != api.ManagedDisks {
+		t.Fatalf("AgentPoolProfile.StorageProfile did not have the expected configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].StorageProfile, api.ManagedDisks)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.StorageProfile != api.ManagedDisks {
+		t.Fatalf("MasterProfile.StorageProfile did not have the expected configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.StorageProfile, api.ManagedDisks)
+	}
+	if !properties.AgentPoolProfiles[0].IsVirtualMachineScaleSets() {
+		t.Fatalf("AgentPoolProfile[0].AvailabilityProfile did not have the expected configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].AvailabilityProfile, api.AvailabilitySet)
+	}
+
+	mockCS = getMockBaseContainerService("1.13.12")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if !properties.AgentPoolProfiles[0].IsVirtualMachineScaleSets() {
+		t.Fatalf("AgentPoolProfile[0].AvailabilityProfile did not have the expected configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].AvailabilityProfile, api.VirtualMachineScaleSets)
+	}
+
+}
+
+// TestMasterProfileDefaults covers tests for setMasterProfileDefaults
+func TestMasterProfileDefaults(t *testing.T) {
+	// this validates default masterProfile configuration
+	mockCS := getMockBaseContainerService("1.13.12")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = ""
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginAzure
+	properties.MasterProfile.AvailabilityProfile = ""
+	properties.MasterProfile.Count = 3
+	mockCS.Properties = properties
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if properties.MasterProfile.IsVirtualMachineScaleSets() {
+		t.Fatalf("Master VMAS, AzureCNI: MasterProfile AvailabilityProfile did not have the expected default configuration, got %s, expected %s",
+			properties.MasterProfile.AvailabilityProfile, api.AvailabilitySet)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet != api.DefaultKubernetesSubnet {
+		t.Fatalf("Master VMAS, AzureCNI: MasterProfile ClusterSubnet did not have the expected default configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet, api.DefaultKubernetesSubnet)
+	}
+	if properties.MasterProfile.Subnet != properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet {
+		t.Fatalf("Master VMAS, AzureCNI: MasterProfile Subnet did not have the expected default configuration, got %s, expected %s",
+			properties.MasterProfile.Subnet, properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet)
+	}
+	if properties.AgentPoolProfiles[0].Subnet != properties.MasterProfile.Subnet {
+		t.Fatalf("Master VMAS, AzureCNI: AgentPoolProfiles Subnet did not have the expected default configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].Subnet, properties.MasterProfile.Subnet)
+	}
+	if properties.MasterProfile.FirstConsecutiveStaticIP != "10.255.255.5" {
+		t.Fatalf("Master VMAS, AzureCNI: MasterProfile FirstConsecutiveStaticIP did not have the expected default configuration, got %s, expected %s",
+			properties.MasterProfile.FirstConsecutiveStaticIP, "10.255.255.5")
+	}
+
+	// this validates default VMSS masterProfile configuration
+	mockCS = getMockBaseContainerService("1.13.12")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginAzure
+	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = ""
+	properties.MasterProfile.AvailabilityProfile = api.VirtualMachineScaleSets
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  true,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if !properties.MasterProfile.IsVirtualMachineScaleSets() {
+		t.Fatalf("Master VMSS, AzureCNI: MasterProfile AvailabilityProfile did not have the expected default configuration, got %s, expected %s",
+			properties.MasterProfile.AvailabilityProfile, api.VirtualMachineScaleSets)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet != api.DefaultKubernetesSubnet {
+		t.Fatalf("Master VMSS, AzureCNI: MasterProfile ClusterSubnet did not have the expected default configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet, api.DefaultKubernetesSubnet)
+	}
+	if properties.MasterProfile.FirstConsecutiveStaticIP != api.DefaultFirstConsecutiveKubernetesStaticIPVMSS {
+		t.Fatalf("Master VMSS, AzureCNI: MasterProfile FirstConsecutiveStaticIP did not have the expected default configuration, got %s, expected %s",
+			properties.MasterProfile.FirstConsecutiveStaticIP, api.DefaultFirstConsecutiveKubernetesStaticIPVMSS)
+	}
+	if properties.MasterProfile.Subnet != api.DefaultKubernetesMasterSubnet {
+		t.Fatalf("Master VMSS, AzureCNI: MasterProfile Subnet did not have the expected default configuration, got %s, expected %s",
+			properties.MasterProfile.Subnet, api.DefaultKubernetesMasterSubnet)
+	}
+	if properties.MasterProfile.AgentSubnet != api.DefaultKubernetesAgentSubnetVMSS {
+		t.Fatalf("Master VMSS, AzureCNI: MasterProfile AgentSubnet did not have the expected default configuration, got %s, expected %s",
+			properties.MasterProfile.AgentSubnet, api.DefaultKubernetesAgentSubnetVMSS)
+	}
+
+	// this validates default masterProfile configuration and kubenet
+	mockCS = getMockBaseContainerService("1.13.12")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = ""
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginKubenet
+	properties.MasterProfile.AvailabilityProfile = api.VirtualMachineScaleSets
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    true,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet != api.DefaultKubernetesClusterSubnet {
+		t.Fatalf("Master VMSS, kubenet: MasterProfile ClusterSubnet did not have the expected default configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet, api.DefaultKubernetesClusterSubnet)
+	}
+	if properties.MasterProfile.Subnet != api.DefaultKubernetesMasterSubnet {
+		t.Fatalf("Master VMSS, kubenet: MasterProfile Subnet did not have the expected default configuration, got %s, expected %s",
+			properties.MasterProfile.Subnet, api.DefaultKubernetesMasterSubnet)
+	}
+	if properties.MasterProfile.FirstConsecutiveStaticIP != api.DefaultFirstConsecutiveKubernetesStaticIPVMSS {
+		t.Fatalf("Master VMSS, kubenet: MasterProfile FirstConsecutiveStaticIP did not have the expected default configuration, got %s, expected %s",
+			properties.MasterProfile.FirstConsecutiveStaticIP, api.DefaultFirstConsecutiveKubernetesStaticIPVMSS)
+	}
+	if properties.MasterProfile.AgentSubnet != api.DefaultKubernetesAgentSubnetVMSS {
+		t.Fatalf("Master VMSS, kubenet: MasterProfile AgentSubnet did not have the expected default configuration, got %s, expected %s",
+			properties.MasterProfile.AgentSubnet, api.DefaultKubernetesAgentSubnetVMSS)
+	}
+	properties.MasterProfile.AvailabilityProfile = api.AvailabilitySet
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    true,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if properties.MasterProfile.FirstConsecutiveStaticIP != api.DefaultFirstConsecutiveKubernetesStaticIP {
+		t.Fatalf("Master VMAS, kubenet: MasterProfile FirstConsecutiveStaticIP did not have the expected default configuration, got %s, expected %s",
+			properties.MasterProfile.FirstConsecutiveStaticIP, api.DefaultFirstConsecutiveKubernetesStaticIP)
+	}
+
+	// this validates default vmas masterProfile configuration, AzureCNI, and custom vnet
+	mockCS = getMockBaseContainerService("1.10.3")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.VnetSubnetID = "/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Network/virtualNetworks/ExampleCustomVNET/subnets/ExampleMasterSubnet"
+	properties.MasterProfile.VnetCidr = "10.239.0.0/16"
+	properties.MasterProfile.FirstConsecutiveStaticIP = "10.239.255.239"
+	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = ""
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginAzure
+	properties.MasterProfile.AvailabilityProfile = api.AvailabilitySet
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    true,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	if properties.MasterProfile.FirstConsecutiveStaticIP != "10.239.255.239" {
+		t.Fatalf("Master VMAS, AzureCNI, customvnet: MasterProfile FirstConsecutiveStaticIP did not have the expected default configuration, got %s, expected %s",
+			properties.MasterProfile.FirstConsecutiveStaticIP, "10.239.255.239")
+	}
+
+	// this validates default VMSS masterProfile configuration, AzureCNI, and custom VNET
+	mockCS = getMockBaseContainerService("1.10.3")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.VnetSubnetID = "/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Network/virtualNetworks/ExampleCustomVNET/subnets/ExampleMasterSubnet"
+	properties.MasterProfile.VnetCidr = "10.239.0.0/16"
+	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = ""
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginAzure
+	properties.MasterProfile.AvailabilityProfile = api.VirtualMachineScaleSets
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    true,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if properties.MasterProfile.FirstConsecutiveStaticIP != "10.239.0.4" {
+		t.Fatalf("Master VMSS, AzureCNI, customvnet: MasterProfile FirstConsecutiveStaticIP did not have the expected default configuration, got %s, expected %s",
+			properties.MasterProfile.FirstConsecutiveStaticIP, "10.239.0.4")
+	}
+
+	// this validates default configurations for LoadBalancerSku and ExcludeMasterFromStandardLB
+	mockCS = getMockBaseContainerService("1.13.12")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = api.StandardLoadBalancerSku
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	excludeMaster := api.DefaultExcludeMasterFromStandardLB
+	if *properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB != excludeMaster {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB did not have the expected configuration, got %t, expected %t",
+			*properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB, excludeMaster)
+	}
+
+	// this validates default configurations for MaximumLoadBalancerRuleCount.
+	mockCS = getMockBaseContainerService("1.13.12")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if properties.OrchestratorProfile.KubernetesConfig.MaximumLoadBalancerRuleCount != api.DefaultMaximumLoadBalancerRuleCount {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.MaximumLoadBalancerRuleCount did not have the expected configuration, got %d, expected %d",
+			properties.OrchestratorProfile.KubernetesConfig.MaximumLoadBalancerRuleCount, api.DefaultMaximumLoadBalancerRuleCount)
+	}
+
+	// this validates cluster subnet default configuration for dual stack feature with 1.16
+	mockCS = getMockBaseContainerService("1.16.0")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.FeatureFlags = &api.FeatureFlags{EnableIPv6DualStack: true}
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	expectedClusterSubnet := strings.Join([]string{api.DefaultKubernetesClusterSubnet, "fc00::/8"}, ",")
+	if properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet != expectedClusterSubnet {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.ClusterSubnet did not have the expected configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet, expectedClusterSubnet)
+	}
+
+	// this validates cluster subnet default configuration for dual stack feature in 1.16 when only ipv4 subnet provided
+	mockCS = getMockBaseContainerService("1.16.0")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.FeatureFlags = &api.FeatureFlags{EnableIPv6DualStack: true}
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	expectedClusterSubnet = strings.Join([]string{api.DefaultKubernetesClusterSubnet, "fc00::/8"}, ",")
+	if properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet != expectedClusterSubnet {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.ClusterSubnet did not have the expected configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet, expectedClusterSubnet)
+	}
+
+	// this validates cluster subnet default configuration for dual stack feature.
+	mockCS = getMockBaseContainerService("1.17.0")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.FeatureFlags = &api.FeatureFlags{EnableIPv6DualStack: true}
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	expectedClusterSubnet = strings.Join([]string{api.DefaultKubernetesClusterSubnet, api.DefaultKubernetesClusterSubnetIPv6}, ",")
+	if properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet != expectedClusterSubnet {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.ClusterSubnet did not have the expected configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet, expectedClusterSubnet)
+	}
+
+	// this validates cluster subnet default configuration for dual stack feature when only ipv4 subnet provided
+	mockCS = getMockBaseContainerService("1.17.0")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = "10.244.0.0/16"
+	properties.FeatureFlags = &api.FeatureFlags{EnableIPv6DualStack: true}
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	expectedClusterSubnet = strings.Join([]string{"10.244.0.0/16", api.DefaultKubernetesClusterSubnetIPv6}, ",")
+	if properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet != expectedClusterSubnet {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.ClusterSubnet did not have the expected configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet, expectedClusterSubnet)
+	}
+
+	// this validates cluster subnet default configuration for dual stack feature when only ipv6 subnet provided
+	mockCS = getMockBaseContainerService("1.17.0")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = "ace:cab:deca::/8"
+	properties.FeatureFlags = &api.FeatureFlags{EnableIPv6DualStack: true}
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	expectedClusterSubnet = strings.Join([]string{api.DefaultKubernetesClusterSubnet, "ace:cab:deca::/8"}, ",")
+	if properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet != expectedClusterSubnet {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.ClusterSubnet did not have the expected configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet, expectedClusterSubnet)
+	}
+
+	// this validates default configurations for OutboundRuleIdleTimeoutInMinutes.
+	mockCS = getMockBaseContainerService("1.14.4")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = api.StandardLoadBalancerSku
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if properties.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes != api.DefaultOutboundRuleIdleTimeoutInMinutes {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes did not have the expected configuration, got %d, expected %d",
+			properties.OrchestratorProfile.KubernetesConfig.OutboundRuleIdleTimeoutInMinutes, api.DefaultOutboundRuleIdleTimeoutInMinutes)
+	}
+
+	// this validates cluster subnet default configuration for single stack IPv6 only cluster
+	mockCS = getMockBaseContainerService("1.18.0")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.FeatureFlags = &api.FeatureFlags{EnableIPv6Only: true}
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if properties.OrchestratorProfile.KubernetesConfig.DNSServiceIP != api.DefaultKubernetesDNSServiceIPv6 {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.DNSServiceIP did not have the expected configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.DNSServiceIP, api.DefaultKubernetesDNSServiceIPv6)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.ServiceCIDR != api.DefaultKubernetesServiceCIDRIPv6 {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.ServiceCIDR did not have the expected configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ServiceCIDR, api.DefaultKubernetesServiceCIDRIPv6)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet != api.DefaultKubernetesClusterSubnetIPv6 {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.ClusterSubnet did not have the expected configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet, api.DefaultKubernetesClusterSubnetIPv6)
+	}
+}
+
+func TestAgentPoolProfile(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.10")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.Count = 1
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if properties.AgentPoolProfiles[0].ScaleSetPriority != "" {
+		t.Fatalf("AgentPoolProfiles[0].ScaleSetPriority did not have the expected configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].ScaleSetPriority, "")
+	}
+	if properties.AgentPoolProfiles[0].ScaleSetEvictionPolicy != "" {
+		t.Fatalf("AgentPoolProfiles[0].ScaleSetEvictionPolicy did not have the expected configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].ScaleSetEvictionPolicy, "")
+	}
+	properties.AgentPoolProfiles[0].ScaleSetPriority = api.ScaleSetPriorityLow
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if properties.AgentPoolProfiles[0].ScaleSetEvictionPolicy != api.ScaleSetEvictionPolicyDelete {
+		t.Fatalf("AgentPoolProfile[0].ScaleSetEvictionPolicy did not have the expected configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].ScaleSetEvictionPolicy, api.ScaleSetEvictionPolicyDelete)
+	}
+	properties.AgentPoolProfiles[0].ScaleSetPriority = api.ScaleSetPrioritySpot
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if properties.AgentPoolProfiles[0].ScaleSetEvictionPolicy != api.ScaleSetEvictionPolicyDelete {
+		t.Fatalf("AgentPoolProfile[0].ScaleSetEvictionPolicy did not have the expected configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].ScaleSetEvictionPolicy, api.ScaleSetEvictionPolicyDelete)
+	}
+	if *properties.AgentPoolProfiles[0].SpotMaxPrice != float64(-1) {
+		t.Fatalf("AgentPoolProfile[0].SpotMaxPrice did not have the expected value, got %g, expected %g",
+			*properties.AgentPoolProfiles[0].SpotMaxPrice, float64(-1))
+	}
+
+	properties.AgentPoolProfiles[0].SpotMaxPrice = to.Float64Ptr(float64(88))
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if *properties.AgentPoolProfiles[0].SpotMaxPrice != float64(88) {
+		t.Fatalf("AgentPoolProfile[0].SpotMaxPrice did not have the expected value, got %g, expected %g",
+			*properties.AgentPoolProfiles[0].SpotMaxPrice, float64(88))
+	}
+}
+
+// TestDistroDefaults covers tests for setMasterProfileDefaults and setAgentProfileDefaults
+func TestDistroDefaults(t *testing.T) {
+
+	var tests = []struct {
+		name                   string                  // test case name
+		orchestratorProfile    api.OrchestratorProfile // orchestrator to be tested
+		masterProfileDistro    api.Distro
+		agentPoolProfileDistro api.Distro
+		expectedAgentDistro    api.Distro // expected agent result default disto to be used
+		expectedMasterDistro   api.Distro // expected master result default disto to be used
+		isUpgrade              bool
+		isScale                bool
+		cloudName              string
+	}{
+		{
+			"default_kubernetes",
+			api.OrchestratorProfile{
+				OrchestratorType: api.Kubernetes,
+				KubernetesConfig: &api.KubernetesConfig{},
+			},
+			"",
+			"",
+			api.AKSUbuntu1604,
+			api.AKSUbuntu1604,
+			false,
+			false,
+			api.AzurePublicCloud,
+		},
+		{
+			"default_kubernetes_usgov",
+			api.OrchestratorProfile{
+				OrchestratorType: api.Kubernetes,
+				KubernetesConfig: &api.KubernetesConfig{},
+			},
+			"",
+			"",
+			api.AKSUbuntu1604,
+			api.AKSUbuntu1604,
+			false,
+			false,
+			api.AzureUSGovernmentCloud,
+		},
+		{
+			"1804_upgrade_kubernetes",
+			api.OrchestratorProfile{
+				OrchestratorType: api.Kubernetes,
+				KubernetesConfig: &api.KubernetesConfig{},
+			},
+			api.AKSUbuntu1804,
+			api.AKSUbuntu1804,
+			api.AKSUbuntu1804,
+			api.AKSUbuntu1804,
+			true,
+			false,
+			api.AzurePublicCloud,
+		},
+		{
+			"default_kubernetes_germancloud",
+			api.OrchestratorProfile{
+				OrchestratorType: api.Kubernetes,
+				KubernetesConfig: &api.KubernetesConfig{},
+			},
+			api.AKS1604Deprecated,
+			api.AKS1604Deprecated,
+			api.Ubuntu,
+			api.Ubuntu,
+			true,
+			false,
+			api.AzureGermanCloud,
+		},
+		{
+			"deprecated_distro_kubernetes",
+			api.OrchestratorProfile{
+				OrchestratorType: api.Kubernetes,
+				KubernetesConfig: &api.KubernetesConfig{},
+			},
+			api.AKS1604Deprecated,
+			api.AKS1604Deprecated,
+			api.AKSUbuntu1604,
+			api.AKSUbuntu1604,
+			true,
+			false,
+			api.AzureChinaCloud,
+		},
+		{
+			"docker_engine_kubernetes",
+			api.OrchestratorProfile{
+				OrchestratorType: api.Kubernetes,
+				KubernetesConfig: &api.KubernetesConfig{},
+			},
+			api.AKS1604Deprecated,
+			api.AKSDockerEngine,
+			api.AKSUbuntu1604,
+			api.AKSUbuntu1604,
+			false,
+			true,
+			api.AzurePublicCloud,
+		},
+		{
+			"default_swarm",
+			api.OrchestratorProfile{
+				OrchestratorType: api.Swarm,
+			},
+			"",
+			"",
+			api.Ubuntu,
+			api.Ubuntu,
+			false,
+			false,
+			api.AzurePublicCloud,
+		},
+		{
+			"default_swarmmode",
+			api.OrchestratorProfile{
+				OrchestratorType: api.SwarmMode,
+			},
+			"",
+			"",
+			api.Ubuntu,
+			api.Ubuntu,
+			false,
+			false,
+			api.AzurePublicCloud,
+		},
+		{
+			"default_dcos",
+			api.OrchestratorProfile{
+				OrchestratorType: api.DCOS,
+			},
+			"",
+			"",
+			api.Ubuntu,
+			api.Ubuntu,
+			false,
+			false,
+			api.AzurePublicCloud,
+		},
+	}
+
+	for _, test := range tests {
+		mockAPI := getMockAPIProperties("1.0.0")
+		mockAPI.OrchestratorProfile = &test.orchestratorProfile
+		mockAPI.MasterProfile.Distro = test.masterProfileDistro
+		for _, agent := range mockAPI.AgentPoolProfiles {
+			agent.Distro = test.agentPoolProfileDistro
+		}
+		cs := &ContainerService{
+			Properties: &mockAPI,
+		}
+		switch test.cloudName {
+		case api.AzurePublicCloud:
+			cs.Location = "westus2"
+		case api.AzureChinaCloud:
+			cs.Location = "chinaeast"
+		case api.AzureGermanCloud:
+			cs.Location = "germanynortheast"
+		case api.AzureUSGovernmentCloud:
+			cs.Location = "usgovnorth"
+		default:
+			cs.Location = "westus2"
+		}
+		cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{
+			LoadBalancerSku: api.StandardLoadBalancerSku,
+		}
+		cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+			IsScale:    test.isScale,
+			IsUpgrade:  test.isUpgrade,
+			PkiKeySize: helpers.DefaultPkiKeySize,
+		})
+		if cs.Properties.MasterProfile.Distro != test.expectedMasterDistro {
+			t.Fatalf("SetPropertiesDefaults() test case %v did not return right masterProfile Distro configurations %v != %v", test.name, cs.Properties.MasterProfile.Distro, test.expectedMasterDistro)
+		}
+		for _, agent := range cs.Properties.AgentPoolProfiles {
+			if agent.Distro != test.expectedAgentDistro {
+				t.Fatalf("SetPropertiesDefaults() test case %v did not return right pool Distro configurations %v != %v", test.name, agent.Distro, test.expectedAgentDistro)
+			}
+			if to.Bool(agent.SinglePlacementGroup) != false {
+				t.Fatalf("SetPropertiesDefaults() test case %v did not return right singlePlacementGroup configurations %v != %v", test.name, agent.SinglePlacementGroup, false)
+			}
+		}
+	}
+}
+
+func TestWindowsProfileDefaults(t *testing.T) {
+	trueVar := true
+
+	var tests = []struct {
+		name                   string // test case name
+		windowsProfile         api.WindowsProfile
+		expectedWindowsProfile api.WindowsProfile
+		isAzureStack           bool
+		isUpgrade              bool
+		isScale                bool
+	}{
+		{
+			"defaults in creating",
+			api.WindowsProfile{},
+			api.WindowsProfile{
+				WindowsPublisher:      api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            api.AKSWindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:          api.AKSWindowsServer2019OSImageConfig.ImageVersion,
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            &trueVar,
+			},
+			false,
+			false,
+			false,
+		},
+		{
+			"aks vhd current version in creating",
+			api.WindowsProfile{
+				WindowsPublisher: api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:       api.AKSWindowsServer2019OSImageConfig.ImageSku,
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            api.AKSWindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:          api.AKSWindowsServer2019OSImageConfig.ImageVersion,
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            &trueVar,
+			},
+			false,
+			false,
+			false,
+		},
+		{
+			"aks vhd override sku in creating",
+			api.WindowsProfile{
+				WindowsPublisher: api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:       "override",
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            "override",
+				ImageVersion:          "latest",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            &trueVar,
+			},
+			false,
+			false,
+			false,
+		},
+		{
+			"aks vhd override version in creating",
+			api.WindowsProfile{
+				WindowsPublisher: api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:       api.AKSWindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:     "override",
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            api.AKSWindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:          "override",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            &trueVar,
+			},
+			false,
+			false,
+			false,
+		},
+		{
+			"vanilla vhd current version in creating",
+			api.WindowsProfile{
+				WindowsPublisher: api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:       api.WindowsServer2019OSImageConfig.ImageSku,
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            api.WindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:          api.WindowsServer2019OSImageConfig.ImageVersion,
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            &trueVar,
+			},
+			false,
+			false,
+			false,
+		},
+		{
+			"vanilla vhd override sku in creating",
+			api.WindowsProfile{
+				WindowsPublisher: api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:       "override",
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            "override",
+				ImageVersion:          "latest",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            &trueVar,
+			},
+			false,
+			false,
+			false,
+		},
+		{
+			"vanilla vhd override version in creating",
+			api.WindowsProfile{
+				WindowsPublisher: api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.WindowsServer2019OSImageConfig.ImageOffer,
+				ImageVersion:     "override",
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            api.WindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:          "override",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            &trueVar,
+			},
+			false,
+			false,
+			false,
+		},
+		{
+			"vanilla vhd spepcific version in creating",
+			api.WindowsProfile{
+				WindowsPublisher: api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:       api.WindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:     "override",
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            api.WindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:          "override",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            &trueVar,
+			},
+			false,
+			false,
+			false,
+		},
+		{
+			"user overrides latest version in creating",
+			api.WindowsProfile{
+				WindowsPublisher: "override",
+				WindowsOffer:     "override",
+				WindowsSku:       "override",
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      "override",
+				WindowsOffer:          "override",
+				WindowsSku:            "override",
+				ImageVersion:          "latest",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            &trueVar,
+			},
+			false,
+			false,
+			false,
+		},
+		{
+			"user overrides specific version in creating",
+			api.WindowsProfile{
+				WindowsPublisher: "override",
+				WindowsOffer:     "override",
+				WindowsSku:       "override",
+				ImageVersion:     "override",
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      "override",
+				WindowsOffer:          "override",
+				WindowsSku:            "override",
+				ImageVersion:          "override",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            &trueVar,
+			},
+			false,
+			false,
+			false,
+		},
+		{
+			"aks-engine does not set default ProvisioningScriptsPackageURL when it is not empty in upgrading",
+			api.WindowsProfile{
+				WindowsPublisher: api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:       api.WindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:     api.WindowsServer2019OSImageConfig.ImageVersion,
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            api.WindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:          api.WindowsServer2019OSImageConfig.ImageVersion,
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            nil,
+			},
+			false,
+			true,
+			false,
+		},
+		{
+			"aks-engine sets default WindowsSku and ImageVersion when they are empty in upgrading",
+			api.WindowsProfile{
+				WindowsPublisher: api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:       "",
+				ImageVersion:     "",
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            api.AKSWindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:          api.AKSWindowsServer2019OSImageConfig.ImageVersion,
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            nil,
+			},
+			false,
+			true,
+			false,
+		},
+		{
+			"aks-engine does not set default WindowsSku and ImageVersion when they are not empty in upgrading",
+			api.WindowsProfile{
+				WindowsPublisher: api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:       "override",
+				ImageVersion:     "override",
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            "override",
+				ImageVersion:          "override",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            nil,
+			},
+			false,
+			true,
+			false,
+		},
+		{
+			"aks-engine sets default vanilla WindowsSku and ImageVersion when they are empty in upgrading",
+			api.WindowsProfile{
+				WindowsPublisher: api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:       "",
+				ImageVersion:     "",
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            api.WindowsServer2019OSImageConfig.ImageSku,
+				ImageVersion:          api.WindowsServer2019OSImageConfig.ImageVersion,
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            nil,
+			},
+			false,
+			true,
+			false,
+		},
+		{
+			"aks-engine does not set vanilla default WindowsSku and ImageVersion when they are not empty in upgrading",
+			api.WindowsProfile{
+				WindowsPublisher: api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:       "override",
+				ImageVersion:     "override",
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            "override",
+				ImageVersion:          "override",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            nil,
+			},
+			false,
+			true,
+			false,
+		},
+		{
+			"aks-engine does not override version when WindowsPublisher does not match in upgrading",
+			api.WindowsProfile{
+				WindowsPublisher: api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:       "override",
+				ImageVersion:     "",
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.WindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            "override",
+				ImageVersion:          "",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            nil,
+			},
+			false,
+			true,
+			false,
+		},
+		{
+			"aks-engine does not override version when WindowsOffer does not match in upgrading",
+			api.WindowsProfile{
+				WindowsPublisher: api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:       "",
+				ImageVersion:     "override",
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.WindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            "",
+				ImageVersion:          "override",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            nil,
+			},
+			false,
+			true,
+			false,
+		},
+		{
+			"aks-engine does not change any value in scaling",
+			api.WindowsProfile{
+				WindowsPublisher: api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:     api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:       "",
+				ImageVersion:     "override",
+			},
+			api.WindowsProfile{
+				WindowsPublisher:      api.AKSWindowsServer2019OSImageConfig.ImagePublisher,
+				WindowsOffer:          api.AKSWindowsServer2019OSImageConfig.ImageOffer,
+				WindowsSku:            "",
+				ImageVersion:          "override",
+				AdminUsername:         "",
+				AdminPassword:         "",
+				WindowsImageSourceURL: "",
+				WindowsDockerVersion:  "",
+				SSHEnabled:            nil,
+			},
+			false,
+			false,
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockAPI := getMockAPIProperties("1.16.0")
+			mockAPI.WindowsProfile = &test.windowsProfile
+			if test.isAzureStack {
+				mockAPI.CustomCloudProfile = &api.CustomCloudProfile{}
+			}
+			cs := ContainerService{
+				Properties: &mockAPI,
+			}
+			cs.setWindowsProfileDefaults(test.isUpgrade, test.isScale)
+
+			actual := mockAPI.WindowsProfile
+			expected := &test.expectedWindowsProfile
+
+			equal := reflect.DeepEqual(actual, expected)
+			if !equal {
+				t.Errorf("unexpected diff while comparing WindowsProfile. expected: %v, actual: %v", *expected, *actual)
+			}
+		})
+	}
+}
+
+func TestIsAzureCNINetworkmonitorAddon(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.10.3")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.Count = 1
+	properties.OrchestratorProfile.KubernetesConfig.Addons = []api.KubernetesAddon{
+		{
+			Name: common.AzureCNINetworkMonitorAddonName,
+			Containers: []api.KubernetesContainerSpec{
+				{
+					Name:           common.AzureCNINetworkMonitorAddonName,
+					CPURequests:    "50m",
+					MemoryRequests: "150Mi",
+					CPULimits:      "50m",
+					MemoryLimits:   "150Mi",
+				},
+			},
+			Enabled: to.BoolPtr(true),
+		},
+	}
+	mockCS.setOrchestratorDefaults(true, true)
+
+	i := getAddonsIndexByName(properties.OrchestratorProfile.KubernetesConfig.Addons, common.AzureCNINetworkMonitorAddonName)
+	if !to.Bool(properties.OrchestratorProfile.KubernetesConfig.Addons[i].Enabled) {
+		t.Fatalf("Azure CNI networkmonitor addon should be present")
+	}
+
+	mockCS = getMockBaseContainerService("1.10.3")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.Count = 1
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginAzure
+	mockCS.setOrchestratorDefaults(true, true)
+
+	i = getAddonsIndexByName(properties.OrchestratorProfile.KubernetesConfig.Addons, common.AzureCNINetworkMonitorAddonName)
+	if !to.Bool(properties.OrchestratorProfile.KubernetesConfig.Addons[i].Enabled) {
+		t.Fatalf("Azure CNI networkmonitor addon should be present by default if Azure CNI is set")
+	}
+}
+
+// TestSetVMSSDefaultsAndZones covers tests for setVMSSDefaultsForAgents and masters
+func TestSetVMSSDefaultsAndZones(t *testing.T) {
+	// masters with VMSS and no zones
+	mockCS := getMockBaseContainerService("1.12.0")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.AvailabilityProfile = api.VirtualMachineScaleSets
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if properties.MasterProfile.HasAvailabilityZones() {
+		t.Fatalf("MasterProfile.HasAvailabilityZones did not have the expected return, got %t, expected %t",
+			properties.MasterProfile.HasAvailabilityZones(), false)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != api.DefaultLoadBalancerSku {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.LoadBalancerSku did not have the expected configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, api.DefaultLoadBalancerSku)
+	}
+	// masters with VMSS and zones
+	mockCS = getMockBaseContainerService("1.12.0")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.AvailabilityProfile = api.VirtualMachineScaleSets
+	properties.MasterProfile.AvailabilityZones = []string{"1", "2"}
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	singlePlacementGroup := api.DefaultSinglePlacementGroup
+	if *properties.MasterProfile.SinglePlacementGroup != singlePlacementGroup {
+		t.Fatalf("MasterProfile.SinglePlacementGroup default did not have the expected configuration, got %t, expected %t",
+			*properties.MasterProfile.SinglePlacementGroup, singlePlacementGroup)
+	}
+	if !properties.MasterProfile.HasAvailabilityZones() {
+		t.Fatalf("MasterProfile.HasAvailabilityZones did not have the expected return, got %t, expected %t",
+			properties.MasterProfile.HasAvailabilityZones(), true)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != api.StandardLoadBalancerSku {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.LoadBalancerSku did not have the expected configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, api.StandardLoadBalancerSku)
+	}
+	excludeMaster := api.DefaultExcludeMasterFromStandardLB
+	if *properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB != excludeMaster {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB did not have the expected configuration, got %t, expected %t",
+			*properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB, excludeMaster)
+	}
+	// agents with VMSS and no zones
+	mockCS = getMockBaseContainerService("1.12.0")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.AgentPoolProfiles[0].Count = 4
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if properties.AgentPoolProfiles[0].HasAvailabilityZones() {
+		t.Fatalf("AgentPoolProfiles[0].HasAvailabilityZones did not have the expected return, got %t, expected %t",
+			properties.AgentPoolProfiles[0].HasAvailabilityZones(), false)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != api.DefaultLoadBalancerSku {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.LoadBalancerSku did not have the expected configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, api.DefaultLoadBalancerSku)
+	}
+	// agents with VMSS and zones
+	mockCS = getMockBaseContainerService("1.13.12")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.AgentPoolProfiles[0].Count = 4
+	properties.AgentPoolProfiles[0].SinglePlacementGroup = nil
+	properties.AgentPoolProfiles[0].AvailabilityZones = []string{"1", "2"}
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if !properties.AgentPoolProfiles[0].IsVirtualMachineScaleSets() {
+		t.Fatalf("AgentPoolProfile[0].AvailabilityProfile did not have the expected configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].AvailabilityProfile, api.VirtualMachineScaleSets)
+	}
+	if !properties.AgentPoolProfiles[0].HasAvailabilityZones() {
+		t.Fatalf("AgentPoolProfiles[0].HasAvailabilityZones did not have the expected return, got %t, expected %t",
+			properties.AgentPoolProfiles[0].HasAvailabilityZones(), true)
+	}
+	singlePlacementGroup = false
+	if *properties.AgentPoolProfiles[0].SinglePlacementGroup != singlePlacementGroup {
+		t.Fatalf("AgentPoolProfile[0].SinglePlacementGroup default did not have the expected configuration, got %t, expected %t",
+			*properties.AgentPoolProfiles[0].SinglePlacementGroup, singlePlacementGroup)
+	}
+	if properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != api.StandardLoadBalancerSku {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.LoadBalancerSku did not have the expected configuration, got %s, expected %s",
+			properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, api.StandardLoadBalancerSku)
+	}
+	excludeMaster = api.DefaultExcludeMasterFromStandardLB
+	if *properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB != excludeMaster {
+		t.Fatalf("OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB did not have the expected configuration, got %t, expected %t",
+			*properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB, excludeMaster)
+	}
+
+	properties.AgentPoolProfiles[0].SinglePlacementGroup = nil
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if to.Bool(properties.AgentPoolProfiles[0].SinglePlacementGroup) {
+		t.Fatalf("AgentPoolProfile[0].SinglePlacementGroup did not have the expected configuration, got %t, expected %t",
+			*properties.AgentPoolProfiles[0].SinglePlacementGroup, false)
+	}
+
+	if !*properties.AgentPoolProfiles[0].SinglePlacementGroup && properties.AgentPoolProfiles[0].StorageProfile != api.ManagedDisks {
+		t.Fatalf("AgentPoolProfile[0].StorageProfile did not have the expected configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].StorageProfile, api.ManagedDisks)
+	}
+
+}
+
+func TestAzureCNIVersionString(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.10.3")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.Count = 1
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginAzure
+	mockCS.setOrchestratorDefaults(true, true)
+
+	if properties.OrchestratorProfile.KubernetesConfig.AzureCNIVersion != api.AzureCniPluginVerLinux {
+		t.Fatalf("Azure CNI Version string not the expected value, got %s, expected %s", properties.OrchestratorProfile.KubernetesConfig.AzureCNIVersion, api.AzureCniPluginVerLinux)
+	}
+
+	mockCS = getMockBaseContainerService("1.10.3")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.Count = 1
+	properties.AgentPoolProfiles[0].OSType = api.Windows
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginAzure
+	mockCS.setOrchestratorDefaults(true, true)
+
+	if properties.OrchestratorProfile.KubernetesConfig.AzureCNIVersion != api.AzureCniPluginVerWindows {
+		t.Fatalf("Azure CNI Version string not the expected value, got %s, expected %s", properties.OrchestratorProfile.KubernetesConfig.AzureCNIVersion, api.AzureCniPluginVerWindows)
+	}
+
+	mockCS = getMockBaseContainerService("1.10.3")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.Count = 1
+	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginKubenet
+	mockCS.setOrchestratorDefaults(true, true)
+
+	if properties.OrchestratorProfile.KubernetesConfig.AzureCNIVersion != "" {
+		t.Fatalf("Azure CNI Version string not the expected value, got %s, expected %s", properties.OrchestratorProfile.KubernetesConfig.AzureCNIVersion, "")
+	}
+}
+
+func TestEnableAggregatedAPIs(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.10.3")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(false)
+	mockCS.setOrchestratorDefaults(true, true)
+
+	if properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs {
+		t.Fatalf("got unexpected EnableAggregatedAPIs config value for EnableRbac=false: %t",
+			properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs)
+	}
+
+	mockCS = getMockBaseContainerService("1.10.3")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.EnableRbac = to.BoolPtr(true)
+	mockCS.setOrchestratorDefaults(true, true)
+
+	if !properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs {
+		t.Fatalf("got unexpected EnableAggregatedAPIs config value for EnableRbac=true: %t",
+			properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs)
+	}
+}
+
+func TestCloudControllerManagerEnabled(t *testing.T) {
+	// test that 1.16 defaults to false
+	cs := CreateMockContainerService("testcluster", "1.16.1", 3, 2, false)
+	cs.setOrchestratorDefaults(false, false)
+	if cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager == to.BoolPtr(true) {
+		t.Fatal("expected UseCloudControllerManager to default to false")
+	}
+
+	// test that 1.17 defaults to false
+	cs = CreateMockContainerService("testcluster", "1.17.0", 3, 2, false)
+	cs.setOrchestratorDefaults(false, false)
+	if cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager == to.BoolPtr(true) {
+		t.Fatal("expected UseCloudControllerManager to default to false")
+	}
+}
+
+func TestDefaultCloudProvider(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.10.3")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	mockCS.setOrchestratorDefaults(true, true)
+
+	if to.Bool(properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoff) {
+		t.Fatalf("got unexpected CloudProviderBackoff expected false, got %t",
+			to.Bool(properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoff))
+	}
+
+	if !to.Bool(properties.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimit) {
+		t.Fatalf("got unexpected CloudProviderBackoff expected true, got %t",
+			to.Bool(properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoff))
+	}
+
+	mockCS = getMockBaseContainerService("1.10.3")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoff = to.BoolPtr(false)
+	properties.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimit = to.BoolPtr(false)
+	mockCS.setOrchestratorDefaults(true, true)
+
+	if to.Bool(properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoff) {
+		t.Fatalf("got unexpected CloudProviderBackoff expected true, got %t",
+			to.Bool(properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoff))
+	}
+
+	if to.Bool(properties.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimit) {
+		t.Fatalf("got unexpected CloudProviderBackoff expected true, got %t",
+			to.Bool(properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoff))
+	}
+}
+
+func TestCloudProviderBackoff(t *testing.T) {
+	cases := []struct {
+		name      string
+		cs        ContainerService
+		isUpgrade bool
+		isScale   bool
+		expected  api.KubernetesConfig
+	}{
+		{
+			name: "default",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType: api.Kubernetes,
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: api.KubernetesConfig{
+				CloudProviderBackoffMode:          "v1",
+				CloudProviderBackoff:              to.BoolPtr(false),
+				CloudProviderBackoffRetries:       api.DefaultKubernetesCloudProviderBackoffRetries,
+				CloudProviderBackoffJitter:        api.DefaultKubernetesCloudProviderBackoffJitter,
+				CloudProviderBackoffDuration:      api.DefaultKubernetesCloudProviderBackoffDuration,
+				CloudProviderBackoffExponent:      api.DefaultKubernetesCloudProviderBackoffExponent,
+				CloudProviderRateLimit:            to.BoolPtr(api.DefaultKubernetesCloudProviderRateLimit),
+				CloudProviderRateLimitQPS:         api.DefaultKubernetesCloudProviderRateLimitQPS,
+				CloudProviderRateLimitQPSWrite:    api.DefaultKubernetesCloudProviderRateLimitQPSWrite,
+				CloudProviderRateLimitBucket:      api.DefaultKubernetesCloudProviderRateLimitBucket,
+				CloudProviderRateLimitBucketWrite: api.DefaultKubernetesCloudProviderRateLimitBucketWrite,
+			},
+		},
+		{
+			name: "Kubernetes 1.14.0",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: api.KubernetesConfig{
+				CloudProviderBackoffMode:          "v2",
+				CloudProviderBackoff:              to.BoolPtr(true),
+				CloudProviderBackoffRetries:       api.DefaultKubernetesCloudProviderBackoffRetries,
+				CloudProviderBackoffJitter:        0,
+				CloudProviderBackoffDuration:      api.DefaultKubernetesCloudProviderBackoffDuration,
+				CloudProviderBackoffExponent:      0,
+				CloudProviderRateLimit:            to.BoolPtr(api.DefaultKubernetesCloudProviderRateLimit),
+				CloudProviderRateLimitQPS:         api.DefaultKubernetesCloudProviderRateLimitQPS,
+				CloudProviderRateLimitQPSWrite:    api.DefaultKubernetesCloudProviderRateLimitQPSWrite,
+				CloudProviderRateLimitBucket:      api.DefaultKubernetesCloudProviderRateLimitBucket,
+				CloudProviderRateLimitBucketWrite: api.DefaultKubernetesCloudProviderRateLimitBucketWrite,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			c.cs.setOrchestratorDefaults(c.isUpgrade, c.isScale)
+			if c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoffMode != c.expected.CloudProviderBackoffMode {
+				t.Errorf("expected %s, but got %s", c.expected.CloudProviderBackoffMode, c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoffMode)
+			}
+			if to.Bool(c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoff) != to.Bool(c.expected.CloudProviderBackoff) {
+				t.Errorf("expected %t, but got %t", to.Bool(c.expected.CloudProviderBackoff), to.Bool(c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoff))
+			}
+			if c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoffRetries != c.expected.CloudProviderBackoffRetries {
+				t.Errorf("expected %d, but got %d", c.expected.CloudProviderBackoffRetries, c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoffRetries)
+			}
+			if c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoffJitter != c.expected.CloudProviderBackoffJitter {
+				t.Errorf("expected %f, but got %f", c.expected.CloudProviderBackoffJitter, c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoffJitter)
+			}
+			if c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoffDuration != c.expected.CloudProviderBackoffDuration {
+				t.Errorf("expected %d, but got %d", c.expected.CloudProviderBackoffDuration, c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoffDuration)
+			}
+			if c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoffExponent != c.expected.CloudProviderBackoffExponent {
+				t.Errorf("expected %f, but got %f", c.expected.CloudProviderBackoffExponent, c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderBackoffExponent)
+			}
+			if to.Bool(c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimit) != to.Bool(c.expected.CloudProviderRateLimit) {
+				t.Errorf("expected %t, but got %t", to.Bool(c.expected.CloudProviderRateLimit), to.Bool(c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimit))
+			}
+			if c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPS != c.expected.CloudProviderRateLimitQPS {
+				t.Errorf("expected %f, but got %f", c.expected.CloudProviderRateLimitQPS, c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPS)
+			}
+			if c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPSWrite != c.expected.CloudProviderRateLimitQPSWrite {
+				t.Errorf("expected %f, but got %f", c.expected.CloudProviderRateLimitQPSWrite, c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitQPSWrite)
+			}
+			if c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket != c.expected.CloudProviderRateLimitBucket {
+				t.Errorf("expected %d, but got %d", c.expected.CloudProviderRateLimitBucket, c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucket)
+			}
+			if c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite != c.expected.CloudProviderRateLimitBucketWrite {
+				t.Errorf("expected %d, but got %d", c.expected.CloudProviderRateLimitBucketWrite, c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderRateLimitBucketWrite)
+			}
+		})
+	}
+}
+
+func TestSetCertDefaults(t *testing.T) {
+	cs := &ContainerService{
+		Properties: &api.Properties{
+			ServicePrincipalProfile: &api.ServicePrincipalProfile{
+				ClientID: "barClientID",
+				Secret:   "bazSecret",
+			},
+			MasterProfile: &api.MasterProfile{
+				Count:     3,
+				DNSPrefix: "myprefix1",
+				VMSize:    "Standard_DS2_v2",
+			},
+			OrchestratorProfile: &api.OrchestratorProfile{
+				OrchestratorType:    api.Kubernetes,
+				OrchestratorVersion: "1.10.2",
+				KubernetesConfig: &api.KubernetesConfig{
+					NetworkPlugin: api.NetworkPluginAzure,
+				},
+			},
+		},
+	}
+
+	cs.setOrchestratorDefaults(false, false)
+	cs.setMasterProfileDefaults(false)
+	result, ips, err := cs.SetDefaultCerts(api.DefaultCertParams{
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	if !result {
+		t.Error("expected SetDefaultCerts to return true")
+	}
+
+	if err != nil {
+		t.Errorf("unexpected error thrown while executing SetDefaultCerts %s", err.Error())
+	}
+
+	if ips == nil {
+		t.Error("expected SetDefaultCerts to create a list of IPs")
+	} else {
+
+		if len(ips) != cs.Properties.MasterProfile.Count+3 {
+			t.Errorf("expected length of IPs from SetDefaultCerts %d, actual length %d", cs.Properties.MasterProfile.Count+3, len(ips))
+		}
+
+		firstMasterIP := net.ParseIP(cs.Properties.MasterProfile.FirstConsecutiveStaticIP).To4()
+		offsetMultiplier := 1
+		addr := binary.BigEndian.Uint32(firstMasterIP)
+		expectedNewAddr := getNewAddr(addr, cs.Properties.MasterProfile.Count-1, offsetMultiplier)
+		actualLastIPAddr := binary.BigEndian.Uint32(ips[len(ips)-2])
+		if actualLastIPAddr != expectedNewAddr {
+			expectedLastIP := make(net.IP, 4)
+			binary.BigEndian.PutUint32(expectedLastIP, expectedNewAddr)
+			t.Errorf("expected last IP of master vm from SetDefaultCerts %d, actual %d", expectedLastIP, ips[len(ips)-2])
+		}
+
+		if cs.Properties.MasterProfile.HasMultipleNodes() {
+			expectedILBIP := net.IP{firstMasterIP[0], firstMasterIP[1], firstMasterIP[2], firstMasterIP[3] + byte(api.DefaultInternalLbStaticIPOffset)}
+			actualILBIPAddr := binary.BigEndian.Uint32(ips[2])
+			expectedILBIPAddr := binary.BigEndian.Uint32(expectedILBIP)
+
+			if actualILBIPAddr != expectedILBIPAddr {
+				t.Errorf("expected IP of master ILB from SetDefaultCerts %d, actual %d", expectedILBIP, ips[2])
+			}
+		}
+	}
+}
+
+func TestSetCertDefaultsVMSS(t *testing.T) {
+	cs := &ContainerService{
+		Properties: &api.Properties{
+			ServicePrincipalProfile: &api.ServicePrincipalProfile{
+				ClientID: "barClientID",
+				Secret:   "bazSecret",
+			},
+			MasterProfile: &api.MasterProfile{
+				Count:               3,
+				DNSPrefix:           "myprefix1",
+				VMSize:              "Standard_DS2_v2",
+				AvailabilityProfile: api.VirtualMachineScaleSets,
+			},
+			OrchestratorProfile: &api.OrchestratorProfile{
+				OrchestratorType:    api.Kubernetes,
+				OrchestratorVersion: "1.10.2",
+				KubernetesConfig: &api.KubernetesConfig{
+					NetworkPlugin: api.NetworkPluginAzure,
+				},
+			},
+		},
+	}
+
+	cs.setOrchestratorDefaults(false, false)
+	cs.setMasterProfileDefaults(false)
+	result, ips, err := cs.SetDefaultCerts(api.DefaultCertParams{
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	if !result {
+		t.Error("expected SetDefaultCerts to return true")
+	}
+
+	if err != nil {
+		t.Errorf("unexpected error thrown while executing SetDefaultCerts %s", err.Error())
+	}
+
+	if ips == nil {
+		t.Error("expected SetDefaultCerts to create a list of IPs")
+	} else {
+
+		if len(ips) != cs.Properties.MasterProfile.Count+3 {
+			t.Errorf("expected length of IPs from SetDefaultCerts %d, actual length %d", cs.Properties.MasterProfile.Count+3, len(ips))
+		}
+
+		firstMasterIP := net.ParseIP(cs.Properties.MasterProfile.FirstConsecutiveStaticIP).To4()
+		offsetMultiplier := cs.Properties.MasterProfile.IPAddressCount
+		addr := binary.BigEndian.Uint32(firstMasterIP)
+		expectedNewAddr := getNewAddr(addr, cs.Properties.MasterProfile.Count-1, offsetMultiplier)
+		actualLastIPAddr := binary.BigEndian.Uint32(ips[len(ips)-2])
+		if actualLastIPAddr != expectedNewAddr {
+			expectedLastIP := make(net.IP, 4)
+			binary.BigEndian.PutUint32(expectedLastIP, expectedNewAddr)
+			t.Errorf("expected last IP of master vm from SetDefaultCerts %d, actual %d", expectedLastIP, ips[len(ips)-2])
+		}
+
+		if cs.Properties.MasterProfile.HasMultipleNodes() {
+			expectedILBIP := net.IP{firstMasterIP[0], firstMasterIP[1], byte(255), byte(api.DefaultInternalLbStaticIPOffset)}
+			actualILBIPAddr := binary.BigEndian.Uint32(ips[2])
+			expectedILBIPAddr := binary.BigEndian.Uint32(expectedILBIP)
+
+			if actualILBIPAddr != expectedILBIPAddr {
+				t.Errorf("expected IP of master ILB from SetDefaultCerts %d, actual %d", expectedILBIP, ips[2])
+			}
+		}
+	}
+}
+
+func TestSetOrchestratorDefaultsVMAS(t *testing.T) {
+	cs := &ContainerService{
+		Properties: &api.Properties{
+			ServicePrincipalProfile: &api.ServicePrincipalProfile{
+				ClientID: "barClientID",
+				Secret:   "bazSecret",
+			},
+			MasterProfile: &api.MasterProfile{
+				Count:               3,
+				DNSPrefix:           "myprefix1",
+				VMSize:              "Standard_DS2_v2",
+				AvailabilityProfile: api.AvailabilitySet,
+			},
+			OrchestratorProfile: &api.OrchestratorProfile{
+				OrchestratorType:    api.Kubernetes,
+				OrchestratorVersion: "1.12.8",
+				KubernetesConfig: &api.KubernetesConfig{
+					NetworkPlugin: api.NetworkPluginAzure,
+				},
+			},
+		},
+	}
+
+	cs.setOrchestratorDefaults(false, false)
+	if cs.Properties.OrchestratorProfile.OrchestratorVersion != "1.12.8" {
+		t.Error("setOrchestratorDefaults should not adjust given OrchestratorVersion")
+	}
+
+	cs.Properties.OrchestratorProfile.OrchestratorVersion = ""
+	cs.setOrchestratorDefaults(false, false)
+	if cs.Properties.OrchestratorProfile.OrchestratorVersion == "" {
+		t.Error("setOrchestratorDefaults should provide a version if it is not given.")
+	}
+}
+
+func TestProxyModeDefaults(t *testing.T) {
+	// Test that default is what we expect
+	mockCS := getMockBaseContainerService("1.10.12")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.MasterProfile.Count = 1
+	mockCS.setOrchestratorDefaults(true, true)
+
+	if properties.OrchestratorProfile.KubernetesConfig.ProxyMode != api.DefaultKubeProxyMode {
+		t.Fatalf("ProxyMode string not the expected default value, got %s, expected %s", properties.OrchestratorProfile.KubernetesConfig.ProxyMode, api.DefaultKubeProxyMode)
+	}
+
+	// Test that default assignment flow doesn't overwrite a user-provided config
+	mockCS = getMockBaseContainerService("1.10.12")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	properties.OrchestratorProfile.KubernetesConfig.ProxyMode = api.KubeProxyModeIPVS
+	properties.MasterProfile.Count = 1
+	mockCS.setOrchestratorDefaults(true, true)
+
+	if properties.OrchestratorProfile.KubernetesConfig.ProxyMode != api.KubeProxyModeIPVS {
+		t.Fatalf("ProxyMode string not the expected default value, got %s, expected %s", properties.OrchestratorProfile.KubernetesConfig.ProxyMode, api.KubeProxyModeIPVS)
+	}
+}
+func TestSetCustomCloudProfileDefaults(t *testing.T) {
+
+	// Test that the ResourceManagerVMDNSSuffix is set in EndpointConfig
+	mockCS := getMockBaseContainerService("1.11.6")
+	mockCSP := GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, false)
+	vmDNSSuffix := "contoso.net"
+	mockCSP.CustomCloudProfile.Environment.ResourceManagerVMDNSSuffix = vmDNSSuffix
+	mockCS.Properties.CustomCloudProfile = mockCSP.CustomCloudProfile
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	if api.AzureCloudSpecEnvMap[api.AzureStackCloud].EndpointConfig.ResourceManagerVMDNSSuffix != vmDNSSuffix {
+		t.Errorf("setCustomCloudProfileDefaults(): ResourceManagerVMDNSSuffix string in AzureCloudSpecEnvMap[AzureStackCloud] not the expected default value, got %s, expected %s", api.AzureCloudSpecEnvMap[api.AzureStackCloud].EndpointConfig.ResourceManagerVMDNSSuffix, vmDNSSuffix)
+	}
+
+	// Test that the AzureStackCloudSpec is default when azureEnvironmentSpecConfig is empty in api model JSON file
+	mockCSDefaultSpec := getMockBaseContainerService("1.11.6")
+	mockCSPDefaultSpec := GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, false)
+	mockCSDefaultSpec.Properties.CustomCloudProfile = mockCSPDefaultSpec.CustomCloudProfile
+	mockCSDefaultSpec.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	actualEnv := api.AzureCloudSpecEnvMap[api.AzureStackCloud]
+	expectedEnv := api.AzureCloudSpecEnvMap[api.AzurePublicCloud]
+	expectedEnv.EndpointConfig.ResourceManagerVMDNSSuffix = mockCSPDefaultSpec.CustomCloudProfile.Environment.ResourceManagerVMDNSSuffix
+	expectedEnv.CloudName = api.AzureStackCloud
+	expectedEnv.KubernetesSpecConfig.AzureTelemetryPID = api.DefaultAzureStackDeployTelemetryPID
+
+	if equal := reflect.DeepEqual(actualEnv, expectedEnv); !equal {
+		t.Errorf("setCustomCloudProfileDefaults(): did not set AzureStackCloudSpec as default when azureEnvironmentSpecConfig is empty in api model JSON file. expected: %s, actual: %s", expectedEnv, actualEnv)
+	}
+
+	modeToSpec := map[string]string{
+		"public":       "AzurePublicCloud",
+		"china":        "AzureChinaCloud",
+		"german":       "AzureGermanCloud",
+		"usgovernment": "AzureUSGovernmentCloud",
+	}
+
+	for key, value := range modeToSpec {
+		mockCSAzureChinaSpec := getMockBaseContainerService("1.11.6")
+		mockCSPAzureChinaSpec := GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, false)
+		mockCSPAzureChinaSpec.CustomCloudProfile.DependenciesLocation = api.DependenciesLocation(key)
+		mockCSAzureChinaSpec.Properties.CustomCloudProfile = mockCSPAzureChinaSpec.CustomCloudProfile
+
+		mockCSAzureChinaSpec.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+			IsScale:    false,
+			IsUpgrade:  false,
+			PkiKeySize: helpers.DefaultPkiKeySize,
+		})
+
+		actualEnvAzureChinaSpec := api.AzureCloudSpecEnvMap[api.AzureStackCloud]
+		expectedEnvAzureChinaSpec := api.AzureCloudSpecEnvMap[value]
+		expectedEnvAzureChinaSpec.EndpointConfig.ResourceManagerVMDNSSuffix = mockCSPDefaultSpec.CustomCloudProfile.Environment.ResourceManagerVMDNSSuffix
+		expectedEnvAzureChinaSpec.CloudName = api.AzureStackCloud
+		expectedEnvAzureChinaSpec.KubernetesSpecConfig.AzureTelemetryPID = api.DefaultAzureStackDeployTelemetryPID
+		t.Logf("verifying dependenciesLocation: %s", key)
+		if equal := reflect.DeepEqual(actualEnvAzureChinaSpec, expectedEnvAzureChinaSpec); !equal {
+			t.Errorf("setCustomCloudProfileDefaults(): did not set AzureStackCloudSpec as default when connection Mode is %s in api model JSON file. expected: %s, actual: %s", key, expectedEnvAzureChinaSpec, actualEnvAzureChinaSpec)
+		}
+	}
+
+	// Test that correct error message if ResourceManagerVMDNSSuffix is empty
+	mockCSEmptyResourceManagerVMDNSSuffix := getMockBaseContainerService("1.11.6")
+	mockCSPEmptyResourceManagerVMDNSSuffix := GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, false)
+	mockCSEmptyResourceManagerVMDNSSuffix.Properties.CustomCloudProfile = mockCSPEmptyResourceManagerVMDNSSuffix.CustomCloudProfile
+	mockCSEmptyResourceManagerVMDNSSuffix.Properties.CustomCloudProfile.Environment.ResourceManagerVMDNSSuffix = ""
+
+	acutalerr := mockCSEmptyResourceManagerVMDNSSuffix.Properties.SetAzureStackCloudSpec(api.AzureStackCloudSpecParams{
+		IsUpgrade: false,
+		IsScale:   false,
+	})
+	expectError := errors.New("Failed to set Cloud Spec for Azure Stack due to invalid environment")
+	if !helpers.EqualError(acutalerr, expectError) {
+		t.Errorf("verify ResourceManagerVMDNSSuffix empty: expected error: %s - got: %s", acutalerr, expectError)
+	}
+
+	// Test that correct error message if environment is nil
+	mockCSNilEnvironment := getMockBaseContainerService("1.11.6")
+	mockCSPNilEnvironment := GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, false)
+	mockCSNilEnvironment.Properties.CustomCloudProfile = mockCSPNilEnvironment.CustomCloudProfile
+	mockCSNilEnvironment.Properties.CustomCloudProfile.Environment = nil
+	acutalerr = mockCSEmptyResourceManagerVMDNSSuffix.Properties.SetAzureStackCloudSpec(api.AzureStackCloudSpecParams{
+		IsUpgrade: false,
+		IsScale:   false,
+	})
+	if !helpers.EqualError(acutalerr, expectError) {
+		t.Errorf("verify environment nil: expected error: %s - got: %s", acutalerr, expectError)
+	}
+
+	// Test that default assignment flow doesn't overwrite a user-provided config
+	mockCSCustom := getMockBaseContainerService("1.11.6")
+	mockCSPCustom := GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, false)
+
+	//Mock AzureEnvironmentSpecConfig
+	customCloudSpec := api.AzureEnvironmentSpecConfig{
+		CloudName: "AzuReStackCloud",
+		//DockerSpecConfig specify the docker engine download repo
+		DockerSpecConfig: api.DockerSpecConfig{
+			DockerEngineRepo:         "DockerEngineRepo",
+			DockerComposeDownloadURL: "DockerComposeDownloadURL",
+		},
+		//KubernetesSpecConfig - Due to Chinese firewall issue, the default containers from google is blocked, use the Chinese local mirror instead
+		KubernetesSpecConfig: api.KubernetesSpecConfig{
+			AzureTelemetryPID:                "AzureTelemetryPID",
+			KubernetesImageBase:              "KubernetesImageBase",
+			MCRKubernetesImageBase:           "MCRKubernetesImageBase",
+			TillerImageBase:                  "TillerImageBase",
+			ACIConnectorImageBase:            "ACIConnectorImageBase",
+			NVIDIAImageBase:                  "NVIDIAImageBase",
+			AzureCNIImageBase:                "AzureCNIImageBase",
+			CalicoImageBase:                  "CalicoImageBase",
+			EtcdDownloadURLBase:              "EtcdDownloadURLBase",
+			KubeBinariesSASURLBase:           "KubeBinariesSASURLBase",
+			WindowsTelemetryGUID:             "WindowsTelemetryGUID",
+			CNIPluginsDownloadURL:            "CNIPluginsDownloadURL",
+			VnetCNILinuxPluginsDownloadURL:   "VnetCNILinuxPluginsDownloadURL",
+			VnetCNIWindowsPluginsDownloadURL: "VnetCNIWindowsPluginsDownloadURL",
+			ContainerdDownloadURLBase:        "ContainerdDownloadURLBase",
+		},
+		DCOSSpecConfig: api.DefaultDCOSSpecConfig,
+		EndpointConfig: api.AzureEndpointConfig{
+			ResourceManagerVMDNSSuffix: "ResourceManagerVMDNSSuffix",
+		},
+		OSImageConfig: map[api.Distro]api.AzureOSImageConfig{
+			api.Distro("Test"): {
+				ImageOffer:     "ImageOffer",
+				ImageSku:       "ImageSku",
+				ImagePublisher: "ImagePublisher",
+				ImageVersion:   "ImageVersion",
+			},
+			api.AKSUbuntu1604: api.AKSUbuntu1604OSImageConfig,
+		},
+	}
+	mockCSPCustom.CustomCloudProfile.AzureEnvironmentSpecConfig = &customCloudSpec
+	mockCSCustom.Properties.CustomCloudProfile = mockCSPCustom.CustomCloudProfile
+	mockCSCustom.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	if equal := reflect.DeepEqual(api.AzureCloudSpecEnvMap[api.AzureStackCloud], customCloudSpec); !equal {
+		t.Errorf("setCustomCloudProfileDefaults(): did not set AzureStackCloudSpec as default when azureEnvironmentSpecConfig is empty in api model JSON file")
+	}
+
+	if equal := reflect.DeepEqual(mockCSCustom.Properties.CustomCloudProfile.AzureEnvironmentSpecConfig, &customCloudSpec); !equal {
+		t.Errorf("setCustomCloudProfileDefaults(): did not set CustomCloudProfile.AzureEnvironmentSpecConfig with customer input")
+	}
+
+	// Test that default assignment flow set the value if the field is partially  missing in user-provided config
+	mockCSCustomP := getMockBaseContainerService("1.11.6")
+	mockCSPCustomP := GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, false)
+
+	//Mock AzureEnvironmentSpecConfig
+	customCloudSpecP := api.AzureEnvironmentSpecConfig{
+		CloudName: "AzureStackCloud",
+		//DockerSpecConfig specify the docker engine download repo
+		DockerSpecConfig: api.DockerSpecConfig{
+			DockerEngineRepo: "DockerEngineRepo",
+		},
+		//KubernetesSpecConfig - Due to Chinese firewall issue, the default containers from google is blocked, use the Chinese local mirror instead
+		KubernetesSpecConfig: api.KubernetesSpecConfig{
+			KubernetesImageBase:            "KubernetesImageBase",
+			TillerImageBase:                "TillerImageBase",
+			NVIDIAImageBase:                "NVIDIAImageBase",
+			AzureCNIImageBase:              "AzureCNIImageBase",
+			CalicoImageBase:                "CalicoImageBase",
+			EtcdDownloadURLBase:            "EtcdDownloadURLBase",
+			WindowsTelemetryGUID:           "WindowsTelemetryGUID",
+			CNIPluginsDownloadURL:          "CNIPluginsDownloadURL",
+			VnetCNILinuxPluginsDownloadURL: "VnetCNILinuxPluginsDownloadURL",
+			ContainerdDownloadURLBase:      "ContainerdDownloadURLBase",
+		},
+		DCOSSpecConfig: api.DefaultDCOSSpecConfig,
+		EndpointConfig: api.AzureEndpointConfig{
+			ResourceManagerVMDNSSuffix: "ResourceManagerVMDNSSuffix",
+		},
+		OSImageConfig: map[api.Distro]api.AzureOSImageConfig{
+			api.Distro("Test"): {
+				ImageOffer:     "ImageOffer",
+				ImageSku:       "ImageSku",
+				ImagePublisher: "ImagePublisher",
+				ImageVersion:   "ImageVersion",
+			},
+			api.AKSUbuntu1604: api.AKSUbuntu1604OSImageConfig,
+		},
+	}
+	mockCSPCustomP.CustomCloudProfile.AzureEnvironmentSpecConfig = &customCloudSpecP
+	mockCSCustomP.Properties.CustomCloudProfile = mockCSPCustomP.CustomCloudProfile
+	mockCSCustomP.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	if mockCSCustomP.Properties.CustomCloudProfile.AzureEnvironmentSpecConfig.DockerSpecConfig.DockerComposeDownloadURL != api.DefaultDockerSpecConfig.DockerComposeDownloadURL {
+		t.Errorf("setCustomCloudProfileDefaults(): did not set DockerComposeDownloadURL with default Value, got '%s', expected %s", mockCSCustomP.Properties.CustomCloudProfile.AzureEnvironmentSpecConfig.DockerSpecConfig.DockerComposeDownloadURL, api.DefaultDockerSpecConfig.DockerComposeDownloadURL)
+	}
+	if mockCSCustomP.Properties.CustomCloudProfile.AzureEnvironmentSpecConfig.KubernetesSpecConfig.ACIConnectorImageBase != api.DefaultKubernetesSpecConfig.ACIConnectorImageBase {
+		t.Errorf("setCustomCloudProfileDefaults(): did not set ACIConnectorImageBase with default Value, got '%s', expected %s", mockCSCustomP.Properties.CustomCloudProfile.AzureEnvironmentSpecConfig.KubernetesSpecConfig.ACIConnectorImageBase, api.DefaultKubernetesSpecConfig.ACIConnectorImageBase)
+	}
+	if mockCSCustomP.Properties.CustomCloudProfile.AzureEnvironmentSpecConfig.KubernetesSpecConfig.KubeBinariesSASURLBase != api.DefaultKubernetesSpecConfig.KubeBinariesSASURLBase {
+		t.Errorf("setCustomCloudProfileDefaults(): did not set KubeBinariesSASURLBase with default Value, got '%s', expected %s", mockCSCustomP.Properties.CustomCloudProfile.AzureEnvironmentSpecConfig.KubernetesSpecConfig.KubeBinariesSASURLBase, api.DefaultKubernetesSpecConfig.KubeBinariesSASURLBase)
+	}
+	if mockCSCustomP.Properties.CustomCloudProfile.AzureEnvironmentSpecConfig.KubernetesSpecConfig.VnetCNIWindowsPluginsDownloadURL != api.DefaultKubernetesSpecConfig.VnetCNIWindowsPluginsDownloadURL {
+		t.Errorf("setCustomCloudProfileDefaults(): did not set VnetCNIWindowsPluginsDownloadURL with default Value, got '%s', expected %s", mockCSCustomP.Properties.CustomCloudProfile.AzureEnvironmentSpecConfig.KubernetesSpecConfig.VnetCNIWindowsPluginsDownloadURL, api.DefaultKubernetesSpecConfig.VnetCNIWindowsPluginsDownloadURL)
+	}
+	// Test that the default values are set for IdentitySystem and AuthenticationMethod if they are not in the configuration
+	mockCSAuth := getMockBaseContainerService("1.11.6")
+	mockCSPAuth := GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, true)
+	mockCSPAuth.CustomCloudProfile.IdentitySystem = ""
+	mockCSPAuth.CustomCloudProfile.AuthenticationMethod = ""
+	mockCSAuth.Properties.CustomCloudProfile = mockCSPAuth.CustomCloudProfile
+	mockCSAuth.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	if mockCSAuth.Properties.CustomCloudProfile.AuthenticationMethod != api.ClientSecretAuthMethod {
+		t.Errorf("setCustomCloudProfileDefaults(): AuthenticationMethod string not the expected default value, got %s, expected %s", mockCSAuth.Properties.CustomCloudProfile.AuthenticationMethod, api.ClientSecretAuthMethod)
+	}
+	if mockCSAuth.Properties.CustomCloudProfile.IdentitySystem != api.AzureADIdentitySystem {
+		t.Errorf("setCustomCloudProfileDefaults(): IdentitySystem string not the expected default value, got %s, expected %s", mockCSAuth.Properties.CustomCloudProfile.IdentitySystem, api.AzureADIdentitySystem)
+	}
+
+	// Test that the custom input values are not overiwrited if they are in the configuration
+	mockCSI := getMockBaseContainerService("1.11.6")
+	mockCSPI := GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, true)
+	mockCSPI.CustomCloudProfile.IdentitySystem = api.ADFSIdentitySystem
+	mockCSPI.CustomCloudProfile.AuthenticationMethod = api.ClientCertificateAuthMethod
+	mockCSI.Properties.CustomCloudProfile = mockCSPI.CustomCloudProfile
+	mockCSI.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	if mockCSI.Properties.CustomCloudProfile.AuthenticationMethod != api.ClientCertificateAuthMethod {
+		t.Errorf("setCustomCloudProfileDefaults(): AuthenticationMethod string from customer not the expected default value, got %s, expected %s", mockCSI.Properties.CustomCloudProfile.AuthenticationMethod, api.ClientCertificateAuthMethod)
+	}
+	if mockCSI.Properties.CustomCloudProfile.IdentitySystem != api.ADFSIdentitySystem {
+		t.Errorf("setCustomCloudProfileDefaults(): IdentitySystem string from customer not the expected default value, got %s, expected %s", mockCSI.Properties.CustomCloudProfile.IdentitySystem, api.ADFSIdentitySystem)
+	}
+}
+
+func TestCustomCloudLocation(t *testing.T) {
+
+	// Test that the ResourceManagerVMDNSSuffix is set in EndpointConfig
+	mockCS := getMockBaseContainerService("1.11.6")
+	mockCSP := GetMockPropertiesWithCustomCloudProfile("AzureStackCloud", true, true, true)
+	mockCS.Properties = &mockCSP
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	dnsPrefix := "santest"
+	actual := []string{api.FormatProdFQDNByLocation(dnsPrefix, mockCS.Location, "AzureStackCloud")}
+
+	expected := []string{fmt.Sprintf("%s.%s.%s", dnsPrefix, mockCS.Location, api.AzureCloudSpecEnvMap[api.AzureStackCloud].EndpointConfig.ResourceManagerVMDNSSuffix)}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("expected formatted fqdns %s, but got %s", expected, actual)
+	}
+}
+
+// Comment this test case out since it requires import "github.com/jarcoal/httpmock", which
+// hasn't been vendored in yet.
+/*
+func TestSetCustomCloudProfileEnvironmentDefaults(t *testing.T) {
+	location := "testlocation"
+	cs := ContainerService{
+		Location: location,
+		Properties: &Properties{
+			CustomCloudProfile: &api.CustomCloudProfile{
+				IdentitySystem: "adfs",
+				PortalURL:      "https://portal.testlocation.contoso.com/",
+			},
+		},
+	}
+
+	csPortal := ContainerService{
+		Location: location,
+		Properties: &Properties{
+			CustomCloudProfile: &api.CustomCloudProfile{
+				IdentitySystem: "adfs",
+				PortalURL:      "https://portal.testlocation.contoso.com",
+			},
+		},
+	}
+
+	expectedEnv := &azure.Environment{
+		Name:                       "AzureStackCloud",
+		ManagementPortalURL:        "https://portal.testlocation.contoso.com/",
+		ServiceManagementEndpoint:  "https://management.adfs.azurestack.testlocation/ce080287-be51-42e5-b99e-9de760fecae7",
+		ResourceManagerEndpoint:    fmt.Sprintf("https://management.%s.contoso.com/", location),
+		ActiveDirectoryEndpoint:    "https://adfs.testlocation.contoso.com/",
+		GalleryEndpoint:            "https://galleryartifacts.hosting.testlocation.contoso.com/galleryartifacts/",
+		GraphEndpoint:              "https://graph.testlocation.contoso.com/",
+		StorageEndpointSuffix:      "testlocation.contoso.com",
+		KeyVaultDNSSuffix:          "vault.testlocation.contoso.com",
+		ResourceManagerVMDNSSuffix: "cloudapp.contoso.com",
+	}
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("GET", fmt.Sprintf("%smetadata/endpoints?api-version=1.0", fmt.Sprintf("https://management.%s.contoso.com/", location)),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, `{"galleryEndpoint":"https://galleryartifacts.hosting.testlocation.contoso.com/galleryartifacts/","graphEndpoint":"https://graph.testlocation.contoso.com/","portalEndpoint":"https://portal.testlocation.contoso.com/","authentication":{"loginEndpoint":"https://adfs.testlocation.contoso.com/adfs","audiences":["https://management.adfs.azurestack.testlocation/ce080287-be51-42e5-b99e-9de760fecae7"]}}`)
+			return resp, nil
+		},
+	)
+
+	err := cs.SetCustomCloudProfileEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(cs.Properties.CustomCloudProfile.Environment, expectedEnv); diff != "" {
+		t.Errorf("Fail to compare, Environment adfs %q", diff)
+	}
+
+	err = csPortal.SetCustomCloudProfileEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(csPortal.Properties.CustomCloudProfile.Environment, expectedEnv); diff != "" {
+		t.Errorf("Fail to compare, Environment portal url adfs %q", diff)
+	}
+
+	csAzureAD := ContainerService{
+		Location: location,
+		Properties: &Properties{
+			CustomCloudProfile: &CustomCloudProfile{
+				IdentitySystem: "azure_ad",
+				PortalURL:      "https://portal.testlocation.contoso.com/",
+			},
+		},
+	}
+
+	//test setCustomCloudProfileDefaults with portal url
+	mockCS := getMockBaseContainerService("1.11.6")
+	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
+		PortalURL: "https://portal.testlocation.contoso.com",
+	}
+
+	httpmock.DeactivateAndReset()
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", fmt.Sprintf("%smetadata/endpoints?api-version=1.0", fmt.Sprintf("https://management.%s.contoso.com/", location)),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, `{"galleryEndpoint":"https://galleryartifacts.hosting.testlocation.contoso.com/galleryartifacts/","graphEndpoint":"https://graph.testlocation.contoso.com/","portalEndpoint":"https://portal.testlocation.contoso.com/","authentication":{"loginEndpoint":"https://adfs.testlocation.contoso.com/","audiences":["https://management.adfs.azurestack.testlocation/ce080287-be51-42e5-b99e-9de760fecae7"]}}`)
+			return resp, nil
+		},
+	)
+	mockCS.Location = location
+	_, err = mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: DefaultPkiKeySize,
+	})
+	if err != nil {
+		t.Errorf("Failed to test setCustomCloudProfileDefaults with portal url - %s", err)
+	}
+	if diff := cmp.Diff(mockCS.Properties.CustomCloudProfile.Environment, expectedEnv); diff != "" {
+		t.Errorf("Fail to compare, Environment setCustomCloudProfileDefaults %q", diff)
+	}
+
+	cloudSpec := AzureCloudSpecEnvMap[AzurePublicCloud]
+	cloudSpec.CloudName = AzureStackCloud
+	cloudSpec.KubernetesSpecConfig.AzureTelemetryPID = DefaultAzureStackDeployTelemetryPID
+	cloudSpec.EndpointConfig.ResourceManagerVMDNSSuffix = mockCS.Properties.CustomCloudProfile.Environment.ResourceManagerVMDNSSuffix
+	if diff := cmp.Diff(AzureCloudSpecEnvMap[AzureStackCloud], cloudSpec); diff != "" {
+		t.Errorf("Fail to compare, AzureCloudSpec AzureStackCloud %q", diff)
+	}
+
+	// Test for azure_ad
+	httpmock.DeactivateAndReset()
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", fmt.Sprintf("%smetadata/endpoints?api-version=1.0", fmt.Sprintf("https://management.%s.contoso.com/", location)),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, `{"galleryEndpoint":"https://galleryartifacts.hosting.testlocation.contoso.com/galleryartifacts/","graphEndpoint":"https://graph.testlocation.contoso.com/","portalEndpoint":"https://portal.testlocation.contoso.com/","authentication":{"loginEndpoint":"https://adfs.testlocation.contoso.com/","audiences":["https://management.adfs.azurestack.testlocation/ce080287-be51-42e5-b99e-9de760fecae7"]}}`)
+			return resp, nil
+		},
+	)
+
+	err = csAzureAD.SetCustomCloudProfileEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(csAzureAD.Properties.CustomCloudProfile.Environment, expectedEnv); diff != "" {
+		t.Errorf("Fail to compare, Environment azure_ad %q", diff)
+	}
+
+	csError := ContainerService{
+		Location: location,
+		Properties: &Properties{
+			CustomCloudProfile: &CustomCloudProfile{
+				IdentitySystem: "azure_ad",
+				PortalURL:      "https://portal.abc.contoso.com/",
+			},
+		},
+	}
+
+	err = csError.SetCustomCloudProfileEnvironment()
+	expectedError := fmt.Errorf("portalURL needs to start with https://portal.%s. ", location)
+	if !helpers.EqualError(err, expectedError) {
+		t.Errorf("expected error %s, got %s", expectedError, err)
+	}
+}
+*/
+
+// Comment this test case out since it requires import "github.com/jarcoal/httpmock", which
+// hasn't been vendored in yet.
+/*
+func TestSetOrchestratorProfileDefaultsOnAzureStack(t *testing.T) {
+	location := "testlocation"
+	//Test setMasterProfileDefaults with portal url
+	mockCS := getMockBaseContainerService("1.11.6")
+	mockCS.Properties.CustomCloudProfile = &api.CustomCloudProfile{
+		PortalURL: "https://portal.testlocation.contoso.com",
+	}
+	mockCS.Location = location
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = "Kubernetes"
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("GET", fmt.Sprintf("%smetadata/endpoints?api-version=1.0", fmt.Sprintf("https://management.%s.contoso.com/", location)),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, `{"galleryEndpoint":"https://galleryartifacts.hosting.testlocation.contoso.com/galleryartifacts/","graphEndpoint":"https://graph.testlocation.contoso.com/","portalEndpoint":"https://portal.testlocation.contoso.com/","authentication":{"loginEndpoint":"https://adfs.testlocation.contoso.com/adfs","audiences":["https://management.adfs.azurestack.testlocation/ce080287-be51-42e5-b99e-9de760fecae7"]}}`)
+			return resp, nil
+		},
+	)
+
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: DefaultPkiKeySize,
+	})
+	if (*mockCS.Properties.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata) != DefaultAzureStackUseInstanceMetadata {
+		t.Fatalf("DefaultAzureStackUseInstanceMetadata did not have the expected value, got %t, expected %t",
+			(*mockCS.Properties.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata), DefaultAzureStackUseInstanceMetadata)
+	}
+}
+*/
+
+// Comment this test case out since it requires import "github.com/jarcoal/httpmock", which
+// hasn't been vendored in yet.
+/*
+func TestSetMasterProfileDefaultsOnAzureStack(t *testing.T) {
+	location := "testlocation"
+	oldFaultDomainCount := 2
+	//Test setMasterProfileDefaults with portal url
+	mockCS := getMockBaseContainerService("1.11.6")
+	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
+		PortalURL: "https://portal.testlocation.contoso.com",
+	}
+	mockCS.Location = location
+	mockCS.Properties.MasterProfile.AvailabilityProfile = ""
+	mockCS.Properties.MasterProfile.Count = 1
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("GET", fmt.Sprintf("%smetadata/endpoints?api-version=1.0", fmt.Sprintf("https://management.%s.contoso.com/", location)),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, `{"galleryEndpoint":"https://galleryartifacts.hosting.testlocation.contoso.com/galleryartifacts/","graphEndpoint":"https://graph.testlocation.contoso.com/","portalEndpoint":"https://portal.testlocation.contoso.com/","authentication":{"loginEndpoint":"https://adfs.testlocation.contoso.com/adfs","audiences":["https://management.adfs.azurestack.testlocation/ce080287-be51-42e5-b99e-9de760fecae7"]}}`)
+			return resp, nil
+		},
+	)
+
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: DefaultPkiKeySize,
+	})
+	if (*mockCS.Properties.MasterProfile.PlatformFaultDomainCount) != DefaultAzureStackFaultDomainCount {
+		t.Fatalf("PlatformFaultDomainCount did not have the expected value, got %d, expected %d",
+			(*mockCS.Properties.MasterProfile.PlatformFaultDomainCount), DefaultAzureStackFaultDomainCount)
+	}
+
+	// Check scenario where value is already set.
+	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
+		PortalURL: "https://portal.testlocation.contoso.com",
+	}
+	mockCS.Properties.MasterProfile.AvailabilityProfile = ""
+	mockCS.Properties.MasterProfile.Count = 1
+	mockCS.Properties.MasterProfile.PlatformFaultDomainCount = &oldFaultDomainCount
+	mockCS.Location = location
+	httpmock.DeactivateAndReset()
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", fmt.Sprintf("%smetadata/endpoints?api-version=1.0", fmt.Sprintf("https://management.%s.contoso.com/", location)),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, `{"galleryEndpoint":"https://galleryartifacts.hosting.testlocation.contoso.com/galleryartifacts/","graphEndpoint":"https://graph.testlocation.contoso.com/","portalEndpoint":"https://portal.testlocation.contoso.com/","authentication":{"loginEndpoint":"https://adfs.testlocation.contoso.com/","audiences":["https://management.adfs.azurestack.testlocation/ce080287-be51-42e5-b99e-9de760fecae7"]}}`)
+			return resp, nil
+		},
+	)
+
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: DefaultPkiKeySize,
+	})
+	if (*mockCS.Properties.MasterProfile.PlatformFaultDomainCount) != oldFaultDomainCount {
+		t.Fatalf("PlatformFaultDomainCount did not have the expected value, got %d, expected %d",
+			(*mockCS.Properties.MasterProfile.PlatformFaultDomainCount), oldFaultDomainCount)
+	}
+}
+*/
+
+// Comment this test case out since it requires import "github.com/jarcoal/httpmock", which
+// hasn't been vendored in yet.
+/*
+func TestSetAgentProfileDefaultsOnAzureStack(t *testing.T) {
+	location := "testlocation"
+	oldFaultDomainCount := 2
+	//Test setMasterProfileDefaults with portal url
+	mockCS := getMockBaseContainerService("1.11.6")
+	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
+		PortalURL: "https://portal.testlocation.contoso.com",
+	}
+	mockCS.Location = location
+	mockCS.Properties.MasterProfile.AvailabilityProfile = ""
+	mockCS.Properties.MasterProfile.Count = 1
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("GET", fmt.Sprintf("%smetadata/endpoints?api-version=1.0", fmt.Sprintf("https://management.%s.contoso.com/", location)),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, `{"galleryEndpoint":"https://galleryartifacts.hosting.testlocation.contoso.com/galleryartifacts/","graphEndpoint":"https://graph.testlocation.contoso.com/","portalEndpoint":"https://portal.testlocation.contoso.com/","authentication":{"loginEndpoint":"https://adfs.testlocation.contoso.com/adfs","audiences":["https://management.adfs.azurestack.testlocation/ce080287-be51-42e5-b99e-9de760fecae7"]}}`)
+			return resp, nil
+		},
+	)
+
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: DefaultPkiKeySize,
+	})
+	for _, pool := range mockCS.Properties.AgentPoolProfiles {
+		if (*pool.PlatformFaultDomainCount) != DefaultAzureStackFaultDomainCount {
+			t.Fatalf("PlatformFaultDomainCount did not have the expected value, got %d, expected %d",
+				(*pool.PlatformFaultDomainCount), DefaultAzureStackFaultDomainCount)
+		}
+
+		if (*pool.AcceleratedNetworkingEnabled) != DefaultAzureStackAcceleratedNetworking {
+			t.Fatalf("AcceleratedNetworkingEnabled did not have the expected value, got %t, expected %t",
+				(*pool.AcceleratedNetworkingEnabled), DefaultAzureStackAcceleratedNetworking)
+		}
+
+		if (*pool.AcceleratedNetworkingEnabledWindows) != DefaultAzureStackAcceleratedNetworking {
+			t.Fatalf("AcceleratedNetworkingEnabledWindows did not have the expected value, got %t, expected %t",
+				(*pool.AcceleratedNetworkingEnabledWindows), DefaultAzureStackAcceleratedNetworking)
+		}
+	}
+	// Check scenario where value is already set.
+	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
+		PortalURL: "https://portal.testlocation.contoso.com",
+	}
+	mockCS.Properties.MasterProfile.AvailabilityProfile = ""
+	mockCS.Properties.MasterProfile.Count = 1
+	for _, pool := range mockCS.Properties.AgentPoolProfiles {
+		pool.PlatformFaultDomainCount = &oldFaultDomainCount
+	}
+	mockCS.Location = location
+
+	httpmock.DeactivateAndReset()
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", fmt.Sprintf("%smetadata/endpoints?api-version=1.0", fmt.Sprintf("https://management.%s.contoso.com/", location)),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, `{"galleryEndpoint":"https://galleryartifacts.hosting.testlocation.contoso.com/galleryartifacts/","graphEndpoint":"https://graph.testlocation.contoso.com/","portalEndpoint":"https://portal.testlocation.contoso.com/","authentication":{"loginEndpoint":"https://adfs.testlocation.contoso.com/","audiences":["https://management.adfs.azurestack.testlocation/ce080287-be51-42e5-b99e-9de760fecae7"]}}`)
+			return resp, nil
+		},
+	)
+
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: DefaultPkiKeySize,
+	})
+	for _, pool := range mockCS.Properties.AgentPoolProfiles {
+		if (*pool.PlatformFaultDomainCount) != oldFaultDomainCount {
+			t.Fatalf("PlatformFaultDomainCount did not have the expected value, got %d, expected %d",
+				(*pool.PlatformFaultDomainCount), oldFaultDomainCount)
+		}
+	}
+}
+*/
+
+// Comment this test case out since it requires import "github.com/jarcoal/httpmock", which
+// hasn't been vendored in yet.
+/*
+func TestEtcdDiskSizeOnAzureStack(t *testing.T) {
+	location := "testlocation"
+	mockCS := getMockBaseContainerService("1.11.6")
+	mockCS.Location = location
+	mockCS.Properties.MasterProfile.Count = 1
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
+	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
+		PortalURL: "https://portal.testlocation.contoso.com",
+	}
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("GET", fmt.Sprintf("%smetadata/endpoints?api-version=1.0", fmt.Sprintf("https://management.%s.contoso.com/", location)),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, `{"galleryEndpoint":"https://galleryartifacts.hosting.testlocation.contoso.com/galleryartifacts/","graphEndpoint":"https://graph.testlocation.contoso.com/","portalEndpoint":"https://portal.testlocation.contoso.com/","authentication":{"loginEndpoint":"https://adfs.testlocation.contoso.com/adfs","audiences":["https://management.adfs.azurestack.testlocation/ce080287-be51-42e5-b99e-9de760fecae7"]}}`)
+			return resp, nil
+		},
+	)
+
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: DefaultPkiKeySize,
+	})
+	if mockCS.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB != DefaultEtcdDiskSize {
+		t.Fatalf("EtcdDiskSizeGB did not have the expected size, got %s, expected %s",
+			mockCS.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB, DefaultEtcdDiskSize)
+	}
+
+	// Case where total node count is 5.
+	mockCS = getMockBaseContainerService("1.11.6")
+	mockCS.Location = location
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
+	mockCS.Properties.MasterProfile.Count = 5
+	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
+		PortalURL: "https://portal.testlocation.contoso.com",
+	}
+
+	httpmock.DeactivateAndReset()
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", fmt.Sprintf("%smetadata/endpoints?api-version=1.0", fmt.Sprintf("https://management.%s.contoso.com/", location)),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, `{"galleryEndpoint":"https://galleryartifacts.hosting.testlocation.contoso.com/galleryartifacts/","graphEndpoint":"https://graph.testlocation.contoso.com/","portalEndpoint":"https://portal.testlocation.contoso.com/","authentication":{"loginEndpoint":"https://adfs.testlocation.contoso.com/","audiences":["https://management.adfs.azurestack.testlocation/ce080287-be51-42e5-b99e-9de760fecae7"]}}`)
+			return resp, nil
+		},
+	)
+
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: DefaultPkiKeySize,
+	})
+	if mockCS.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB != DefaultEtcdDiskSizeGT3Nodes {
+		t.Fatalf("EtcdDiskSizeGB did not have the expected size, got %s, expected %s",
+			mockCS.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB, DefaultEtcdDiskSizeGT3Nodes)
+	}
+
+	// Case where total node count is 11.
+	mockCS = getMockBaseContainerService("1.11.6")
+	mockCS.Location = location
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
+	mockCS.Properties.MasterProfile.Count = 5
+	mockCS.Properties.AgentPoolProfiles[0].Count = 6
+	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
+		PortalURL: "https://portal.testlocation.contoso.com",
+	}
+
+	httpmock.DeactivateAndReset()
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", fmt.Sprintf("%smetadata/endpoints?api-version=1.0", fmt.Sprintf("https://management.%s.contoso.com/", location)),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, `{"galleryEndpoint":"https://galleryartifacts.hosting.testlocation.contoso.com/galleryartifacts/","graphEndpoint":"https://graph.testlocation.contoso.com/","portalEndpoint":"https://portal.testlocation.contoso.com/","authentication":{"loginEndpoint":"https://adfs.testlocation.contoso.com/","audiences":["https://management.adfs.azurestack.testlocation/ce080287-be51-42e5-b99e-9de760fecae7"]}}`)
+			return resp, nil
+		},
+	)
+
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: DefaultPkiKeySize,
+	})
+	if mockCS.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB != MaxAzureStackManagedDiskSize {
+		t.Fatalf("EtcdDiskSizeGB did not have the expected size, got %s, expected %s",
+			mockCS.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB, MaxAzureStackManagedDiskSize)
+	}
+
+	// Case where total node count is 21.
+	mockCS = getMockBaseContainerService("1.11.6")
+	mockCS.Location = location
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
+	mockCS.Properties.MasterProfile.Count = 5
+	mockCS.Properties.AgentPoolProfiles[0].Count = 16
+	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
+		PortalURL: "https://portal.testlocation.contoso.com",
+	}
+
+	httpmock.DeactivateAndReset()
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", fmt.Sprintf("%smetadata/endpoints?api-version=1.0", fmt.Sprintf("https://management.%s.contoso.com/", location)),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, `{"galleryEndpoint":"https://galleryartifacts.hosting.testlocation.contoso.com/galleryartifacts/","graphEndpoint":"https://graph.testlocation.contoso.com/","portalEndpoint":"https://portal.testlocation.contoso.com/","authentication":{"loginEndpoint":"https://adfs.testlocation.contoso.com/","audiences":["https://management.adfs.azurestack.testlocation/ce080287-be51-42e5-b99e-9de760fecae7"]}}`)
+			return resp, nil
+		},
+	)
+
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: DefaultPkiKeySize,
+	})
+	if mockCS.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB != MaxAzureStackManagedDiskSize {
+		t.Fatalf("EtcdDiskSizeGB did not have the expected size, got %s, expected %s",
+			mockCS.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB, MaxAzureStackManagedDiskSize)
+	}
+
+	// Case where total node count is 55 but EtcdDiskSizeGB size is passed
+	mockCS = getMockBaseContainerService("1.11.6")
+	mockCS.Location = location
+	mockCS.Properties.OrchestratorProfile.OrchestratorType = Kubernetes
+	mockCS.Properties.MasterProfile.Count = 5
+	mockCS.Properties.AgentPoolProfiles[0].Count = 50
+	customEtcdDiskSize := "512"
+	mockCS.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = customEtcdDiskSize
+	mockCS.Properties.CustomCloudProfile = &CustomCloudProfile{
+		PortalURL: "https://portal.testlocation.contoso.com",
+	}
+
+	httpmock.DeactivateAndReset()
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", fmt.Sprintf("%smetadata/endpoints?api-version=1.0", fmt.Sprintf("https://management.%s.contoso.com/", location)),
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, `{"galleryEndpoint":"https://galleryartifacts.hosting.testlocation.contoso.com/galleryartifacts/","graphEndpoint":"https://graph.testlocation.contoso.com/","portalEndpoint":"https://portal.testlocation.contoso.com/","authentication":{"loginEndpoint":"https://adfs.testlocation.contoso.com/","audiences":["https://management.adfs.azurestack.testlocation/ce080287-be51-42e5-b99e-9de760fecae7"]}}`)
+			return resp, nil
+		},
+	)
+
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: DefaultPkiKeySize,
+	})
+	if mockCS.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB != customEtcdDiskSize {
+		t.Fatalf("EtcdDiskSizeGB did not have the expected size, got %s, expected %s",
+			mockCS.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB, customEtcdDiskSize)
+	}
+}
+*/
+
+func TestPreserveNodesProperties(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.10.8")
+	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	if !to.Bool(mockCS.Properties.AgentPoolProfiles[0].PreserveNodesProperties) {
+		t.Errorf("expected preserveNodesProperties to be %t instead got %t", true, to.Bool(mockCS.Properties.AgentPoolProfiles[0].PreserveNodesProperties))
+	}
+}
+
+func TestUbuntu1804Flags(t *testing.T) {
+	// Validate --resolv-conf is missing with 16.04 distro and present with 18.04
+	cs := CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
+	cs.Properties.MasterProfile.Distro = api.AKSUbuntu1604
+	cs.Properties.AgentPoolProfiles[0].Distro = api.AKSUbuntu1804
+	cs.Properties.AgentPoolProfiles[0].OSType = api.Linux
+	cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	km := cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
+	if _, ok := km["--resolv-conf"]; ok {
+		t.Fatalf("got unexpected '--resolv-conf' kubelet config value '%s' with Ubuntu 16.04 ",
+			km["--resolv-conf"])
+	}
+	ka := cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	if ka["--resolv-conf"] != "/run/systemd/resolve/resolv.conf" {
+		t.Fatalf("got unexpected '--resolv-conf' kubelet config value %s with Ubuntu 18.04, the expected value is %s",
+			ka["--resolv-conf"], "/run/systemd/resolve/resolv.conf")
+	}
+
+	cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
+	cs.Properties.MasterProfile.Distro = api.Ubuntu1804
+	cs.Properties.AgentPoolProfiles[0].Distro = api.Ubuntu
+	cs.Properties.AgentPoolProfiles[0].OSType = api.Linux
+	cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	km = cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
+	if km["--resolv-conf"] != "/run/systemd/resolve/resolv.conf" {
+		t.Fatalf("got unexpected '--resolv-conf' kubelet config value %s with Ubuntu 18.04, the expected value is %s",
+			km["--resolv-conf"], "/run/systemd/resolve/resolv.conf")
+	}
+	ka = cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	if _, ok := ka["--resolv-conf"]; ok {
+		t.Fatalf("got unexpected '--resolv-conf' kubelet config value '%s' with Ubuntu 16.04 ",
+			ka["--resolv-conf"])
+	}
+
+	cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, false)
+	cs.Properties.MasterProfile.Distro = api.Ubuntu
+	cs.Properties.AgentPoolProfiles[0].Distro = ""
+	cs.Properties.AgentPoolProfiles[0].OSType = api.Windows
+	cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+	km = cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig
+	if _, ok := km["--resolv-conf"]; ok {
+		t.Fatalf("got unexpected '--resolv-conf' kubelet config value '%s' with Ubuntu 16.04 ",
+			km["--resolv-conf"])
+	}
+	ka = cs.Properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig
+	if ka["--resolv-conf"] != "\"\"\"\"" {
+		t.Fatalf("got unexpected '--resolv-conf' kubelet config value %s with Windows, the expected value is %s",
+			ka["--resolv-conf"], "\"\"\"\"")
+	}
+}
+
+func getMockBaseContainerService(orchestratorVersion string) ContainerService {
+	mockAPIProperties := getMockAPIProperties(orchestratorVersion)
+	return ContainerService{
+		Properties: &mockAPIProperties,
+	}
+}
+
+func getMockAPIProperties(orchestratorVersion string) api.Properties {
+	return api.Properties{
+		ProvisioningState: "",
+		OrchestratorProfile: &api.OrchestratorProfile{
+			OrchestratorVersion: orchestratorVersion,
+			KubernetesConfig:    &api.KubernetesConfig{},
+		},
+		MasterProfile: &api.MasterProfile{},
+		AgentPoolProfiles: []*api.AgentPoolProfile{
+			{},
+			{},
+			{},
+			{},
+		}}
+}
+
+func getKubernetesConfigWithFeatureGates(featureGates string) *api.KubernetesConfig {
+	return &api.KubernetesConfig{
+		KubeletConfig: map[string]string{"--feature-gates": featureGates},
+	}
+}
+
+func TestDefaultEnablePodSecurityPolicy(t *testing.T) {
+	cases := []struct {
+		name     string
+		cs       ContainerService
+		expected bool
+	}{
+		{
+			name: "default",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "default",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.0-alpha.1",
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "default",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.0-beta.1",
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "default",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.15.0",
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			c.cs.setOrchestratorDefaults(false, false)
+			if to.Bool(c.cs.Properties.OrchestratorProfile.KubernetesConfig.EnablePodSecurityPolicy) != c.expected {
+				t.Errorf("expected  %t, but got %t", c.expected, to.Bool(c.cs.Properties.OrchestratorProfile.KubernetesConfig.EnablePodSecurityPolicy))
+			}
+		})
+	}
+}
+
+func TestDefaultLoadBalancerSKU(t *testing.T) {
+	cases := []struct {
+		name     string
+		cs       ContainerService
+		expected string
+	}{
+		{
+			name: "default",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: api.BasicLoadBalancerSku,
+		},
+		{
+			name: "basic",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							LoadBalancerSku: "basic",
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: api.BasicLoadBalancerSku,
+		},
+		{
+			name: "default",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							LoadBalancerSku: api.BasicLoadBalancerSku,
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: api.BasicLoadBalancerSku,
+		},
+		{
+			name: "default",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							LoadBalancerSku: "standard",
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: api.StandardLoadBalancerSku,
+		},
+		{
+			name: "default",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							LoadBalancerSku: api.StandardLoadBalancerSku,
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: api.StandardLoadBalancerSku,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			c.cs.setLoadBalancerSkuDefaults()
+			if c.cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != c.expected {
+				t.Errorf("expected %s, but got %s", c.expected, c.cs.Properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku)
+			}
+		})
+	}
+}
+
+func TestEnableRBAC(t *testing.T) {
+	cases := []struct {
+		name      string
+		cs        ContainerService
+		isUpgrade bool
+		isScale   bool
+		expected  bool
+	}{
+		{
+			name: "default",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType: api.Kubernetes,
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "1.14 disabled",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: common.GetLatestPatchVersion("1.14", common.GetAllSupportedKubernetesVersions(false, false)),
+						KubernetesConfig: &api.KubernetesConfig{
+							EnableRbac: to.BoolPtr(false),
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "1.14 disabled upgrade",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: common.GetLatestPatchVersion("1.14", common.GetAllSupportedKubernetesVersions(false, false)),
+						KubernetesConfig: &api.KubernetesConfig{
+							EnableRbac: to.BoolPtr(false),
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			isUpgrade: true,
+			expected:  false,
+		},
+		{
+			name: "1.15",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: common.GetLatestPatchVersion("1.15", common.GetAllSupportedKubernetesVersions(false, false)),
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "1.15 upgrade",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: common.GetLatestPatchVersion("1.15", common.GetAllSupportedKubernetesVersions(false, false)),
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			isUpgrade: true,
+			expected:  true,
+		},
+		{
+			name: "1.15 upgrade false--> true override",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: common.GetLatestPatchVersion("1.15", common.GetAllSupportedKubernetesVersions(false, false)),
+						KubernetesConfig: &api.KubernetesConfig{
+							EnableRbac: to.BoolPtr(false),
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			isUpgrade: true,
+			expected:  true,
+		},
+		{
+			name: "1.16 upgrade false--> true override",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: common.GetLatestPatchVersion("1.16", common.GetAllSupportedKubernetesVersions(false, false)),
+						KubernetesConfig: &api.KubernetesConfig{
+							EnableRbac: to.BoolPtr(false),
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			isUpgrade: true,
+			expected:  true,
+		},
+		{
+			name: "1.15 upgrade no false--> true override in AKS scenario",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: common.GetLatestPatchVersion("1.15", common.GetAllSupportedKubernetesVersions(false, false)),
+						KubernetesConfig: &api.KubernetesConfig{
+							EnableRbac: to.BoolPtr(false),
+						},
+					},
+					HostedMasterProfile: &api.HostedMasterProfile{
+						FQDN: "foo",
+					},
+				},
+			},
+			isUpgrade: true,
+			expected:  false,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			c.cs.setOrchestratorDefaults(c.isUpgrade, c.isScale)
+			if to.Bool(c.cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac) != c.expected {
+				t.Errorf("expected %t, but got %t", c.expected, to.Bool(c.cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac))
+			}
+		})
+	}
+}
+
+func TestDefaultAzureTelemetryPid(t *testing.T) {
+	// Test that the AzureTelemetryPID is set to DefaultAzureStackDeployTelemetryPID  by default
+	mockCSDefaultSpec := getMockBaseContainerService("1.11.6")
+	mockCSPDefaultSpec := GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, false)
+	mockCSDefaultSpec.Properties.CustomCloudProfile = mockCSPDefaultSpec.CustomCloudProfile
+	mockCSDefaultSpec.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	actualEnv := api.AzureCloudSpecEnvMap[api.AzureStackCloud]
+	expectedEnv := api.AzureCloudSpecEnvMap[api.AzurePublicCloud]
+	expectedEnv.EndpointConfig.ResourceManagerVMDNSSuffix = mockCSPDefaultSpec.CustomCloudProfile.Environment.ResourceManagerVMDNSSuffix
+	expectedEnv.CloudName = api.AzureStackCloud
+	expectedEnv.KubernetesSpecConfig.AzureTelemetryPID = api.DefaultAzureStackDeployTelemetryPID
+	if equal := reflect.DeepEqual(actualEnv, expectedEnv); !equal {
+		t.Errorf("setCustomCloudProfileDefaults(): did not set AzureTelemetryPID as DefaultAzureStackDeployTelemetryPID. expected: %s, actual: %s", expectedEnv, actualEnv)
+	}
+
+	// Test that the AzureTelemetryPID is set to DefaultAzureStackScaleTelemetryPID by in Scale scenario
+	mockCSScaleSpec := getMockBaseContainerService("1.11.6")
+	mockCSPScaleSpec := GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, false)
+	mockCSScaleSpec.Properties.CustomCloudProfile = mockCSPScaleSpec.CustomCloudProfile
+	mockCSScaleSpec.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    true,
+		IsUpgrade:  false,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	actualScaleEnv := api.AzureCloudSpecEnvMap[api.AzureStackCloud]
+	expectedScaleEnv := api.AzureCloudSpecEnvMap[api.AzurePublicCloud]
+	expectedScaleEnv.EndpointConfig.ResourceManagerVMDNSSuffix = mockCSPDefaultSpec.CustomCloudProfile.Environment.ResourceManagerVMDNSSuffix
+	expectedScaleEnv.CloudName = api.AzureStackCloud
+	expectedScaleEnv.KubernetesSpecConfig.AzureTelemetryPID = api.DefaultAzureStackScaleTelemetryPID
+	if equal := reflect.DeepEqual(actualScaleEnv, expectedScaleEnv); !equal {
+		t.Errorf("setCustomCloudProfileDefaults(): did not set AzureTelemetryPID as DefaultAzureStackDeployTelemetryPID. expected: %s, actual: %s", expectedScaleEnv, actualScaleEnv)
+	}
+
+	// Test that the AzureTelemetryPID is set to DefaultAzureStackUpgradeTelemetryPID in Upgrade scenario
+	mockCSSUpgradeSpec := getMockBaseContainerService("1.11.6")
+	mockCSPSUpgradeSpec := GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, false)
+	mockCSSUpgradeSpec.Properties.CustomCloudProfile = mockCSPSUpgradeSpec.CustomCloudProfile
+	mockCSSUpgradeSpec.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+		IsScale:    false,
+		IsUpgrade:  true,
+		PkiKeySize: helpers.DefaultPkiKeySize,
+	})
+
+	actualSUpgradeEnv := api.AzureCloudSpecEnvMap[api.AzureStackCloud]
+	expectedSUpgradeEnv := api.AzureCloudSpecEnvMap[api.AzurePublicCloud]
+	expectedSUpgradeEnv.EndpointConfig.ResourceManagerVMDNSSuffix = mockCSPDefaultSpec.CustomCloudProfile.Environment.ResourceManagerVMDNSSuffix
+	expectedSUpgradeEnv.CloudName = api.AzureStackCloud
+	expectedSUpgradeEnv.KubernetesSpecConfig.AzureTelemetryPID = api.DefaultAzureStackUpgradeTelemetryPID
+	if equal := reflect.DeepEqual(actualSUpgradeEnv, expectedSUpgradeEnv); !equal {
+		t.Errorf("setCustomCloudProfileDefaults(): did not set AzureTelemetryPID as DefaultAzureStackUpgradeTelemetryPID. expected: %s, actual: %s", expectedSUpgradeEnv, actualSUpgradeEnv)
+	}
+}
+
+func TestDefaultCloudProviderDisableOutboundSNAT(t *testing.T) {
+	cases := []struct {
+		name     string
+		cs       ContainerService
+		expected bool
+	}{
+		{
+			name: "default",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "basic LB",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							LoadBalancerSku: api.BasicLoadBalancerSku,
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "basic LB w/ true",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							LoadBalancerSku:                  api.BasicLoadBalancerSku,
+							CloudProviderDisableOutboundSNAT: to.BoolPtr(true),
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "basic LB w/ false",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							LoadBalancerSku:                  api.BasicLoadBalancerSku,
+							CloudProviderDisableOutboundSNAT: to.BoolPtr(false),
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "standard LB w/ true",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							LoadBalancerSku:                  api.StandardLoadBalancerSku,
+							CloudProviderDisableOutboundSNAT: to.BoolPtr(true),
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "standard LB w/ false",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							LoadBalancerSku:                  api.StandardLoadBalancerSku,
+							CloudProviderDisableOutboundSNAT: to.BoolPtr(false),
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			c.cs.setOrchestratorDefaults(false, false)
+			if to.Bool(c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderDisableOutboundSNAT) != c.expected {
+				t.Errorf("expected %t, but got %t", c.expected, to.Bool(c.cs.Properties.OrchestratorProfile.KubernetesConfig.CloudProviderDisableOutboundSNAT))
+			}
+		})
+	}
+}
+
+func TestSetTelemetryProfileDefaults(t *testing.T) {
+	cases := []struct {
+		name             string
+		telemetryProfile *api.TelemetryProfile
+		expected         *api.TelemetryProfile
+	}{
+		{
+			name:             "default",
+			telemetryProfile: nil,
+			expected: &api.TelemetryProfile{
+				ApplicationInsightsKey: api.DefaultApplicationInsightsKey,
+			},
+		},
+		{
+			name:             "key not set",
+			telemetryProfile: &api.TelemetryProfile{},
+			expected: &api.TelemetryProfile{
+				ApplicationInsightsKey: api.DefaultApplicationInsightsKey,
+			},
+		},
+		{
+			name: "key set",
+			telemetryProfile: &api.TelemetryProfile{
+				ApplicationInsightsKey: "app-insights-key",
+			},
+			expected: &api.TelemetryProfile{
+				ApplicationInsightsKey: "app-insights-key",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			props := api.Properties{
+				TelemetryProfile: c.telemetryProfile,
+			}
+
+			cs := ContainerService{
+				Properties: &props,
+			}
+			cs.setTelemetryProfileDefaults()
+
+			actual := props.TelemetryProfile
+			expected := c.expected
+
+			equal := reflect.DeepEqual(actual, expected)
+
+			if !equal {
+				t.Errorf("unexpected diff while conparing Properties.TelemetryProfile: expected: %s, actual: %s", expected, actual)
+			}
+		})
+	}
+}
+
+func TestSetPropertiesDefaults(t *testing.T) {
+	cases := []struct {
+		name   string
+		params api.PropertiesDefaultsParams
+	}{
+		{
+			name: "default",
+			params: api.PropertiesDefaultsParams{
+				IsUpgrade:  false,
+				IsScale:    false,
+				PkiKeySize: helpers.DefaultPkiKeySize,
+			},
+		},
+		{
+			name: "upgrade",
+			params: api.PropertiesDefaultsParams{
+				IsUpgrade:  true,
+				IsScale:    false,
+				PkiKeySize: helpers.DefaultPkiKeySize,
+			},
+		},
+		{
+			name: "scale",
+			params: api.PropertiesDefaultsParams{
+				IsUpgrade:  false,
+				IsScale:    true,
+				PkiKeySize: helpers.DefaultPkiKeySize,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			cs := getMockBaseContainerService("1.16")
+
+			_, err := cs.SetPropertiesDefaults(c.params)
+
+			if err != nil {
+				t.Errorf("ContainerService.SetPropertiesDefaults returned error: %s", err)
+			}
+
+			// verify TelemetryProfile is set
+			if cs.Properties.TelemetryProfile == nil {
+				t.Errorf("ContainerService.Properties.TelemetryProfile should be set")
+			}
+		})
+	}
+}
+
+func TestImageReference(t *testing.T) {
+	cases := []struct {
+		name                      string
+		cs                        ContainerService
+		isUpgrade                 bool
+		isScale                   bool
+		expectedMasterProfile     api.MasterProfile
+		expectedAgentPoolProfiles []api.AgentPoolProfile
+	}{
+		{
+			name: "default",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType: api.Kubernetes,
+					},
+					MasterProfile: &api.MasterProfile{},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{},
+					},
+				},
+			},
+			expectedMasterProfile: api.MasterProfile{
+				Distro:   api.AKSUbuntu1604,
+				ImageRef: nil,
+			},
+			expectedAgentPoolProfiles: []api.AgentPoolProfile{
+				{
+					Distro:   api.AKSUbuntu1604,
+					ImageRef: nil,
+				},
+			},
+		},
+		{
+			name: "image references",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType: api.Kubernetes,
+					},
+					MasterProfile: &api.MasterProfile{
+						ImageRef: &api.ImageReference{
+							Name:           "name",
+							ResourceGroup:  "resource-group",
+							SubscriptionID: "sub-id",
+							Gallery:        "gallery",
+							Version:        "version",
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							ImageRef: &api.ImageReference{
+								Name:           "name",
+								ResourceGroup:  "resource-group",
+								SubscriptionID: "sub-id",
+								Gallery:        "gallery",
+								Version:        "version",
+							},
+						},
+					},
+				},
+			},
+			expectedMasterProfile: api.MasterProfile{
+				Distro: "",
+				ImageRef: &api.ImageReference{
+					Name:           "name",
+					ResourceGroup:  "resource-group",
+					SubscriptionID: "sub-id",
+					Gallery:        "gallery",
+					Version:        "version",
+				},
+			},
+			expectedAgentPoolProfiles: []api.AgentPoolProfile{
+				{
+					Distro: "",
+					ImageRef: &api.ImageReference{
+						Name:           "name",
+						ResourceGroup:  "resource-group",
+						SubscriptionID: "sub-id",
+						Gallery:        "gallery",
+						Version:        "version",
+					},
+				},
+			},
+		},
+		{
+			name: "mixed",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType: api.Kubernetes,
+					},
+					MasterProfile: &api.MasterProfile{},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							ImageRef: &api.ImageReference{
+								Name:           "name",
+								ResourceGroup:  "resource-group",
+								SubscriptionID: "sub-id",
+								Gallery:        "gallery",
+								Version:        "version",
+							},
+						},
+						{},
+					},
+				},
+			},
+			expectedMasterProfile: api.MasterProfile{
+				Distro:   api.AKSUbuntu1604,
+				ImageRef: nil,
+			},
+			expectedAgentPoolProfiles: []api.AgentPoolProfile{
+				{
+					Distro: "",
+					ImageRef: &api.ImageReference{
+						Name:           "name",
+						ResourceGroup:  "resource-group",
+						SubscriptionID: "sub-id",
+						Gallery:        "gallery",
+						Version:        "version",
+					},
+				},
+				{
+					Distro:   api.AKSUbuntu1604,
+					ImageRef: nil,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			c.cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{
+				LoadBalancerSku: api.BasicLoadBalancerSku,
+			}
+
+			c.cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+				IsUpgrade:  c.isUpgrade,
+				IsScale:    c.isScale,
+				PkiKeySize: helpers.DefaultPkiKeySize,
+			})
+			if c.cs.Properties.MasterProfile.Distro != c.expectedMasterProfile.Distro {
+				t.Errorf("expected %s, but got %s", c.expectedMasterProfile.Distro, c.cs.Properties.MasterProfile.Distro)
+			}
+			if c.expectedMasterProfile.ImageRef == nil {
+				if c.cs.Properties.MasterProfile.ImageRef != nil {
+					t.Errorf("expected nil, but got an ImageRef")
+				}
+			} else {
+				if c.cs.Properties.MasterProfile.ImageRef == nil {
+					t.Errorf("got unexpected nil MasterProfile.ImageRef")
+				}
+				if c.cs.Properties.MasterProfile.ImageRef.Name != c.expectedMasterProfile.ImageRef.Name {
+					t.Errorf("expected %s, but got %s", c.expectedMasterProfile.ImageRef.Name, c.cs.Properties.MasterProfile.ImageRef.Name)
+				}
+				if c.cs.Properties.MasterProfile.ImageRef.ResourceGroup != c.expectedMasterProfile.ImageRef.ResourceGroup {
+					t.Errorf("expected %s, but got %s", c.expectedMasterProfile.ImageRef.ResourceGroup, c.cs.Properties.MasterProfile.ImageRef.ResourceGroup)
+				}
+				if c.cs.Properties.MasterProfile.ImageRef.SubscriptionID != c.expectedMasterProfile.ImageRef.SubscriptionID {
+					t.Errorf("expected %s, but got %s", c.expectedMasterProfile.ImageRef.SubscriptionID, c.cs.Properties.MasterProfile.ImageRef.SubscriptionID)
+				}
+				if c.cs.Properties.MasterProfile.ImageRef.Gallery != c.expectedMasterProfile.ImageRef.Gallery {
+					t.Errorf("expected %s, but got %s", c.expectedMasterProfile.ImageRef.Gallery, c.cs.Properties.MasterProfile.ImageRef.Gallery)
+				}
+				if c.cs.Properties.MasterProfile.ImageRef.Version != c.expectedMasterProfile.ImageRef.Version {
+					t.Errorf("expected %s, but got %s", c.expectedMasterProfile.ImageRef.Version, c.cs.Properties.MasterProfile.ImageRef.Version)
+				}
+			}
+			for i, profile := range c.cs.Properties.AgentPoolProfiles {
+				if profile.Distro != c.expectedAgentPoolProfiles[i].Distro {
+					t.Errorf("expected %s, but got %s", c.expectedAgentPoolProfiles[i].Distro, profile.Distro)
+				}
+				if c.expectedAgentPoolProfiles[i].ImageRef == nil {
+					if profile.ImageRef != nil {
+						t.Errorf("expected nil, but got an ImageRef")
+					}
+				} else {
+					if profile.ImageRef == nil {
+						t.Errorf("got unexpected nil MasterProfile.ImageRef")
+					}
+					if profile.ImageRef.Name != c.expectedAgentPoolProfiles[i].ImageRef.Name {
+						t.Errorf("expected %s, but got %s", c.expectedAgentPoolProfiles[i].ImageRef.Name, profile.ImageRef.Name)
+					}
+					if profile.ImageRef.ResourceGroup != c.expectedAgentPoolProfiles[i].ImageRef.ResourceGroup {
+						t.Errorf("expected %s, but got %s", c.expectedAgentPoolProfiles[i].ImageRef.ResourceGroup, profile.ImageRef.ResourceGroup)
+					}
+					if profile.ImageRef.SubscriptionID != c.expectedAgentPoolProfiles[i].ImageRef.SubscriptionID {
+						t.Errorf("expected %s, but got %s", c.expectedAgentPoolProfiles[i].ImageRef.SubscriptionID, profile.ImageRef.SubscriptionID)
+					}
+					if profile.ImageRef.Gallery != c.expectedAgentPoolProfiles[i].ImageRef.Gallery {
+						t.Errorf("expected %s, but got %s", c.expectedAgentPoolProfiles[i].ImageRef.Gallery, profile.ImageRef.Gallery)
+					}
+					if profile.ImageRef.Version != c.expectedAgentPoolProfiles[i].ImageRef.Version {
+						t.Errorf("expected %s, but got %s", c.expectedAgentPoolProfiles[i].ImageRef.Version, profile.ImageRef.Version)
+					}
+				}
+				if to.Bool(profile.SinglePlacementGroup) != true {
+					t.Errorf("expected %v, but got %v", true, to.Bool(profile.SinglePlacementGroup))
+				}
+			}
+		})
+	}
+}
+
+func TestCustomHyperkubeDistro(t *testing.T) {
+	cases := []struct {
+		name                      string
+		cs                        ContainerService
+		isUpgrade                 bool
+		isScale                   bool
+		expectedMasterProfile     api.MasterProfile
+		expectedAgentPoolProfiles []api.AgentPoolProfile
+	}{
+		{
+			name: "default",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType: api.Kubernetes,
+						KubernetesConfig: &api.KubernetesConfig{
+							LoadBalancerSku: api.BasicLoadBalancerSku,
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{},
+					},
+				},
+			},
+			expectedMasterProfile: api.MasterProfile{
+				Distro:   api.AKSUbuntu1604,
+				ImageRef: nil,
+			},
+			expectedAgentPoolProfiles: []api.AgentPoolProfile{
+				{
+					Distro:   api.AKSUbuntu1604,
+					ImageRef: nil,
+				},
+			},
+		},
+		{
+			name: "custom hyperkube",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType: api.Kubernetes,
+						KubernetesConfig: &api.KubernetesConfig{
+							CustomHyperkubeImage: "myimage",
+							LoadBalancerSku:      api.BasicLoadBalancerSku,
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{},
+					},
+				},
+			},
+			expectedMasterProfile: api.MasterProfile{
+				Distro: api.Ubuntu,
+			},
+			expectedAgentPoolProfiles: []api.AgentPoolProfile{
+				{
+					Distro: api.Ubuntu,
+				},
+			},
+		},
+		{
+			name: "custom hyperkube w/ distro",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType: api.Kubernetes,
+						KubernetesConfig: &api.KubernetesConfig{
+							CustomHyperkubeImage: "myimage",
+							LoadBalancerSku:      api.BasicLoadBalancerSku,
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						Distro: api.Ubuntu1804,
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Distro: api.Ubuntu1804,
+						},
+					},
+				},
+			},
+			expectedMasterProfile: api.MasterProfile{
+				Distro: api.Ubuntu1804,
+			},
+			expectedAgentPoolProfiles: []api.AgentPoolProfile{
+				{
+					Distro: api.Ubuntu1804,
+				},
+			},
+		},
+		{
+			name: "custom hyperkube w/ mixed distro config",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType: api.Kubernetes,
+						KubernetesConfig: &api.KubernetesConfig{
+							CustomHyperkubeImage: "myimage",
+							LoadBalancerSku:      api.BasicLoadBalancerSku,
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:   "pool1",
+							Distro: api.Ubuntu1804,
+						},
+						{
+							Name: "pool2",
+						},
+					},
+				},
+			},
+			expectedMasterProfile: api.MasterProfile{
+				Distro: api.Ubuntu,
+			},
+			expectedAgentPoolProfiles: []api.AgentPoolProfile{
+				{
+					Distro: api.Ubuntu1804,
+				},
+				{
+					Distro: api.Ubuntu,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			c.cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+				IsUpgrade:  c.isUpgrade,
+				IsScale:    c.isScale,
+				PkiKeySize: helpers.DefaultPkiKeySize,
+			})
+			if c.cs.Properties.MasterProfile.Distro != c.expectedMasterProfile.Distro {
+				t.Errorf("expected %s, but got %s", c.expectedMasterProfile.Distro, c.cs.Properties.MasterProfile.Distro)
+			}
+			for i, profile := range c.cs.Properties.AgentPoolProfiles {
+				if profile.Distro != c.expectedAgentPoolProfiles[i].Distro {
+					t.Errorf("expected %s, but got %s", c.expectedAgentPoolProfiles[i].Distro, profile.Distro)
+				}
+				if to.Bool(profile.SinglePlacementGroup) != true {
+					t.Errorf("expected %v, but got %v", true, to.Bool(profile.SinglePlacementGroup))
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultIPAddressCount(t *testing.T) {
+	cases := []struct {
+		name           string
+		cs             ContainerService
+		expectedMaster int
+		expectedPool0  int
+		expectedPool1  int
+	}{
+		{
+			name: "kubenet",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							NetworkPlugin:   api.NetworkPluginKubenet,
+							LoadBalancerSku: api.StandardLoadBalancerSku,
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name: "pool1",
+						},
+						{
+							Name: "pool2",
+						},
+					},
+				},
+			},
+			expectedMaster: 1,
+			expectedPool0:  1,
+			expectedPool1:  1,
+		},
+		{
+			name: "Azure CNI",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							NetworkPlugin:   api.NetworkPluginAzure,
+							LoadBalancerSku: api.StandardLoadBalancerSku,
+						},
+					},
+					MasterProfile: &api.MasterProfile{},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name: "pool1",
+						},
+						{
+							Name: "pool2",
+						},
+					},
+				},
+			},
+			expectedMaster: api.DefaultKubernetesMaxPodsVNETIntegrated + 1,
+			expectedPool0:  api.DefaultKubernetesMaxPodsVNETIntegrated + 1,
+			expectedPool1:  api.DefaultKubernetesMaxPodsVNETIntegrated + 1,
+		},
+		{
+			name: "Azure CNI + custom IPAddressCount",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							NetworkPlugin:   api.NetworkPluginAzure,
+							LoadBalancerSku: api.StandardLoadBalancerSku,
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						IPAddressCount: 24,
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:           "pool1",
+							IPAddressCount: 24,
+						},
+						{
+							Name:           "pool2",
+							IPAddressCount: 24,
+						},
+					},
+				},
+			},
+			expectedMaster: 24,
+			expectedPool0:  24,
+			expectedPool1:  24,
+		},
+		{
+			name: "kubenet + custom IPAddressCount",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							NetworkPlugin:   api.NetworkPluginKubenet,
+							LoadBalancerSku: api.StandardLoadBalancerSku,
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						IPAddressCount: 24,
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name:           "pool1",
+							IPAddressCount: 24,
+						},
+						{
+							Name:           "pool2",
+							IPAddressCount: 24,
+						},
+					},
+				},
+			},
+			expectedMaster: 24,
+			expectedPool0:  24,
+			expectedPool1:  24,
+		},
+		{
+			name: "Azure CNI + mixed config",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							NetworkPlugin:   api.NetworkPluginAzure,
+							LoadBalancerSku: api.StandardLoadBalancerSku,
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--max-pods": "24",
+							},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name: "pool1",
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--max-pods": "128",
+								},
+							},
+						},
+						{
+							Name: "pool2",
+						},
+					},
+				},
+			},
+			expectedMaster: 25,
+			expectedPool0:  129,
+			expectedPool1:  api.DefaultKubernetesMaxPodsVNETIntegrated + 1,
+		},
+		{
+			name: "kubenet + mixed config",
+			cs: ContainerService{
+				Properties: &api.Properties{
+					OrchestratorProfile: &api.OrchestratorProfile{
+						OrchestratorType:    api.Kubernetes,
+						OrchestratorVersion: "1.14.0",
+						KubernetesConfig: &api.KubernetesConfig{
+							NetworkPlugin:   api.NetworkPluginKubenet,
+							LoadBalancerSku: api.StandardLoadBalancerSku,
+						},
+					},
+					MasterProfile: &api.MasterProfile{
+						KubernetesConfig: &api.KubernetesConfig{
+							KubeletConfig: map[string]string{
+								"--max-pods": "24",
+							},
+						},
+					},
+					AgentPoolProfiles: []*api.AgentPoolProfile{
+						{
+							Name: "pool1",
+							KubernetesConfig: &api.KubernetesConfig{
+								KubeletConfig: map[string]string{
+									"--max-pods": "128",
+								},
+							},
+						},
+						{
+							Name: "pool2",
+						},
+					},
+				},
+			},
+			expectedMaster: 1,
+			expectedPool0:  1,
+			expectedPool1:  1,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			c.cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
+				IsScale:    false,
+				IsUpgrade:  true,
+				PkiKeySize: helpers.DefaultPkiKeySize,
+			})
+			if c.cs.Properties.MasterProfile.IPAddressCount != c.expectedMaster {
+				t.Errorf("expected %d, but got %d", c.expectedMaster, c.cs.Properties.MasterProfile.IPAddressCount)
+			}
+			if c.cs.Properties.AgentPoolProfiles[0].IPAddressCount != c.expectedPool0 {
+				t.Errorf("expected %d, but got %d", c.expectedPool0, c.cs.Properties.AgentPoolProfiles[0].IPAddressCount)
+			}
+			if c.cs.Properties.AgentPoolProfiles[1].IPAddressCount != c.expectedPool1 {
+				t.Errorf("expected %d, but got %d", c.expectedPool1, c.cs.Properties.AgentPoolProfiles[1].IPAddressCount)
+			}
+			if to.Bool(c.cs.Properties.AgentPoolProfiles[1].SinglePlacementGroup) != false {
+				t.Errorf("expected %v, but got %v", false, to.Bool(c.cs.Properties.AgentPoolProfiles[1].SinglePlacementGroup))
+			}
+		})
+	}
+}

--- a/pkg/agent/datamodel/mocks.go
+++ b/pkg/agent/datamodel/mocks.go
@@ -1,0 +1,261 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/google/uuid"
+)
+
+// CreateMockAgentPoolProfile creates a mock AgentPoolResource for testing
+func CreateMockAgentPoolProfile(agentPoolName, orchestratorVersion string, provisioningState api.ProvisioningState, agentCount int) *api.AgentPoolResource {
+	agentPoolResource := api.AgentPoolResource{}
+	agentPoolResource.ID = uuid.Must(uuid.NewRandom()).String()
+	agentPoolResource.Location = "westus2"
+	agentPoolResource.Name = agentPoolName
+
+	agentPoolResource.Properties = &api.AgentPoolProfile{}
+	// AgentPoolProfile needs to be remain same, so the name is repeated inside.
+	agentPoolResource.Properties.Name = agentPoolName
+	agentPoolResource.Properties.Count = agentCount
+	agentPoolResource.Properties.OrchestratorVersion = orchestratorVersion
+	agentPoolResource.Properties.ProvisioningState = provisioningState
+	return &agentPoolResource
+}
+
+// CreateMockContainerService returns a mock container service for testing purposes
+func CreateMockContainerService(containerServiceName, orchestratorVersion string, masterCount, agentCount int, certs bool) *ContainerService {
+	cs := ContainerService{}
+	cs.ID = uuid.Must(uuid.NewRandom()).String()
+	cs.Location = "eastus"
+	cs.Name = containerServiceName
+
+	cs.Properties = &api.Properties{}
+
+	cs.Properties.MasterProfile = &api.MasterProfile{}
+	cs.Properties.MasterProfile.Count = masterCount
+	cs.Properties.MasterProfile.DNSPrefix = "testmaster"
+	cs.Properties.MasterProfile.VMSize = "Standard_D2_v2"
+
+	cs.Properties.AgentPoolProfiles = []*api.AgentPoolProfile{}
+	agentPool := &api.AgentPoolProfile{}
+	agentPool.Count = agentCount
+	agentPool.Name = "agentpool1"
+	agentPool.VMSize = "Standard_D2_v2"
+	agentPool.OSType = api.Linux
+	agentPool.AvailabilityProfile = "AvailabilitySet"
+	agentPool.StorageProfile = "StorageAccount"
+
+	cs.Properties.AgentPoolProfiles = append(cs.Properties.AgentPoolProfiles, agentPool)
+
+	cs.Properties.LinuxProfile = &api.LinuxProfile{
+		AdminUsername: "azureuser",
+		SSH: struct {
+			PublicKeys []api.PublicKey `json:"publicKeys"`
+		}{},
+	}
+
+	cs.Properties.LinuxProfile.AdminUsername = "azureuser"
+	cs.Properties.LinuxProfile.SSH.PublicKeys = append(
+		cs.Properties.LinuxProfile.SSH.PublicKeys, api.PublicKey{KeyData: "test"})
+
+	cs.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{}
+	cs.Properties.ServicePrincipalProfile.ClientID = "DEC923E3-1EF1-4745-9516-37906D56DEC4"
+	cs.Properties.ServicePrincipalProfile.Secret = "DEC923E3-1EF1-4745-9516-37906D56DEC4"
+
+	cs.Properties.OrchestratorProfile = &api.OrchestratorProfile{}
+	cs.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	cs.Properties.OrchestratorProfile.OrchestratorVersion = orchestratorVersion
+	cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{
+		EnableSecureKubelet:     to.BoolPtr(api.DefaultSecureKubeletEnabled),
+		EnableRbac:              to.BoolPtr(api.DefaultRBACEnabled),
+		EtcdDiskSizeGB:          api.DefaultEtcdDiskSize,
+		ServiceCIDR:             api.DefaultKubernetesServiceCIDR,
+		DockerBridgeSubnet:      api.DefaultDockerBridgeSubnet,
+		DNSServiceIP:            api.DefaultKubernetesDNSServiceIP,
+		GCLowThreshold:          api.DefaultKubernetesGCLowThreshold,
+		GCHighThreshold:         api.DefaultKubernetesGCHighThreshold,
+		MaxPods:                 api.DefaultKubernetesMaxPodsVNETIntegrated,
+		ClusterSubnet:           api.DefaultKubernetesSubnet,
+		ContainerRuntime:        api.DefaultContainerRuntime,
+		NetworkPlugin:           api.DefaultNetworkPlugin,
+		NetworkPolicy:           api.DefaultNetworkPolicy,
+		EtcdVersion:             api.DefaultEtcdVersion,
+		MobyVersion:             api.DefaultMobyVersion,
+		ContainerdVersion:       api.DefaultContainerdVersion,
+		LoadBalancerSku:         api.DefaultLoadBalancerSku,
+		KubeletConfig:           make(map[string]string),
+		ControllerManagerConfig: make(map[string]string),
+	}
+
+	cs.Properties.CertificateProfile = &api.CertificateProfile{}
+	if certs {
+		cs.Properties.CertificateProfile.CaCertificate = "cacert"
+		cs.Properties.CertificateProfile.CaPrivateKey = "cakey"
+		cs.Properties.CertificateProfile.KubeConfigCertificate = "kubeconfigcert"
+		cs.Properties.CertificateProfile.KubeConfigPrivateKey = "kubeconfigkey"
+		cs.Properties.CertificateProfile.APIServerCertificate = "apiservercert"
+		cs.Properties.CertificateProfile.APIServerPrivateKey = "apiserverkey"
+		cs.Properties.CertificateProfile.ClientCertificate = "clientcert"
+		cs.Properties.CertificateProfile.ClientPrivateKey = "clientkey"
+		cs.Properties.CertificateProfile.EtcdServerCertificate = "etcdservercert"
+		cs.Properties.CertificateProfile.EtcdServerPrivateKey = "etcdserverkey"
+		cs.Properties.CertificateProfile.EtcdClientCertificate = "etcdclientcert"
+		cs.Properties.CertificateProfile.EtcdClientPrivateKey = "etcdclientkey"
+		cs.Properties.CertificateProfile.EtcdPeerCertificates = []string{"etcdpeercert1", "etcdpeercert2", "etcdpeercert3", "etcdpeercert4", "etcdpeercert5"}
+		cs.Properties.CertificateProfile.EtcdPeerPrivateKeys = []string{"etcdpeerkey1", "etcdpeerkey2", "etcdpeerkey3", "etcdpeerkey4", "etcdpeerkey5"}
+
+	}
+
+	return &cs
+}
+
+// GetK8sDefaultProperties returns a struct of type api.Properties for testing purposes.
+func GetK8sDefaultProperties(hasWindows bool) *api.Properties {
+	p := &api.Properties{
+		OrchestratorProfile: &api.OrchestratorProfile{
+			OrchestratorType: api.Kubernetes,
+			KubernetesConfig: &api.KubernetesConfig{},
+		},
+		MasterProfile: &api.MasterProfile{
+			Count:     1,
+			DNSPrefix: "foo",
+			VMSize:    "Standard_DS2_v2",
+		},
+		AgentPoolProfiles: []*api.AgentPoolProfile{
+			{
+				Name:                "agentpool",
+				VMSize:              "Standard_D2_v2",
+				Count:               1,
+				AvailabilityProfile: api.AvailabilitySet,
+			},
+		},
+		ServicePrincipalProfile: &api.ServicePrincipalProfile{
+			ClientID: "clientID",
+			Secret:   "clientSecret",
+		},
+	}
+
+	if hasWindows {
+		p.AgentPoolProfiles = []*api.AgentPoolProfile{
+			{
+				Name:                "agentpool",
+				VMSize:              "Standard_D2_v2",
+				Count:               1,
+				AvailabilityProfile: api.AvailabilitySet,
+				OSType:              api.Windows,
+			},
+		}
+		p.WindowsProfile = &api.WindowsProfile{
+			AdminUsername: "azureuser",
+			AdminPassword: "replacepassword1234$",
+		}
+	}
+
+	return p
+}
+
+// GetMockPropertiesWithCustomCloudProfile returns a Properties object w/ mock CustomCloudProfile data
+func GetMockPropertiesWithCustomCloudProfile(name string, hasCustomCloudProfile, hasEnvironment, hasAzureEnvironmentSpecConfig bool) api.Properties {
+	var (
+		managementPortalURL          = "https://management.local.azurestack.external/"
+		publishSettingsURL           = "https://management.local.azurestack.external/publishsettings/index"
+		serviceManagementEndpoint    = "https://management.azurestackci15.onmicrosoft.com/36f71706-54df-4305-9847-5b038a4cf189"
+		resourceManagerEndpoint      = "https://management.local.azurestack.external/"
+		activeDirectoryEndpoint      = "https://login.windows.net/"
+		galleryEndpoint              = "https://portal.local.azurestack.external=30015/"
+		keyVaultEndpoint             = "https://vault.azurestack.external/"
+		graphEndpoint                = "https://graph.windows.net/"
+		serviceBusEndpoint           = "https://servicebus.azurestack.external/"
+		batchManagementEndpoint      = "https://batch.azurestack.external/"
+		storageEndpointSuffix        = "core.azurestack.external"
+		sqlDatabaseDNSSuffix         = "database.azurestack.external"
+		trafficManagerDNSSuffix      = "trafficmanager.cn"
+		keyVaultDNSSuffix            = "vault.azurestack.external"
+		serviceBusEndpointSuffix     = "servicebus.azurestack.external"
+		serviceManagementVMDNSSuffix = "chinacloudapp.cn"
+		resourceManagerVMDNSSuffix   = "cloudapp.azurestack.external"
+		containerRegistryDNSSuffix   = "azurecr.io"
+		tokenAudience                = "https://management.azurestack.external/"
+	)
+
+	p := api.Properties{}
+	if hasCustomCloudProfile {
+		p.CustomCloudProfile = &api.CustomCloudProfile{}
+		if hasEnvironment {
+			p.CustomCloudProfile.Environment = &azure.Environment{
+				Name:                         name,
+				ManagementPortalURL:          managementPortalURL,
+				PublishSettingsURL:           publishSettingsURL,
+				ServiceManagementEndpoint:    serviceManagementEndpoint,
+				ResourceManagerEndpoint:      resourceManagerEndpoint,
+				ActiveDirectoryEndpoint:      activeDirectoryEndpoint,
+				GalleryEndpoint:              galleryEndpoint,
+				KeyVaultEndpoint:             keyVaultEndpoint,
+				GraphEndpoint:                graphEndpoint,
+				ServiceBusEndpoint:           serviceBusEndpoint,
+				BatchManagementEndpoint:      batchManagementEndpoint,
+				StorageEndpointSuffix:        storageEndpointSuffix,
+				SQLDatabaseDNSSuffix:         sqlDatabaseDNSSuffix,
+				TrafficManagerDNSSuffix:      trafficManagerDNSSuffix,
+				KeyVaultDNSSuffix:            keyVaultDNSSuffix,
+				ServiceBusEndpointSuffix:     serviceBusEndpointSuffix,
+				ServiceManagementVMDNSSuffix: serviceManagementVMDNSSuffix,
+				ResourceManagerVMDNSSuffix:   resourceManagerVMDNSSuffix,
+				ContainerRegistryDNSSuffix:   containerRegistryDNSSuffix,
+				TokenAudience:                tokenAudience,
+			}
+		}
+		if hasAzureEnvironmentSpecConfig {
+			//azureStackCloudSpec is the default configurations for azure stack with public Azure.
+			azureStackCloudSpec := api.AzureEnvironmentSpecConfig{
+				CloudName: api.AzureStackCloud,
+				//DockerSpecConfig specify the docker engine download repo
+				DockerSpecConfig: api.DefaultDockerSpecConfig,
+				//KubernetesSpecConfig is the default kubernetes container image url.
+				KubernetesSpecConfig: api.DefaultKubernetesSpecConfig,
+				DCOSSpecConfig:       api.DefaultDCOSSpecConfig,
+				EndpointConfig: api.AzureEndpointConfig{
+					ResourceManagerVMDNSSuffix: "",
+				},
+				OSImageConfig: map[api.Distro]api.AzureOSImageConfig{
+					api.Ubuntu:        api.Ubuntu1604OSImageConfig,
+					api.RHEL:          api.RHELOSImageConfig,
+					api.CoreOS:        api.CoreOSImageConfig,
+					api.AKSUbuntu1604: api.AKSUbuntu1604OSImageConfig,
+				},
+			}
+			p.CustomCloudProfile.AzureEnvironmentSpecConfig = &azureStackCloudSpec
+		}
+		p.CustomCloudProfile.IdentitySystem = api.AzureADIdentitySystem
+		p.CustomCloudProfile.AuthenticationMethod = api.ClientSecretAuthMethod
+	}
+	return p
+}
+
+func getMockAddon(name string) api.KubernetesAddon {
+	return api.KubernetesAddon{
+		Name: name,
+		Containers: []api.KubernetesContainerSpec{
+			{
+				Name:           name,
+				CPURequests:    "50m",
+				MemoryRequests: "150Mi",
+				CPULimits:      "50m",
+				MemoryLimits:   "150Mi",
+			},
+		},
+		Pools: []api.AddonNodePoolsConfig{
+			{
+				Name: "pool1",
+				Config: map[string]string{
+					"min-nodes": "3",
+					"max-nodes": "3",
+				},
+			},
+		},
+	}
+}

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"strings"
+
+	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/aks-engine/pkg/helpers"
+)
+
+// ContainerService complies with the ARM model of
+// resource definition in a JSON template.
+type ContainerService struct {
+	ID       string                    `json:"id"`
+	Location string                    `json:"location"`
+	Name     string                    `json:"name"`
+	Plan     *api.ResourcePurchasePlan `json:"plan,omitempty"`
+	Tags     map[string]string         `json:"tags"`
+	Type     string                    `json:"type"`
+
+	Properties *api.Properties `json:"properties,omitempty"`
+}
+
+// GetCloudSpecConfig returns the Kubernetes container images URL configurations based on the deploy target environment.
+//for example: if the target is the public azure, then the default container image url should be k8s.gcr.io/...
+//if the target is azure china, then the default container image should be mirror.azure.cn:5000/google_container/...
+func (cs *ContainerService) GetCloudSpecConfig() api.AzureEnvironmentSpecConfig {
+	targetEnv := helpers.GetTargetEnv(cs.Location, cs.Properties.GetCustomCloudName())
+	return api.AzureCloudSpecEnvMap[targetEnv]
+}
+
+// IsAKSCustomCloud checks if it's in AKS custom cloud
+func (cs *ContainerService) IsAKSCustomCloud() bool {
+	return cs.Properties.CustomCloudEnv != nil &&
+		strings.EqualFold(cs.Properties.CustomCloudEnv.Name, "akscustom")
+}
+
+// FromAksEngineContainerService converts aks-engine's ContainerService to our
+// own ContainerService. This is temporarily needed while we are still using
+// aks-engine's ApiLoader to load ContainerService from file. Once that code
+// is ported into our code base, we'll be using our own datamodel consistently
+// through out the code base and this conversion function won't be needed.
+func FromAksEngineContainerService(aksEngineCS *api.ContainerService) *ContainerService {
+	return &ContainerService{
+		ID:         aksEngineCS.ID,
+		Location:   aksEngineCS.Location,
+		Name:       aksEngineCS.Name,
+		Plan:       aksEngineCS.Plan,
+		Tags:       aksEngineCS.Tags,
+		Type:       aksEngineCS.Type,
+		Properties: aksEngineCS.Properties,
+	}
+}
+
+// ToAksEngineContainerService converts our ContainerService to aks-engine's
+// ContainerService to our. This is temporarily needed until we have finished
+// porting all aks-engine code that's used by us into our own code base.
+func ToAksEngineContainerService(cs *ContainerService) *api.ContainerService {
+	return &api.ContainerService{
+		ID:         cs.ID,
+		Location:   cs.Location,
+		Name:       cs.Name,
+		Plan:       cs.Plan,
+		Tags:       cs.Tags,
+		Type:       cs.Type,
+		Properties: cs.Properties,
+	}
+}
+
+// GetLocations returns all supported regions.
+// If AzureStackCloud, GetLocations provides the location of container service
+// If AzurePublicCloud, AzureChinaCloud,AzureGermanCloud or AzureUSGovernmentCloud, GetLocations provides all azure regions in prod.
+func (cs *ContainerService) GetLocations() []string {
+	var allLocations []string
+	if cs.Properties.IsAzureStackCloud() {
+		allLocations = []string{cs.Location}
+	} else {
+		allLocations = helpers.GetAzureLocations()
+	}
+	return allLocations
+}

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package datamodel
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Azure/aks-engine/pkg/api"
+)
+
+func TestGetAzureCNIURLFuncs(t *testing.T) {
+	// Default case
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 1, 3, false)
+	cs.Location = "eastus"
+	cloudSpecConfig := cs.GetCloudSpecConfig()
+
+	o := api.OrchestratorProfile{
+		OrchestratorType: "Kubernetes",
+		KubernetesConfig: &api.KubernetesConfig{},
+	}
+	linuxURL := o.KubernetesConfig.GetAzureCNIURLLinux(cloudSpecConfig)
+	windowsURL := o.KubernetesConfig.GetAzureCNIURLWindows(cloudSpecConfig)
+	if linuxURL != cloudSpecConfig.KubernetesSpecConfig.VnetCNILinuxPluginsDownloadURL {
+		t.Fatalf("GetAzureCNIURLLinux() should return default %s, instead returned %s", cloudSpecConfig.KubernetesSpecConfig.VnetCNILinuxPluginsDownloadURL, linuxURL)
+	}
+	if windowsURL != cloudSpecConfig.KubernetesSpecConfig.VnetCNIWindowsPluginsDownloadURL {
+		t.Fatalf("GetAzureCNIURLWindows() should return default %s, instead returned %s", cloudSpecConfig.KubernetesSpecConfig.VnetCNIWindowsPluginsDownloadURL, windowsURL)
+	}
+
+	// User-configurable case
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 1, 3, false)
+	cs.Location = "eastus"
+	cloudSpecConfig = cs.GetCloudSpecConfig()
+
+	customLinuxURL := "https://custom-url/azure-cni-linux.0.0.1.tgz"
+	customWindowsURL := "https://custom-url/azure-cni-windows.0.0.1.tgz"
+	o = api.OrchestratorProfile{
+		OrchestratorType: "Kubernetes",
+		KubernetesConfig: &api.KubernetesConfig{
+			AzureCNIURLLinux:   customLinuxURL,
+			AzureCNIURLWindows: customWindowsURL,
+		},
+	}
+
+	linuxURL = o.KubernetesConfig.GetAzureCNIURLLinux(cloudSpecConfig)
+	windowsURL = o.KubernetesConfig.GetAzureCNIURLWindows(cloudSpecConfig)
+	if linuxURL != customLinuxURL {
+		t.Fatalf("GetAzureCNIURLLinux() should return custom URL %s, instead returned %s", customLinuxURL, linuxURL)
+	}
+	if windowsURL != customWindowsURL {
+		t.Fatalf("GetAzureCNIURLWindows() should return custom URL %s, instead returned %s", customWindowsURL, windowsURL)
+	}
+}
+
+func TestGetLocations(t *testing.T) {
+
+	// Test location for Azure Stack Cloud
+	mockCSDefaultSpec := getMockBaseContainerService("1.11.6")
+	mockCSPDefaultSpec := GetMockPropertiesWithCustomCloudProfile("azurestackcloud", true, true, false)
+	mockCSDefaultSpec.Properties.CustomCloudProfile = mockCSPDefaultSpec.CustomCloudProfile
+	mockCSDefaultSpec.Location = "randomlocation"
+
+	expectedResult := []string{"randomlocation"}
+	actualResult := mockCSDefaultSpec.GetLocations()
+	if !reflect.DeepEqual(expectedResult, actualResult) {
+		t.Errorf("Test TestGetLocations() : expected to return %s, but got %s . ", expectedResult, actualResult)
+	}
+
+	// Test locations for Azure
+	mockCSDefault := getMockBaseContainerService("1.11.6")
+	mockCSDefault.Location = "eastus"
+
+	expected := []string{
+		"australiacentral",
+		"australiacentral2",
+		"australiaeast",
+		"australiasoutheast",
+		"brazilsouth",
+		"canadacentral",
+		"canadaeast",
+		"centralindia",
+		"centralus",
+		"centraluseuap",
+		"chinaeast",
+		"chinaeast2",
+		"chinanorth",
+		"chinanorth2",
+		"eastasia",
+		"eastus",
+		"eastus2",
+		"eastus2euap",
+		"francecentral",
+		"francesouth",
+		"germanynorth",
+		"germanywestcentral",
+		"japaneast",
+		"japanwest",
+		"koreacentral",
+		"koreasouth",
+		"northcentralus",
+		"northeurope",
+		"norwayeast",
+		"norwaywest",
+		"southafricanorth",
+		"southafricawest",
+		"southcentralus",
+		"southeastasia",
+		"southindia",
+		"switzerlandnorth",
+		"switzerlandwest",
+		"uaecentral",
+		"uaenorth",
+		"uksouth",
+		"ukwest",
+		"usdodcentral",
+		"usdodeast",
+		"westcentralus",
+		"westeurope",
+		"westindia",
+		"westus",
+		"westus2",
+		"chinaeast",
+		"chinanorth",
+		"chinanorth2",
+		"chinaeast2",
+		"germanycentral",
+		"germanynortheast",
+		"usgovvirginia",
+		"usgoviowa",
+		"usgovarizona",
+		"usgovtexas",
+		"francecentral",
+	}
+	actual := mockCSDefault.GetLocations()
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Test TestGetLocations() : expected to return %s, but got %s . ", expected, actual)
+	}
+}

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -1,6 +1,9 @@
 package agent
 
-import "github.com/Azure/aks-engine/pkg/api"
+import (
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
+	"github.com/Azure/aks-engine/pkg/api"
+)
 
 // KeyVaultID represents a KeyVault instance on Azure
 type KeyVaultID struct {
@@ -16,7 +19,7 @@ type KeyVaultRef struct {
 
 // NodeBootstrappingConfiguration represents configurations for node bootstrapping
 type NodeBootstrappingConfiguration struct {
-	ContainerService              *api.ContainerService
+	ContainerService              *datamodel.ContainerService
 	AgentPoolProfile              *api.AgentPoolProfile
 	TenantID                      string
 	SubscriptionID                string

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/Azure/agentbaker/pkg/templates"
 	"github.com/blang/semver"
 
@@ -66,7 +67,7 @@ func init() {
 type paramsMap map[string]interface{}
 
 // validateDistro checks if the requested orchestrator type is supported on the requested Linux distro.
-func validateDistro(cs *api.ContainerService) bool {
+func validateDistro(cs *datamodel.ContainerService) bool {
 	// Check Master distro
 	if cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.Distro == api.RHEL &&
 		(cs.Properties.OrchestratorProfile.OrchestratorType != api.SwarmMode) {
@@ -141,7 +142,7 @@ func addSecret(m paramsMap, k string, v interface{}, encode bool) {
 	addKeyvaultReference(m, k, parts[1], parts[2], parts[4])
 }
 
-func makeAgentExtensionScriptCommands(cs *api.ContainerService, profile *api.AgentPoolProfile) string {
+func makeAgentExtensionScriptCommands(cs *datamodel.ContainerService, profile *api.AgentPoolProfile) string {
 	if profile.OSType == api.Windows {
 		return makeWindowsExtensionScriptCommands(profile.PreprovisionExtension,
 			cs.Properties.ExtensionProfiles)
@@ -453,7 +454,7 @@ func getAddonFuncMap(addon api.KubernetesAddon) template.FuncMap {
 	}
 }
 
-func getClusterAutoscalerAddonFuncMap(addon api.KubernetesAddon, cs *api.ContainerService) template.FuncMap {
+func getClusterAutoscalerAddonFuncMap(addon api.KubernetesAddon, cs *datamodel.ContainerService) template.FuncMap {
 	return template.FuncMap{
 		"ContainerImage": func(name string) string {
 			i := addon.GetAddonContainersIndexByName(name)
@@ -486,7 +487,7 @@ func getClusterAutoscalerAddonFuncMap(addon api.KubernetesAddon, cs *api.Contain
 			return addon.Mode
 		},
 		"GetClusterAutoscalerNodesConfig": func() string {
-			return api.GetClusterAutoscalerNodesConfig(addon, cs)
+			return datamodel.GetClusterAutoscalerNodesConfig(addon, cs)
 		},
 		"GetVolumeMounts": func() string {
 			if cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity {
@@ -821,7 +822,7 @@ func getCustomDataFromJSON(jsonStr string) string {
 
 // GetOrderedKubeletConfigFlagString returns an ordered string of key/val pairs
 // copied from AKS-Engine and filter out flags that already translated to config file
-func GetOrderedKubeletConfigFlagString(k *api.KubernetesConfig, cs *api.ContainerService, dynamicKubeletToggleEnabled bool) string {
+func GetOrderedKubeletConfigFlagString(k *api.KubernetesConfig, cs *datamodel.ContainerService, dynamicKubeletToggleEnabled bool) string {
 	if k.KubeletConfig == nil {
 		return ""
 	}
@@ -841,7 +842,7 @@ func GetOrderedKubeletConfigFlagString(k *api.KubernetesConfig, cs *api.Containe
 }
 
 // IsDynamicKubeletEnabled get if dynamic kubelet is supported in AKS
-func IsDynamicKubeletEnabled(cs *api.ContainerService, dynamicKubeletToggleEnabled bool) bool {
+func IsDynamicKubeletEnabled(cs *datamodel.ContainerService, dynamicKubeletToggleEnabled bool) bool {
 	// TODO(bowa) remove toggle when backfill
 	return dynamicKubeletToggleEnabled && cs.Properties.OrchestratorProfile.IsKubernetes() && IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.14.0")
 }

--- a/pkg/agent/variables.go
+++ b/pkg/agent/variables.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"strconv"
 
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/api/common"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -85,20 +86,20 @@ func getCSECommandVariables(config *NodeBootstrappingConfiguration) paramsMap {
 	}
 }
 
-func useManagedIdentity(cs *api.ContainerService) string {
+func useManagedIdentity(cs *datamodel.ContainerService) string {
 	useManagedIdentity := cs.Properties.OrchestratorProfile.KubernetesConfig != nil &&
 		cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity
 	return strconv.FormatBool(useManagedIdentity)
 }
 
-func useInstanceMetadata(cs *api.ContainerService) string {
+func useInstanceMetadata(cs *datamodel.ContainerService) string {
 	useInstanceMetadata := cs.Properties.OrchestratorProfile.KubernetesConfig != nil &&
 		cs.Properties.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata != nil &&
 		*cs.Properties.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata
 	return strconv.FormatBool(useInstanceMetadata)
 }
 
-func getMaximumLoadBalancerRuleCount(cs *api.ContainerService) int {
+func getMaximumLoadBalancerRuleCount(cs *datamodel.ContainerService) int {
 	if cs.Properties.OrchestratorProfile.KubernetesConfig != nil {
 		return cs.Properties.OrchestratorProfile.KubernetesConfig.MaximumLoadBalancerRuleCount
 	}
@@ -110,7 +111,7 @@ func isVHD(profile *api.AgentPoolProfile) string {
 	return strconv.FormatBool(profile.IsVHDDistro())
 }
 
-func getOutBoundCmd(cs *api.ContainerService) string {
+func getOutBoundCmd(cs *datamodel.ContainerService) string {
 	if cs.Properties.FeatureFlags.IsFeatureEnabled("BlockOutboundInternet") {
 		return ""
 	}


### PR DESCRIPTION
This change copies the ContainerService struct and related functions that are used by us. It also ported the necessary defaults-***.go code and their tests (defaults-custom-cloud-profile.go has no test in aks-engine code base).
Not all aks-engine datastructs are ported in this change because it would make the change list too big. After this code goes in, I'll immediately start working on porting other structs such as Properties, AgentPoolProfile, etc. The end goal is to port over all data structs so that we don't depend on aks-engine's data model.