### PR TITLE
script to generate windows sku for reference

### DIFF
--- a/vhdbuilder/scripts/windows/new-sku.sh
+++ b/vhdbuilder/scripts/windows/new-sku.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -e
+
+required_env_vars=(
+    "IMAGE_SKU"
+    "CONTAINER_RUNTIME"
+)
+
+for v in "${required_env_vars[@]}"
+do
+    if [ -z "${!v}" ]; then
+        echo "$v was not set!"
+        exit 1
+    fi
+done
+
+# As Marketpalce(Platform Image Repository) demonstrates the SKU title prominently,  
+# ensuring each SKU title unique helps users locate the correct SKU
+case "${IMAGE_SKU}" in
+"2019-Datacenter-Core-smalldisk") 
+    WINDOWS_VERSION_SHORT="windows-2019"
+    ;;
+"datacenter-core-2004-with-containers-smalldisk")
+    WINDOWS_VERSION_SHORT="windows-2004"
+    ;;
+*)  
+    echo "unsupported windows sku: ${IMAGE_SKU}" 
+    exit 1
+    ;; 
+esac
+
+valid_container_runtimes=("docker" "containerd")
+if [[ ! " ${valid_container_runtimes[@]} " =~ " ${CONTAINER_RUNTIME} " ]]; then
+    echo "CONTAINER_RUNTIME should be among [${valid_container_runtimes[*]}]"
+    exit 1
+fi
+
+short_date=$(date +"%y%m")
+pretty_date=$(date +"%b %Y")
+sku_id="${IMAGE_SKU}-${short_date}"
+
+BASEDIR=$(dirname "$0")
+SKU_TEMPLATE_FILE_NAME="sku-template.json"
+SKU_TEMPLATE_FILE=$BASEDIR/$SKU_TEMPLATE_FILE_NAME
+
+cat $SKU_TEMPLATE_FILE |sed s/{{ID}}/"$sku_id"/ | sed s/{{MONTH-YEAR}}/"$pretty_date/" | sed s/{{CONTAINER_RUNTIME}}/"$CONTAINER_RUNTIME/" | sed s/{{WINDOWS_VERSION}}/"$WINDOWS_VERSION_SHORT/"

