### PR TITLE
fix: use curl.exe and add retries when downloading artifacts to Windows VHD

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -154,7 +154,7 @@ function Get-FilesToCacheOnVHD {
             $dest = [IO.Path]::Combine($dir, $fileName)
 
             Write-Log "Downloading $URL to $dest"
-            Invoke-WebRequest -UseBasicParsing -Uri $URL -OutFile $dest
+            curl.exe --retry 5 --retry-delay 0 -L $URL -o $dest
         }
     }
 }


### PR DESCRIPTION
Reference https://github.com/Azure/aks-engine/pull/4206