### PR TITLE
add proper storage profile and storage tier labels for ephemeral

### DIFF
--- a/pkg/agent/datamodel/const.go
+++ b/pkg/agent/datamodel/const.go
@@ -49,6 +49,8 @@ const (
 const (
 	// ManagedDisks means that the nodes use managed disks for their os and attached volumes
 	ManagedDisks = "ManagedDisks"
+	// Ephemeral means that the node's os disk is ephemeral. This is not compatible with attached volumes.
+	Ephemeral = "Ephemeral"
 )
 
 const (

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -973,6 +973,9 @@ func (a *AgentPoolProfile) GetKubernetesLabels(rg string, deprecated bool, nvidi
 		// label key storageprofile and storagetier will be depreated soon
 		buf.WriteString(fmt.Sprintf(",storageprofile=managed,storagetier=%s", storagetier))
 		buf.WriteString(fmt.Sprintf(",kubernetes.azure.com/storageprofile=managed,kubernetes.azure.com/storagetier=%s", storagetier))
+	} else if strings.EqualFold(a.StorageProfile, Ephemeral) {
+		buf.WriteString(fmt.Sprintf(",storageprofile=ephemeral,storagetier=%s", "Standard_LRS"))
+		buf.WriteString(fmt.Sprintf(",kubernetes.azure.com/storageprofile=ephemeral,kubernetes.azure.com/storagetier=%s", "Standard_LRS"))
 	}
 	if nvidiaEnabled {
 		accelerator := "nvidia"

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -18,8 +18,6 @@ const (
 	ScaleSetPriorityLow = "Low"
 	// StorageAccount means that the nodes use raw storage accounts for their os and attached volumes
 	StorageAccount = "StorageAccount"
-	// Ephemeral means that the node's os disk is ephemeral. This is not compatible with attached volumes.
-	Ephemeral = "Ephemeral"
 )
 
 func TestHasAadProfile(t *testing.T) {
@@ -944,6 +942,17 @@ func TestAgentPoolProfileGetKubernetesLabels(t *testing.T) {
 			nvidiaEnabled: false,
 			fipsEnabled:   false,
 			expected:      "kubernetes.azure.com/role=agent,node-role.kubernetes.io/agent=,kubernetes.io/role=agent,agentpool=,kubernetes.azure.com/agentpool=,storageprofile=managed,storagetier=,kubernetes.azure.com/storageprofile=managed,kubernetes.azure.com/storagetier=,kubernetes.azure.com/cluster=my-resource-group",
+		},
+		{
+			name: "with managed disk",
+			ap: AgentPoolProfile{
+				StorageProfile: Ephemeral,
+			},
+			rg:            "my-resource-group",
+			deprecated:    true,
+			nvidiaEnabled: false,
+			fipsEnabled:   false,
+			expected:      "kubernetes.azure.com/role=agent,node-role.kubernetes.io/agent=,kubernetes.io/role=agent,agentpool=,kubernetes.azure.com/agentpool=,storageprofile=ephemeral,storagetier=Standard_LRS,kubernetes.azure.com/storageprofile=ephemeral,kubernetes.azure.com/storagetier=Standard_LRS,kubernetes.azure.com/cluster=my-resource-group",
 		},
 		{
 			name: "N series",


### PR DESCRIPTION
Previously, it would drop the `storagetier` and `storageprofile` if storage account type is not managed disk