### PR TITLE
Correct wrong image name

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -689,7 +689,7 @@ AZURE_CLOUD_NODE_MANAGER_VERSIONS="
 0.7.0
 "
 for AZURE_CLOUD_NODE_MANAGER_VERSION in ${AZURE_CLOUD_NODE_MANAGER_VERSIONS}; do
-  CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:${AZURE_CLOUD_NODE_MANAGER_VERSION}"
+  CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v${AZURE_CLOUD_NODE_MANAGER_VERSION}"
   pullContainerImage ${cliTool} "${CONTAINER_IMAGE}"
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -221,6 +221,10 @@ imagesToBePulled='
     "versions": ["3.17.2"]
   },
   {
+    "downloadURL": "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v*",
+    "versions": ["0.5.1","0.6.0","0.7.0"]
+  },
+  {
     "downloadURL": "mcr.microsoft.com/oss/kubernetes/autoscaler/cluster-proportional-autoscaler:*",
     "versions": ["1.3.0_v0.0.5","1.7.1","1.7.1-hotfix.20200403"]
   },


### PR DESCRIPTION
In our VHD build we're not correctly retrieving azure-cloud-node-manager images, this fixes the issue