### PR TITLE
chore: update Windows base image versions

### DIFF
--- a/vhdbuilder/packer/windows-image.env
+++ b/vhdbuilder/packer/windows-image.env
@@ -4,6 +4,6 @@
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core-with-Containers-smalldisk:latest
 WINDOWS_2019_BASE_IMAGE_SKU=2019-Datacenter-Core-smalldisk
-WINDOWS_2019_BASE_IMAGE_VERSION=17763.1518.2010132039
+WINDOWS_2019_BASE_IMAGE_VERSION=17763.1577.2011031610
 WINDOWS_2004_BASE_IMAGE_SKU=datacenter-core-2004-with-containers-smalldisk
-WINDOWS_2004_BASE_IMAGE_VERSION=19041.450.2008080726
+WINDOWS_2004_BASE_IMAGE_VERSION=19041.630.2011061636


### PR DESCRIPTION
chore: update Windows base image versions
1. 2019
```
az vm image show --urn MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core-with-Containers-smalldisk:latest
{
  "automaticOsUpgradeProperties": {
    "automaticOsUpgradeSupported": false
  },
  "dataDiskImages": [],
  "disallowed": {
    "vmDiskType": "None"
  },
  "hyperVgeneration": "V1",
  "id": "/Subscriptions/c4528d9e-c99a-48bb-b12d-fde2176a43b8/Providers/Microsoft.Compute/Locations/westus/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2019-Datacenter-Core-with-Containers-smalldisk/Versions/17763.1577.2011031610",
  "location": "westus",
  "name": "17763.1577.2011031610",
  "osDiskImage": {
    "operatingSystem": "Windows",
    "sizeInBytes": 32214352384,
    "sizeInGb": 31
  },
  "plan": null,
  "tags": null
}
```
2. 2004
```
az vm image show --urn MicrosoftWindowsServer:WindowsServer:datacenter-core-2004-with-containers-smalldisk:latest
{
  "automaticOsUpgradeProperties": {
    "automaticOsUpgradeSupported": false
  },
  "dataDiskImages": [],
  "disallowed": {
    "vmDiskType": "None"
  },
  "hyperVgeneration": "V1",
  "id": "/Subscriptions/c4528d9e-c99a-48bb-b12d-fde2176a43b8/Providers/Microsoft.Compute/Locations/westus/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/datacenter-core-2004-with-containers-smalldisk/Versions/19041.630.2011061636",
  "location": "westus",
  "name": "19041.630.2011061636",
  "osDiskImage": {
    "operatingSystem": "Windows",
    "sizeInBytes": 32214352384,
    "sizeInGb": 31
  },
  "plan": null,
  "tags": null
}
```