### PR TITLE
Add build number for the AKS VHD Linux Pipeline - Release

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -1,4 +1,4 @@
-name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)_$(BuildID)
+name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)_$(Build.BuildID)
 trigger: none
 
 variables:

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -1,4 +1,4 @@
-name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)_$(Build.BuildId)
+name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)_$(BuildID)
 trigger: none
 
 variables:

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -1,4 +1,4 @@
-name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)_$(Build.BuildID)
+name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)_$(Build.BuildId)
 trigger: none
 
 variables:

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -1,4 +1,4 @@
-name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)
+name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)_$(BuildID)
 trigger: none
 
 variables:

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -1,4 +1,4 @@
-name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)_$(BuildID)
+name: $(BuildID)
 trigger: none
 
 variables:

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -1,4 +1,4 @@
-name: $(BuildID)
+name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)_$(BuildID)
 trigger: none
 
 variables:

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -1,4 +1,4 @@
-name: $(Date:yyyyMMdd)$(Rev:.r)_$(UBUNTU_SKU)_$(HYPERV_GENERATION)_$(FEATURE_FLAGS)_$(Build.SourceBranchName)
+name: $(Date:yyyyMMdd)$(Rev:.r)_$(UBUNTU_SKU)_$(HYPERV_GENERATION)_$(FEATURE_FLAGS)_$(Build.SourceBranchName)_$(BuildID)
 trigger: none
 
 # Three modes in prioritized order

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -1,4 +1,4 @@
-name: $(Date:yyyyMMdd)$(Rev:.r)_$(UBUNTU_SKU)_$(HYPERV_GENERATION)_$(FEATURE_FLAGS)_$(Build.SourceBranchName)_$(BuildID)
+name: $(Date:yyyyMMdd)$(Rev:.r)_$(UBUNTU_SKU)_$(HYPERV_GENERATION)_$(FEATURE_FLAGS)_$(Build.SourceBranchName)
 trigger: none
 
 # Three modes in prioritized order


### PR DESCRIPTION
We need build id so that the ev2 pipeline can pick up the artifact from the release pipeline