### PR TITLE
fix: Windows VHD pipeline tests

### DIFF
--- a/vhdbuilder/packer/sysprep.ps1
+++ b/vhdbuilder/packer/sysprep.ps1
@@ -1,0 +1,36 @@
+# Stop and remove Azure Agents to enable use in Azure Stack
+# If deploying an Azure VM the agents will be re-added to the VMs at deployment time
+Stop-Service WindowsAzureGuestAgent
+Stop-Service WindowsAzureNetAgentSvc
+Stop-Service RdAgent
+& sc.exe delete WindowsAzureGuestAgent
+& sc.exe delete WindowsAzureNetAgentSvc
+& sc.exe delete RdAgent
+
+# Remove the WindowsAzureGuestAgent registry key for sysprep 
+# This removes AzureGuestAgent from participating in sysprep 
+# There was an update that is missing VMAgentDisabler.dll
+$path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\SysPrepExternal\Generalize"
+$generalizeKey = Get-Item -Path $path
+$generalizeProperties = $generalizeKey | Select-Object -ExpandProperty property
+$values = $generalizeProperties | ForEach-Object {
+    New-Object psobject -Property @{"Name"=$_;
+    "Value" = (Get-ItemProperty -Path $path -Name $_).$_}
+}
+
+$values | ForEach-Object {
+    $item = $_;
+    if( $item.Value.Contains("VMAgentDisabler.dll")) {
+            Write-HOST "Removing " $item.Name - $item.Value;
+            Remove-ItemProperty -Path $path -Name $item.Name;
+    }
+}
+
+# run Sysprep
+if( Test-Path $Env:SystemRoot\\system32\\Sysprep\\unattend.xml ) {  Remove-Item $Env:SystemRoot\\system32\\Sysprep\\unattend.xml -Force }
+& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /mode:vm /quiet /quit
+
+# when done clean up
+while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }
+Get-ChildItem c:\\WindowsAzure -Force | Sort-Object -Property FullName -Descending | ForEach-Object { try { Remove-Item -Path $_.FullName -Force -Recurse -ErrorAction SilentlyContinue; } catch { } }
+Remove-Item -Path WSMan:\\Localhost\\listener\\listener* -Recurse

--- a/vhdbuilder/packer/windows-vhd-builder.json
+++ b/vhdbuilder/packer/windows-vhd-builder.json
@@ -1,4 +1,3 @@
-
 {
     "variables": {
         "build_branch": "{{env `GIT_BRANCH`}}",
@@ -97,7 +96,7 @@
         {
             "elevated_user": "packer",
             "elevated_password": "{{.WinRMPassword}}",
-            "environment_vars" : [
+            "environment_vars": [
                 "BUILD_BRANCH={{user `build_branch`}}",
                 "BUILD_COMMIT={{user `build_commit`}}",
                 "BUILD_ID={{user `build_id`}}",
@@ -114,21 +113,10 @@
             "destination": "release-notes.txt"
         },
         {
+            "elevated_user": "packer",
+            "elevated_password": "{{.WinRMPassword}}",
             "type": "powershell",
-            "inline": [
-                "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /mode:vm /quiet /quit",
-                "Stop-Service WindowsAzureGuestAgent",
-                "Stop-Service WindowsAzureNetAgentSvc",
-                "Stop-Service RdAgent",
-                "Stop-Service WindowsAzureTelemetryService",
-                "& sc.exe delete WindowsAzureGuestAgent",
-                "& sc.exe delete WindowsAzureNetAgentSvc",
-                "& sc.exe delete RdAgent",
-                "& sc.exe delete WindowsAzureTelemetryService",
-                "Get-ChildItem c:\\WindowsAzure -Force | Sort-Object -Property FullName -Descending | ForEach-Object { try { Remove-Item -Path $_.FullName -Force -Recurse -ErrorAction SilentlyContinue; } catch { } }",
-                "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }",
-                "Remove-Item -Path WSMan:\\Localhost\\listener\\listener* -Recurse"
-            ]
+            "script": "vhdbuilder/packer/sysprep.ps1"
         }
     ]
 }


### PR DESCRIPTION
fix: Windows VHD pipeline tests
https://github.com/Azure/aks-engine/pull/3977
```
Removes Azure VM agents from the sysprep process
  - this fixes an issue where there was a missing DLL on recent upgrade of the Azure VM agents that caused sysprep to fail: 
   azure-arm: IMAGE_STATE_UNDEPLOYABLE - missing VMAgentDisabler.dll. The VM agent doesn't do anything during sysprep so it is ok to remove it. If the image is deployed to Azure as a VM the agent will redeployed.
```