### PR TITLE
Port many types from aks-engine into our code base.

### DIFF
--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -448,35 +448,35 @@ func getContainerServiceFuncMap(config *NodeBootstrappingConfiguration) template
 		},
 		"GetMasterOSImageOffer": func() string {
 			cloudSpecConfig := cs.GetCloudSpecConfig()
-			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[cs.Properties.MasterProfile.Distro].ImageOffer)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[api.Distro(cs.Properties.MasterProfile.Distro)].ImageOffer)
 		},
 		"GetMasterOSImagePublisher": func() string {
 			cloudSpecConfig := cs.GetCloudSpecConfig()
-			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[cs.Properties.MasterProfile.Distro].ImagePublisher)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[api.Distro(cs.Properties.MasterProfile.Distro)].ImagePublisher)
 		},
 		"GetMasterOSImageSKU": func() string {
 			cloudSpecConfig := cs.GetCloudSpecConfig()
-			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[cs.Properties.MasterProfile.Distro].ImageSku)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[api.Distro(cs.Properties.MasterProfile.Distro)].ImageSku)
 		},
 		"GetMasterOSImageVersion": func() string {
 			cloudSpecConfig := cs.GetCloudSpecConfig()
-			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[cs.Properties.MasterProfile.Distro].ImageVersion)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[api.Distro(cs.Properties.MasterProfile.Distro)].ImageVersion)
 		},
 		"GetAgentOSImageOffer": func(profile *datamodel.AgentPoolProfile) string {
 			cloudSpecConfig := cs.GetCloudSpecConfig()
-			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[profile.Distro].ImageOffer)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[api.Distro(profile.Distro)].ImageOffer)
 		},
 		"GetAgentOSImagePublisher": func(profile *datamodel.AgentPoolProfile) string {
 			cloudSpecConfig := cs.GetCloudSpecConfig()
-			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[profile.Distro].ImagePublisher)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[api.Distro(profile.Distro)].ImagePublisher)
 		},
 		"GetAgentOSImageSKU": func(profile *datamodel.AgentPoolProfile) string {
 			cloudSpecConfig := cs.GetCloudSpecConfig()
-			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[profile.Distro].ImageSku)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[api.Distro(profile.Distro)].ImageSku)
 		},
 		"GetAgentOSImageVersion": func(profile *datamodel.AgentPoolProfile) string {
 			cloudSpecConfig := cs.GetCloudSpecConfig()
-			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[profile.Distro].ImageVersion)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[api.Distro(profile.Distro)].ImageVersion)
 		},
 		"UseCloudControllerManager": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager != nil && *cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 						Count:               3,
 						VMSize:              "Standard_DS1_v2",
 						StorageProfile:      "ManagedDisks",
-						OSType:              api.Linux,
+						OSType:              datamodel.Linux,
 						VnetSubnetID:        "/subscriptions/359833f5/resourceGroups/MC_rg/providers/Microsoft.Network/virtualNetworks/aks-vnet-07752737/subnet/subnet1",
 						AvailabilityProfile: api.VirtualMachineScaleSets,
 						KubernetesConfig: &api.KubernetesConfig{
@@ -77,7 +77,7 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 								"--kube-reserved":                     "cpu=100m,memory=1638Mi",
 							},
 						},
-						Distro: api.AKSUbuntu1604,
+						Distro: datamodel.AKSUbuntu1604,
 					},
 				},
 				LinuxProfile: &datamodel.LinuxProfile{
@@ -89,7 +89,7 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 				},
 			},
 		}
