### PR TITLE
adjust windows image version pattern in SIG

### DIFF
--- a/vhdbuilder/publish/sig-version-create.sh
+++ b/vhdbuilder/publish/sig-version-create.sh
@@ -16,6 +16,9 @@
 
 MANAGED_IMAGE_NAME="MI_${REGION}_${GALLERY_NAME}_${IMAGEDEFINITION_NAME}_${IMAGE_VERSION}"
 
+# TODO(qinhao): change image version pattern of Windows to ${WINDOWS_VERSION}.$(date +"%y%m%d"), e.g. 17763.1457.200909,
+# in which, WINDOWS_VERSION can be obtained from vhd-publishing-info.json in VHD building artifacts
+
 echo "Creating managed image ${MANAGED_IMAGE_NAME} from VHD, inside resource group ${MANAGED_IMAGE_RG_NAME}"
 create_managed_image_command="az image create --resource-group ${MANAGED_IMAGE_RG_NAME} --name ${MANAGED_IMAGE_NAME} --os-type ${OS_NAME} --hyper-v-generation ${HYPERV_GENERATION} --source ${VHD_SOURCE}"
 eval $create_managed_image_command


### PR DESCRIPTION
Update windows image version used in SIG as `${WINDOWS_VERSION}.$(date +"%y%m%d")`, e.g. 17763.678.190905

Linux image version is unchanged.

WINDOWS_VERSION is obtained from vhd-publishing-info.json in VHD building artifact list