--- a/vhdbuilder/scripts/windows/sku-template.json
+++ b/vhdbuilder/scripts/windows/sku-template.json
@@ -1,0 +1,43 @@
+    
+{
+    "planId": "{{ID}}",
+    "microsoft-azure-corevm.skuTitle": "Windows K8s base image - {{WINDOWS_VERSION}}, {{CONTAINER_RUNTIME}}, {{MONTH-YEAR}}",
+    "microsoft-azure-corevm.skuSummary": "Windows K8s base image - {{WINDOWS_VERSION}}, {{CONTAINER_RUNTIME}}, {{MONTH-YEAR}}",
+    "microsoft-azure-corevm.skuLongSummary": "Windows K8s base image - {{WINDOWS_VERSION}}, {{CONTAINER_RUNTIME}}, {{MONTH-YEAR}}",
+    "microsoft-azure-corevm.hideSKUForSolutionTemplate": true,
+    "microsoft-azure-corevm.hardened": false,
+    "microsoft-azure-corevm.deploymentModels": [
+      "ARM"
+    ],
+    "microsoft-azure-corevm.cloudAvailability": [
+      "PublicAzure",
+      "Mooncake",
+      "Fairfax"
+    ],
+    "microsoft-azure-corevm.imageType": "VmImage",
+    "microsoft-azure-corevm.imageVisibility": true,
+    "microsoft-azure-corevm.generation": "1",
+    "microsoft-azure-corevm.operatingSystemFamily": "Windows",
+    "microsoft-azure-corevm.osType": "Other",
+    "microsoft-azure-corevm.supportsHubOnOffSwitch": false,
+    "microsoft-azure-corevm.supportsClientHub": false,
+    "microsoft-azure-corevm.isPremiumThirdParty": false,
+    "microsoft-azure-corevm.supportsHub": false,
+    "microsoft-azure-corevm.supportsBackup": false,
+    "microsoft-azure-corevm.freeTierEligible": true,
+    "microsoft-azure-corevm.supportsSriov": false,
+    "microsoft-azure-corevm.supportsAADLogin": false,
+    "microsoft-azure-corevm.defaultImageSizeGB": "30",
+    "microsoft-azure-corevm.vmImagesPublicAzure": {},
+    "microsoft-azure-corevm.skuDescriptionPublicAzure": "Windows Base Image for Azure Kubernetes",
+    "microsoft-azure-corevm.skuDescriptionFairfax": "Windows Base Image for Azure Kubernetes",
+    "microsoft-azure-corevm.skuDescriptionMooncake": "Windows Base Image for Azure Kubernetes",
+    "microsoft-azure-corevm.smallLogo": "https://publishingstoredm.blob.core.windows.net/prodcontent/D6191_publishers_microsoft:2Daks/aks:2Dwindows/8dd0a573-9b12-45fe-8251-b873d69b5640.png?sv=2014-02-14&sr=b&sig=FhbGgRkK29YWTPffGx8Fl1z%2BR6TsgWKhFdst%2FQa7QG4%3D&se=2021-12-30T22%3A20%3A06Z&sp=r",
+    "microsoft-azure-corevm.mediumLogo": "https://publishingstoredm.blob.core.windows.net/prodcontent/D6191_publishers_microsoft:2Daks/aks:2Dwindows/04333b54-e40a-4a4d-8b71-9aecaef0610d.png?sv=2014-02-14&sr=b&sig=Kjs%2FjzgNOkBziUL1X92OAGA2Xkvl%2BTqvo3Efniny0CY%3D&se=2021-12-30T22%3A20%3A06Z&sp=r",
+    "microsoft-azure-corevm.largeLogo": "https://publishingstoredm.blob.core.windows.net/prodcontent/D6191_publishers_microsoft:2Daks/aks:2Dwindows/cdca9982-cc33-4af8-94dc-2de23754bb5d.png?sv=2014-02-14&sr=b&sig=giqzJbU7Lccszadxa3%2F70Am4dCpyHmYuIXjYVKktXvE%3D&se=2021-12-30T22%3A20%3A06Z&sp=r",
+    "microsoft-azure-corevm.wideLogo": "https://publishingstoredm.blob.core.windows.net/prodcontent/D6191_publishers_microsoft:2Daks/aks:2Dwindows/35252318-2364-4c0c-aa52-835c8e1c95a8.png?sv=2014-02-14&sr=b&sig=uX1L0gMiBPR4FmkeaK19F4NI5fshzoG05BMfIjKnVKI%3D&se=2021-12-30T22%3A20%3A06Z&sp=r",
+    "microsoft-azure-corevm.privacyURL": "https://github.com/Azure/aks-engine/blob/master/LICENSE",
+    "microsoft-azure-corevm.termsOfUseURL": "https://github.com/Azure/aks-engine/blob/master/LICENSE",
+    "microsoft-azure-corevm.migratedOffer": false
+  }
+  


### PR DESCRIPTION
This borrows the implementation from [WS2019-docker-Marketplace-SKU](https://dev.azure.com/AzureContainerUpstream/Kubernetes/_apps/hub/ms.vss-build-web.ci-designer-hub?pipelineId=72), but instead of pushing the SKU directly to the PIR(marketplace), we print the new SKU manifest to help create the SKU manually later.

Two reasons not to create a pipeline to push the SKU:
- As we'll move to SIG in the long term, maintaining another pipeline and credentials does not count too much
- This gives us a chance to review the new SKU, providing the chance to review the content of the SKU, as we seems not able to remove an SKU from the PIR