### PR TITLE
using full path for update-ca-certificates

### DIFF
--- a/parts/linux/cloud-init/artifacts/init-aks-custom-cloud.sh
+++ b/parts/linux/cloud-init/artifacts/init-aks-custom-cloud.sh
@@ -12,7 +12,7 @@ done
 IFS=$IFS_backup
 
 cp /root/AzureCACertificates/*.crt /usr/local/share/ca-certificates/
-update-ca-certificates
+/usr/sbin/update-ca-certificates
 
 # This copies the updated bundle to the location used by OpenSSL which is commonly used
 cp /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl/cert.pem

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -2202,7 +2202,7 @@ done
 IFS=$IFS_backup
 
 cp /root/AzureCACertificates/*.crt /usr/local/share/ca-certificates/
-update-ca-certificates
+/usr/sbin/update-ca-certificates
 
 # This copies the updated bundle to the location used by OpenSSL which is commonly used
 cp /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl/cert.pem


### PR DESCRIPTION
When running the custom cloud init script to update ca certificates, we got command not found errors. Using full path fixes this issue.