### PR TITLE
Remove unused params from apiloader.LoadContainerServiceFromFile

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -146,7 +146,7 @@ func (gc *generateCmd) loadAPIModel() error {
 		},
 	}
 	var aksEngineContainerService *api.ContainerService
-	aksEngineContainerService, gc.apiVersion, err = apiloader.LoadContainerServiceFromFile(gc.apimodelPath, false, false, nil)
+	aksEngineContainerService, gc.apiVersion, err = apiloader.LoadContainerServiceFromFile(gc.apimodelPath)
 	if err != nil {
 		return errors.Wrap(err, "error parsing the api model")
 	}

--- a/pkg/aks-engine/api/strictjson_test.go
+++ b/pkg/aks-engine/api/strictjson_test.go
@@ -231,7 +231,7 @@ func TestStrictJSONValidationIsAppliedToVersionsAbove20170701(t *testing.T) {
 		Translator: nil,
 	}
 	for _, version := range strictVersions {
-		_, e := a.LoadContainerService([]byte(jsonWithTypo), version, true, false, nil)
+		_, e := a.LoadContainerService([]byte(jsonWithTypo), version)
 		if e == nil {
 			t.Error("Expected mistyped 'ventSubnetID' key to be detected but it wasn't")
 		} else if !strings.Contains(e.Error(), "ventSubnetID") {


### PR DESCRIPTION
The only place we use LoadContainerServiceFromFile is in cmd/generate.go, with this call:
    apiloader.LoadContainerServiceFromFile(gc.apimodelPath, false, false, nil)
Since "validate", "isUpdate" params are always false and existingContainerService is always nil, we can simplify the code a lot.