### PR TITLE
add DisableSnapshotAnnotation flag

### DIFF
--- a/parts/linux/cloud-init/nodecustomdata.yml
+++ b/parts/linux/cloud-init/nodecustomdata.yml
@@ -222,6 +222,7 @@ write_files:
       [plugins."io.containerd.grpc.v1.cri".containerd]
         {{ if TeleportEnabled }}
         snapshotter = "teleportd"
+        disable_snapshot_annotations = false
         {{ end}}
         [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
           runtime_type = "io.containerd.runtime.v1.linux"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Teleport/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Teleport/CustomData
@@ -79,6 +79,7 @@ write_files:
       [plugins."io.containerd.grpc.v1.cri".containerd]
         
         snapshotter = "teleportd"
+        disable_snapshot_annotations = false
         
         [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
           runtime_type = "io.containerd.runtime.v1.linux"

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -3740,6 +3740,7 @@ write_files:
       [plugins."io.containerd.grpc.v1.cri".containerd]
         {{ if TeleportEnabled }}
         snapshotter = "teleportd"
+        disable_snapshot_annotations = false
         {{ end}}
         [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
           runtime_type = "io.containerd.runtime.v1.linux"


### PR DESCRIPTION
Since the default value of the flag changed from `false` to `true`, we need to explicitly set it to `false`
https://github.com/containerd/cri/commit/99015cca6155121ea0924e7e73d1b3022d919efb

cc: @eriksywu 