### PR TITLE
updated sgx-device-plugin image and added webhook image

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -294,9 +294,16 @@ fi
 
 installSGX=${SGX_DEVICE_PLUGIN_INSTALL:-"False"}
 if [[ ${installSGX} == "True" ]]; then
-    SGX_DEVICE_PLUGIN_VERSIONS="1.0"
-    for SGX_DEVICE_PLUGIN_VERSION in ${SGX_DEVICE_PLUGIN_VERSIONS}; do
-        CONTAINER_IMAGE="mcr.microsoft.com/aks/acc/sgx-device-plugin:${SGX_DEVICE_PLUGIN_VERSION}"
+    SGX_PLUGIN_VERSIONS="0.1"
+    for SGX_PLUGIN_VERSION in ${SGX_PLUGIN_VERSIONS}; do
+        CONTAINER_IMAGE="mcr.microsoft.com/aks/acc/sgx-plugin:${SGX_PLUGIN_VERSION}"
+        pullContainerImage ${cliTool} ${CONTAINER_IMAGE}
+        echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
+    done
+
+    SGX_WEBHOOK_VERSIONS="0.1"
+    for SGX_WEBHOOK_VERSION in ${SGX_WEBHOOK_VERSIONS}; do
+        CONTAINER_IMAGE="mcr.microsoft.com/aks/acc/sgx-webhook:${SGX_WEBHOOK_VERSION}"
         pullContainerImage ${cliTool} ${CONTAINER_IMAGE}
         echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
     done

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -294,6 +294,13 @@ fi
 
 installSGX=${SGX_DEVICE_PLUGIN_INSTALL:-"False"}
 if [[ ${installSGX} == "True" ]]; then
+    SGX_DEVICE_PLUGIN_VERSIONS="1.0"
+    for SGX_DEVICE_PLUGIN_VERSION in ${SGX_DEVICE_PLUGIN_VERSIONS}; do
+        CONTAINER_IMAGE="mcr.microsoft.com/aks/acc/sgx-device-plugin:${SGX_DEVICE_PLUGIN_VERSION}"
+        pullContainerImage ${cliTool} ${CONTAINER_IMAGE}
+        echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
+    done
+
     SGX_PLUGIN_VERSIONS="0.1"
     for SGX_PLUGIN_VERSION in ${SGX_PLUGIN_VERSIONS}; do
         CONTAINER_IMAGE="mcr.microsoft.com/aks/acc/sgx-plugin:${SGX_PLUGIN_VERSION}"


### PR DESCRIPTION
The implementation of SGX device plugin daemonset, which advertises EPC memory as an additional resource type in Kubernetes, has been updated to allow better integration with Intel's Icelake. With this implementation, in addition to the daemonset itself, there is also an SGX admission webhook service and deployment to ensure backward compatibility for customer workloads. This was required as the new implementation also updates the name of the EPC memory resource being advertised to the AKS cluster nodes.