### PR TITLE
feat: Support multiple vnetCidrs

### DIFF
--- a/parts/linux/cloud-init/nodecustomdata.yml
+++ b/parts/linux/cloud-init/nodecustomdata.yml
@@ -394,7 +394,12 @@ write_files:
     #!/bin/bash
 {{if not IsIPMasqAgentEnabled}}
     {{if IsAzureCNI}}
-    iptables -t nat -A POSTROUTING -m iprange ! --dst-range 168.63.129.16 -m addrtype ! --dst-type local ! -d {{GetParameter "vnetCidr"}} -j MASQUERADE
+    IFS=','
+    read -ra vnetCidrs <<< {{GetParameter "vnetCidr"}}
+    for vnetCidr in "${vnetCidrs[@]}"; do
+      iptables -t nat -A POSTROUTING -m iprange ! --dst-range 168.63.129.16 -m addrtype ! --dst-type local ! -d $vnetCidr -j MASQUERADE
+    done
+    IFS=' '
     {{end}}
 {{end}}
     #EOF

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -3610,7 +3610,12 @@ write_files:
     #!/bin/bash
 {{if not IsIPMasqAgentEnabled}}
     {{if IsAzureCNI}}
-    iptables -t nat -A POSTROUTING -m iprange ! --dst-range 168.63.129.16 -m addrtype ! --dst-type local ! -d {{GetParameter "vnetCidr"}} -j MASQUERADE
+    IFS=','
+    read -ra vnetCidrs <<< {{GetParameter "vnetCidr"}}
+    for vnetCidr in "${vnetCidrs[@]}"; do
+      iptables -t nat -A POSTROUTING -m iprange ! --dst-range 168.63.129.16 -m addrtype ! --dst-type local ! -d $vnetCidr -j MASQUERADE
+    done
+    IFS=' '
     {{end}}
 {{end}}
     #EOF


### PR DESCRIPTION
feat: Support multiple vnetCidrs
Current code only support one vnetCidr. With this change, we can pass multiple vnetCidrs with the format `vnetCidr1` or `vnetCidr1,vnetCidr2,vnetCidr3`.