### PR TITLE
feat: add kernel-memcg-notification to kubelet config file

### DIFF
--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -1623,6 +1623,13 @@ type AKSKubeletConfiguration struct {
 	// Default: []
 	// +optional
 	AllowedUnsafeSysctls []string `json:"allowedUnsafeSysctls,omitempty"`
+	// KernelMemcgNotification, if set, the kubelet will integrate with the kernel memcg notification
+	// to determine if memory eviction thresholds are crossed rather than polling.
+	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// it may impact the way Kubelet interacts with the kernel.
+	// Default: false
+	// +optional
+	KernelMemcgNotification bool `json:"kernelMemcgNotification,omitempty"`
 }
 
 type Duration string

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -58,6 +58,7 @@ var TranslatedKubeletConfigFlags map[string]bool = map[string]bool{
 	"--topology-manager-policy":           true,
 	"--allowed-unsafe-sysctls":            true,
 	"--fail-swap-on":                      true,
+	"--kernel-memcg-notification":         true,
 }
 
 var keyvaultSecretPathRe *regexp.Regexp
@@ -411,6 +412,7 @@ func GetKubeletConfigFileContent(kc map[string]string, customKc *datamodel.Custo
 		ReadOnlyPort:                   strToInt32(kc["--read-only-port"]),
 		ProtectKernelDefaults:          strToBool(kc["--protect-kernel-defaults"]),
 		ResolverConfig:                 kc["--resolv-conf"],
+		KernelMemcgNotification:        strToBool(kc["--kernel-memcg-notification"]),
 	}
 
 	// Authentication


### PR DESCRIPTION
this should enable kubelet to detect node memory pressure much more quickly than polling cgroup sysfs like it currently does.

adding it to the config file so it's compatible with dynamic kubelet config.