### PR TITLE
Copy some aks-engine data structs into our code base.

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -174,7 +174,7 @@ func (gc *generateCmd) loadAPIModel() error {
 
 		prop := gc.containerService.Properties
 		if prop.CertificateProfile == nil {
-			prop.CertificateProfile = &api.CertificateProfile{}
+			prop.CertificateProfile = &datamodel.CertificateProfile{}
 		}
 		prop.CertificateProfile.CaCertificate = string(caCertificateBytes)
 		prop.CertificateProfile.CaPrivateKey = string(caKeyBytes)
@@ -192,7 +192,7 @@ func (gc *generateCmd) autofillApimodel() error {
 	useManagedIdentity := k8sConfig != nil && k8sConfig.UseManagedIdentity
 	if !useManagedIdentity {
 		if (gc.containerService.Properties.ServicePrincipalProfile == nil || ((gc.containerService.Properties.ServicePrincipalProfile.ClientID == "" || gc.containerService.Properties.ServicePrincipalProfile.ClientID == "00000000-0000-0000-0000-000000000000") && gc.containerService.Properties.ServicePrincipalProfile.Secret == "")) && gc.ClientID.String() != "" && gc.ClientSecret != "" {
-			gc.containerService.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{
+			gc.containerService.Properties.ServicePrincipalProfile = &datamodel.ServicePrincipalProfile{
 				ClientID: gc.ClientID.String(),
 				Secret:   gc.ClientSecret,
 			}
@@ -216,7 +216,7 @@ func (gc *generateCmd) run() error {
 	templateGenerator := agent.InitializeTemplateGenerator()
 
 	//extra parameters
-	gc.containerService.Properties.HostedMasterProfile = &api.HostedMasterProfile{
+	gc.containerService.Properties.HostedMasterProfile = &datamodel.HostedMasterProfile{
 		FQDN: "abc.aks.com",
 	}
 	gc.containerService.Properties.MasterProfile.VnetCidr = "vnetcidr"

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 						},
 					},
 				},
-				HostedMasterProfile: &api.HostedMasterProfile{
+				HostedMasterProfile: &datamodel.HostedMasterProfile{
 					DNSPrefix: "uttestdom",
 				},
 				AgentPoolProfiles: []*datamodel.AgentPoolProfile{
@@ -83,7 +83,7 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 				LinuxProfile: &datamodel.LinuxProfile{
 					AdminUsername: "azureuser",
 				},
-				ServicePrincipalProfile: &api.ServicePrincipalProfile{
+				ServicePrincipalProfile: &datamodel.ServicePrincipalProfile{
 					ClientID: "ClientID",
 					Secret:   "Secret",
 				},

--- a/pkg/agent/datamodel/defaults-apiserver_test.go
+++ b/pkg/agent/datamodel/defaults-apiserver_test.go
@@ -143,7 +143,7 @@ func TestAPIServerConfigUseCloudControllerManager(t *testing.T) {
 func TestAPIServerConfigHasAadProfile(t *testing.T) {
 	// Test HasAadProfile = true
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
-	cs.Properties.AADProfile = &api.AADProfile{
+	cs.Properties.AADProfile = &AADProfile{
 		ServerAppID: "test-id",
 		TenantID:    "test-tenant",
 	}
@@ -168,7 +168,7 @@ func TestAPIServerConfigHasAadProfile(t *testing.T) {
 
 	// Test OIDC user overrides
 	cs = CreateMockContainerService("testcluster", "1.7.12", 3, 2, false)
-	cs.Properties.AADProfile = &api.AADProfile{
+	cs.Properties.AADProfile = &AADProfile{
 		ServerAppID: "test-id",
 		TenantID:    "test-tenant",
 	}
@@ -203,7 +203,7 @@ func TestAPIServerConfigHasAadProfile(t *testing.T) {
 
 	// Test China Cloud settings
 	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
-	cs.Properties.AADProfile = &api.AADProfile{
+	cs.Properties.AADProfile = &AADProfile{
 		ServerAppID: "test-id",
 		TenantID:    "test-tenant",
 	}
@@ -510,7 +510,7 @@ func TestAPIServerFeatureGates(t *testing.T) {
 
 func TestAPIServerIPv6Only(t *testing.T) {
 	cs := CreateMockContainerService("testcluster", "1.18.0", 3, 2, false)
-	cs.Properties.FeatureFlags = &api.FeatureFlags{EnableIPv6Only: true}
+	cs.Properties.FeatureFlags = &FeatureFlags{EnableIPv6Only: true}
 	cs.setAPIServerConfig()
 
 	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig

--- a/pkg/agent/datamodel/defaults-kubelet_test.go
+++ b/pkg/agent/datamodel/defaults-kubelet_test.go
@@ -427,7 +427,7 @@ func TestKubeletHostedMasterIPMasqAgentDisabled(t *testing.T) {
 	subnet := "172.16.0.0/16"
 	// MasterIPMasqAgent disabled, --non-masquerade-cidr should be subnet
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, true)
-	cs.Properties.HostedMasterProfile = &api.HostedMasterProfile{
+	cs.Properties.HostedMasterProfile = &HostedMasterProfile{
 		IPMasqAgent: false,
 	}
 	cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = subnet
@@ -447,7 +447,7 @@ func TestKubeletHostedMasterIPMasqAgentDisabled(t *testing.T) {
 
 	// MasterIPMasqAgent enabled, --non-masquerade-cidr should be 0.0.0.0/0
 	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, true)
-	cs.Properties.HostedMasterProfile = &api.HostedMasterProfile{
+	cs.Properties.HostedMasterProfile = &HostedMasterProfile{
 		IPMasqAgent: true,
 	}
 	cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = subnet
@@ -1994,7 +1994,7 @@ func TestReadOnlyPort(t *testing.T) {
 			name: "AKS 1.16",
 			cs: &ContainerService{
 				Properties: &Properties{
-					HostedMasterProfile: &api.HostedMasterProfile{
+					HostedMasterProfile: &HostedMasterProfile{
 						FQDN: "foo",
 					},
 					OrchestratorProfile: &OrchestratorProfile{

--- a/pkg/agent/datamodel/defaults.go
+++ b/pkg/agent/datamodel/defaults.go
@@ -565,7 +565,7 @@ func (cs *ContainerService) SetDefaultCerts(params api.DefaultCertParams) (bool,
 		ips = append(ips, ip)
 	}
 	if p.CertificateProfile == nil {
-		p.CertificateProfile = &api.CertificateProfile{}
+		p.CertificateProfile = &CertificateProfile{}
 	}
 
 	// use the specified Certificate Authority pair, or generate p new pair
@@ -663,7 +663,7 @@ func getNewAddr(addr uint32, count int, offsetMultiplier int) uint32 {
 }
 
 // certsAlreadyPresent already present returns a map where each key is a type of cert and each value is true if that cert/key pair is user-provided
-func certsAlreadyPresent(c *api.CertificateProfile, m int) map[string]bool {
+func certsAlreadyPresent(c *CertificateProfile, m int) map[string]bool {
 	g := map[string]bool{
 		"ca":         false,
 		"apiserver":  false,
@@ -1026,7 +1026,7 @@ func (cs *ContainerService) setWindowsProfileDefaults(isUpgrade, isScale bool) {
 func (cs *ContainerService) setTelemetryProfileDefaults() {
 	p := cs.Properties
 	if p.TelemetryProfile == nil {
-		p.TelemetryProfile = &api.TelemetryProfile{}
+		p.TelemetryProfile = &TelemetryProfile{}
 	}
 
 	if len(p.TelemetryProfile.ApplicationInsightsKey) == 0 {

--- a/pkg/agent/datamodel/defaults_test.go
+++ b/pkg/agent/datamodel/defaults_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestCertsAlreadyPresent(t *testing.T) {
-	var cert *api.CertificateProfile
+	var cert *CertificateProfile
 
 	result := certsAlreadyPresent(nil, 1)
 	expected := map[string]bool{
@@ -32,7 +32,7 @@ func TestCertsAlreadyPresent(t *testing.T) {
 	if !reflect.DeepEqual(result, expected) {
 		t.Fatalf("certsAlreadyPresent() did not return false for all certs for a non-existent CertificateProfile")
 	}
-	cert = &api.CertificateProfile{}
+	cert = &CertificateProfile{}
 	result = certsAlreadyPresent(cert, 1)
 	expected = map[string]bool{
 		"ca":         false,
@@ -45,7 +45,7 @@ func TestCertsAlreadyPresent(t *testing.T) {
 	if !reflect.DeepEqual(result, expected) {
 		t.Fatalf("certsAlreadyPresent() did not return false for all certs for empty CertificateProfile")
 	}
-	cert = &api.CertificateProfile{
+	cert = &CertificateProfile{
 		APIServerCertificate: "a",
 	}
 	result = certsAlreadyPresent(cert, 1)
@@ -61,7 +61,7 @@ func TestCertsAlreadyPresent(t *testing.T) {
 		t.Fatalf("certsAlreadyPresent() did not return false for all certs for 1 cert in CertificateProfile")
 	}
 
-	cert = &api.CertificateProfile{
+	cert = &CertificateProfile{
 		APIServerCertificate:  "a",
 		CaCertificate:         "c",
 		CaPrivateKey:          "d",
@@ -86,7 +86,7 @@ func TestCertsAlreadyPresent(t *testing.T) {
 	if !reflect.DeepEqual(result, expected) {
 		t.Fatalf("certsAlreadyPresent() did not return expected result for some certs in CertificateProfile")
 	}
-	cert = &api.CertificateProfile{
+	cert = &CertificateProfile{
 		APIServerCertificate:  "a",
 		APIServerPrivateKey:   "b",
 		CaCertificate:         "c",
@@ -1114,7 +1114,7 @@ func TestMasterProfileDefaults(t *testing.T) {
 	mockCS = getMockBaseContainerService("1.16.0")
 	properties = mockCS.Properties
 	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
-	properties.FeatureFlags = &api.FeatureFlags{EnableIPv6DualStack: true}
+	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
 	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 		IsScale:    false,
 		IsUpgrade:  false,
@@ -1130,7 +1130,7 @@ func TestMasterProfileDefaults(t *testing.T) {
 	mockCS = getMockBaseContainerService("1.16.0")
 	properties = mockCS.Properties
 	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
-	properties.FeatureFlags = &api.FeatureFlags{EnableIPv6DualStack: true}
+	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
 	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 		IsScale:    false,
 		IsUpgrade:  false,
@@ -1146,7 +1146,7 @@ func TestMasterProfileDefaults(t *testing.T) {
 	mockCS = getMockBaseContainerService("1.17.0")
 	properties = mockCS.Properties
 	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
-	properties.FeatureFlags = &api.FeatureFlags{EnableIPv6DualStack: true}
+	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
 	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 		IsScale:    false,
 		IsUpgrade:  false,
@@ -1163,7 +1163,7 @@ func TestMasterProfileDefaults(t *testing.T) {
 	properties = mockCS.Properties
 	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = "10.244.0.0/16"
-	properties.FeatureFlags = &api.FeatureFlags{EnableIPv6DualStack: true}
+	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
 	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 		IsScale:    false,
 		IsUpgrade:  false,
@@ -1180,7 +1180,7 @@ func TestMasterProfileDefaults(t *testing.T) {
 	properties = mockCS.Properties
 	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
 	properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = "ace:cab:deca::/8"
-	properties.FeatureFlags = &api.FeatureFlags{EnableIPv6DualStack: true}
+	properties.FeatureFlags = &FeatureFlags{EnableIPv6DualStack: true}
 	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 		IsScale:    false,
 		IsUpgrade:  false,
@@ -1211,7 +1211,7 @@ func TestMasterProfileDefaults(t *testing.T) {
 	mockCS = getMockBaseContainerService("1.18.0")
 	properties = mockCS.Properties
 	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
-	properties.FeatureFlags = &api.FeatureFlags{EnableIPv6Only: true}
+	properties.FeatureFlags = &FeatureFlags{EnableIPv6Only: true}
 	mockCS.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 		IsScale:    false,
 		IsUpgrade:  false,
@@ -2223,7 +2223,7 @@ func TestCloudProviderBackoff(t *testing.T) {
 func TestSetCertDefaults(t *testing.T) {
 	cs := &ContainerService{
 		Properties: &Properties{
-			ServicePrincipalProfile: &api.ServicePrincipalProfile{
+			ServicePrincipalProfile: &ServicePrincipalProfile{
 				ClientID: "barClientID",
 				Secret:   "bazSecret",
 			},
@@ -2290,7 +2290,7 @@ func TestSetCertDefaults(t *testing.T) {
 func TestSetCertDefaultsVMSS(t *testing.T) {
 	cs := &ContainerService{
 		Properties: &Properties{
-			ServicePrincipalProfile: &api.ServicePrincipalProfile{
+			ServicePrincipalProfile: &ServicePrincipalProfile{
 				ClientID: "barClientID",
 				Secret:   "bazSecret",
 			},
@@ -2358,7 +2358,7 @@ func TestSetCertDefaultsVMSS(t *testing.T) {
 func TestSetOrchestratorDefaultsVMAS(t *testing.T) {
 	cs := &ContainerService{
 		Properties: &Properties{
-			ServicePrincipalProfile: &api.ServicePrincipalProfile{
+			ServicePrincipalProfile: &ServicePrincipalProfile{
 				ClientID: "barClientID",
 				Secret:   "bazSecret",
 			},
@@ -2502,8 +2502,8 @@ func getMockBaseContainerService(orchestratorVersion string) ContainerService {
 // Adds some fake certficates would bypass the "SetDefaultCerts" part of setting default
 // values, which accelerates test case run dramatically. This is useful for test
 // cases that are not testing the certificate generation part of the code.
-func getMockCertificateProfile() *api.CertificateProfile {
-	return &api.CertificateProfile{
+func getMockCertificateProfile() *CertificateProfile {
+	return &CertificateProfile{
 		CaCertificate:         "FakeCert",
 		CaPrivateKey:          "FakePrivateKey",
 		ClientCertificate:     "FakeClientCertificate",
@@ -2836,7 +2836,7 @@ func TestEnableRBAC(t *testing.T) {
 							EnableRbac: to.BoolPtr(false),
 						},
 					},
-					HostedMasterProfile: &api.HostedMasterProfile{
+					HostedMasterProfile: &HostedMasterProfile{
 						FQDN: "foo",
 					},
 				},
@@ -2978,29 +2978,29 @@ func TestDefaultCloudProviderDisableOutboundSNAT(t *testing.T) {
 func TestSetTelemetryProfileDefaults(t *testing.T) {
 	cases := []struct {
 		name             string
-		telemetryProfile *api.TelemetryProfile
-		expected         *api.TelemetryProfile
+		telemetryProfile *TelemetryProfile
+		expected         *TelemetryProfile
 	}{
 		{
 			name:             "default",
 			telemetryProfile: nil,
-			expected: &api.TelemetryProfile{
+			expected: &TelemetryProfile{
 				ApplicationInsightsKey: api.DefaultApplicationInsightsKey,
 			},
 		},
 		{
 			name:             "key not set",
-			telemetryProfile: &api.TelemetryProfile{},
-			expected: &api.TelemetryProfile{
+			telemetryProfile: &TelemetryProfile{},
+			expected: &TelemetryProfile{
 				ApplicationInsightsKey: api.DefaultApplicationInsightsKey,
 			},
 		},
 		{
 			name: "key set",
-			telemetryProfile: &api.TelemetryProfile{
+			telemetryProfile: &TelemetryProfile{
 				ApplicationInsightsKey: "app-insights-key",
 			},
-			expected: &api.TelemetryProfile{
+			expected: &TelemetryProfile{
 				ApplicationInsightsKey: "app-insights-key",
 			},
 		},

--- a/pkg/agent/datamodel/mocks.go
+++ b/pkg/agent/datamodel/mocks.go
@@ -45,7 +45,7 @@ func CreateMockContainerService(containerServiceName, orchestratorVersion string
 	cs.Properties.LinuxProfile.SSH.PublicKeys = append(
 		cs.Properties.LinuxProfile.SSH.PublicKeys, api.PublicKey{KeyData: "test"})
 
-	cs.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{}
+	cs.Properties.ServicePrincipalProfile = &ServicePrincipalProfile{}
 	cs.Properties.ServicePrincipalProfile.ClientID = "DEC923E3-1EF1-4745-9516-37906D56DEC4"
 	cs.Properties.ServicePrincipalProfile.Secret = "DEC923E3-1EF1-4745-9516-37906D56DEC4"
 
@@ -74,7 +74,7 @@ func CreateMockContainerService(containerServiceName, orchestratorVersion string
 		ControllerManagerConfig: make(map[string]string),
 	}
 
-	cs.Properties.CertificateProfile = &api.CertificateProfile{}
+	cs.Properties.CertificateProfile = &CertificateProfile{}
 	if certs {
 		cs.Properties.CertificateProfile.CaCertificate = "cacert"
 		cs.Properties.CertificateProfile.CaPrivateKey = "cakey"
@@ -116,7 +116,7 @@ func GetK8sDefaultProperties(hasWindows bool) *Properties {
 				AvailabilityProfile: api.AvailabilitySet,
 			},
 		},
-		ServicePrincipalProfile: &api.ServicePrincipalProfile{
+		ServicePrincipalProfile: &ServicePrincipalProfile{
 			ClientID: "clientID",
 			Secret:   "clientSecret",
 		},

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -20,6 +20,179 @@ import (
 	"sync"
 )
 
+// CustomCloudEnv represents the custom cloud env info of the AKS cluster.
+type CustomCloudEnv struct {
+	Name                         string                  `json:"Name,omitempty"`
+	McrURL                       string                  `json:"mcrURL,omitempty"`
+	RepoDepotEndpoint            string                  `json:"repoDepotEndpoint,omitempty"`
+	ManagementPortalURL          string                  `json:"managementPortalURL,omitempty"`
+	PublishSettingsURL           string                  `json:"publishSettingsURL,omitempty"`
+	ServiceManagementEndpoint    string                  `json:"serviceManagementEndpoint,omitempty"`
+	ResourceManagerEndpoint      string                  `json:"resourceManagerEndpoint,omitempty"`
+	ActiveDirectoryEndpoint      string                  `json:"activeDirectoryEndpoint,omitempty"`
+	GalleryEndpoint              string                  `json:"galleryEndpoint,omitempty"`
+	KeyVaultEndpoint             string                  `json:"keyVaultEndpoint,omitempty"`
+	GraphEndpoint                string                  `json:"graphEndpoint,omitempty"`
+	ServiceBusEndpoint           string                  `json:"serviceBusEndpoint,omitempty"`
+	BatchManagementEndpoint      string                  `json:"batchManagementEndpoint,omitempty"`
+	StorageEndpointSuffix        string                  `json:"storageEndpointSuffix,omitempty"`
+	SQLDatabaseDNSSuffix         string                  `json:"sqlDatabaseDNSSuffix,omitempty"`
+	TrafficManagerDNSSuffix      string                  `json:"trafficManagerDNSSuffix,omitempty"`
+	KeyVaultDNSSuffix            string                  `json:"keyVaultDNSSuffix,omitempty"`
+	ServiceBusEndpointSuffix     string                  `json:"serviceBusEndpointSuffix,omitempty"`
+	ServiceManagementVMDNSSuffix string                  `json:"serviceManagementVMDNSSuffix,omitempty"`
+	ResourceManagerVMDNSSuffix   string                  `json:"resourceManagerVMDNSSuffix,omitempty"`
+	ContainerRegistryDNSSuffix   string                  `json:"containerRegistryDNSSuffix,omitempty"`
+	CosmosDBDNSSuffix            string                  `json:"cosmosDBDNSSuffix,omitempty"`
+	TokenAudience                string                  `json:"tokenAudience,omitempty"`
+	ResourceIdentifiers          api.ResourceIdentifiers `json:"resourceIdentifiers,omitempty"`
+}
+
+// TelemetryProfile contains settings for collecting telemtry.
+// Note telemtry is currently enabled/disabled with the 'EnableTelemetry' feature flag.
+type TelemetryProfile struct {
+	ApplicationInsightsKey string `json:"applicationInsightsKey,omitempty"`
+}
+
+// FeatureFlags defines feature-flag restricted functionality
+type FeatureFlags struct {
+	EnableCSERunInBackground bool `json:"enableCSERunInBackground,omitempty"`
+	BlockOutboundInternet    bool `json:"blockOutboundInternet,omitempty"`
+	EnableIPv6DualStack      bool `json:"enableIPv6DualStack,omitempty"`
+	EnableTelemetry          bool `json:"enableTelemetry,omitempty"`
+	EnableIPv6Only           bool `json:"enableIPv6Only,omitempty"`
+}
+
+// AddonProfile represents an addon for managed cluster
+type AddonProfile struct {
+	Enabled bool              `json:"enabled"`
+	Config  map[string]string `json:"config"`
+	// Identity contains information of the identity associated with this addon.
+	// This property will only appear in an MSI-enabled cluster.
+	Identity *api.UserAssignedIdentity `json:"identity,omitempty"`
+}
+
+// HostedMasterProfile defines properties for a hosted master
+type HostedMasterProfile struct {
+	// Master public endpoint/FQDN with port
+	// The format will be FQDN:2376
+	// Not used during PUT, returned as part of GETFQDN
+	FQDN      string `json:"fqdn,omitempty"`
+	DNSPrefix string `json:"dnsPrefix"`
+	// Subnet holds the CIDR which defines the Azure Subnet in which
+	// Agents will be provisioned. This is stored on the HostedMasterProfile
+	// and will become `masterSubnet` in the compiled template.
+	Subnet string `json:"subnet"`
+	// ApiServerWhiteListRange is a comma delimited CIDR which is whitelisted to AKS
+	APIServerWhiteListRange *string `json:"apiServerWhiteListRange"`
+	IPMasqAgent             bool    `json:"ipMasqAgent"`
+}
+
+// CustomProfile specifies custom properties that are used for
+// cluster instantiation.  Should not be used by most users.
+type CustomProfile struct {
+	Orchestrator string `json:"orchestrator,omitempty"`
+}
+
+// AADProfile specifies attributes for AAD integration
+type AADProfile struct {
+	// The client AAD application ID.
+	ClientAppID string `json:"clientAppID,omitempty"`
+	// The server AAD application ID.
+	ServerAppID string `json:"serverAppID,omitempty"`
+	// The server AAD application secret
+	ServerAppSecret string `json:"serverAppSecret,omitempty" conform:"redact"`
+	// The AAD tenant ID to use for authentication.
+	// If not specified, will use the tenant of the deployment subscription.
+	// Optional
+	TenantID string `json:"tenantID,omitempty"`
+	// The Azure Active Directory Group Object ID that will be assigned the
+	// cluster-admin RBAC role.
+	// Optional
+	AdminGroupID string `json:"adminGroupID,omitempty"`
+	// The authenticator to use, either "oidc" or "webhook".
+	Authenticator api.AuthenticatorType `json:"authenticator"`
+}
+
+// CertificateProfile represents the definition of the master cluster
+type CertificateProfile struct {
+	// CaCertificate is the certificate authority certificate.
+	CaCertificate string `json:"caCertificate,omitempty" conform:"redact"`
+	// CaPrivateKey is the certificate authority key.
+	CaPrivateKey string `json:"caPrivateKey,omitempty" conform:"redact"`
+	// ApiServerCertificate is the rest api server certificate, and signed by the CA
+	APIServerCertificate string `json:"apiServerCertificate,omitempty" conform:"redact"`
+	// ApiServerPrivateKey is the rest api server private key, and signed by the CA
+	APIServerPrivateKey string `json:"apiServerPrivateKey,omitempty" conform:"redact"`
+	// ClientCertificate is the certificate used by the client kubelet services and signed by the CA
+	ClientCertificate string `json:"clientCertificate,omitempty" conform:"redact"`
+	// ClientPrivateKey is the private key used by the client kubelet services and signed by the CA
+	ClientPrivateKey string `json:"clientPrivateKey,omitempty" conform:"redact"`
+	// KubeConfigCertificate is the client certificate used for kubectl cli and signed by the CA
+	KubeConfigCertificate string `json:"kubeConfigCertificate,omitempty" conform:"redact"`
+	// KubeConfigPrivateKey is the client private key used for kubectl cli and signed by the CA
+	KubeConfigPrivateKey string `json:"kubeConfigPrivateKey,omitempty" conform:"redact"`
+	// EtcdServerCertificate is the server certificate for etcd, and signed by the CA
+	EtcdServerCertificate string `json:"etcdServerCertificate,omitempty" conform:"redact"`
+	// EtcdServerPrivateKey is the server private key for etcd, and signed by the CA
+	EtcdServerPrivateKey string `json:"etcdServerPrivateKey,omitempty" conform:"redact"`
+	// EtcdClientCertificate is etcd client certificate, and signed by the CA
+	EtcdClientCertificate string `json:"etcdClientCertificate,omitempty" conform:"redact"`
+	// EtcdClientPrivateKey is the etcd client private key, and signed by the CA
+	EtcdClientPrivateKey string `json:"etcdClientPrivateKey,omitempty" conform:"redact"`
+	// EtcdPeerCertificates is list of etcd peer certificates, and signed by the CA
+	EtcdPeerCertificates []string `json:"etcdPeerCertificates,omitempty" conform:"redact"`
+	// EtcdPeerPrivateKeys is list of etcd peer private keys, and signed by the CA
+	EtcdPeerPrivateKeys []string `json:"etcdPeerPrivateKeys,omitempty" conform:"redact"`
+}
+
+// ServicePrincipalProfile contains the client and secret used by the cluster for Azure Resource CRUD
+type ServicePrincipalProfile struct {
+	ClientID          string                 `json:"clientId"`
+	Secret            string                 `json:"secret,omitempty" conform:"redact"`
+	ObjectID          string                 `json:"objectId,omitempty"`
+	KeyvaultSecretRef *api.KeyvaultSecretRef `json:"keyvaultSecretRef,omitempty"`
+}
+
+// JumpboxProfile describes properties of the jumpbox setup
+// in the AKS container cluster.
+type JumpboxProfile struct {
+	OSType    api.OSType `json:"osType"`
+	DNSPrefix string     `json:"dnsPrefix"`
+
+	// Jumpbox public endpoint/FQDN with port
+	// The format will be FQDN:2376
+	// Not used during PUT, returned as part of GET
+	FQDN string `json:"fqdn,omitempty"`
+}
+
+// DiagnosticsProfile setting to enable/disable capturing
+// diagnostics for VMs hosting container cluster.
+type DiagnosticsProfile struct {
+	VMDiagnostics *api.VMDiagnostics `json:"vmDiagnostics"`
+}
+
+// ExtensionProfile represents an extension definition
+type ExtensionProfile struct {
+	Name                           string                 `json:"name"`
+	Version                        string                 `json:"version"`
+	ExtensionParameters            string                 `json:"extensionParameters,omitempty"`
+	ExtensionParametersKeyVaultRef *api.KeyvaultSecretRef `json:"parametersKeyvaultSecretRef,omitempty"`
+	RootURL                        string                 `json:"rootURL,omitempty"`
+	// This is only needed for preprovision extensions and it needs to be a bash script
+	Script   string `json:"script,omitempty"`
+	URLQuery string `json:"urlQuery,omitempty"`
+}
+
+// ResourcePurchasePlan defines resource plan as required by ARM
+// for billing purposes.
+type ResourcePurchasePlan struct {
+	Name          string `json:"name"`
+	Product       string `json:"product"`
+	PromotionCode string `json:"promotionCode"`
+	Publisher     string `json:"publisher"`
+}
+
 // WindowsProfile represents the windows parameters passed to the cluster
 type WindowsProfile struct {
 	AdminUsername                 string                `json:"adminUsername"`
@@ -164,35 +337,35 @@ type AgentPoolProfile struct {
 // Properties represents the AKS cluster definition
 type Properties struct {
 	ClusterID               string
-	ProvisioningState       ProvisioningState            `json:"provisioningState,omitempty"`
-	OrchestratorProfile     *OrchestratorProfile         `json:"orchestratorProfile,omitempty"`
-	MasterProfile           *MasterProfile               `json:"masterProfile,omitempty"`
-	AgentPoolProfiles       []*AgentPoolProfile          `json:"agentPoolProfiles,omitempty"`
-	LinuxProfile            *LinuxProfile                `json:"linuxProfile,omitempty"`
-	WindowsProfile          *WindowsProfile              `json:"windowsProfile,omitempty"`
-	ExtensionProfiles       []*api.ExtensionProfile      `json:"extensionProfiles"`
-	DiagnosticsProfile      *api.DiagnosticsProfile      `json:"diagnosticsProfile,omitempty"`
-	JumpboxProfile          *api.JumpboxProfile          `json:"jumpboxProfile,omitempty"`
-	ServicePrincipalProfile *api.ServicePrincipalProfile `json:"servicePrincipalProfile,omitempty"`
-	CertificateProfile      *api.CertificateProfile      `json:"certificateProfile,omitempty"`
-	AADProfile              *api.AADProfile              `json:"aadProfile,omitempty"`
-	CustomProfile           *api.CustomProfile           `json:"customProfile,omitempty"`
-	HostedMasterProfile     *api.HostedMasterProfile     `json:"hostedMasterProfile,omitempty"`
-	AddonProfiles           map[string]api.AddonProfile  `json:"addonProfiles,omitempty"`
-	FeatureFlags            *api.FeatureFlags            `json:"featureFlags,omitempty"`
-	TelemetryProfile        *api.TelemetryProfile        `json:"telemetryProfile,omitempty"`
-	CustomCloudEnv          *api.CustomCloudEnv          `json:"customCloudEnv,omitempty"`
+	ProvisioningState       ProvisioningState        `json:"provisioningState,omitempty"`
+	OrchestratorProfile     *OrchestratorProfile     `json:"orchestratorProfile,omitempty"`
+	MasterProfile           *MasterProfile           `json:"masterProfile,omitempty"`
+	AgentPoolProfiles       []*AgentPoolProfile      `json:"agentPoolProfiles,omitempty"`
+	LinuxProfile            *LinuxProfile            `json:"linuxProfile,omitempty"`
+	WindowsProfile          *WindowsProfile          `json:"windowsProfile,omitempty"`
+	ExtensionProfiles       []*ExtensionProfile      `json:"extensionProfiles"`
+	DiagnosticsProfile      *DiagnosticsProfile      `json:"diagnosticsProfile,omitempty"`
+	JumpboxProfile          *JumpboxProfile          `json:"jumpboxProfile,omitempty"`
+	ServicePrincipalProfile *ServicePrincipalProfile `json:"servicePrincipalProfile,omitempty"`
+	CertificateProfile      *CertificateProfile      `json:"certificateProfile,omitempty"`
+	AADProfile              *AADProfile              `json:"aadProfile,omitempty"`
+	CustomProfile           *CustomProfile           `json:"customProfile,omitempty"`
+	HostedMasterProfile     *HostedMasterProfile     `json:"hostedMasterProfile,omitempty"`
+	AddonProfiles           map[string]AddonProfile  `json:"addonProfiles,omitempty"`
+	FeatureFlags            *FeatureFlags            `json:"featureFlags,omitempty"`
+	TelemetryProfile        *TelemetryProfile        `json:"telemetryProfile,omitempty"`
+	CustomCloudEnv          *CustomCloudEnv          `json:"customCloudEnv,omitempty"`
 }
 
 // ContainerService complies with the ARM model of
 // resource definition in a JSON template.
 type ContainerService struct {
-	ID       string                    `json:"id"`
-	Location string                    `json:"location"`
-	Name     string                    `json:"name"`
-	Plan     *api.ResourcePurchasePlan `json:"plan,omitempty"`
-	Tags     map[string]string         `json:"tags"`
-	Type     string                    `json:"type"`
+	ID       string                `json:"id"`
+	Location string                `json:"location"`
+	Name     string                `json:"name"`
+	Plan     *ResourcePurchasePlan `json:"plan,omitempty"`
+	Tags     map[string]string     `json:"tags"`
+	Type     string                `json:"type"`
 
 	Properties *Properties `json:"properties,omitempty"`
 }
@@ -841,4 +1014,25 @@ func (m *MasterProfile) HasAvailabilityZones() bool {
 // HasMultipleNodes returns true if there are more than one master nodes
 func (m *MasterProfile) HasMultipleNodes() bool {
 	return m.Count > 1
+}
+
+// IsFeatureEnabled returns true if a feature flag is on for the provided feature
+func (f *FeatureFlags) IsFeatureEnabled(feature string) bool {
+	if f != nil {
+		switch feature {
+		case "CSERunInBackground":
+			return f.EnableCSERunInBackground
+		case "BlockOutboundInternet":
+			return f.BlockOutboundInternet
+		case "EnableIPv6DualStack":
+			return f.EnableIPv6DualStack
+		case "EnableTelemetry":
+			return f.EnableTelemetry
+		case "EnableIPv6Only":
+			return f.EnableIPv6Only
+		default:
+			return false
+		}
+	}
+	return false
 }

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -137,7 +137,7 @@ func TestHasAadProfile(t *testing.T) {
 		t.Fatalf("Expected HasAadProfile() to return false")
 	}
 
-	p.AADProfile = &api.AADProfile{
+	p.AADProfile = &AADProfile{
 		ClientAppID: "test",
 		ServerAppID: "test",
 	}
@@ -162,7 +162,7 @@ func TestPropertiesIsIPMasqAgentDisabled(t *testing.T) {
 		{
 			name: "hostedMasterProfile disabled",
 			p: &Properties{
-				HostedMasterProfile: &api.HostedMasterProfile{
+				HostedMasterProfile: &HostedMasterProfile{
 					IPMasqAgent: false,
 				},
 			},
@@ -171,7 +171,7 @@ func TestPropertiesIsIPMasqAgentDisabled(t *testing.T) {
 		{
 			name: "hostedMasterProfile enabled",
 			p: &Properties{
-				HostedMasterProfile: &api.HostedMasterProfile{
+				HostedMasterProfile: &HostedMasterProfile{
 					IPMasqAgent: true,
 				},
 			},
@@ -305,7 +305,7 @@ func TestPropertiesIsHostedMasterProfile(t *testing.T) {
 		{
 			name: "zero value hosted master",
 			p: Properties{
-				HostedMasterProfile: &api.HostedMasterProfile{},
+				HostedMasterProfile: &HostedMasterProfile{},
 			},
 			expected: true,
 		},
@@ -754,7 +754,7 @@ func TestCloudProviderDefaults(t *testing.T) {
 				AvailabilityProfile: api.VirtualMachineScaleSets,
 			},
 		},
-		HostedMasterProfile: &api.HostedMasterProfile{
+		HostedMasterProfile: &HostedMasterProfile{
 			FQDN: "my-cluster",
 		},
 	}
@@ -1213,7 +1213,7 @@ func TestIsIPMasqAgentEnabled(t *testing.T) {
 						},
 					},
 				},
-				HostedMasterProfile: &api.HostedMasterProfile{
+				HostedMasterProfile: &HostedMasterProfile{
 					IPMasqAgent: true,
 				},
 			},
@@ -1238,7 +1238,7 @@ func TestIsIPMasqAgentEnabled(t *testing.T) {
 						},
 					},
 				},
-				HostedMasterProfile: &api.HostedMasterProfile{
+				HostedMasterProfile: &HostedMasterProfile{
 					IPMasqAgent: true,
 				},
 			},
@@ -1263,7 +1263,7 @@ func TestIsIPMasqAgentEnabled(t *testing.T) {
 						},
 					},
 				},
-				HostedMasterProfile: &api.HostedMasterProfile{
+				HostedMasterProfile: &HostedMasterProfile{
 					IPMasqAgent: false,
 				},
 			},
@@ -1305,7 +1305,7 @@ func TestGenerateClusterID(t *testing.T) {
 		{
 			name: "From Hosted Master Profile",
 			properties: &Properties{
-				HostedMasterProfile: &api.HostedMasterProfile{
+				HostedMasterProfile: &HostedMasterProfile{
 					DNSPrefix: "foo_hosted_master",
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
@@ -1756,7 +1756,7 @@ func TestGetSubnetName(t *testing.T) {
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorType: api.Kubernetes,
 				},
-				HostedMasterProfile: &api.HostedMasterProfile{
+				HostedMasterProfile: &HostedMasterProfile{
 					FQDN:      "fqdn",
 					DNSPrefix: "foo",
 					Subnet:    "mastersubnet",
@@ -1778,7 +1778,7 @@ func TestGetSubnetName(t *testing.T) {
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorType: api.Kubernetes,
 				},
-				HostedMasterProfile: &api.HostedMasterProfile{
+				HostedMasterProfile: &HostedMasterProfile{
 					FQDN:      "fqdn",
 					DNSPrefix: "foo",
 					Subnet:    "mastersubnet",
@@ -1883,7 +1883,7 @@ func TestGetRouteTableName(t *testing.T) {
 		OrchestratorProfile: &OrchestratorProfile{
 			OrchestratorType: api.Kubernetes,
 		},
-		HostedMasterProfile: &api.HostedMasterProfile{
+		HostedMasterProfile: &HostedMasterProfile{
 			FQDN:      "fqdn",
 			DNSPrefix: "foo",
 			Subnet:    "mastersubnet",
@@ -1955,7 +1955,7 @@ func TestProperties_GetVirtualNetworkName(t *testing.T) {
 		{
 			name: "Cluster with HostedMasterProfile and Custom VNET AgentProfiles",
 			properties: &Properties{
-				HostedMasterProfile: &api.HostedMasterProfile{
+				HostedMasterProfile: &HostedMasterProfile{
 					FQDN:      "fqdn",
 					DNSPrefix: "foo",
 					Subnet:    "mastersubnet",
@@ -1978,7 +1978,7 @@ func TestProperties_GetVirtualNetworkName(t *testing.T) {
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorType: api.Kubernetes,
 				},
-				HostedMasterProfile: &api.HostedMasterProfile{
+				HostedMasterProfile: &HostedMasterProfile{
 					FQDN:      "fqdn",
 					DNSPrefix: "foo",
 					Subnet:    "mastersubnet",
@@ -2011,7 +2011,7 @@ func TestProperties_GetVirtualNetworkName(t *testing.T) {
 
 func TestProperties_GetVNetResourceGroupName(t *testing.T) {
 	p := &Properties{
-		HostedMasterProfile: &api.HostedMasterProfile{
+		HostedMasterProfile: &HostedMasterProfile{
 			FQDN:      "fqdn",
 			DNSPrefix: "foo",
 			Subnet:    "mastersubnet",
@@ -3182,6 +3182,72 @@ func TestMasterProfileHasMultipleNodes(t *testing.T) {
 			t.Parallel()
 			if c.expected != c.m.HasMultipleNodes() {
 				t.Fatalf("Got unexpected MasterProfile.HasMultipleNodes() result. Expected: %t. Got: %t.", c.expected, c.m.HasMultipleNodes())
+			}
+		})
+	}
+}
+
+func TestIsFeatureEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		feature  string
+		flags    *FeatureFlags
+		expected bool
+	}{
+		{
+			name:     "nil flags",
+			feature:  "BlockOutboundInternet",
+			flags:    nil,
+			expected: false,
+		},
+		{
+			name:     "empty flags",
+			feature:  "BlockOutboundInternet",
+			flags:    &FeatureFlags{},
+			expected: false,
+		},
+		{
+			name:     "telemetry",
+			feature:  "EnableTelemetry",
+			flags:    &FeatureFlags{},
+			expected: false,
+		},
+		{
+			name:    "Enabled feature",
+			feature: "CSERunInBackground",
+			flags: &FeatureFlags{
+				EnableCSERunInBackground: true,
+				BlockOutboundInternet:    false,
+			},
+			expected: true,
+		},
+		{
+			name:    "Disabled feature",
+			feature: "CSERunInBackground",
+			flags: &FeatureFlags{
+				EnableCSERunInBackground: false,
+				BlockOutboundInternet:    true,
+			},
+			expected: false,
+		},
+		{
+			name:    "Non-existent feature",
+			feature: "Foo",
+			flags: &FeatureFlags{
+				EnableCSERunInBackground: true,
+				BlockOutboundInternet:    true,
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			actual := test.flags.IsFeatureEnabled(test.feature)
+			if actual != test.expected {
+				t.Errorf("expected feature %s to be enabled:%v, but got %v", test.feature, test.expected, actual)
 			}
 		})
 	}

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -149,8 +149,8 @@ func makeAgentExtensionScriptCommands(cs *datamodel.ContainerService, profile *d
 		"", cs.Properties.ExtensionProfiles)
 }
 
-func makeExtensionScriptCommands(extension *api.Extension, curlCaCertOpt string, extensionProfiles []*api.ExtensionProfile) string {
-	var extensionProfile *api.ExtensionProfile
+func makeExtensionScriptCommands(extension *api.Extension, curlCaCertOpt string, extensionProfiles []*datamodel.ExtensionProfile) string {
+	var extensionProfile *datamodel.ExtensionProfile
 	for _, eP := range extensionProfiles {
 		if strings.EqualFold(eP.Name, extension.Name) {
 			extensionProfile = eP
@@ -169,8 +169,8 @@ func makeExtensionScriptCommands(extension *api.Extension, curlCaCertOpt string,
 		scriptFilePath, curlCaCertOpt, scriptURL, scriptFilePath, scriptFilePath, extensionsParameterReference, extensionProfile.Name)
 }
 
-func makeWindowsExtensionScriptCommands(extension *api.Extension, extensionProfiles []*api.ExtensionProfile) string {
-	var extensionProfile *api.ExtensionProfile
+func makeWindowsExtensionScriptCommands(extension *api.Extension, extensionProfiles []*datamodel.ExtensionProfile) string {
+	var extensionProfile *datamodel.ExtensionProfile
 	for _, eP := range extensionProfiles {
 		if strings.EqualFold(eP.Name, extension.Name) {
 			extensionProfile = eP

--- a/pkg/aks-engine/api/apiloader_test.go
+++ b/pkg/aks-engine/api/apiloader_test.go
@@ -319,7 +319,7 @@ func TestSerializeContainerService(t *testing.T) {
 	// Test with HostedMasterProfile and v20170831
 	cs := getDefaultContainerService()
 
-	cs.Properties.HostedMasterProfile = &api.HostedMasterProfile{
+	cs.Properties.HostedMasterProfile = &datamodel.HostedMasterProfile{
 		FQDN:        "blueorange.westus2.azure.com",
 		DNSPrefix:   "blueorange",
 		Subnet:      "sampleSubnet",
@@ -342,7 +342,7 @@ func getDefaultContainerService() *datamodel.ContainerService {
 		ID:       "sampleID",
 		Location: "westus2",
 		Name:     "sampleCS",
-		Plan: &api.ResourcePurchasePlan{
+		Plan: &datamodel.ResourcePurchasePlan{
 			Name:          "sampleRPP",
 			Product:       "sampleProduct",
 			PromotionCode: "sampleCode",
@@ -357,7 +357,7 @@ func getDefaultContainerService() *datamodel.ContainerService {
 				AdminUsername: "sampleAdminUsername",
 				AdminPassword: "sampleAdminPassword",
 			},
-			DiagnosticsProfile: &api.DiagnosticsProfile{
+			DiagnosticsProfile: &datamodel.DiagnosticsProfile{
 				VMDiagnostics: &api.VMDiagnostics{
 					Enabled:    true,
 					StorageURL: u,
@@ -396,7 +396,7 @@ func getDefaultContainerService() *datamodel.ContainerService {
 					RealmPassword: "sampleRealmPassword",
 				},
 			},
-			ServicePrincipalProfile: &api.ServicePrincipalProfile{
+			ServicePrincipalProfile: &datamodel.ServicePrincipalProfile{
 				ClientID: "fooClientID",
 				Secret:   "fooSecret",
 				ObjectID: "fooObjectID",
@@ -406,7 +406,7 @@ func getDefaultContainerService() *datamodel.ContainerService {
 					SecretVersion: "fooSecretVersion",
 				},
 			},
-			ExtensionProfiles: []*api.ExtensionProfile{
+			ExtensionProfiles: []*datamodel.ExtensionProfile{
 				{
 					Name:                "fooExtension",
 					Version:             "fooVersion",
@@ -421,12 +421,12 @@ func getDefaultContainerService() *datamodel.ContainerService {
 					URLQuery: "fooURL",
 				},
 			},
-			JumpboxProfile: &api.JumpboxProfile{
+			JumpboxProfile: &datamodel.JumpboxProfile{
 				OSType:    "Linux",
 				DNSPrefix: "blueorange",
 				FQDN:      "blueorange.westus2.com",
 			},
-			CertificateProfile: &api.CertificateProfile{
+			CertificateProfile: &datamodel.CertificateProfile{
 				CaCertificate:         "SampleCACert",
 				CaPrivateKey:          "SampleCAPrivateKey",
 				APIServerCertificate:  "SampleAPIServerCert",
@@ -440,12 +440,12 @@ func getDefaultContainerService() *datamodel.ContainerService {
 				EtcdServerCertificate: "SampleEtcdServerCert",
 				EtcdServerPrivateKey:  "SampleEtcdServerPrivateKey",
 			},
-			FeatureFlags: &api.FeatureFlags{
+			FeatureFlags: &datamodel.FeatureFlags{
 				EnableCSERunInBackground: true,
 				BlockOutboundInternet:    false,
 				EnableTelemetry:          false,
 			},
-			AADProfile: &api.AADProfile{
+			AADProfile: &datamodel.AADProfile{
 				ClientAppID:     "SampleClientAppID",
 				ServerAppID:     "ServerAppID",
 				ServerAppSecret: "ServerAppSecret",
@@ -453,7 +453,7 @@ func getDefaultContainerService() *datamodel.ContainerService {
 				AdminGroupID:    "SampleAdminGroupID",
 				Authenticator:   api.Webhook,
 			},
-			CustomProfile: &api.CustomProfile{
+			CustomProfile: &datamodel.CustomProfile{
 				Orchestrator: "Kubernetes",
 			},
 			OrchestratorProfile: &datamodel.OrchestratorProfile{

--- a/pkg/aks-engine/engine/engine_test.go
+++ b/pkg/aks-engine/engine/engine_test.go
@@ -75,7 +75,7 @@ func TestGenerateKubeConfig(t *testing.T) {
 		t.Errorf("Failed to call GenerateKubeConfig with simple Kubernetes config from file: %v", testData)
 	}
 
-	containerService.Properties.AADProfile = &api.AADProfile{
+	containerService.Properties.AADProfile = &datamodel.AADProfile{
 		ClientAppID: "fooClientAppID",
 		TenantID:    "fooTenantID",
 		ServerAppID: "fooServerAppID",


### PR DESCRIPTION
This change copies the following data structs: ResourcePurchasePlan, ExtensionProfile, DiagnosticsProfile, JumpboxProfile, ServicePrincipalProfile, CertificateProfile, AADProfile, CustomProfile, HostedMasterProfile, AddonProfile, FeatureFlags, TelemetryProfile and CustomCloudEnv.
This removes our dependency on those data types from aks-engine. Our end goal is to remove all aks-engine dependencies.