### PR TITLE
chore: Upgrade calico Windows to v3.17.2

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -152,8 +152,9 @@ function Get-FilesToCacheOnVHD {
             "https://acs-mirror.azureedge.net/azure-cni/v1.2.0_hotfix/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.0_hotfix.zip",
             "https://acs-mirror.azureedge.net/azure-cni/v1.2.2/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.2.zip"
         );
-        "c:\akse-cache\calico\" = @(,
-            "https://acs-mirror.azureedge.net/calico-node/v3.17.1/binaries/calico-windows-v3.17.1.zip"
+        "c:\akse-cache\calico\" = @(
+            "https://acs-mirror.azureedge.net/calico-node/v3.17.1/binaries/calico-windows-v3.17.1.zip",
+            "https://acs-mirror.azureedge.net/calico-node/v3.17.2/binaries/calico-windows-v3.17.2.zip"
         )
     }
 

--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -94,8 +94,9 @@ function Test-FilesToCacheOnVHD
             "https://acs-mirror.azureedge.net/azure-cni/v1.2.0_hotfix/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.0_hotfix.zip",
             "https://acs-mirror.azureedge.net/azure-cni/v1.2.2/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.2.zip"
         );
-        "c:\akse-cache\calico\" = @(,
-            "https://acs-mirror.azureedge.net/calico-node/v3.17.1/binaries/calico-windows-v3.17.1.zip"
+        "c:\akse-cache\calico\" = @(
+            "https://acs-mirror.azureedge.net/calico-node/v3.17.1/binaries/calico-windows-v3.17.1.zip",
+            "https://acs-mirror.azureedge.net/calico-node/v3.17.2/binaries/calico-windows-v3.17.2.zip"
         )
     }
 


### PR DESCRIPTION
Upgrade calico Windows to v3.17.2