### PR TITLE
chore: add Windows server 2019 patch of Feb 16, 2021 

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -15,7 +15,7 @@ $ErrorActionPreference = "Stop"
 
 filter Timestamp { "$(Get-Date -Format o): $_" }
 
-$global:containerdPackageUrl = "https://acs-mirror.azureedge.net/containerd/ms/0.0.11-1/binaries/containerd-windows-0.0.11-1.zip"
+$global:containerdPackageUrl = "https://mobyartifacts.azureedge.net/moby/moby-containerd/1.4.3+azure/windows/windows_amd64/moby-containerd-1.4.3+azure-1.amd64.zip"
 
 function Write-Log($Message) {
     $msg = $message | Timestamp

--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -231,7 +231,7 @@ function Install-WindowsPatches {
     # Windows Server 2019 update history can be found at https://support.microsoft.com/en-us/help/4464619
     # then you can get download links by searching for specific KBs at http://www.catalog.update.microsoft.com/home.aspx
 
-    $patchUrls = @("http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/02/windows10.0-kb4601345-x64_6dfee9d6f028678d7988eb35cd5c0867bf96e4c6.msu")
+    $patchUrls = @("http://download.windowsupdate.com/c/msdownload/update/software/updt/2021/02/windows10.0-kb4601383-x64_0161100ba8b1413a84cbd26b514b00c299bac8a4.msu")
 
     foreach ($patchUrl in $patchUrls) {
         $pathOnly = $patchUrl.Split("?")[0]

--- a/vhdbuilder/packer/test/vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/vhd-content-test.ps1
@@ -157,7 +157,7 @@ function Test-FilesToCacheOnVHD
 function Test-PatchInstalled
 {
     # patchIDs contains a list of hotfixes patched in "configure-windows-vhd.ps1", like "kb4558998"
-    $patchIDs = @("KB4601345")
+    $patchIDs = @("KB4601383")
     $hotfix = Get-HotFix
     $currenHotfixes = @()
     foreach($hotfixID in $hotfix.HotFixID)

--- a/vhdbuilder/packer/windows-image.env
+++ b/vhdbuilder/packer/windows-image.env
@@ -4,6 +4,6 @@
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core-with-Containers-smalldisk:latest
 WINDOWS_2019_BASE_IMAGE_SKU=2019-Datacenter-Core-smalldisk
-WINDOWS_2019_BASE_IMAGE_VERSION=17763.1697.2101090203
+WINDOWS_2019_BASE_IMAGE_VERSION=17763.1757.2102060435
 WINDOWS_2004_BASE_IMAGE_SKU=datacenter-core-2004-with-containers-smalldisk
 WINDOWS_2004_BASE_IMAGE_VERSION=19041.630.2011061636


### PR DESCRIPTION
changes included in this PR:
- Add Windows server 2019 patch of Feb 16, 2021
- Align left brackets with the function name in vhd test PS script
- Update Windows containerD. containerD VHD is for testing only
- Update base image to 17763.1757.2102060435