### PR TITLE
chore: Updating azure CNI to v1.2.0_hotfix

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -151,7 +151,8 @@ function Get-FilesToCacheOnVHD {
         "c:\akse-cache\win-vnet-cni\" = @(
             "https://acs-mirror.azureedge.net/azure-cni/v1.1.6/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.6.zip",
             "https://acs-mirror.azureedge.net/azure-cni/v1.1.8/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.8.zip",
-            "https://acs-mirror.azureedge.net/azure-cni/v1.2.0/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.0.zip"
+            "https://acs-mirror.azureedge.net/azure-cni/v1.2.0/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.0.zip",
+            "https://acs-mirror.azureedge.net/azure-cni/v1.2.0/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.0_hotfix.zip"
         )
     }
 

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -97,6 +97,7 @@ cat << EOF >> ${VHD_LOGS_FILEPATH}
 EOF
 
 VNET_CNI_VERSIONS="
+1.2.0_hotfix
 1.2.0
 1.1.8
 1.1.6

--- a/vhdbuilder/packer/test/vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/vhd-content-test.ps1
@@ -100,7 +100,8 @@ function Test-FilesToCacheOnVHD
         "c:\akse-cache\win-vnet-cni\" = @(
             "https://acs-mirror.azureedge.net/azure-cni/v1.1.6/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.6.zip",
             "https://acs-mirror.azureedge.net/azure-cni/v1.1.8/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.8.zip",
-            "https://acs-mirror.azureedge.net/azure-cni/v1.2.0/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.0.zip"
+            "https://acs-mirror.azureedge.net/azure-cni/v1.2.0/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.0.zip",
+            "https://acs-mirror.azureedge.net/azure-cni/v1.2.0/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.0_hotfix.zip"
         )
     }
 


### PR DESCRIPTION
Updating Azure CNI transparent mode to v1.2.0_hotfix to solve issue with initial latency.


Related PR: https://github.com/Azure/aks-engine/pull/4129