### PR TITLE
Use our own ContainerService in ArtifactWriter.WriteTLSArtifacts.

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -245,7 +245,7 @@ func (gc *generateCmd) run() error {
 			Locale: gc.locale,
 		},
 	}
-	if err = writer.WriteTLSArtifacts(datamodel.ToAksEngineContainerService(gc.containerService), gc.apiVersion, customDataStr, cseCmdStr, gc.outputDirectory, certsGenerated, gc.parametersOnly); err != nil {
+	if err = writer.WriteTLSArtifacts(gc.containerService, gc.apiVersion, customDataStr, cseCmdStr, gc.outputDirectory, certsGenerated, gc.parametersOnly); err != nil {
 		return errors.Wrap(err, "writing artifacts")
 	}
 

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -65,49 +65,6 @@ func (cs *ContainerService) IsAKSCustomCloud() bool {
 		strings.EqualFold(cs.Properties.CustomCloudEnv.Name, "akscustom")
 }
 
-// ToAksEngineContainerService converts our ContainerService to aks-engine's
-// ContainerService to our. This is temporarily needed until we have finished
-// porting all aks-engine code that's used by us into our own code base.
-func ToAksEngineContainerService(cs *ContainerService) *api.ContainerService {
-	ret := &api.ContainerService{
-		ID:       cs.ID,
-		Location: cs.Location,
-		Name:     cs.Name,
-		Plan:     cs.Plan,
-		Tags:     cs.Tags,
-		Type:     cs.Type,
-	}
-	if cs.Properties != nil {
-		ret.Properties = toAksEngineProperties(cs.Properties)
-	}
-	return ret
-}
-
-func toAksEngineProperties(p *Properties) *api.Properties {
-	ret := &api.Properties{
-		ClusterID:               p.ClusterID,
-		ProvisioningState:       p.ProvisioningState,
-		OrchestratorProfile:     p.OrchestratorProfile,
-		MasterProfile:           p.MasterProfile,
-		AgentPoolProfiles:       p.AgentPoolProfiles,
-		LinuxProfile:            p.LinuxProfile,
-		WindowsProfile:          p.WindowsProfile,
-		ExtensionProfiles:       p.ExtensionProfiles,
-		DiagnosticsProfile:      p.DiagnosticsProfile,
-		JumpboxProfile:          p.JumpboxProfile,
-		ServicePrincipalProfile: p.ServicePrincipalProfile,
-		CertificateProfile:      p.CertificateProfile,
-		AADProfile:              p.AADProfile,
-		CustomProfile:           p.CustomProfile,
-		HostedMasterProfile:     p.HostedMasterProfile,
-		AddonProfiles:           p.AddonProfiles,
-		FeatureFlags:            p.FeatureFlags,
-		TelemetryProfile:        p.TelemetryProfile,
-		CustomCloudEnv:          p.CustomCloudEnv,
-	}
-	return ret
-}
-
 // GetLocations returns all supported regions.
 // If AzurePublicCloud, AzureChinaCloud,AzureGermanCloud or AzureUSGovernmentCloud, GetLocations provides all azure regions in prod.
 func (cs *ContainerService) GetLocations() []string {

--- a/pkg/aks-engine/api/apiloader_test.go
+++ b/pkg/aks-engine/api/apiloader_test.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/Azure/aks-engine/pkg/api"
 	v20170831 "github.com/Azure/aks-engine/pkg/api/agentPoolOnlyApi/v20170831"
 	v20180331 "github.com/Azure/aks-engine/pkg/api/agentPoolOnlyApi/v20180331"
@@ -328,90 +329,16 @@ func TestSerializeContainerService(t *testing.T) {
 		Translator: &i18n.Translator{},
 	}
 
-	b, err := apiloader.SerializeContainerService(cs, v20170831.APIVersion)
-
-	if err != nil {
-		t.Errorf("unexpected error while trying to Serialize Container Service: %s", err.Error())
-	}
-
-	expected := `{
-  "apiVersion": "2017-08-31",
-  "id": "sampleID",
-  "location": "westus2",
-  "name": "sampleCS",
-  "plan": {
-    "name": "sampleRPP",
-    "product": "sampleProduct",
-    "promotionCode": "sampleCode",
-    "publisher": "samplePublisher"
-  },
-  "tags": {
-    "foo": "bar"
-  },
-  "type": "sampleType",
-  "properties": {
-    "kubernetesVersion": "1.11.6",
-    "dnsPrefix": "blueorange",
-    "fqdn": "blueorange.westus2.azure.com",
-    "agentPoolProfiles": [
-      {
-        "name": "sampleAgent",
-        "count": 2,
-        "vmSize": "sampleVM",
-        "storageProfile": "",
-        "osType": "Linux"
-      },
-      {
-        "name": "sampleAgent-public",
-        "count": 2,
-        "vmSize": "sampleVM",
-        "storageProfile": "",
-        "osType": "Linux"
-      }
-    ],
-    "linuxProfile": {
-      "adminUsername": "azureuser",
-      "ssh": {
-        "publicKeys": [
-          {
-            "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEApD8+lRvLtUcyfO8N2Cwq0zY9DG1Un9d+tcmU3HgnAzBr6UR/dDT5M07NV7DN1lmu/0dt6Ay/ItjF9xK//nwVJL3ezEX32yhLKkCKFMB1LcANNzlhT++SB5tlRBx65CTL8z9FORe4UCWVJNafxu3as/BshQSrSaYt3hjSeYuzTpwd4+4xQutzbTXEUBDUr01zEfjjzfUu0HDrg1IFae62hnLm3ajG6b432IIdUhFUmgjZDljUt5bI3OEz5IWPsNOOlVTuo6fqU8lJHClAtAlZEZkyv0VotidC7ZSCfV153rRsEk9IWscwL2PQIQnCw7YyEYEffDeLjBwkH6MIdJ6OgQ== rsa-key-20170510"
-          }
-        ]
-      }
-    },
-    "windowsProfile": {
-      "adminUsername": "sampleAdminUsername",
-      "adminPassword": "sampleAdminPassword"
-    },
-    "servicePrincipalProfile": {
-      "clientId": "fooClientID",
-      "secret": "fooSecret"
-    }
-  }
-}
-`
-	if string(b) != expected {
-		t.Errorf("expected SerializedCS JSON %s, but got %s", expected, string(b))
-	}
-
-	b, err = apiloader.SerializeContainerService(cs, v20180331.APIVersion)
-
-	if b == nil || err != nil {
-		t.Errorf("unexpected error while trying to Serialize Container Service with version v20180331: %s", err.Error())
-	}
-
-	cs.Properties.HostedMasterProfile = nil
-
 	// Test with version vlabs
-	b, err = apiloader.SerializeContainerService(cs, vlabs.APIVersion)
+	b, err := apiloader.SerializeContainerService(cs, vlabs.APIVersion)
 	if b == nil || err != nil {
-		t.Errorf("unexpected error while trying to Serialize Container Service with version v20180331: %s", err.Error())
+		t.Errorf("unexpected error while trying to Serialize Container Service with version vlabs: %s", err.Error())
 	}
 }
 
-func getDefaultContainerService() *api.ContainerService {
+func getDefaultContainerService() *datamodel.ContainerService {
 	u, _ := url.Parse("http://foobar.com/search")
-	return &api.ContainerService{
+	return &datamodel.ContainerService{
 		ID:       "sampleID",
 		Location: "westus2",
 		Name:     "sampleCS",
@@ -425,7 +352,7 @@ func getDefaultContainerService() *api.ContainerService {
 			"foo": "bar",
 		},
 		Type: "sampleType",
-		Properties: &api.Properties{
+		Properties: &datamodel.Properties{
 			WindowsProfile: &api.WindowsProfile{
 				AdminUsername: "sampleAdminUsername",
 				AdminPassword: "sampleAdminPassword",

--- a/pkg/aks-engine/engine/engine.go
+++ b/pkg/aks-engine/engine/engine.go
@@ -9,10 +9,10 @@ import (
 	"net"
 	"strings"
 
-	"github.com/Azure/go-autorest/autorest/to"
-
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/helpers"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/azure" // register azure (AD) authentication plugin
@@ -56,7 +56,7 @@ const (
 )
 
 // GenerateKubeConfig returns a JSON string representing the KubeConfig
-func GenerateKubeConfig(properties *api.Properties, location string) (string, error) {
+func GenerateKubeConfig(properties *datamodel.Properties, location string) (string, error) {
 	if properties == nil {
 		return "", errors.New("Properties nil in GenerateKubeConfig")
 	}

--- a/pkg/aks-engine/engine/engine_test.go
+++ b/pkg/aks-engine/engine/engine_test.go
@@ -7,19 +7,19 @@ import (
 	"path"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/to"
-
-	"github.com/leonelquinteros/gotext"
-
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
+	aksenginefork "github.com/Azure/agentbaker/pkg/aks-engine/api"
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/i18n"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/leonelquinteros/gotext"
 )
 
 func TestGenerateKubeConfig(t *testing.T) {
 	locale := gotext.NewLocale(path.Join("..", "..", "translations"), "en_US")
 	i18n.Initialize(locale)
 
-	apiloader := &api.Apiloader{
+	apiloader := &aksenginefork.Apiloader{
 		Translator: &i18n.Translator{
 			Locale: locale,
 		},
@@ -27,7 +27,7 @@ func TestGenerateKubeConfig(t *testing.T) {
 
 	testData := "./testdata/simple/kubernetes.json"
 
-	containerService, _, err := apiloader.LoadContainerServiceFromFile(testData, true, false, nil)
+	containerService, _, err := apiloader.LoadContainerServiceFromFile(testData)
 	if err != nil {
 		t.Errorf("Failed to load container service from file: %v", err)
 	}
@@ -40,7 +40,7 @@ func TestGenerateKubeConfig(t *testing.T) {
 		t.Errorf("Failed to call GenerateKubeConfig with simple Kubernetes config from file: %v", testData)
 	}
 
-	p := api.Properties{}
+	p := datamodel.Properties{}
 	_, err = GenerateKubeConfig(&p, "westus2")
 	if err == nil {
 		t.Errorf("Expected an error result from nil Properties child properties")
@@ -51,6 +51,9 @@ func TestGenerateKubeConfig(t *testing.T) {
 		t.Errorf("Expected an error result from nil Properties child properties")
 	}
 
+	containerService.Properties.OrchestratorProfile = &api.OrchestratorProfile{
+		KubernetesConfig: &api.KubernetesConfig{},
+	}
 	containerService.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster = &api.PrivateCluster{
 		Enabled: to.BoolPtr(true),
 	}

--- a/pkg/aks-engine/engine/output.go
+++ b/pkg/aks-engine/engine/output.go
@@ -8,7 +8,8 @@ import (
 	"path"
 	"strconv"
 
-	"github.com/Azure/aks-engine/pkg/api"
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
+	"github.com/Azure/agentbaker/pkg/aks-engine/api"
 	"github.com/Azure/aks-engine/pkg/helpers"
 	"github.com/Azure/aks-engine/pkg/i18n"
 	"github.com/pkg/errors"
@@ -20,7 +21,7 @@ type ArtifactWriter struct {
 }
 
 // WriteTLSArtifacts saves TLS certificates and keys to the server filesystem
-func (w *ArtifactWriter) WriteTLSArtifacts(containerService *api.ContainerService, apiVersion, template, parameters, artifactsDir string, certsGenerated bool, parametersOnly bool) error {
+func (w *ArtifactWriter) WriteTLSArtifacts(containerService *datamodel.ContainerService, apiVersion, template, parameters, artifactsDir string, certsGenerated bool, parametersOnly bool) error {
 	if len(artifactsDir) == 0 {
 		artifactsDir = fmt.Sprintf("%s-%s", containerService.Properties.OrchestratorProfile.OrchestratorType, containerService.Properties.GetClusterID())
 		artifactsDir = path.Join("_output", artifactsDir)

--- a/pkg/aks-engine/engine/output_test.go
+++ b/pkg/aks-engine/engine/output_test.go
@@ -9,8 +9,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/azure"
-
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/helpers"
 	"github.com/Azure/aks-engine/pkg/i18n"
@@ -18,7 +17,7 @@ import (
 
 func TestWriteTLSArtifacts(t *testing.T) {
 
-	cs := api.CreateMockContainerService("testcluster", "1.7.12", 1, 2, true)
+	cs := datamodel.CreateMockContainerService("testcluster", "1.7.12", 1, 2, true)
 	writer := &ArtifactWriter{
 		Translator: &i18n.Translator{
 			Locale: nil,
@@ -76,32 +75,8 @@ func TestWriteTLSArtifacts(t *testing.T) {
 	os.RemoveAll(defaultDir)
 
 	// Generate files with custom cloud profile in configuration
-	csCustom := api.CreateMockContainerService("testcluster", "1.11.6", 1, 2, false)
+	csCustom := datamodel.CreateMockContainerService("testcluster", "1.11.6", 1, 2, false)
 	csCustom.Location = "customlocation"
-	csCustom.Properties.CustomCloudProfile = &api.CustomCloudProfile{
-		Environment: &azure.Environment{
-			Name:                         "azurestackcloud",
-			ManagementPortalURL:          "managementPortalURL",
-			PublishSettingsURL:           "publishSettingsURL",
-			ServiceManagementEndpoint:    "serviceManagementEndpoint",
-			ResourceManagerEndpoint:      "resourceManagerEndpoint",
-			ActiveDirectoryEndpoint:      "activeDirectoryEndpoint",
-			GalleryEndpoint:              "galleryEndpoint",
-			KeyVaultEndpoint:             "keyVaultEndpoint",
-			GraphEndpoint:                "graphEndpoint",
-			ServiceBusEndpoint:           "serviceBusEndpoint",
-			BatchManagementEndpoint:      "batchManagementEndpoint",
-			StorageEndpointSuffix:        "storageEndpointSuffix",
-			SQLDatabaseDNSSuffix:         "sqlDatabaseDNSSuffix",
-			TrafficManagerDNSSuffix:      "trafficManagerDNSSuffix",
-			KeyVaultDNSSuffix:            "keyVaultDNSSuffix",
-			ServiceBusEndpointSuffix:     "serviceBusEndpointSuffix",
-			ServiceManagementVMDNSSuffix: "serviceManagementVMDNSSuffix",
-			ResourceManagerVMDNSSuffix:   "resourceManagerVMDNSSuffix",
-			ContainerRegistryDNSSuffix:   "containerRegistryDNSSuffix",
-			TokenAudience:                "tokenAudience",
-		},
-	}
 	csCustom.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 		IsScale:    false,
 		IsUpgrade:  false,


### PR DESCRIPTION
This removes the need to have conversion functions for data models.
Also in SerializeContainerService removed support for the older API versions v20170831 and v20180331.