### PR TITLE
Bring in 3.8.9.2 and remove 3.8.9.1 for images we can't patch

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -363,9 +363,9 @@ for CALICO_NODE_IMAGE in ${CALICO_NODE_IMAGES}; do
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
+# typha and pod2daemon can't be patched like cni and node can as they use scratch as a base
 CALICO_TYPHA_IMAGES="
 v3.8.9
-v3.8.9.1
 "
 for CALICO_TYPHA_IMAGE in ${CALICO_TYPHA_IMAGES}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/calico/typha:${CALICO_TYPHA_IMAGE}"
@@ -375,7 +375,6 @@ done
 
 CALICO_POD2DAEMON_IMAGES="
 v3.8.9
-v3.8.9.1
 "
 for CALICO_POD2DAEMON_IMAGE in ${CALICO_POD2DAEMON_IMAGES}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/calico/pod2daemon-flexvol:${CALICO_POD2DAEMON_IMAGE}"

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -344,8 +344,8 @@ done
 
 # calico images used by AKS
 CALICO_CNI_IMAGES="
-v3.8.9
 v3.8.9.1
+v3.8.9.2
 "
 for CALICO_CNI_IMAGE in ${CALICO_CNI_IMAGES}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/calico/cni:${CALICO_CNI_IMAGE}"
@@ -354,8 +354,8 @@ for CALICO_CNI_IMAGE in ${CALICO_CNI_IMAGES}; do
 done
 
 CALICO_NODE_IMAGES="
-v3.8.9
 v3.8.9.1
+v3.8.9.2
 "
 for CALICO_NODE_IMAGE in ${CALICO_NODE_IMAGES}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/calico/node:${CALICO_NODE_IMAGE}"


### PR DESCRIPTION
only node an cni can be patched. So this fails to pull v3.8.9.1 for typha and pod2daemon. This should allow us to fail fast https://github.com/Azure/AgentBaker/pull/501

