### PR TITLE
Use AgentBaker's own ContainerService struct in ApiLoader's LoadContainerServiceFromFile.

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -145,12 +145,11 @@ func (gc *generateCmd) loadAPIModel() error {
 			Locale: gc.locale,
 		},
 	}
-	var aksEngineContainerService *api.ContainerService
-	aksEngineContainerService, gc.apiVersion, err = apiloader.LoadContainerServiceFromFile(gc.apimodelPath)
+
+	gc.containerService, gc.apiVersion, err = apiloader.LoadContainerServiceFromFile(gc.apimodelPath)
 	if err != nil {
 		return errors.Wrap(err, "error parsing the api model")
 	}
-	gc.containerService = datamodel.FromAksEngineContainerService(aksEngineContainerService)
 
 	if gc.outputDirectory == "" {
 		if gc.containerService.Properties.MasterProfile != nil {

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -65,50 +65,6 @@ func (cs *ContainerService) IsAKSCustomCloud() bool {
 		strings.EqualFold(cs.Properties.CustomCloudEnv.Name, "akscustom")
 }
 
-// FromAksEngineContainerService converts aks-engine's ContainerService to our
-// own ContainerService. This is temporarily needed while we are still using
-// aks-engine's ApiLoader to load ContainerService from file. Once that code
-// is ported into our code base, we'll be using our own datamodel consistently
-// through out the code base and this conversion function won't be needed.
-func FromAksEngineContainerService(aksEngineCS *api.ContainerService) *ContainerService {
-	ret := &ContainerService{
-		ID:       aksEngineCS.ID,
-		Location: aksEngineCS.Location,
-		Name:     aksEngineCS.Name,
-		Plan:     aksEngineCS.Plan,
-		Tags:     aksEngineCS.Tags,
-		Type:     aksEngineCS.Type,
-	}
-	if aksEngineCS.Properties != nil {
-		ret.Properties = fromAksEngineProperties(aksEngineCS.Properties)
-	}
-	return ret
-}
-
-func fromAksEngineProperties(aksEngineProperties *api.Properties) *Properties {
-	return &Properties{
-		ClusterID:               aksEngineProperties.ClusterID,
-		ProvisioningState:       aksEngineProperties.ProvisioningState,
-		OrchestratorProfile:     aksEngineProperties.OrchestratorProfile,
-		MasterProfile:           aksEngineProperties.MasterProfile,
-		AgentPoolProfiles:       aksEngineProperties.AgentPoolProfiles,
-		LinuxProfile:            aksEngineProperties.LinuxProfile,
-		WindowsProfile:          aksEngineProperties.WindowsProfile,
-		ExtensionProfiles:       aksEngineProperties.ExtensionProfiles,
-		DiagnosticsProfile:      aksEngineProperties.DiagnosticsProfile,
-		JumpboxProfile:          aksEngineProperties.JumpboxProfile,
-		ServicePrincipalProfile: aksEngineProperties.ServicePrincipalProfile,
-		CertificateProfile:      aksEngineProperties.CertificateProfile,
-		AADProfile:              aksEngineProperties.AADProfile,
-		CustomProfile:           aksEngineProperties.CustomProfile,
-		HostedMasterProfile:     aksEngineProperties.HostedMasterProfile,
-		AddonProfiles:           aksEngineProperties.AddonProfiles,
-		FeatureFlags:            aksEngineProperties.FeatureFlags,
-		TelemetryProfile:        aksEngineProperties.TelemetryProfile,
-		CustomCloudEnv:          aksEngineProperties.CustomCloudEnv,
-	}
-}
-
 // ToAksEngineContainerService converts our ContainerService to aks-engine's
 // ContainerService to our. This is temporarily needed until we have finished
 // porting all aks-engine code that's used by us into our own code base.

--- a/pkg/aks-engine/api/apiloader_test.go
+++ b/pkg/aks-engine/api/apiloader_test.go
@@ -191,7 +191,6 @@ func TestLoadContainerServiceWithEmptyLocationPublicCloud(t *testing.T) {
 		"properties": {
 			"orchestratorProfile": {
 				"orchestratorType": "Kubernetes",
-				"orchestratorRelease": "1.13",
 				"kubernetesConfig": {
 					"kubernetesImageBase": "msazurestackqa/",
 					"useInstanceMetadata": false,
@@ -242,7 +241,7 @@ func TestLoadContainerServiceWithEmptyLocationPublicCloud(t *testing.T) {
 	apiloaderwithoutlocationpubliccloud := &Apiloader{}
 	_, _, err = apiloaderwithoutlocationpubliccloud.LoadContainerServiceFromFile(fileNamewithoutlocationpubliccloud)
 	if err != nil {
-		t.Errorf("Expected no error for missing loation for public cloud to be thrown")
+		t.Errorf("Expected no error for missing loation for public cloud to be thrown. %v", err)
 	}
 }
 

--- a/pkg/aks-engine/api/strictjson_test.go
+++ b/pkg/aks-engine/api/strictjson_test.go
@@ -7,8 +7,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/Azure/aks-engine/pkg/api/vlabs"
 )
 
 type SubTestProfile struct {
@@ -226,16 +224,13 @@ const jsonWithTypo = `
 }`
 
 func TestStrictJSONValidationIsAppliedToVersionsAbove20170701(t *testing.T) {
-	strictVersions := []string{vlabs.APIVersion}
 	a := &Apiloader{
 		Translator: nil,
 	}
-	for _, version := range strictVersions {
-		_, e := a.LoadContainerService([]byte(jsonWithTypo), version)
-		if e == nil {
-			t.Error("Expected mistyped 'ventSubnetID' key to be detected but it wasn't")
-		} else if !strings.Contains(e.Error(), "ventSubnetID") {
-			t.Errorf("Expected error on 'ventSubnetID' but error was %v", e)
-		}
+	_, e := a.LoadContainerService([]byte(jsonWithTypo))
+	if e == nil {
+		t.Error("Expected mistyped 'ventSubnetID' key to be detected but it wasn't")
+	} else if !strings.Contains(e.Error(), "ventSubnetID") {
+		t.Errorf("Expected error on 'ventSubnetID' but error was %v", e)
 	}
 }


### PR DESCRIPTION
This removes the need for conversion functions for different ContainerService structs.
Also removed the check for "case vlabs.APIVersion". We'll just load the ContainerService regardless of the version.