### PR TITLE
Port FormatProdFQDNByLocation from aks-engine.

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -249,7 +249,7 @@ func (gc *generateCmd) run(cloudSpecConfig *datamodel.AzureEnvironmentSpecConfig
 	cseCmdStr := templateGenerator.GetNodeBootstrappingCmd(config)
 
 	writer := &engine.ArtifactWriter{}
-	if err = writer.WriteTLSArtifacts(gc.containerService, gc.apiVersion, customDataStr, cseCmdStr, gc.outputDirectory, false, gc.parametersOnly); err != nil {
+	if err = writer.WriteTLSArtifacts(gc.containerService, gc.apiVersion, customDataStr, cseCmdStr, gc.outputDirectory, false, gc.parametersOnly, cloudSpecConfig); err != nil {
 		return errors.Wrap(err, "writing artifacts")
 	}
 

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -100,29 +100,9 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 
 		agentPool := cs.Properties.AgentPoolProfiles[0]
 		baker := InitializeTemplateGenerator()
-
-		azurePublicCloudSpec := &datamodel.AzureEnvironmentSpecConfig{
-			CloudName: datamodel.AzurePublicCloud,
-			//DockerSpecConfig specify the docker engine download repo
-			DockerSpecConfig: datamodel.DefaultDockerSpecConfig,
-			//KubernetesSpecConfig is the default kubernetes container image url.
-			KubernetesSpecConfig: datamodel.DefaultKubernetesSpecConfig,
-
-			EndpointConfig: datamodel.AzureEndpointConfig{
-				ResourceManagerVMDNSSuffix: "cloudapp.azure.com",
-			},
-
-			OSImageConfig: map[datamodel.Distro]datamodel.AzureOSImageConfig{
-				datamodel.Ubuntu:         datamodel.Ubuntu1604OSImageConfig,
-				datamodel.Ubuntu1804:     datamodel.Ubuntu1804OSImageConfig,
-				datamodel.Ubuntu1804Gen2: datamodel.Ubuntu1804Gen2OSImageConfig,
-				datamodel.AKSUbuntu1604:  datamodel.AKSUbuntu1604OSImageConfig,
-				datamodel.AKSUbuntu1804:  datamodel.AKSUbuntu1804OSImageConfig,
-			},
-		}
 		config := &NodeBootstrappingConfiguration{
 			ContainerService:              cs,
-			CloudSpecConfig:               azurePublicCloudSpec,
+			CloudSpecConfig:               datamodel.AzurePublicCloudSpecForTest,
 			AgentPoolProfile:              agentPool,
 			TenantID:                      "tenantID",
 			SubscriptionID:                "subID",

--- a/pkg/agent/datamodel/mocks.go
+++ b/pkg/agent/datamodel/mocks.go
@@ -163,3 +163,25 @@ func getMockAddon(name string) KubernetesAddon {
 		},
 	}
 }
+
+var (
+	AzurePublicCloudSpecForTest = &AzureEnvironmentSpecConfig{
+		CloudName: AzurePublicCloud,
+		//DockerSpecConfig specify the docker engine download repo
+		DockerSpecConfig: DefaultDockerSpecConfig,
+		//KubernetesSpecConfig is the default kubernetes container image url.
+		KubernetesSpecConfig: DefaultKubernetesSpecConfig,
+
+		EndpointConfig: AzureEndpointConfig{
+			ResourceManagerVMDNSSuffix: "cloudapp.azure.com",
+		},
+
+		OSImageConfig: map[Distro]AzureOSImageConfig{
+			Ubuntu:         Ubuntu1604OSImageConfig,
+			Ubuntu1804:     Ubuntu1804OSImageConfig,
+			Ubuntu1804Gen2: Ubuntu1804Gen2OSImageConfig,
+			AKSUbuntu1604:  AKSUbuntu1604OSImageConfig,
+			AKSUbuntu1804:  AKSUbuntu1804OSImageConfig,
+		},
+	}
+)

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -1429,3 +1429,12 @@ func (a KubernetesAddon) GetAddonContainersIndexByName(containerName string) int
 	}
 	return -1
 }
+
+// FormatProdFQDNByLocation constructs an Azure prod fqdn with custom cloud profile
+// CustomCloudName is name of environment if customCloudProfile is provided, it will be empty string if customCloudProfile is empty.
+// Because customCloudProfile is empty for deployment for AzurePublicCloud, AzureChinaCloud,AzureGermanCloud,AzureUSGovernmentCloud,
+// The customCloudName value will be empty string for those clouds
+func FormatProdFQDNByLocation(fqdnPrefix string, location string, cloudSpecConfig *AzureEnvironmentSpecConfig) string {
+	FQDNFormat := cloudSpecConfig.EndpointConfig.ResourceManagerVMDNSSuffix
+	return fmt.Sprintf("%s.%s."+FQDNFormat, fqdnPrefix, location)
+}

