### PR TITLE
take a another point release of calico as 3.8.9 stil has 3/7 vulnerab…

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -346,8 +346,8 @@ done
 
 # calico images used by AKS
 CALICO_CNI_IMAGES="
-v3.8.0
 v3.8.9
+v3.8.9.1
 "
 for CALICO_CNI_IMAGE in ${CALICO_CNI_IMAGES}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/calico/cni:${CALICO_CNI_IMAGE}"
@@ -356,8 +356,8 @@ for CALICO_CNI_IMAGE in ${CALICO_CNI_IMAGES}; do
 done
 
 CALICO_NODE_IMAGES="
-v3.8.0
 v3.8.9
+v3.8.9.1
 "
 for CALICO_NODE_IMAGE in ${CALICO_NODE_IMAGES}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/calico/node:${CALICO_NODE_IMAGE}"
@@ -366,8 +366,8 @@ for CALICO_NODE_IMAGE in ${CALICO_NODE_IMAGES}; do
 done
 
 CALICO_TYPHA_IMAGES="
-v3.8.0
 v3.8.9
+v3.8.9.1
 "
 for CALICO_TYPHA_IMAGE in ${CALICO_TYPHA_IMAGES}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/calico/typha:${CALICO_TYPHA_IMAGE}"
@@ -377,7 +377,7 @@ done
 
 CALICO_POD2DAEMON_IMAGES="
 v3.8.0
-v3.8.9
+v3.8.9.1
 "
 for CALICO_POD2DAEMON_IMAGE in ${CALICO_POD2DAEMON_IMAGES}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/calico/pod2daemon-flexvol:${CALICO_POD2DAEMON_IMAGE}"


### PR DESCRIPTION
 Michael Withrow <Michael.Withrow@microsoft.com>; Jonathan Chauncey <Jonathan.Chauncey@microsoft.com> validated that we have 4 cve's in 3.8.9 and we still can't go upt o 3.16 as it requries chart changes so Jonathan rebuilt/patched 3.8.9 with a more up to date base image. 
 
 
