### PR TITLE
Copy apiloader.LoadDefaultContainerServiceProperties from aks-engine.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/Azure/agentbaker/pkg/aks-engine/api"
 	"github.com/Azure/agentbaker/pkg/aks-engine/helpers"
-	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/aks-engine/pkg/api/vlabs"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/google/uuid"

--- a/pkg/aks-engine/api/apiloader.go
+++ b/pkg/aks-engine/api/apiloader.go
@@ -15,6 +15,17 @@ import (
 	"github.com/Azure/aks-engine/pkg/api/vlabs"
 )
 
+const (
+	defaultOrchestrator  = api.Kubernetes
+	defaultAPIVersion    = vlabs.APIVersion
+	defaultMasterCount   = 3
+	defaultVMSize        = "Standard_DS2_v2"
+	defaultOSDiskSizeGB  = 200
+	defaultAgentPoolName = "agent"
+	defaultAgentCount    = 3
+	defaultAdminUser     = "azureuser"
+)
+
 // Apiloader represents the object that loads api model
 type Apiloader struct{}
 
@@ -98,4 +109,27 @@ func (a *Apiloader) LoadAgentPoolProfile(contents []byte) (*datamodel.AgentPoolP
 		return nil, e
 	}
 	return agentPoolProfile, nil
+}
+
+// LoadDefaultContainerServiceProperties loads the default API model
+func LoadDefaultContainerServiceProperties() (api.TypeMeta, *vlabs.Properties) {
+	return api.TypeMeta{APIVersion: defaultAPIVersion}, &vlabs.Properties{
+		OrchestratorProfile: &vlabs.OrchestratorProfile{
+			OrchestratorType: defaultOrchestrator,
+		},
+		MasterProfile: &vlabs.MasterProfile{
+			Count:        defaultMasterCount,
+			VMSize:       defaultVMSize,
+			OSDiskSizeGB: defaultOSDiskSizeGB,
+		},
+		AgentPoolProfiles: []*vlabs.AgentPoolProfile{
+			{
+				Name:         defaultAgentPoolName,
+				Count:        defaultAgentCount,
+				VMSize:       defaultVMSize,
+				OSDiskSizeGB: defaultOSDiskSizeGB,
+			},
+		},
+		LinuxProfile: &vlabs.LinuxProfile{AdminUsername: defaultAdminUser},
+	}
 }

--- a/pkg/aks-engine/api/apiloader_test.go
+++ b/pkg/aks-engine/api/apiloader_test.go
@@ -437,3 +437,51 @@ func getDefaultContainerService() *datamodel.ContainerService {
 }
 
 const ValidSSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEApD8+lRvLtUcyfO8N2Cwq0zY9DG1Un9d+tcmU3HgnAzBr6UR/dDT5M07NV7DN1lmu/0dt6Ay/ItjF9xK//nwVJL3ezEX32yhLKkCKFMB1LcANNzlhT++SB5tlRBx65CTL8z9FORe4UCWVJNafxu3as/BshQSrSaYt3hjSeYuzTpwd4+4xQutzbTXEUBDUr01zEfjjzfUu0HDrg1IFae62hnLm3ajG6b432IIdUhFUmgjZDljUt5bI3OEz5IWPsNOOlVTuo6fqU8lJHClAtAlZEZkyv0VotidC7ZSCfV153rRsEk9IWscwL2PQIQnCw7YyEYEffDeLjBwkH6MIdJ6OgQ== rsa-key-20170510"
+
+func TestLoadDefaultContainerServiceProperties(t *testing.T) {
+	m, p := LoadDefaultContainerServiceProperties()
+
+	if m.APIVersion != defaultAPIVersion {
+		t.Errorf("Expected LoadDefaultContainerServiceProperties() to return API version %s, instead got %s", defaultAPIVersion, m.APIVersion)
+	}
+
+	if p.OrchestratorProfile.OrchestratorType != defaultOrchestrator {
+		t.Errorf("Expected LoadDefaultContainerServiceProperties() to return %s OrchestratorProfile.OrchestratorType, instead got %s", datamodel.Kubernetes, p.OrchestratorProfile.OrchestratorType)
+	}
+
+	if p.MasterProfile.Count != defaultMasterCount {
+		t.Errorf("Expected LoadDefaultContainerServiceProperties() to return %d MasterProfile.Count, instead got %d", defaultMasterCount, p.MasterProfile.Count)
+	}
+
+	if p.MasterProfile.VMSize != defaultVMSize {
+		t.Errorf("Expected LoadDefaultContainerServiceProperties() to return %s MasterProfile.VMSize, instead got %s", defaultVMSize, p.MasterProfile.VMSize)
+	}
+
+	if p.MasterProfile.OSDiskSizeGB != defaultOSDiskSizeGB {
+		t.Errorf("Expected LoadDefaultContainerServiceProperties() to return %d MasterProfile.OSDiskSizeGB, instead got %d", defaultOSDiskSizeGB, p.MasterProfile.OSDiskSizeGB)
+	}
+
+	if len(p.AgentPoolProfiles) != 1 {
+		t.Errorf("Expected 1 agent pool, instead got %d", len(p.AgentPoolProfiles))
+	}
+
+	if p.AgentPoolProfiles[0].Name != defaultAgentPoolName {
+		t.Errorf("Expected LoadDefaultContainerServiceProperties() to return %s AgentPoolProfiles[0].Name, instead got %s", defaultAgentPoolName, p.AgentPoolProfiles[0].Name)
+	}
+
+	if p.AgentPoolProfiles[0].Count != defaultAgentCount {
+		t.Errorf("Expected LoadDefaultContainerServiceProperties() to return %d AgentPoolProfiles[0].Count, instead got %d", defaultAgentCount, p.AgentPoolProfiles[0].Count)
+	}
+
+	if p.AgentPoolProfiles[0].VMSize != defaultVMSize {
+		t.Errorf("Expected LoadDefaultContainerServiceProperties() to return %s AgentPoolProfiles[0].VMSize, instead got %s", defaultVMSize, p.AgentPoolProfiles[0].VMSize)
+	}
+
+	if p.AgentPoolProfiles[0].OSDiskSizeGB != defaultOSDiskSizeGB {
+		t.Errorf("Expected LoadDefaultContainerServiceProperties() to return %d AgentPoolProfiles[0].OSDiskSizeGB, instead got %d", defaultOSDiskSizeGB, p.AgentPoolProfiles[0].OSDiskSizeGB)
+	}
+
+	if p.LinuxProfile.AdminUsername != defaultAdminUser {
+		t.Errorf("Expected LoadDefaultContainerServiceProperties() to return %s LinuxProfile.AdminAdminUsernameUsername, instead got %s", defaultAdminUser, p.LinuxProfile.AdminUsername)
+	}
+}


### PR DESCRIPTION
Copy apiloader.LoadDefaultContainerServiceProperties from aks-engine and use it in cmd/root.go.

This removes our dependency on that function from the aks-engine code base. Our end goal is to remove all aks-engine dependencies.