### PR TITLE
chore: Update AKS Windows 2019 VHD with 2021 1B patch

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -204,7 +204,7 @@ function Install-WindowsPatches {
     # Windows Server 2019 update history can be found at https://support.microsoft.com/en-us/help/4464619
     # then you can get download links by searching for specific KBs at http://www.catalog.update.microsoft.com/home.aspx
 
-    $patchUrls = @()
+    $patchUrls = @("http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598230-x64_f69498ce0cac1307eb0e6701ca334ff332364289.msu")
 
     foreach ($patchUrl in $patchUrls) {
         $pathOnly = $patchUrl.Split("?")[0]

--- a/vhdbuilder/packer/test/vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/vhd-content-test.ps1
@@ -134,7 +134,7 @@ function Test-FilesToCacheOnVHD
 function Test-PatchInstalled
 {
     # patchIDs contains a list of hotfixes patched in "configure-windows-vhd.ps1", like "kb4558998"
-    $patchIDs = @()
+    $patchIDs = @("kb4598230")
     $hotfix = Get-HotFix
     $currenHotfixes = @()
     foreach($hotfixID in $hotfix.HotFixID)


### PR DESCRIPTION
Update AKS Windows 2019 VHD with 2021 1B patch [kb4598230](https://support.microsoft.com/en-us/help/4598230/windows-10-update-kb4598230)
 - URL: http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598230-x64_f69498ce0cac1307eb0e6701ca334ff332364289.msu
 - The latest Windows 2019 base image is still `17763.1637.2012040632`