### PR TITLE
feat: collect more logs for Windows

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -88,7 +88,7 @@ function Get-FilesToCacheOnVHD {
 
     $map = @{
         "c:\akse-cache\"              = @(
-            "https://github.com/Azure/aks-engine/raw/master/scripts/collect-windows-logs.ps1",
+            "https://github.com/Azure/AgentBaker/raw/master/vhdbuilder/scripts/windows/collect-windows-logs.ps1",
             "https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/cni/win-bridge.exe",
             "https://github.com/microsoft/SDN/raw/master/Kubernetes/windows/debug/collectlogs.ps1",
             "https://github.com/microsoft/SDN/raw/master/Kubernetes/windows/debug/dumpVfpPolicies.ps1",

--- a/vhdbuilder/packer/test/vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/vhd-content-test.ps1
@@ -90,7 +90,7 @@ function Test-FilesToCacheOnVHD
         )
     }
 
-    $emptyFiles = @()
+    $invalidFiles = @()
     $missingPaths = @()
     foreach ($dir in $map.Keys)
     {
@@ -109,24 +109,24 @@ function Test-FilesToCacheOnVHD
             if(![System.IO.File]::Exists($dest))
             {
                 Write-Error "File $dest does not exist"
-                $emptyFiles = $emptyFiles + $dest
+                $invalidFiles = $invalidFiles + $dest
                 continue
             }
+            $remoteFileSize = (Invoke-WebRequest $URL -UseBasicParsing -Method Head).Headers.'Content-Length'
+            $localFileSize = (Get-Item $dest).length
 
-            # NOTE(qinhao): tried to download all the files and compare file MD5 but as it takes
-            #               too long(hours) for the whole process, so check the file size temporarily
-            #               until we have a better way to validate these cached files
-            if ((Get-Item $dest).length -eq 0kb) {
-                Write-Error "File $dest is with size 0kb"
-                $emptyFiles = $emptyFiles + $dest
+            if ($localFileSize -ne $remoteFileSize) {
+                Write-Error "$dest : Local file size is $localFileSize but remote file size is $remoteFileSize"
+                $invalidFiles = $invalidFiles + $dest
+                continue
             }
 
             Write-Output "$dest is cached as expected"
         }
     }
-    if ($emptyFiles.count -gt 0 -Or $missingPaths.count -gt 0)
+    if ($invalidFiles.count -gt 0 -Or $missingPaths.count -gt 0)
     {
-        Write-Error "cache files base paths $missingPaths or(and) cached files $emptyFiles do not exist"
+        Write-Error "cache files base paths $missingPaths or(and) cached files $invalidFiles are invalid"
         exit 1
     }
 

--- a/vhdbuilder/packer/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows-vhd-builder-sig.json
@@ -93,12 +93,6 @@
         {
             "type": "file",
             "direction": "upload",
-            "source": "vhdbuilder/scripts/windows/collect-windows-logs.ps1",
-            "destination": "c:\\akse-cache\\collect-windows-logs.ps1"
-        },
-        {
-            "type": "file",
-            "direction": "upload",
             "source": "vhdbuilder/notice_windows.txt",
             "destination": "c:\\NOTICE.txt"
         },

--- a/vhdbuilder/packer/windows-vhd-builder.json
+++ b/vhdbuilder/packer/windows-vhd-builder.json
@@ -84,12 +84,6 @@
         {
             "type": "file",
             "direction": "upload",
-            "source": "vhdbuilder/scripts/windows/collect-windows-logs.ps1",
-            "destination": "c:\\akse-cache\\collect-windows-logs.ps1"
-        },
-        {
-            "type": "file",
-            "direction": "upload",
             "source": "vhdbuilder/notice_windows.txt",
             "destination": "c:\\NOTICE.txt"
         },

--- a/vhdbuilder/scripts/windows/collect-windows-logs.ps1
+++ b/vhdbuilder/scripts/windows/collect-windows-logs.ps1
@@ -1,6 +1,6 @@
 $ProgressPreference = "SilentlyContinue"
 
-$lockedFiles = "kubelet.err.log", "kubelet.log", "kubeproxy.log", "kubeproxy.err.log", "containerd.err.log", "containerd.log", "azure-vnet-telemetry.log", "azure-vnet.log"
+$lockedFiles = "kubelet.err.log", "kubelet.log", "kubeproxy.log", "kubeproxy.err.log", "containerd.err.log", "containerd.log", "azure-vnet-telemetry.log", "azure-vnet.log", "csi-proxy.log", "csi-proxy.err.log"
 
 $timeStamp = get-date -format 'yyyyMMdd-hhmmss'
 $zipName = "$env:computername-$($timeStamp)_logs.zip"

--- a/vhdbuilder/scripts/windows/collect-windows-logs.ps1
+++ b/vhdbuilder/scripts/windows/collect-windows-logs.ps1
@@ -85,6 +85,22 @@ else {
   Write-Host "Containerd hyperv logs not avalaible"
 }
 
+Write-Host "Collecting calico logs"
+if (Test-Path "c:\CalicoWindows\logs") {
+  $tempCalico = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+  New-Item -Type Directory $tempCalico
+  Get-ChildItem c:\CalicoWindows\logs\*.log* | Foreach-Object {
+    Write-Host "Copying $_ to temp"
+    $tempfile = Copy-Item $_ $tempCalico -Passthru -ErrorAction Ignore
+    if ($tempFile) {
+      $paths += $tempFile
+    }
+  }
+}
+else {
+  Write-Host "Calico logs not avalaible"
+}
+
 Write-Host "Compressing all logs to $zipName"
 $paths | Format-Table FullName, Length -AutoSize
 Compress-Archive -LiteralPath $paths -DestinationPath $zipName


### PR DESCRIPTION
1. fix: fix network cleanup code on windows for contianerd nodes (#[4154](https://github.com/Azure/aks-engine/pull/4154))
2. fix: Adding csi-proxy logs to prevent access denied errors (#[4029](https://github.com/Azure/aks-engine/pull/4029))
3. feat: collect hyperv logs (#[3737](https://github.com/Azure/aks-engine/pull/3737))
4. feat: Collect calico logs