### PR TITLE
Only block 80 port for Azure DNS/LoadBalancer probe IP 168.63.129.16

### DIFF
--- a/parts/linux/cloud-init/nodecustomdata.yml
+++ b/parts/linux/cloud-init/nodecustomdata.yml
@@ -299,7 +299,7 @@ write_files:
   content: |
     runtime-endpoint: unix:///run/containerd/containerd.sock
     #EOF
-    
+
 {{if IsKubenet }}
 - path: /etc/sysctl.d/11-containerd.conf
   permissions: "0644"
@@ -415,7 +415,7 @@ write_files:
     #
     # Note: we should not block all traffic to 168.63.129.16. For example UDP traffic is still needed
     # for DNS.
-    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
+    iptables -I FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+DynamicKubelet/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+DynamicKubelet/CustomData
@@ -167,7 +167,7 @@ write_files:
     #
     # Note: we should not block all traffic to 168.63.129.16. For example UDP traffic is still needed
     # for DNS.
-    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
+    iptables -I FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+EnablePrivateClusterHostsConfigAgent/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+EnablePrivateClusterHostsConfigAgent/CustomData
@@ -178,7 +178,7 @@ write_files:
     #
     # Note: we should not block all traffic to 168.63.129.16. For example UDP traffic is still needed
     # for DNS.
-    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
+    iptables -I FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+GPUDedicatedVHD/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+GPUDedicatedVHD/CustomData
@@ -189,7 +189,7 @@ write_files:
     #
     # Note: we should not block all traffic to 168.63.129.16. For example UDP traffic is still needed
     # for DNS.
-    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
+    iptables -I FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+K8S115/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+K8S115/CustomData
@@ -167,7 +167,7 @@ write_files:
     #
     # Note: we should not block all traffic to 168.63.129.16. For example UDP traffic is still needed
     # for DNS.
-    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
+    iptables -I FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+K8S117/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+K8S117/CustomData
@@ -165,7 +165,7 @@ write_files:
     #
     # Note: we should not block all traffic to 168.63.129.16. For example UDP traffic is still needed
     # for DNS.
-    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
+    iptables -I FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+K8S118/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+K8S118/CustomData
@@ -165,7 +165,7 @@ write_files:
     #
     # Note: we should not block all traffic to 168.63.129.16. For example UDP traffic is still needed
     # for DNS.
-    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
+    iptables -I FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/CustomData
@@ -146,7 +146,7 @@ write_files:
   content: |
     runtime-endpoint: unix:///run/containerd/containerd.sock
     #EOF
-    
+
 
 
 
@@ -224,7 +224,7 @@ write_files:
     #
     # Note: we should not block all traffic to 168.63.129.16. For example UDP traffic is still needed
     # for DNS.
-    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
+    iptables -I FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1604+TempDisk/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+TempDisk/CustomData
@@ -168,7 +168,7 @@ write_files:
     #
     # Note: we should not block all traffic to 168.63.129.16. For example UDP traffic is still needed
     # for DNS.
-    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
+    iptables -I FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/CustomData
@@ -145,7 +145,7 @@ write_files:
   content: |
     runtime-endpoint: unix:///run/containerd/containerd.sock
     #EOF
-    
+
 
 
 
@@ -238,7 +238,7 @@ write_files:
     #
     # Note: we should not block all traffic to 168.63.129.16. For example UDP traffic is still needed
     # for DNS.
-    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
+    iptables -I FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
     #EOF
 
 runcmd:

--- a/pkg/agent/testdata/RawUbuntu/CustomData
+++ b/pkg/agent/testdata/RawUbuntu/CustomData
@@ -225,7 +225,7 @@ write_files:
     #
     # Note: we should not block all traffic to 168.63.129.16. For example UDP traffic is still needed
     # for DNS.
-    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
+    iptables -I FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
     #EOF
 
 runcmd:

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -3663,7 +3663,7 @@ write_files:
   content: |
     runtime-endpoint: unix:///run/containerd/containerd.sock
     #EOF
-    
+
 {{if IsKubenet }}
 - path: /etc/sysctl.d/11-containerd.conf
   permissions: "0644"
@@ -3779,7 +3779,7 @@ write_files:
     #
     # Note: we should not block all traffic to 168.63.129.16. For example UDP traffic is still needed
     # for DNS.
-    iptables -I FORWARD -d 168.63.129.16 -p tcp -j DROP
+    iptables -I FORWARD -d 168.63.129.16 -p tcp --dport 80 -j DROP
     #EOF
 
 runcmd:


### PR DESCRIPTION
Commit [e7ec045c9a95](https://github.com/Azure/AgentBaker/commit/e7ec045c9a956543f2204d759c13a5631f368e8b) blocked all TCP connections to 168.63.129.16, which caused failures for  LoadBalancer probe requests and container DNS resolving requests with TCP protocol.

This PR fixed the issue by only blocking its TCP 80 port.