### PR TITLE
fix: Fix shellcheck in WSL

### DIFF
--- a/.pipelines/scripts/verify_shell.sh
+++ b/.pipelines/scripts/verify_shell.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 #inspired by https://github.com/Azure/aks-engine/blob/master/scripts/validate-shell.sh
-installed=$(which shellcheck 2>&1 >/dev/null)
+installed=$(command -v shellcheck 2>&1 >/dev/null)
 if [[ ${installed} -ne 0 ]]; then
     echo "shellcheck not installed...trying to install."
     DISTRO=$(uname | tr "[:upper:]" "[:lower:]")


### PR DESCRIPTION
It will throw below error when running `make generate` in WSL.

```
In ./.pipelines/scripts/verify_shell.sh line 4:
installed=$(which shellcheck 2>&1 >/dev/null)
            ^---^ SC2230: which is non-standard. Use builtin 'command -v' instead.
```