### PR TITLE
Block container's TCP traffic to the special IP address 168.63.129.16.

### DIFF
--- a/parts/linux/cloud-init/nodecustomdata.yml
+++ b/parts/linux/cloud-init/nodecustomdata.yml
@@ -402,6 +402,17 @@ write_files:
     IFS=' '
     {{end}}
 {{end}}
+
+    # Disallow container from reaching out to the special IP address 168.63.129.16
+    # for TCP protocol (which http uses)
+    #
+    # 168.63.129.16 contains protected settings that have priviledged info.
+    #
+    # The host can still reach 168.63.129.16 because it goes through the OUTPUT chain, not FORWARD.
+    #
+    # Note: we shouldn't block all traffic to 168.63.129.16. For example UDP traffic is still needed
+    # for DNS.
+    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+DynamicKubelet/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+DynamicKubelet/CustomData
@@ -149,6 +149,17 @@ write_files:
 
     
 
+
+    # Disallow container from reaching out to the special IP address 168.63.129.16
+    # for TCP protocol (which http uses)
+    #
+    # 168.63.129.16 contains protected settings that have priviledged info.
+    #
+    # The host can still reach 168.63.129.16 because it goes through the OUTPUT chain, not FORWARD.
+    #
+    # Note: we shouldn't block all traffic to 168.63.129.16. For example UDP traffic is still needed
+    # for DNS.
+    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+EnablePrivateClusterHostsConfigAgent/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+EnablePrivateClusterHostsConfigAgent/CustomData
@@ -160,6 +160,17 @@ write_files:
 
     
 
+
+    # Disallow container from reaching out to the special IP address 168.63.129.16
+    # for TCP protocol (which http uses)
+    #
+    # 168.63.129.16 contains protected settings that have priviledged info.
+    #
+    # The host can still reach 168.63.129.16 because it goes through the OUTPUT chain, not FORWARD.
+    #
+    # Note: we shouldn't block all traffic to 168.63.129.16. For example UDP traffic is still needed
+    # for DNS.
+    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+GPUDedicatedVHD/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+GPUDedicatedVHD/CustomData
@@ -171,6 +171,17 @@ write_files:
 
     
 
+
+    # Disallow container from reaching out to the special IP address 168.63.129.16
+    # for TCP protocol (which http uses)
+    #
+    # 168.63.129.16 contains protected settings that have priviledged info.
+    #
+    # The host can still reach 168.63.129.16 because it goes through the OUTPUT chain, not FORWARD.
+    #
+    # Note: we shouldn't block all traffic to 168.63.129.16. For example UDP traffic is still needed
+    # for DNS.
+    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+K8S115/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+K8S115/CustomData
@@ -149,6 +149,17 @@ write_files:
 
     
 
+
+    # Disallow container from reaching out to the special IP address 168.63.129.16
+    # for TCP protocol (which http uses)
+    #
+    # 168.63.129.16 contains protected settings that have priviledged info.
+    #
+    # The host can still reach 168.63.129.16 because it goes through the OUTPUT chain, not FORWARD.
+    #
+    # Note: we shouldn't block all traffic to 168.63.129.16. For example UDP traffic is still needed
+    # for DNS.
+    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+K8S117/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+K8S117/CustomData
@@ -147,6 +147,17 @@ write_files:
 
     
 
+
+    # Disallow container from reaching out to the special IP address 168.63.129.16
+    # for TCP protocol (which http uses)
+    #
+    # 168.63.129.16 contains protected settings that have priviledged info.
+    #
+    # The host can still reach 168.63.129.16 because it goes through the OUTPUT chain, not FORWARD.
+    #
+    # Note: we shouldn't block all traffic to 168.63.129.16. For example UDP traffic is still needed
+    # for DNS.
+    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+K8S118/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+K8S118/CustomData
@@ -147,6 +147,17 @@ write_files:
 
     
 
+
+    # Disallow container from reaching out to the special IP address 168.63.129.16
+    # for TCP protocol (which http uses)
+    #
+    # 168.63.129.16 contains protected settings that have priviledged info.
+    #
+    # The host can still reach 168.63.129.16 because it goes through the OUTPUT chain, not FORWARD.
+    #
+    # Note: we shouldn't block all traffic to 168.63.129.16. For example UDP traffic is still needed
+    # for DNS.
+    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/CustomData
@@ -206,6 +206,17 @@ write_files:
 
     
 
+
+    # Disallow container from reaching out to the special IP address 168.63.129.16
+    # for TCP protocol (which http uses)
+    #
+    # 168.63.129.16 contains protected settings that have priviledged info.
+    #
+    # The host can still reach 168.63.129.16 because it goes through the OUTPUT chain, not FORWARD.
+    #
+    # Note: we shouldn't block all traffic to 168.63.129.16. For example UDP traffic is still needed
+    # for DNS.
+    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+TempDisk/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+TempDisk/CustomData
@@ -150,6 +150,17 @@ write_files:
 
     
 
+
+    # Disallow container from reaching out to the special IP address 168.63.129.16
+    # for TCP protocol (which http uses)
+    #
+    # 168.63.129.16 contains protected settings that have priviledged info.
+    #
+    # The host can still reach 168.63.129.16 because it goes through the OUTPUT chain, not FORWARD.
+    #
+    # Note: we shouldn't block all traffic to 168.63.129.16. For example UDP traffic is still needed
+    # for DNS.
+    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/CustomData
@@ -220,6 +220,17 @@ write_files:
 
     
 
+
+    # Disallow container from reaching out to the special IP address 168.63.129.16
+    # for TCP protocol (which http uses)
+    #
+    # 168.63.129.16 contains protected settings that have priviledged info.
+    #
+    # The host can still reach 168.63.129.16 because it goes through the OUTPUT chain, not FORWARD.
+    #
+    # Note: we shouldn't block all traffic to 168.63.129.16. For example UDP traffic is still needed
+    # for DNS.
+    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/RawUbuntu/CustomData
+++ b/pkg/agent/testdata/RawUbuntu/CustomData
@@ -207,6 +207,17 @@ write_files:
 
     
 
+
+    # Disallow container from reaching out to the special IP address 168.63.129.16
+    # for TCP protocol (which http uses)
+    #
+    # 168.63.129.16 contains protected settings that have priviledged info.
+    #
+    # The host can still reach 168.63.129.16 because it goes through the OUTPUT chain, not FORWARD.
+    #
+    # Note: we shouldn't block all traffic to 168.63.129.16. For example UDP traffic is still needed
+    # for DNS.
+    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
     #EOF
 
 runcmd:

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -3694,6 +3694,17 @@ write_files:
     IFS=' '
     {{end}}
 {{end}}
+
+    # Disallow container from reaching out to the special IP address 168.63.129.16
+    # for TCP protocol (which http uses)
+    #
+    # 168.63.129.16 contains protected settings that have priviledged info.
+    #
+    # The host can still reach 168.63.129.16 because it goes through the OUTPUT chain, not FORWARD.
+    #
+    # Note: we shouldn't block all traffic to 168.63.129.16. For example UDP traffic is still needed
+    # for DNS.
+    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
     #EOF
 
 runcmd:


### PR DESCRIPTION
168.63.129.16 is a special Azure IP that hosts various info, including priviledged settings, thus we need to block container/pod's access to it.