### PR TITLE
[CHORE]bake 1.1.7 cni into vhd.

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -75,9 +75,9 @@ cat << EOF >> ${VHD_LOGS_FILEPATH}
 EOF
 
 VNET_CNI_VERSIONS="
+1.1.7
 1.1.6
 1.1.3
-1.0.33
 "
 for VNET_CNI_VERSION in $VNET_CNI_VERSIONS; do
     VNET_CNI_PLUGINS_URL="https://acs-mirror.azureedge.net/azure-cni/v${VNET_CNI_VERSION}/binaries/azure-vnet-cni-linux-amd64-v${VNET_CNI_VERSION}.tgz"


### PR DESCRIPTION
Alright these are published to the share
https://dev.azure.com/AzureContainerUpstream/Kubernetes/_build/results?buildId=12437&view=results

Do have a customer asking for this in icm 205269699 so want to make the next vhd publish. 