### PR TITLE
Exit with real exit code from provision.sh

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_cmd.sh
+++ b/parts/linux/cloud-init/artifacts/cse_cmd.sh
@@ -64,7 +64,7 @@ API_SERVER_NAME={{GetKubernetesEndpoint}}
 IS_VHD={{GetVariable "isVHD"}}
 GPU_NODE={{GetVariable "gpuNode"}}
 SGX_NODE={{GetVariable "sgxNode"}}
-AUDITD_ENABLED={{GetVariable "auditdEnabled"}} 
+AUDITD_ENABLED={{GetVariable "auditdEnabled"}}
 CONFIG_GPU_DRIVER_IF_NEEDED={{GetVariable "configGPUDriverIfNeeded"}}
 ENABLE_GPU_DEVICE_PLUGIN_IF_NEEDED={{GetVariable "enableGPUDevicePluginIfNeeded"}}
-/usr/bin/nohup /bin/bash -c "/bin/bash /opt/azure/containers/provision.sh >> /var/log/azure/cluster-provision.log 2>&1 && PROVISION_CODE=$?; systemctl --no-pager -l status kubelet 2>&1 | head -n 100; exit ${PROVISION_CODE}"
+/usr/bin/nohup /bin/bash -c "/bin/bash /opt/azure/containers/provision.sh >> /var/log/azure/cluster-provision.log 2>&1; PROVISION_CODE=$?; if [ ${PROVISION_CODE} -eq 127 ]; then PROVISION_CODE=$(cat /var/log/azure/cluster-provision.log | awk '/+ exit/{print $3}' | tail -n 1); fi; systemctl --no-pager -l status kubelet 2>&1 | head -n 100; exit ${PROVISION_CODE}"

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -430,10 +430,10 @@ API_SERVER_NAME={{GetKubernetesEndpoint}}
 IS_VHD={{GetVariable "isVHD"}}
 GPU_NODE={{GetVariable "gpuNode"}}
 SGX_NODE={{GetVariable "sgxNode"}}
-AUDITD_ENABLED={{GetVariable "auditdEnabled"}} 
+AUDITD_ENABLED={{GetVariable "auditdEnabled"}}
 CONFIG_GPU_DRIVER_IF_NEEDED={{GetVariable "configGPUDriverIfNeeded"}}
 ENABLE_GPU_DEVICE_PLUGIN_IF_NEEDED={{GetVariable "enableGPUDevicePluginIfNeeded"}}
-/usr/bin/nohup /bin/bash -c "/bin/bash /opt/azure/containers/provision.sh >> /var/log/azure/cluster-provision.log 2>&1 && PROVISION_CODE=$?; systemctl --no-pager -l status kubelet 2>&1 | head -n 100; exit ${PROVISION_CODE}"`)
+/usr/bin/nohup /bin/bash -c "/bin/bash /opt/azure/containers/provision.sh >> /var/log/azure/cluster-provision.log 2>&1; PROVISION_CODE=$?; if [ ${PROVISION_CODE} -eq 127 ]; then PROVISION_CODE=$(cat /var/log/azure/cluster-provision.log | awk '/+ exit/{print $3}' | tail -n 1); fi; systemctl --no-pager -l status kubelet 2>&1 | head -n 100; exit ${PROVISION_CODE}"`)
 
 func linuxCloudInitArtifactsCse_cmdShBytes() ([]byte, error) {
 	return _linuxCloudInitArtifactsCse_cmdSh, nil


### PR DESCRIPTION
Fixed two issues:

1) `&& PROVISION_CODE=$?` makes `PROVISION_CODE` always empty on failure.
2) nohup always return 127 on script failures, hence real exit code couldn't get via `$?`.