### PR TITLE
Add aad pod identity 1.7.0 image

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -602,6 +602,7 @@ mcr.microsoft.com/azure-policy/policy-kubernetes-addon-prod:prod_20201015.1
 mcr.microsoft.com/azure-policy/policy-kubernetes-webhook:prod_20200505.3
 mcr.microsoft.com/azure-application-gateway/kubernetes-ingress:1.0.1-rc3
 mcr.microsoft.com/oss/azure/aad-pod-identity/nmi:v1.6.3
+mcr.microsoft.com/oss/azure/aad-pod-identity/nmi:v1.7.0
 "
 for ADDON_IMAGE in ${ADDON_IMAGES}; do
   pullContainerImage ${cliTool} ${ADDON_IMAGE}


### PR DESCRIPTION
We're upgrading this addon image in RP side, need to bake the 1.7.0 image into VHD.