### PR TITLE
Delete dynamic-config-dir if using config file

### DIFF
--- a/pkg/agent/const.go
+++ b/pkg/agent/const.go
@@ -191,9 +191,3 @@ const (
 	// AppGwIngressAddonName appgw addon
 	AppGwIngressAddonName = "appgw-ingress"
 )
-
-// kubelet config
-const (
-	// DynamicKubeletConfigDir specifies the directory for dynamic kubelet to store configs
-	DynamicKubeletConfigDir = "/var/lib/kubelet"
-)

--- a/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+CustomLinuxOSConfig/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+CustomLinuxOSConfig/CustomData
@@ -139,7 +139,7 @@ write_files:
   permissions: "0644"
   owner: root
   content: |
-    KUBELET_FLAGS=--azure-container-registry-config=/etc/kubernetes/azure.json --cloud-config=/etc/kubernetes/azure.json --cloud-provider=azure --dynamic-config-dir=/var/lib/kubelet 
+    KUBELET_FLAGS=--azure-container-registry-config=/etc/kubernetes/azure.json --cloud-config=/etc/kubernetes/azure.json --cloud-provider=azure 
     KUBELET_REGISTER_SCHEDULABLE=true
     NETWORK_POLICY=
     KUBELET_IMAGE=hyperkube-amd64:v1.16.13

--- a/pkg/agent/testdata/AKSUbuntu1604+KubeletConfigFile/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+KubeletConfigFile/CustomData
@@ -139,7 +139,7 @@ write_files:
   permissions: "0644"
   owner: root
   content: |
-    KUBELET_FLAGS=--azure-container-registry-config=/etc/kubernetes/azure.json --cloud-config=/etc/kubernetes/azure.json --cloud-provider=azure --dynamic-config-dir=/var/lib/kubelet 
+    KUBELET_FLAGS=--azure-container-registry-config=/etc/kubernetes/azure.json --cloud-config=/etc/kubernetes/azure.json --cloud-provider=azure 
     KUBELET_REGISTER_SCHEDULABLE=true
     NETWORK_POLICY=
     KUBELET_IMAGE=hyperkube-amd64:v1.15.7

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -382,8 +382,9 @@ func IsKubeletConfigFileEnabled(cs *datamodel.ContainerService, profile *datamod
 
 func ensureKubeletConfigFlagsValue(kubeletFlags map[string]string, kubeletConfigFileEnabled bool) {
 	// for now it's only dynamic kubelet, we could add more in future
-	if kubeletConfigFileEnabled && kubeletFlags["--dynamic-config-dir"] == "" {
-		kubeletFlags["--dynamic-config-dir"] = DynamicKubeletConfigDir
+	// if using kubelet config file, then we turned off DynamicKubeletConfig feature gate
+	if kubeletConfigFileEnabled {
+		delete(kubeletFlags, "--dynamic-config-dir")
 	}
 }
 

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -38,7 +38,7 @@ func TestGetKubeletConfigFileFromFlags(t *testing.T) {
 		"--authentication-token-webhook":      "true",
 		"--authorization-mode":                "Webhook",
 		"--eviction-hard":                     "memory.available<750Mi,nodefs.available<10%,nodefs.inodesFree<5%",
-		"--feature-gates":                     "RotateKubeletServerCertificate=true,DynamicKubeletConfig=true", // what if you turn off dynamic kubelet using dynamic kubelet?
+		"--feature-gates":                     "RotateKubeletServerCertificate=true,DynamicKubeletConfig=false", // what if you turn off dynamic kubelet using dynamic kubelet?
 		"--system-reserved":                   "cpu=2,memory=1Gi",
 		"--kube-reserved":                     "cpu=100m,memory=1638Mi",
 	}


### PR DESCRIPTION
We need to delete this flag for kubelet config file, since we disabled DynamicKubeletConfig feature gate.