--- a/pkg/aks-engine/engine/engine.go
+++ b/pkg/aks-engine/engine/engine.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/Azure/agentbaker/pkg/aks-engine/helpers"
-	"github.com/Azure/aks-engine/pkg/api"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
 
@@ -56,7 +55,7 @@ const (
 )
 
 // GenerateKubeConfig returns a JSON string representing the KubeConfig
-func GenerateKubeConfig(properties *datamodel.Properties, location string) (string, error) {
+func GenerateKubeConfig(properties *datamodel.Properties, location string, cloudSpecConfig *datamodel.AzureEnvironmentSpecConfig) (string, error) {
 	if properties == nil {
 		return "", errors.New("Properties nil in GenerateKubeConfig")
 	}
@@ -83,7 +82,7 @@ func GenerateKubeConfig(properties *datamodel.Properties, location string) (stri
 			kubeconfig = strings.Replace(kubeconfig, "{{WrapAsVerbatim \"reference(concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))).dnsSettings.fqdn\"}}", properties.MasterProfile.FirstConsecutiveStaticIP, -1)
 		}
 	} else {
-		kubeconfig = strings.Replace(kubeconfig, "{{WrapAsVerbatim \"reference(concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))).dnsSettings.fqdn\"}}", api.FormatProdFQDNByLocation(properties.MasterProfile.DNSPrefix, location, properties.GetCustomCloudName()), -1)
+		kubeconfig = strings.Replace(kubeconfig, "{{WrapAsVerbatim \"reference(concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))).dnsSettings.fqdn\"}}", datamodel.FormatProdFQDNByLocation(properties.MasterProfile.DNSPrefix, location, cloudSpecConfig), -1)
 	}
 	kubeconfig = strings.Replace(kubeconfig, "{{WrapAsVariable \"resourceGroup\"}}", properties.MasterProfile.DNSPrefix, -1)
 

--- a/pkg/aks-engine/engine/engine_test.go
+++ b/pkg/aks-engine/engine/engine_test.go
@@ -19,7 +19,7 @@ func TestGenerateKubeConfig(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to load container service from file: %v", err)
 	}
-	kubeConfig, err := GenerateKubeConfig(containerService.Properties, "westus2")
+	kubeConfig, err := GenerateKubeConfig(containerService.Properties, "westus2", datamodel.AzurePublicCloudSpecForTest)
 	// TODO add actual kubeconfig validation
 	if len(kubeConfig) < 1 {
 		t.Errorf("Got unexpected kubeconfig payload: %v", kubeConfig)
@@ -29,12 +29,12 @@ func TestGenerateKubeConfig(t *testing.T) {
 	}
 
 	p := datamodel.Properties{}
-	_, err = GenerateKubeConfig(&p, "westus2")
+	_, err = GenerateKubeConfig(&p, "westus2", datamodel.AzurePublicCloudSpecForTest)
 	if err == nil {
 		t.Errorf("Expected an error result from nil Properties child properties")
 	}
 
-	_, err = GenerateKubeConfig(nil, "westus2")
+	_, err = GenerateKubeConfig(nil, "westus2", datamodel.AzurePublicCloudSpecForTest)
 	if err == nil {
 		t.Errorf("Expected an error result from nil Properties child properties")
 	}
@@ -46,19 +46,19 @@ func TestGenerateKubeConfig(t *testing.T) {
 		Enabled: to.BoolPtr(true),
 	}
 
-	_, err = GenerateKubeConfig(containerService.Properties, "westus2")
+	_, err = GenerateKubeConfig(containerService.Properties, "westus2", datamodel.AzurePublicCloudSpecForTest)
 	if err != nil {
 		t.Errorf("Failed to call GenerateKubeConfig with simple Kubernetes config from file: %v", testData)
 	}
 
 	containerService.Properties.MasterProfile.Count = 3
-	_, err = GenerateKubeConfig(containerService.Properties, "westus2")
+	_, err = GenerateKubeConfig(containerService.Properties, "westus2", datamodel.AzurePublicCloudSpecForTest)
 	if err == nil {
 		t.Errorf("expected an error result when Private Cluster is Enabled and no FirstConsecutiveStaticIP was specified")
 	}
 
 	containerService.Properties.MasterProfile.FirstConsecutiveStaticIP = "10.239.255.239"
-	_, err = GenerateKubeConfig(containerService.Properties, "westus2")
+	_, err = GenerateKubeConfig(containerService.Properties, "westus2", datamodel.AzurePublicCloudSpecForTest)
 	if err != nil {
 		t.Errorf("Failed to call GenerateKubeConfig with simple Kubernetes config from file: %v", testData)
 	}
@@ -69,7 +69,7 @@ func TestGenerateKubeConfig(t *testing.T) {
 		ServerAppID: "fooServerAppID",
 	}
 
-	_, err = GenerateKubeConfig(containerService.Properties, "westus2")
+	_, err = GenerateKubeConfig(containerService.Properties, "westus2", datamodel.AzurePublicCloudSpecForTest)
 	if err != nil {
 		t.Errorf("Failed to call GenerateKubeConfig with simple Kubernetes config from file: %v", testData)
 	}

--- a/pkg/aks-engine/engine/output.go
+++ b/pkg/aks-engine/engine/output.go
@@ -18,7 +18,8 @@ import (
 type ArtifactWriter struct{}
 
 // WriteTLSArtifacts saves TLS certificates and keys to the server filesystem
-func (w *ArtifactWriter) WriteTLSArtifacts(containerService *datamodel.ContainerService, apiVersion, template, parameters, artifactsDir string, certsGenerated bool, parametersOnly bool) error {
+func (w *ArtifactWriter) WriteTLSArtifacts(containerService *datamodel.ContainerService, apiVersion, template, parameters, artifactsDir string, certsGenerated bool, parametersOnly bool,
+	cloudSpecConfig *datamodel.AzureEnvironmentSpecConfig) error {
 	if len(artifactsDir) == 0 {
 		artifactsDir = fmt.Sprintf("%s-%s", containerService.Properties.OrchestratorProfile.OrchestratorType, containerService.Properties.GetClusterID())
 		artifactsDir = path.Join("_output", artifactsDir)
@@ -65,7 +66,7 @@ func (w *ArtifactWriter) WriteTLSArtifacts(containerService *datamodel.Container
 		}
 
 		for _, location := range locations {
-			b, gkcerr := GenerateKubeConfig(properties, location)
+			b, gkcerr := GenerateKubeConfig(properties, location, cloudSpecConfig)
 			if gkcerr != nil {
 				return gkcerr
 			}

--- a/pkg/aks-engine/engine/output_test.go
+++ b/pkg/aks-engine/engine/output_test.go
@@ -24,7 +24,7 @@ func TestWriteTLSArtifacts(t *testing.T) {
 	defer os.RemoveAll(defaultDir)
 
 	// Generate apimodel and azure deploy artifacts without certs
-	err := writer.WriteTLSArtifacts(cs, "vlabs", "fake template", "fake parameters", dir, false, false)
+	err := writer.WriteTLSArtifacts(cs, "vlabs", "fake template", "fake parameters", dir, false, false, datamodel.AzurePublicCloudSpecForTest)
 
 	if err != nil {
 		t.Fatalf("unexpected error trying to write TLS artifacts: %s", err.Error())
@@ -41,7 +41,7 @@ func TestWriteTLSArtifacts(t *testing.T) {
 	os.RemoveAll(dir)
 
 	// Generate parameters only and certs
-	err = writer.WriteTLSArtifacts(cs, "vlabs", "fake template", "fake parameters", "", true, true)
+	err = writer.WriteTLSArtifacts(cs, "vlabs", "fake template", "fake parameters", "", true, true, datamodel.AzurePublicCloudSpecForTest)
 	if err != nil {
 		t.Fatalf("unexpected error trying to write TLS artifacts: %s", err.Error())
 	}
@@ -95,7 +95,7 @@ func TestWriteTLSArtifacts(t *testing.T) {
 		IsUpgrade:  false,
 		PkiKeySize: helpers.DefaultPkiKeySize,
 	}, azurePublicCloudSpec)
-	err = writer.WriteTLSArtifacts(csCustom, "vlabs", "fake template", "fake parameters", "", true, false)
+	err = writer.WriteTLSArtifacts(csCustom, "vlabs", "fake template", "fake parameters", "", true, false, datamodel.AzurePublicCloudSpecForTest)
 	if err != nil {
 		t.Fatalf("unexpected error trying to write TLS artifacts: %s", err.Error())
 	}
@@ -116,7 +116,7 @@ func TestWriteTLSArtifacts(t *testing.T) {
 
 	// Generate certs with all kubeconfig locations
 	cs.Location = ""
-	err = writer.WriteTLSArtifacts(cs, "vlabs", "fake template", "fake parameters", "", true, false)
+	err = writer.WriteTLSArtifacts(cs, "vlabs", "fake template", "fake parameters", "", true, false, datamodel.AzurePublicCloudSpecForTest)
 	if err != nil {
 		t.Fatalf("unexpected error trying to write TLS artifacts: %s", err.Error())
 	}


### PR DESCRIPTION
Changed FormatProdFQDNByLocation to take a *AzureEnvironmentSpecConfig param because the code copied used the global "AzureCloudSpecEnvMap" that's no longer being used in AgentBaker.