-		cs.Properties.LinuxProfile.SSH.PublicKeys = []api.PublicKey{{
+		cs.Properties.LinuxProfile.SSH.PublicKeys = []datamodel.PublicKey{{
 			KeyData: string("testsshkey"),
 		}}
 
@@ -160,7 +160,7 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 			}
 		}),
 		Entry("AKSUbuntu1604 with RawUbuntu", "RawUbuntu", "1.15.7", func(config *NodeBootstrappingConfiguration) {
-			config.ContainerService.Properties.AgentPoolProfiles[0].Distro = api.Ubuntu
+			config.ContainerService.Properties.AgentPoolProfiles[0].Distro = datamodel.Ubuntu
 		}),
 		Entry("AKSUbuntu1604 EnablePrivateClusterHostsConfigAgent", "AKSUbuntu1604+EnablePrivateClusterHostsConfigAgent", "1.18.2", func(config *NodeBootstrappingConfiguration) {
 			cs := config.ContainerService
@@ -171,7 +171,7 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 			}
 		}),
 		Entry("AKSUbuntu1804 with GPU dedicated VHD", "AKSUbuntu1604+GPUDedicatedVHD", "1.15.7", func(config *NodeBootstrappingConfiguration) {
-			config.ContainerService.Properties.AgentPoolProfiles[0].Distro = api.AKSUbuntuGPU1804
+			config.ContainerService.Properties.AgentPoolProfiles[0].Distro = datamodel.AKSUbuntuGPU1804
 			config.AgentPoolProfile.VMSize = "Standard_NC6"
 			config.ConfigGPUDriverIfNeeded = false
 			config.EnableGPUDevicePluginIfNeeded = true

--- a/pkg/agent/datamodel/defaults-kubelet.go
+++ b/pkg/agent/datamodel/defaults-kubelet.go
@@ -204,7 +204,7 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 			profile.KubernetesConfig.KubeletConfig = make(map[string]string)
 		}
 
-		if profile.OSType == api.Windows {
+		if profile.OSType == Windows {
 			for key, val := range staticWindowsKubeletConfig {
 				profile.KubernetesConfig.KubeletConfig[key] = val
 			}

--- a/pkg/agent/datamodel/defaults-kubelet_test.go
+++ b/pkg/agent/datamodel/defaults-kubelet_test.go
@@ -21,7 +21,7 @@ func TestKubeletConfigDefaults(t *testing.T) {
 	winProfile.Count = 1
 	winProfile.Name = "agentpool2"
 	winProfile.VMSize = "Standard_D2_v2"
-	winProfile.OSType = api.Windows
+	winProfile.OSType = Windows
 	cs.Properties.AgentPoolProfiles = append(cs.Properties.AgentPoolProfiles, winProfile)
 	cs.setKubeletConfig(false)
 	kubeletConfig := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
@@ -159,7 +159,7 @@ func TestKubeletConfigDefaultsRemovals(t *testing.T) {
 	poolProfile.Count = 1
 	poolProfile.Name = "agentpool2"
 	poolProfile.VMSize = "Standard_D2_v2"
-	poolProfile.OSType = api.Linux
+	poolProfile.OSType = Linux
 	cs.Properties.AgentPoolProfiles = append(cs.Properties.AgentPoolProfiles, poolProfile)
 	cs.setKubeletConfig(false)
 	kubeletConfig := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
@@ -576,9 +576,9 @@ func TestProtectKernelDefaults(t *testing.T) {
 	}
 
 	// Validate that --protect-kernel-defaults is "true" by default for relevant distros
-	for _, distro := range api.DistroValues {
+	for _, distro := range DistroValues {
 		switch distro {
-		case api.AKSUbuntu1604, api.AKSUbuntu1804:
+		case AKSUbuntu1604, AKSUbuntu1804:
 			cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, true)
 			cs.Properties.MasterProfile.Distro = distro
 			cs.Properties.AgentPoolProfiles[0].Distro = distro
@@ -599,7 +599,7 @@ func TestProtectKernelDefaults(t *testing.T) {
 			}
 
 		// Validate that --protect-kernel-defaults is not enabled for relevant distros
-		case api.Ubuntu, api.Ubuntu1804, api.Ubuntu1804Gen2, api.ACC1604, api.CoreOS:
+		case Ubuntu, Ubuntu1804, Ubuntu1804Gen2, ACC1604, CoreOS:
 			cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, true)
 			cs.Properties.MasterProfile.Distro = distro
 			cs.Properties.AgentPoolProfiles[0].Distro = distro
@@ -618,8 +618,8 @@ func TestProtectKernelDefaults(t *testing.T) {
 
 	// Validate that --protect-kernel-defaults is not enabled for Windows
 	cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, true)
-	cs.Properties.MasterProfile.Distro = api.AKSUbuntu1604
-	cs.Properties.AgentPoolProfiles[0].OSType = api.Windows
+	cs.Properties.MasterProfile.Distro = AKSUbuntu1604
+	cs.Properties.AgentPoolProfiles[0].OSType = Windows
 	cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 		IsScale:    false,
 		IsUpgrade:  false,
@@ -710,7 +710,7 @@ func TestStaticWindowsConfig(t *testing.T) {
 
 	cs.setKubeletConfig(false)
 	for _, profile := range cs.Properties.AgentPoolProfiles {
-		if profile.OSType == api.Windows {
+		if profile.OSType == Windows {
 			for key, val := range expected {
 				if val != profile.KubernetesConfig.KubeletConfig[key] {
 					t.Fatalf("got unexpected '%s' kubelet config value, expected %s, got %s",

--- a/pkg/agent/datamodel/defaults.go
+++ b/pkg/agent/datamodel/defaults.go
@@ -24,6 +24,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// DistroValues is a list of currently supported distros
+var DistroValues = []Distro{"", Ubuntu, Ubuntu1804, RHEL, CoreOS, AKSUbuntu1604, AKSUbuntu1804, Ubuntu1804Gen2, ACC1604, AKSUbuntuGPU1804, AKSUbuntuGPU1804Gen2}
+
 // SetPropertiesDefaults for the container Properties, returns true if certs are generated
 func (cs *ContainerService) SetPropertiesDefaults(params api.PropertiesDefaultsParams) (bool, error) {
 	// Set master profile defaults if this cluster configuration includes master node(s)
@@ -389,20 +392,20 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 			// Distro assignment for masterProfile
 			if cs.Properties.MasterProfile.Distro == "" && cs.Properties.MasterProfile.ImageRef == nil {
 				if cs.Properties.OrchestratorProfile.IsKubernetes() && cs.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage == "" {
-					cs.Properties.MasterProfile.Distro = api.AKSUbuntu1604
+					cs.Properties.MasterProfile.Distro = AKSUbuntu1604
 				} else {
-					cs.Properties.MasterProfile.Distro = api.Ubuntu
+					cs.Properties.MasterProfile.Distro = Ubuntu
 				}
 			} else if cs.Properties.OrchestratorProfile.IsKubernetes() && (isUpgrade || isScale) {
-				if cs.Properties.MasterProfile.Distro == api.AKSDockerEngine || cs.Properties.MasterProfile.Distro == api.AKS1604Deprecated {
-					cs.Properties.MasterProfile.Distro = api.AKSUbuntu1604
-				} else if cs.Properties.MasterProfile.Distro == api.AKS1804Deprecated {
-					cs.Properties.MasterProfile.Distro = api.AKSUbuntu1804
+				if cs.Properties.MasterProfile.Distro == AKSDockerEngine || cs.Properties.MasterProfile.Distro == AKS1604Deprecated {
+					cs.Properties.MasterProfile.Distro = AKSUbuntu1604
+				} else if cs.Properties.MasterProfile.Distro == AKS1804Deprecated {
+					cs.Properties.MasterProfile.Distro = AKSUbuntu1804
 				}
 			}
 			// The AKS Distro is not available in Azure German Cloud.
 			if cloudSpecConfig.CloudName == api.AzureGermanCloud {
-				cs.Properties.MasterProfile.Distro = api.Ubuntu
+				cs.Properties.MasterProfile.Distro = Ubuntu
 			}
 		}
 
@@ -429,30 +432,30 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 				}
 			}
 			// Distro assignment for pools
-			if profile.OSType != api.Windows {
+			if profile.OSType != Windows {
 				if profile.Distro == "" && profile.ImageRef == nil {
 					if cs.Properties.OrchestratorProfile.IsKubernetes() && cs.Properties.OrchestratorProfile.KubernetesConfig != nil && cs.Properties.OrchestratorProfile.KubernetesConfig.CustomHyperkubeImage == "" {
 						if profile.OSDiskSizeGB != 0 && profile.OSDiskSizeGB < api.VHDDiskSizeAKS {
-							profile.Distro = api.Ubuntu
+							profile.Distro = Ubuntu
 						} else {
-							profile.Distro = api.AKSUbuntu1604
+							profile.Distro = AKSUbuntu1604
 						}
 					} else {
-						profile.Distro = api.Ubuntu
+						profile.Distro = Ubuntu
 					}
 					// Ensure deprecated distros are overridden
 					// Previous versions of aks-engine required the docker-engine distro for N series vms,
 					// so we need to hard override it in order to produce a working cluster in upgrade/scale contexts.
 				} else if cs.Properties.OrchestratorProfile.IsKubernetes() && (isUpgrade || isScale) {
-					if profile.Distro == api.AKSDockerEngine || profile.Distro == api.AKS1604Deprecated {
-						profile.Distro = api.AKSUbuntu1604
-					} else if profile.Distro == api.AKS1804Deprecated {
-						profile.Distro = api.AKSUbuntu1804
+					if profile.Distro == AKSDockerEngine || profile.Distro == AKS1604Deprecated {
+						profile.Distro = AKSUbuntu1604
+					} else if profile.Distro == AKS1804Deprecated {
+						profile.Distro = AKSUbuntu1804
 					}
 				}
 				// The AKS Distro is not available in Azure German Cloud.
 				if cloudSpecConfig.CloudName == api.AzureGermanCloud {
-					profile.Distro = api.Ubuntu
+					profile.Distro = Ubuntu
 				}
 			}
 		}
@@ -779,7 +782,7 @@ func (cs *ContainerService) setMasterProfileDefaults(isUpgrade bool) {
 	}
 
 	if !p.OrchestratorProfile.IsKubernetes() {
-		p.MasterProfile.Distro = api.Ubuntu
+		p.MasterProfile.Distro = Ubuntu
 		if !p.MasterProfile.IsCustomVNET() {
 			if p.OrchestratorProfile.OrchestratorType == api.DCOS {
 				p.MasterProfile.Subnet = api.DefaultDCOSMasterSubnet
@@ -874,7 +877,7 @@ func (cs *ContainerService) setAgentProfileDefaults(isUpgrade, isScale bool) {
 		}
 		// set default OSType to Linux
 		if profile.OSType == "" {
-			profile.OSType = api.Linux
+			profile.OSType = Linux
 		}
 
 		if profile.PlatformUpdateDomainCount == nil {
@@ -906,7 +909,7 @@ func (cs *ContainerService) setAgentProfileDefaults(isUpgrade, isScale bool) {
 		}
 
 		if !p.OrchestratorProfile.IsKubernetes() {
-			profile.Distro = api.Ubuntu
+			profile.Distro = Ubuntu
 		}
 	}
 }

--- a/pkg/agent/datamodel/defaults_test.go
+++ b/pkg/agent/datamodel/defaults_test.go
@@ -1292,10 +1292,10 @@ func TestDistroDefaults(t *testing.T) {
 	var tests = []struct {
 		name                   string              // test case name
 		orchestratorProfile    OrchestratorProfile // orchestrator to be tested
-		masterProfileDistro    api.Distro
-		agentPoolProfileDistro api.Distro
-		expectedAgentDistro    api.Distro // expected agent result default disto to be used
-		expectedMasterDistro   api.Distro // expected master result default disto to be used
+		masterProfileDistro    Distro
+		agentPoolProfileDistro Distro
+		expectedAgentDistro    Distro // expected agent result default disto to be used
+		expectedMasterDistro   Distro // expected master result default disto to be used
 		isUpgrade              bool
 		isScale                bool
 		cloudName              string
@@ -1308,8 +1308,8 @@ func TestDistroDefaults(t *testing.T) {
 			},
 			"",
 			"",
-			api.AKSUbuntu1604,
-			api.AKSUbuntu1604,
+			AKSUbuntu1604,
+			AKSUbuntu1604,
 			false,
 			false,
 			api.AzurePublicCloud,
@@ -1322,8 +1322,8 @@ func TestDistroDefaults(t *testing.T) {
 			},
 			"",
 			"",
-			api.AKSUbuntu1604,
-			api.AKSUbuntu1604,
+			AKSUbuntu1604,
+			AKSUbuntu1604,
 			false,
 			false,
 			api.AzureUSGovernmentCloud,
@@ -1334,10 +1334,10 @@ func TestDistroDefaults(t *testing.T) {
 				OrchestratorType: api.Kubernetes,
 				KubernetesConfig: &api.KubernetesConfig{},
 			},
-			api.AKSUbuntu1804,
-			api.AKSUbuntu1804,
-			api.AKSUbuntu1804,
-			api.AKSUbuntu1804,
+			AKSUbuntu1804,
+			AKSUbuntu1804,
+			AKSUbuntu1804,
+			AKSUbuntu1804,
 			true,
 			false,
 			api.AzurePublicCloud,
@@ -1348,10 +1348,10 @@ func TestDistroDefaults(t *testing.T) {
 				OrchestratorType: api.Kubernetes,
 				KubernetesConfig: &api.KubernetesConfig{},
 			},
-			api.AKS1604Deprecated,
-			api.AKS1604Deprecated,
-			api.Ubuntu,
-			api.Ubuntu,
+			AKS1604Deprecated,
+			AKS1604Deprecated,
+			Ubuntu,
+			Ubuntu,
 			true,
 			false,
 			api.AzureGermanCloud,
@@ -1362,10 +1362,10 @@ func TestDistroDefaults(t *testing.T) {
 				OrchestratorType: api.Kubernetes,
 				KubernetesConfig: &api.KubernetesConfig{},
 			},
-			api.AKS1604Deprecated,
-			api.AKS1604Deprecated,
-			api.AKSUbuntu1604,
-			api.AKSUbuntu1604,
+			AKS1604Deprecated,
+			AKS1604Deprecated,
+			AKSUbuntu1604,
+			AKSUbuntu1604,
 			true,
 			false,
 			api.AzureChinaCloud,
@@ -1376,10 +1376,10 @@ func TestDistroDefaults(t *testing.T) {
 				OrchestratorType: api.Kubernetes,
 				KubernetesConfig: &api.KubernetesConfig{},
 			},
-			api.AKS1604Deprecated,
-			api.AKSDockerEngine,
-			api.AKSUbuntu1604,
-			api.AKSUbuntu1604,
+			AKS1604Deprecated,
+			AKSDockerEngine,
+			AKSUbuntu1604,
+			AKSUbuntu1604,
 			false,
 			true,
 			api.AzurePublicCloud,
@@ -1391,8 +1391,8 @@ func TestDistroDefaults(t *testing.T) {
 			},
 			"",
 			"",
-			api.Ubuntu,
-			api.Ubuntu,
+			Ubuntu,
+			Ubuntu,
 			false,
 			false,
 			api.AzurePublicCloud,
@@ -1404,8 +1404,8 @@ func TestDistroDefaults(t *testing.T) {
 			},
 			"",
 			"",
-			api.Ubuntu,
-			api.Ubuntu,
+			Ubuntu,
+			Ubuntu,
 			false,
 			false,
 			api.AzurePublicCloud,
@@ -1417,8 +1417,8 @@ func TestDistroDefaults(t *testing.T) {
 			},
 			"",
 			"",
-			api.Ubuntu,
-			api.Ubuntu,
+			Ubuntu,
+			Ubuntu,
 			false,
 			false,
 			api.AzurePublicCloud,
@@ -2025,7 +2025,7 @@ func TestAzureCNIVersionString(t *testing.T) {
 	properties = mockCS.Properties
 	properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
 	properties.MasterProfile.Count = 1
-	properties.AgentPoolProfiles[0].OSType = api.Windows
+	properties.AgentPoolProfiles[0].OSType = Windows
 	properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = api.NetworkPluginAzure
 	mockCS.setOrchestratorDefaults(true, true)
 
@@ -2430,9 +2430,9 @@ func TestPreserveNodesProperties(t *testing.T) {
 func TestUbuntu1804Flags(t *testing.T) {
 	// Validate --resolv-conf is missing with 16.04 distro and present with 18.04
 	cs := CreateMockContainerService("testcluster", "1.10.13", 3, 2, true)
-	cs.Properties.MasterProfile.Distro = api.AKSUbuntu1604
-	cs.Properties.AgentPoolProfiles[0].Distro = api.AKSUbuntu1804
-	cs.Properties.AgentPoolProfiles[0].OSType = api.Linux
+	cs.Properties.MasterProfile.Distro = AKSUbuntu1604
+	cs.Properties.AgentPoolProfiles[0].Distro = AKSUbuntu1804
+	cs.Properties.AgentPoolProfiles[0].OSType = Linux
 	cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 		IsScale:    false,
 		IsUpgrade:  false,
@@ -2450,9 +2450,9 @@ func TestUbuntu1804Flags(t *testing.T) {
 	}
 
 	cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, true)
-	cs.Properties.MasterProfile.Distro = api.Ubuntu1804
-	cs.Properties.AgentPoolProfiles[0].Distro = api.Ubuntu
-	cs.Properties.AgentPoolProfiles[0].OSType = api.Linux
+	cs.Properties.MasterProfile.Distro = Ubuntu1804
+	cs.Properties.AgentPoolProfiles[0].Distro = Ubuntu
+	cs.Properties.AgentPoolProfiles[0].OSType = Linux
 	cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 		IsScale:    false,
 		IsUpgrade:  false,
@@ -2470,9 +2470,9 @@ func TestUbuntu1804Flags(t *testing.T) {
 	}
 
 	cs = CreateMockContainerService("testcluster", "1.10.13", 3, 2, true)
-	cs.Properties.MasterProfile.Distro = api.Ubuntu
+	cs.Properties.MasterProfile.Distro = Ubuntu
 	cs.Properties.AgentPoolProfiles[0].Distro = ""
-	cs.Properties.AgentPoolProfiles[0].OSType = api.Windows
+	cs.Properties.AgentPoolProfiles[0].OSType = Windows
 	cs.SetPropertiesDefaults(api.PropertiesDefaultsParams{
 		IsScale:    false,
 		IsUpgrade:  false,
@@ -3108,12 +3108,12 @@ func TestImageReference(t *testing.T) {
 				},
 			},
 			expectedMasterProfile: MasterProfile{
-				Distro:   api.AKSUbuntu1604,
+				Distro:   AKSUbuntu1604,
 				ImageRef: nil,
 			},
 			expectedAgentPoolProfiles: []AgentPoolProfile{
 				{
-					Distro:   api.AKSUbuntu1604,
+					Distro:   AKSUbuntu1604,
 					ImageRef: nil,
 				},
 			},
@@ -3126,7 +3126,7 @@ func TestImageReference(t *testing.T) {
 						OrchestratorType: api.Kubernetes,
 					},
 					MasterProfile: &MasterProfile{
-						ImageRef: &api.ImageReference{
+						ImageRef: &ImageReference{
 							Name:           "name",
 							ResourceGroup:  "resource-group",
 							SubscriptionID: "sub-id",
@@ -3137,7 +3137,7 @@ func TestImageReference(t *testing.T) {
 					CertificateProfile: getMockCertificateProfile(),
 					AgentPoolProfiles: []*AgentPoolProfile{
 						{
-							ImageRef: &api.ImageReference{
+							ImageRef: &ImageReference{
 								Name:           "name",
 								ResourceGroup:  "resource-group",
 								SubscriptionID: "sub-id",
@@ -3150,7 +3150,7 @@ func TestImageReference(t *testing.T) {
 			},
 			expectedMasterProfile: MasterProfile{
 				Distro: "",
-				ImageRef: &api.ImageReference{
+				ImageRef: &ImageReference{
 					Name:           "name",
 					ResourceGroup:  "resource-group",
 					SubscriptionID: "sub-id",
@@ -3161,7 +3161,7 @@ func TestImageReference(t *testing.T) {
 			expectedAgentPoolProfiles: []AgentPoolProfile{
 				{
 					Distro: "",
-					ImageRef: &api.ImageReference{
+					ImageRef: &ImageReference{
 						Name:           "name",
 						ResourceGroup:  "resource-group",
 						SubscriptionID: "sub-id",
@@ -3182,7 +3182,7 @@ func TestImageReference(t *testing.T) {
 					CertificateProfile: getMockCertificateProfile(),
 					AgentPoolProfiles: []*AgentPoolProfile{
 						{
-							ImageRef: &api.ImageReference{
+							ImageRef: &ImageReference{
 								Name:           "name",
 								ResourceGroup:  "resource-group",
 								SubscriptionID: "sub-id",
@@ -3195,13 +3195,13 @@ func TestImageReference(t *testing.T) {
 				},
 			},
 			expectedMasterProfile: MasterProfile{
-				Distro:   api.AKSUbuntu1604,
+				Distro:   AKSUbuntu1604,
 				ImageRef: nil,
 			},
 			expectedAgentPoolProfiles: []AgentPoolProfile{
 				{
 					Distro: "",
-					ImageRef: &api.ImageReference{
+					ImageRef: &ImageReference{
 						Name:           "name",
 						ResourceGroup:  "resource-group",
 						SubscriptionID: "sub-id",
@@ -3210,7 +3210,7 @@ func TestImageReference(t *testing.T) {
 					},
 				},
 				{
-					Distro:   api.AKSUbuntu1604,
+					Distro:   AKSUbuntu1604,
 					ImageRef: nil,
 				},
 			},
@@ -3319,12 +3319,12 @@ func TestCustomHyperkubeDistro(t *testing.T) {
 				},
 			},
 			expectedMasterProfile: MasterProfile{
-				Distro:   api.AKSUbuntu1604,
+				Distro:   AKSUbuntu1604,
 				ImageRef: nil,
 			},
 			expectedAgentPoolProfiles: []AgentPoolProfile{
 				{
-					Distro:   api.AKSUbuntu1604,
+					Distro:   AKSUbuntu1604,
 					ImageRef: nil,
 				},
 			},
@@ -3347,11 +3347,11 @@ func TestCustomHyperkubeDistro(t *testing.T) {
 				},
 			},
 			expectedMasterProfile: MasterProfile{
-				Distro: api.Ubuntu,
+				Distro: Ubuntu,
 			},
 			expectedAgentPoolProfiles: []AgentPoolProfile{
 				{
-					Distro: api.Ubuntu,
+					Distro: Ubuntu,
 				},
 			},
 		},
@@ -3367,21 +3367,21 @@ func TestCustomHyperkubeDistro(t *testing.T) {
 						},
 					},
 					MasterProfile: &MasterProfile{
-						Distro: api.Ubuntu1804,
+						Distro: Ubuntu1804,
 					},
 					AgentPoolProfiles: []*AgentPoolProfile{
 						{
-							Distro: api.Ubuntu1804,
+							Distro: Ubuntu1804,
 						},
 					},
 				},
 			},
 			expectedMasterProfile: MasterProfile{
-				Distro: api.Ubuntu1804,
+				Distro: Ubuntu1804,
 			},
 			expectedAgentPoolProfiles: []AgentPoolProfile{
 				{
-					Distro: api.Ubuntu1804,
+					Distro: Ubuntu1804,
 				},
 			},
 		},
@@ -3400,7 +3400,7 @@ func TestCustomHyperkubeDistro(t *testing.T) {
 					AgentPoolProfiles: []*AgentPoolProfile{
 						{
 							Name:   "pool1",
-							Distro: api.Ubuntu1804,
+							Distro: Ubuntu1804,
 						},
 						{
 							Name: "pool2",
@@ -3409,14 +3409,14 @@ func TestCustomHyperkubeDistro(t *testing.T) {
 				},
 			},
 			expectedMasterProfile: MasterProfile{
-				Distro: api.Ubuntu,
+				Distro: Ubuntu,
 			},
 			expectedAgentPoolProfiles: []AgentPoolProfile{
 				{
-					Distro: api.Ubuntu1804,
+					Distro: Ubuntu1804,
 				},
 				{
-					Distro: api.Ubuntu,
+					Distro: Ubuntu,
 				},
 			},
 		},

--- a/pkg/agent/datamodel/mocks.go
+++ b/pkg/agent/datamodel/mocks.go
@@ -28,7 +28,7 @@ func CreateMockContainerService(containerServiceName, orchestratorVersion string
 	agentPool.Count = agentCount
 	agentPool.Name = "agentpool1"
 	agentPool.VMSize = "Standard_D2_v2"
-	agentPool.OSType = api.Linux
+	agentPool.OSType = Linux
 	agentPool.AvailabilityProfile = "AvailabilitySet"
 	agentPool.StorageProfile = "StorageAccount"
 
@@ -37,13 +37,13 @@ func CreateMockContainerService(containerServiceName, orchestratorVersion string
 	cs.Properties.LinuxProfile = &LinuxProfile{
 		AdminUsername: "azureuser",
 		SSH: struct {
-			PublicKeys []api.PublicKey `json:"publicKeys"`
+			PublicKeys []PublicKey `json:"publicKeys"`
 		}{},
 	}
 
 	cs.Properties.LinuxProfile.AdminUsername = "azureuser"
 	cs.Properties.LinuxProfile.SSH.PublicKeys = append(
-		cs.Properties.LinuxProfile.SSH.PublicKeys, api.PublicKey{KeyData: "test"})
+		cs.Properties.LinuxProfile.SSH.PublicKeys, PublicKey{KeyData: "test"})
 
 	cs.Properties.ServicePrincipalProfile = &ServicePrincipalProfile{}
 	cs.Properties.ServicePrincipalProfile.ClientID = "DEC923E3-1EF1-4745-9516-37906D56DEC4"
@@ -129,7 +129,7 @@ func GetK8sDefaultProperties(hasWindows bool) *Properties {
 				VMSize:              "Standard_D2_v2",
 				Count:               1,
 				AvailabilityProfile: api.AvailabilitySet,
-				OSType:              api.Windows,
+				OSType:              Windows,
 			},
 		}
 		p.WindowsProfile = &WindowsProfile{

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -325,15 +325,15 @@ func TestPropertiesIsHostedMasterProfile(t *testing.T) {
 func TestOSType(t *testing.T) {
 	p := Properties{
 		MasterProfile: &MasterProfile{
-			Distro: api.RHEL,
+			Distro: RHEL,
 		},
 		AgentPoolProfiles: []*AgentPoolProfile{
 			{
-				OSType: api.Linux,
+				OSType: Linux,
 			},
 			{
-				OSType: api.Linux,
-				Distro: api.RHEL,
+				OSType: Linux,
+				Distro: RHEL,
 			},
 		},
 	}
@@ -360,9 +360,9 @@ func TestOSType(t *testing.T) {
 		t.Fatalf("expected IsCoreOS() to return false but instead returned true")
 	}
 
-	p.MasterProfile.Distro = api.CoreOS
-	p.AgentPoolProfiles[0].OSType = api.Windows
-	p.AgentPoolProfiles[1].Distro = api.CoreOS
+	p.MasterProfile.Distro = CoreOS
+	p.AgentPoolProfiles[0].OSType = Windows
+	p.AgentPoolProfiles[1].Distro = CoreOS
 
 	if !p.HasWindows() {
 		t.Fatalf("expected HasWindows() to return true but instead returned false")
@@ -1356,7 +1356,7 @@ func TestAnyAgentIsLinux(t *testing.T) {
 						Name:   "agentpool1",
 						VMSize: "Standard_D2_v2",
 						Count:  2,
-						OSType: api.Linux,
+						OSType: Linux,
 					},
 				},
 			},
@@ -1370,12 +1370,12 @@ func TestAnyAgentIsLinux(t *testing.T) {
 						Name:   "agentpool1",
 						VMSize: "Standard_D2_v2",
 						Count:  2,
-						OSType: api.Windows,
+						OSType: Windows,
 					},
 					{
 						Name:   "agentpool1",
 						VMSize: "Standard_D2_v2",
-						OSType: api.Linux,
+						OSType: Linux,
 					},
 				},
 			},
@@ -1412,7 +1412,7 @@ func TestAnyAgentIsLinux(t *testing.T) {
 						Name:   "agentpool1",
 						VMSize: "Standard_D2_v2",
 						Count:  100,
-						OSType: api.Windows,
+						OSType: Windows,
 					},
 				},
 			},
@@ -1500,16 +1500,16 @@ func TestIsVHDDistroForAllNodes(t *testing.T) {
 			p: Properties{
 				MasterProfile: &MasterProfile{
 					Count:  1,
-					Distro: api.AKSUbuntu1604,
+					Distro: AKSUbuntu1604,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
 						Count:  1,
-						Distro: api.Ubuntu,
+						Distro: Ubuntu,
 					},
 					{
 						Count:  1,
-						Distro: api.AKSUbuntu1604,
+						Distro: AKSUbuntu1604,
 					},
 				},
 			},
@@ -1519,7 +1519,7 @@ func TestIsVHDDistroForAllNodes(t *testing.T) {
 			p: Properties{
 				MasterProfile: &MasterProfile{
 					Count:  1,
-					Distro: api.AKSUbuntu1804,
+					Distro: AKSUbuntu1804,
 				},
 			},
 			expected: true,
@@ -1528,7 +1528,7 @@ func TestIsVHDDistroForAllNodes(t *testing.T) {
 			p: Properties{
 				MasterProfile: &MasterProfile{
 					Count:  1,
-					Distro: api.Ubuntu1804,
+					Distro: Ubuntu1804,
 				},
 			},
 			expected: false,
@@ -1537,16 +1537,16 @@ func TestIsVHDDistroForAllNodes(t *testing.T) {
 			p: Properties{
 				MasterProfile: &MasterProfile{
 					Count:  1,
-					Distro: api.AKSUbuntu1804,
+					Distro: AKSUbuntu1804,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
 						Count:  1,
-						Distro: api.AKSUbuntu1804,
+						Distro: AKSUbuntu1804,
 					},
 					{
 						Count:  1,
-						Distro: api.AKSUbuntu1804,
+						Distro: AKSUbuntu1804,
 					},
 				},
 			},
@@ -1556,31 +1556,16 @@ func TestIsVHDDistroForAllNodes(t *testing.T) {
 			p: Properties{
 				MasterProfile: &MasterProfile{
 					Count:  1,
-					Distro: api.Ubuntu1804,
+					Distro: Ubuntu1804,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
 						Count:  1,
-						Distro: api.Ubuntu,
+						Distro: Ubuntu,
 					},
 					{
 						Count:  1,
-						Distro: api.Ubuntu1804Gen2,
-					},
-				},
-			},
-			expected: false,
-		},
-		{
-			p: Properties{
-				MasterProfile: &MasterProfile{
-					Count:  1,
-					Distro: api.Ubuntu1804,
-				},
-				AgentPoolProfiles: []*AgentPoolProfile{
-					{
-						Count:  1,
-						Distro: api.Ubuntu1804,
+						Distro: Ubuntu1804Gen2,
 					},
 				},
 			},
@@ -1590,12 +1575,12 @@ func TestIsVHDDistroForAllNodes(t *testing.T) {
 			p: Properties{
 				MasterProfile: &MasterProfile{
 					Count:  1,
-					Distro: api.AKSUbuntu1604,
+					Distro: Ubuntu1804,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
 						Count:  1,
-						OSType: api.Windows,
+						Distro: Ubuntu1804,
 					},
 				},
 			},
@@ -1605,12 +1590,27 @@ func TestIsVHDDistroForAllNodes(t *testing.T) {
 			p: Properties{
 				MasterProfile: &MasterProfile{
 					Count:  1,
-					Distro: api.AKSUbuntu1804,
+					Distro: AKSUbuntu1604,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
 						Count:  1,
-						OSType: api.Windows,
+						OSType: Windows,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			p: Properties{
+				MasterProfile: &MasterProfile{
+					Count:  1,
+					Distro: AKSUbuntu1804,
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Count:  1,
+						OSType: Windows,
 					},
 				},
 			},
@@ -1621,7 +1621,7 @@ func TestIsVHDDistroForAllNodes(t *testing.T) {
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
 						Count:  1,
-						Distro: api.AKSUbuntu1604,
+						Distro: AKSUbuntu1604,
 					},
 				},
 			},
@@ -1632,7 +1632,7 @@ func TestIsVHDDistroForAllNodes(t *testing.T) {
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
 						Count:  1,
-						OSType: api.Windows,
+						OSType: Windows,
 					},
 				},
 			},
@@ -2092,42 +2092,42 @@ func TestAgentPoolProfileIsVHDDistro(t *testing.T) {
 		{
 			name: "16.04 VHD distro",
 			ap: AgentPoolProfile{
-				Distro: api.AKSUbuntu1604,
+				Distro: AKSUbuntu1604,
 			},
 			expected: true,
 		},
 		{
 			name: "18.04 VHD distro",
 			ap: AgentPoolProfile{
-				Distro: api.AKSUbuntu1804,
+				Distro: AKSUbuntu1804,
 			},
 			expected: true,
 		},
 		{
 			name: "coreos distro",
 			ap: AgentPoolProfile{
-				Distro: api.CoreOS,
+				Distro: CoreOS,
 			},
 			expected: false,
 		},
 		{
 			name: "ubuntu distro",
 			ap: AgentPoolProfile{
-				Distro: api.Ubuntu,
+				Distro: Ubuntu,
 			},
 			expected: false,
 		},
 		{
 			name: "ubuntu 18.04 non-VHD distro",
 			ap: AgentPoolProfile{
-				Distro: api.Ubuntu1804,
+				Distro: Ubuntu1804,
 			},
 			expected: false,
 		},
 		{
 			name: "ubuntu 18.04 gen2 non-VHD distro",
 			ap: AgentPoolProfile{
-				Distro: api.Ubuntu1804Gen2,
+				Distro: Ubuntu1804Gen2,
 			},
 			expected: true,
 		},
@@ -2156,13 +2156,13 @@ func TestUbuntuVersion(t *testing.T) {
 			p: Properties{
 				MasterProfile: &MasterProfile{
 					Count:  1,
-					Distro: api.AKSUbuntu1604,
+					Distro: AKSUbuntu1604,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
 						Count:  1,
-						Distro: api.AKSUbuntu1604,
-						OSType: api.Linux,
+						Distro: AKSUbuntu1604,
+						OSType: Linux,
 					},
 				},
 			},
@@ -2175,12 +2175,12 @@ func TestUbuntuVersion(t *testing.T) {
 			p: Properties{
 				MasterProfile: &MasterProfile{
 					Count:  1,
-					Distro: api.AKSUbuntu1804,
+					Distro: AKSUbuntu1804,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
 						Count:  1,
-						Distro: api.ACC1604,
+						Distro: ACC1604,
 					},
 				},
 			},
@@ -2193,13 +2193,13 @@ func TestUbuntuVersion(t *testing.T) {
 			p: Properties{
 				MasterProfile: &MasterProfile{
 					Count:  1,
-					Distro: api.Ubuntu,
+					Distro: Ubuntu,
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
 						Count:  1,
 						Distro: "",
-						OSType: api.Windows,
+						OSType: Windows,
 					},
 				},
 			},
@@ -2676,10 +2676,10 @@ func TestLinuxProfile(t *testing.T) {
 	}
 
 	l = LinuxProfile{
-		Secrets: []api.KeyVaultSecrets{
+		Secrets: []KeyVaultSecrets{
 			{
-				SourceVault: &api.KeyVaultID{"testVault"},
-				VaultCertificates: []api.KeyVaultCertificate{
+				SourceVault: &KeyVaultID{"testVault"},
+				VaultCertificates: []KeyVaultCertificate{
 					{
 						CertificateURL:   "testURL",
 						CertificateStore: "testStore",
@@ -2687,10 +2687,10 @@ func TestLinuxProfile(t *testing.T) {
 				},
 			},
 		},
-		CustomNodesDNS: &api.CustomNodesDNS{
+		CustomNodesDNS: &CustomNodesDNS{
 			DNSServer: "testDNSServer",
 		},
-		CustomSearchDomain: &api.CustomSearchDomain{
+		CustomSearchDomain: &CustomSearchDomain{
 			Name:          "testName",
 			RealmPassword: "testRealmPassword",
 			RealmUser:     "testRealmUser",
@@ -2721,10 +2721,10 @@ func TestWindowsProfile(t *testing.T) {
 	}
 
 	w = WindowsProfile{
-		Secrets: []api.KeyVaultSecrets{
+		Secrets: []KeyVaultSecrets{
 			{
-				SourceVault: &api.KeyVaultID{"testVault"},
-				VaultCertificates: []api.KeyVaultCertificate{
+				SourceVault: &KeyVaultID{"testVault"},
+				VaultCertificates: []KeyVaultCertificate{
 					{
 						CertificateURL:   "testURL",
 						CertificateStore: "testStore",
@@ -2776,7 +2776,7 @@ func TestWindowsProfileCustomOS(t *testing.T) {
 		{
 			name: "valid shared gallery image",
 			w: WindowsProfile{
-				ImageRef: &api.ImageReference{
+				ImageRef: &ImageReference{
 					Name:           "test",
 					ResourceGroup:  "testRG",
 					SubscriptionID: "testSub",
@@ -2791,7 +2791,7 @@ func TestWindowsProfileCustomOS(t *testing.T) {
 		{
 			name: "valid non-shared image",
 			w: WindowsProfile{
-				ImageRef: &api.ImageReference{
+				ImageRef: &ImageReference{
 					Name:          "test",
 					ResourceGroup: "testRG",
 				},

--- a/pkg/agent/params.go
+++ b/pkg/agent/params.go
@@ -28,10 +28,10 @@ func getParameters(config *NodeBootstrappingConfiguration, generatorCode string,
 
 	// Identify Master distro
 	if properties.MasterProfile != nil {
-		addValue(parametersMap, "osImageOffer", cloudSpecConfig.OSImageConfig[properties.MasterProfile.Distro].ImageOffer)
-		addValue(parametersMap, "osImageSKU", cloudSpecConfig.OSImageConfig[properties.MasterProfile.Distro].ImageSku)
-		addValue(parametersMap, "osImagePublisher", cloudSpecConfig.OSImageConfig[properties.MasterProfile.Distro].ImagePublisher)
-		addValue(parametersMap, "osImageVersion", cloudSpecConfig.OSImageConfig[properties.MasterProfile.Distro].ImageVersion)
+		addValue(parametersMap, "osImageOffer", cloudSpecConfig.OSImageConfig[api.Distro(properties.MasterProfile.Distro)].ImageOffer)
+		addValue(parametersMap, "osImageSKU", cloudSpecConfig.OSImageConfig[api.Distro(properties.MasterProfile.Distro)].ImageSku)
+		addValue(parametersMap, "osImagePublisher", cloudSpecConfig.OSImageConfig[api.Distro(properties.MasterProfile.Distro)].ImagePublisher)
+		addValue(parametersMap, "osImageVersion", cloudSpecConfig.OSImageConfig[api.Distro(properties.MasterProfile.Distro)].ImageVersion)
 		if properties.MasterProfile.ImageRef != nil {
 			addValue(parametersMap, "osImageName", properties.MasterProfile.ImageRef.Name)
 			addValue(parametersMap, "osImageResourceGroup", properties.MasterProfile.ImageRef.ResourceGroup)
@@ -101,15 +101,15 @@ func getParameters(config *NodeBootstrappingConfiguration, generatorCode string,
 
 		// Unless distro is defined, default distro is configured by defaults#setAgentProfileDefaults
 		//   Ignores Windows OS
-		if !(agentProfile.OSType == api.Windows) {
+		if !(agentProfile.OSType == datamodel.Windows) {
 			if agentProfile.ImageRef != nil {
 				addValue(parametersMap, fmt.Sprintf("%sosImageName", agentProfile.Name), agentProfile.ImageRef.Name)
 				addValue(parametersMap, fmt.Sprintf("%sosImageResourceGroup", agentProfile.Name), agentProfile.ImageRef.ResourceGroup)
 			}
-			addValue(parametersMap, fmt.Sprintf("%sosImageOffer", agentProfile.Name), cloudSpecConfig.OSImageConfig[agentProfile.Distro].ImageOffer)
-			addValue(parametersMap, fmt.Sprintf("%sosImageSKU", agentProfile.Name), cloudSpecConfig.OSImageConfig[agentProfile.Distro].ImageSku)
-			addValue(parametersMap, fmt.Sprintf("%sosImagePublisher", agentProfile.Name), cloudSpecConfig.OSImageConfig[agentProfile.Distro].ImagePublisher)
-			addValue(parametersMap, fmt.Sprintf("%sosImageVersion", agentProfile.Name), cloudSpecConfig.OSImageConfig[agentProfile.Distro].ImageVersion)
+			addValue(parametersMap, fmt.Sprintf("%sosImageOffer", agentProfile.Name), cloudSpecConfig.OSImageConfig[api.Distro(agentProfile.Distro)].ImageOffer)
+			addValue(parametersMap, fmt.Sprintf("%sosImageSKU", agentProfile.Name), cloudSpecConfig.OSImageConfig[api.Distro(agentProfile.Distro)].ImageSku)
+			addValue(parametersMap, fmt.Sprintf("%sosImagePublisher", agentProfile.Name), cloudSpecConfig.OSImageConfig[api.Distro(agentProfile.Distro)].ImagePublisher)
+			addValue(parametersMap, fmt.Sprintf("%sosImageVersion", agentProfile.Name), cloudSpecConfig.OSImageConfig[api.Distro(agentProfile.Distro)].ImageVersion)
 		}
 	}
 

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -67,14 +67,14 @@ type paramsMap map[string]interface{}
 // validateDistro checks if the requested orchestrator type is supported on the requested Linux distro.
 func validateDistro(cs *datamodel.ContainerService) bool {
 	// Check Master distro
-	if cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.Distro == api.RHEL &&
+	if cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.Distro == datamodel.RHEL &&
 		(cs.Properties.OrchestratorProfile.OrchestratorType != api.SwarmMode) {
 		log.Printf("Orchestrator type %s not suported on RHEL Master", cs.Properties.OrchestratorProfile.OrchestratorType)
 		return false
 	}
 	// Check Agent distros
 	for _, agentProfile := range cs.Properties.AgentPoolProfiles {
-		if agentProfile.Distro == api.RHEL &&
+		if agentProfile.Distro == datamodel.RHEL &&
 			(cs.Properties.OrchestratorProfile.OrchestratorType != api.SwarmMode) {
 			log.Printf("Orchestrator type %s not suported on RHEL Agent", cs.Properties.OrchestratorProfile.OrchestratorType)
 			return false
@@ -141,7 +141,7 @@ func addSecret(m paramsMap, k string, v interface{}, encode bool) {
 }
 
 func makeAgentExtensionScriptCommands(cs *datamodel.ContainerService, profile *datamodel.AgentPoolProfile) string {
-	if profile.OSType == api.Windows {
+	if profile.OSType == datamodel.Windows {
 		return makeWindowsExtensionScriptCommands(profile.PreprovisionExtension,
 			cs.Properties.ExtensionProfiles)
 	}

--- a/pkg/aks-engine/api/apiloader_test.go
+++ b/pkg/aks-engine/api/apiloader_test.go
@@ -358,7 +358,7 @@ func getDefaultContainerService() *datamodel.ContainerService {
 				AdminPassword: "sampleAdminPassword",
 			},
 			DiagnosticsProfile: &datamodel.DiagnosticsProfile{
-				VMDiagnostics: &api.VMDiagnostics{
+				VMDiagnostics: &datamodel.VMDiagnostics{
 					Enabled:    true,
 					StorageURL: u,
 				},
@@ -366,20 +366,20 @@ func getDefaultContainerService() *datamodel.ContainerService {
 			LinuxProfile: &datamodel.LinuxProfile{
 				AdminUsername: "azureuser",
 				SSH: struct {
-					PublicKeys []api.PublicKey `json:"publicKeys"`
+					PublicKeys []datamodel.PublicKey `json:"publicKeys"`
 				}{
-					PublicKeys: []api.PublicKey{
+					PublicKeys: []datamodel.PublicKey{
 						{
 							KeyData: ValidSSHPublicKey,
 						},
 					},
 				},
-				Secrets: []api.KeyVaultSecrets{
+				Secrets: []datamodel.KeyVaultSecrets{
 					{
-						SourceVault: &api.KeyVaultID{
+						SourceVault: &datamodel.KeyVaultID{
 							ID: "sampleKeyVaultID",
 						},
-						VaultCertificates: []api.KeyVaultCertificate{
+						VaultCertificates: []datamodel.KeyVaultCertificate{
 							{
 								CertificateURL:   "FooCertURL",
 								CertificateStore: "BarCertStore",
@@ -387,10 +387,10 @@ func getDefaultContainerService() *datamodel.ContainerService {
 						},
 					},
 				},
-				CustomNodesDNS: &api.CustomNodesDNS{
+				CustomNodesDNS: &datamodel.CustomNodesDNS{
 					DNSServer: "SampleDNSServer",
 				},
-				CustomSearchDomain: &api.CustomSearchDomain{
+				CustomSearchDomain: &datamodel.CustomSearchDomain{
 					Name:          "FooCustomSearchDomain",
 					RealmUser:     "sampleRealmUser",
 					RealmPassword: "sampleRealmPassword",
@@ -400,7 +400,7 @@ func getDefaultContainerService() *datamodel.ContainerService {
 				ClientID: "fooClientID",
 				Secret:   "fooSecret",
 				ObjectID: "fooObjectID",
-				KeyvaultSecretRef: &api.KeyvaultSecretRef{
+				KeyvaultSecretRef: &datamodel.KeyvaultSecretRef{
 					VaultID:       "fooVaultID",
 					SecretName:    "fooSecretName",
 					SecretVersion: "fooSecretVersion",
@@ -411,7 +411,7 @@ func getDefaultContainerService() *datamodel.ContainerService {
 					Name:                "fooExtension",
 					Version:             "fooVersion",
 					ExtensionParameters: "fooExtensionParameters",
-					ExtensionParametersKeyVaultRef: &api.KeyvaultSecretRef{
+					ExtensionParametersKeyVaultRef: &datamodel.KeyvaultSecretRef{
 						VaultID:       "fooVaultID",
 						SecretName:    "fooSecretName",
 						SecretVersion: "fooSecretVersion",
@@ -451,7 +451,7 @@ func getDefaultContainerService() *datamodel.ContainerService {
 				ServerAppSecret: "ServerAppSecret",
 				TenantID:        "SampleTenantID",
 				AdminGroupID:    "SampleAdminGroupID",
-				Authenticator:   api.Webhook,
+				Authenticator:   datamodel.Webhook,
 			},
 			CustomProfile: &datamodel.CustomProfile{
 				Orchestrator: "Kubernetes",
@@ -512,8 +512,8 @@ func getDefaultContainerService() *datamodel.ContainerService {
 						Template:    "{{foobar}}",
 					},
 				},
-				Distro: api.Ubuntu,
-				ImageRef: &api.ImageReference{
+				Distro: datamodel.Ubuntu,
+				ImageRef: &datamodel.ImageReference{
 					Name:          "FooImageRef",
 					ResourceGroup: "FooImageRefResourceGroup",
 				},
@@ -626,7 +626,7 @@ func getDefaultContainerService() *datamodel.ContainerService {
 					FQDN:      "blueorange.westus2.com",
 					OSType:    "Linux",
 					Subnet:    "sampleSubnet",
-					ImageRef: &api.ImageReference{
+					ImageRef: &datamodel.ImageReference{
 						Name:           "testImage",
 						ResourceGroup:  "testRg",
 						SubscriptionID: "testSub",


### PR DESCRIPTION
This ports the following: ResourceIdentifiers, UserAssignedIdentity, AuthenticatorType, KeyvaultSecretRef, OSType, VMDiagnostics, ImageReference, KeyVaultSecrets, KeyVaultID, KeyVaultCertificate, PublicKey, Distro, CustomSearchDomain and CustomNodesDNS.
This removes our dependency on those data types from aks-engine. Our end goal is to remove all aks-engine dependencies.