### PR TITLE
chore: Better logging for kubelet/kubectl

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -709,14 +709,15 @@ for PATCHED_KUBERNETES_VERSION in ${K8S_VERSIONS}; do
     extractKubeBinaries $KUBERNETES_VERSION "https://acs-mirror.azureedge.net/kubernetes/v${PATCHED_KUBERNETES_VERSION}/binaries/kubernetes-node-linux-amd64.tar.gz"
   fi
 done
-{ echo "kubelet/kubectl downloaded:" } >> ${VHD_LOGS_FILEPATH}
+
+echo "kubelet/kubectl downloaded:" >> ${VHD_LOGS_FILEPATH}
 ls -ltr /usr/local/bin/* >> ${VHD_LOGS_FILEPATH}
 
 # shellcheck disable=SC2010
 ls -ltr /dev/* | grep sgx >>  ${VHD_LOGS_FILEPATH} 
 
-{ echo "Disk usage:" } >> ${VHD_LOGS_FILEPATH}
-{ df -h } >> ${VHD_LOGS_FILEPATH}
+echo "Disk usage:" >> ${VHD_LOGS_FILEPATH}
+df -h >> ${VHD_LOGS_FILEPATH}
 # warn at 75% space taken
 [ -s $(df -P | grep '/dev/sda1' | awk '0+$5 >= 75 {print}') ] || echo "WARNING: 75% of /dev/sda1 is used" >> ${VHD_LOGS_FILEPATH}
 # error at 99% space taken

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -709,15 +709,14 @@ for PATCHED_KUBERNETES_VERSION in ${K8S_VERSIONS}; do
     extractKubeBinaries $KUBERNETES_VERSION "https://acs-mirror.azureedge.net/kubernetes/v${PATCHED_KUBERNETES_VERSION}/binaries/kubernetes-node-linux-amd64.tar.gz"
   fi
 done
-echo "kubelet/kubectl downloaded:" >> ${VHD_LOGS_FILEPATH}
+{ echo "kubelet/kubectl downloaded:" } >> ${VHD_LOGS_FILEPATH}
 ls -ltr /usr/local/bin/* >> ${VHD_LOGS_FILEPATH}
 
 # shellcheck disable=SC2010
-echo "Disk usage:" >> ${VHD_LOGS_FILEPATH}
 ls -ltr /dev/* | grep sgx >>  ${VHD_LOGS_FILEPATH} 
 
-df -h
-
+{ echo "Disk usage:" } >> ${VHD_LOGS_FILEPATH}
+{ df -h } >> ${VHD_LOGS_FILEPATH}
 # warn at 75% space taken
 [ -s $(df -P | grep '/dev/sda1' | awk '0+$5 >= 75 {print}') ] || echo "WARNING: 75% of /dev/sda1 is used" >> ${VHD_LOGS_FILEPATH}
 # error at 99% space taken

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -479,147 +479,6 @@ for KMS_PLUGIN_VERSION in ${KMS_PLUGIN_VERSIONS}; do
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
-
-# kubelet and kubectl
-# need to cover previously supported version for VMAS scale up scenario
-# So keeping as many versions as we can - those unsupported version can be removed when we don't have enough space
-# below are the required to support versions
-# v1.17.13
-# v1.17.16
-# v1.18.10
-# v1.18.14
-# v1.19.6
-# v1.19.7
-# v1.20.2
-# NOTE that we only keep the latest one per k8s patch version as kubelet/kubectl is decided by VHD version
-K8S_VERSIONS="
-1.17.3-hotfix.20200601.1
-1.17.7-hotfix.20200817.1
-1.17.9-hotfix.20200824.1
-1.17.11-hotfix.20200901.1
-1.17.13
-1.17.16
-1.18.2-hotfix.20200624.1
-1.18.4-hotfix.20200626.1
-1.18.6-hotfix.20200723.1
-1.18.8-hotfix.20200924
-1.18.10-hotfix.20210118
-1.18.14-hotfix.20210118
-1.19.0
-1.19.1-hotfix.20200923
-1.19.3
-1.19.6-hotfix.20210118
-1.19.7-hotfix.20210122
-1.20.2
-"
-for PATCHED_KUBERNETES_VERSION in ${K8S_VERSIONS}; do
-  # Only need to store k8s components >= 1.19 for containerd VHDs
-  if (($(echo ${PATCHED_KUBERNETES_VERSION} | cut -d"." -f2) < 19)) && [[ ${CONTAINER_RUNTIME} == "containerd" ]]; then
-    continue
-  fi
-  if (($(echo ${PATCHED_KUBERNETES_VERSION} | cut -d"." -f2) < 17)); then
-    HYPERKUBE_URL="mcr.microsoft.com/oss/kubernetes/hyperkube:v${PATCHED_KUBERNETES_VERSION}"
-    # NOTE: the KUBERNETES_VERSION will be used to tag the extracted kubelet/kubectl in /usr/local/bin
-    # it should match the KUBERNETES_VERSION format(just version number, e.g. 1.15.7, no prefix v)
-    # in installKubeletAndKubectl() executed by cse, otherwise cse will need to download the kubelet/kubectl again
-    KUBERNETES_VERSION=$(echo ${PATCHED_KUBERNETES_VERSION} | cut -d"_" -f1 | cut -d"-" -f1 | cut -d"." -f1,2,3)
-    # extractHyperkube will extract the kubelet/kubectl binary from the image: ${HYPERKUBE_URL}
-    # and put them to /usr/local/bin/kubelet-${KUBERNETES_VERSION}
-    extractHyperkube ${cliTool}
-    # remove hyperkube here as the one that we really need is pulled later
-    removeContainerImage ${cliTool} $HYPERKUBE_URL
-  else
-    # strip the last .1 as that is for base image patch for hyperkube
-    if grep -iq hotfix <<< ${PATCHED_KUBERNETES_VERSION}; then
-      # shellcheck disable=SC2006
-      PATCHED_KUBERNETES_VERSION=`echo ${PATCHED_KUBERNETES_VERSION} | cut -d"." -f1,2,3,4`;
-    else
-      PATCHED_KUBERNETES_VERSION=`echo ${PATCHED_KUBERNETES_VERSION} | cut -d"." -f1,2,3`;
-    fi
-    KUBERNETES_VERSION=$(echo ${PATCHED_KUBERNETES_VERSION} | cut -d"_" -f1 | cut -d"-" -f1 | cut -d"." -f1,2,3)
-    extractKubeBinaries $KUBERNETES_VERSION "https://acs-mirror.azureedge.net/kubernetes/v${PATCHED_KUBERNETES_VERSION}/binaries/kubernetes-node-linux-amd64.tar.gz"
-  fi
-done
-ls -ltr /usr/local/bin/* >> ${VHD_LOGS_FILEPATH}
-
-# pull patched hyperkube image for AKS
-# this is used by kube-proxy and need to cover previously supported version for VMAS scale up scenario
-# So keeping as many versions as we can - those unsupported version can be removed when we don't have enough space
-# below are the required to support versions
-# v1.17.13
-# v1.17.16
-# v1.18.10
-# v1.18.14
-# v1.19.6
-# v1.19.7
-# v1.20.2
-# NOTE that we keep multiple files per k8s patch version as kubeproxy version is decided by CCP.
-PATCHED_HYPERKUBE_IMAGES="
-1.17.3-hotfix.20200601.1
-1.17.7-hotfix.20200714.2
-1.17.9-hotfix.20200824.1
-1.17.11-hotfix.20200901
-1.17.11-hotfix.20200901.1
-1.17.13
-1.17.16
-1.18.4-hotfix.20200626.1
-1.18.6-hotfix.20200723.1
-1.18.8-hotfix.20200924
-1.18.10-hotfix.20210118
-1.18.14-hotfix.20210118
-1.19.0
-1.19.1-hotfix.20200923
-1.19.3
-1.19.6-hotfix.20210118
-1.19.7-hotfix.20210122
-1.20.2
-"
-for KUBERNETES_VERSION in ${PATCHED_HYPERKUBE_IMAGES}; do
-  # Only need to store k8s components >= 1.19 for containerd VHDs
-  if (($(echo ${KUBERNETES_VERSION} | cut -d"." -f2) < 19)) && [[ ${CONTAINER_RUNTIME} == "containerd" ]]; then
-    continue
-  fi
-  # TODO: after CCP chart is done, change below to get hyperkube only for versions less than 1.17 only
-  if (($(echo ${KUBERNETES_VERSION} | cut -d"." -f2) < 19)); then
-      CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/hyperkube:v${KUBERNETES_VERSION}"
-      pullContainerImage ${cliTool} ${CONTAINER_IMAGE}
-      echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
-      if [[ ${cliTool} == "docker" ]]; then
-          docker run --rm --entrypoint "" ${CONTAINER_IMAGE} /bin/sh -c "iptables --version" | grep -v nf_tables && echo "Hyperkube contains no nf_tables"
-      else 
-          ctr --namespace k8s.io run --rm ${CONTAINER_IMAGE} checkTask /bin/sh -c "iptables --version" | grep -v nf_tables && echo "Hyperkube contains no nf_tables"
-      fi
-      # shellcheck disable=SC2181
-      if [[ $? != 0 ]]; then
-      echo "Hyperkube contains nf_tables, exiting..."
-      exit 99
-      fi
-  fi
-
-  # from 1.17 onwards start using kube-proxy as well
-  # strip the last .1 as that is for base image patch for hyperkube
-  if (($(echo ${KUBERNETES_VERSION} | cut -d"." -f2) >= 17)); then
-      if grep -iq hotfix <<< ${KUBERNETES_VERSION}; then
-      KUBERNETES_VERSION=`echo ${KUBERNETES_VERSION} | cut -d"." -f1,2,3,4`;
-      else
-      KUBERNETES_VERSION=`echo ${KUBERNETES_VERSION} | cut -d"." -f1,2,3`;
-      fi
-      CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/kube-proxy:v${KUBERNETES_VERSION}"
-      pullContainerImage ${cliTool} ${CONTAINER_IMAGE}
-      if [[ ${cliTool} == "docker" ]]; then
-          docker run --rm --entrypoint "" ${CONTAINER_IMAGE} /bin/sh -c "iptables --version" | grep -v nf_tables && echo "kube-proxy contains no nf_tables"
-      else
-          ctr --namespace k8s.io run --rm ${CONTAINER_IMAGE} checkTask /bin/sh -c "iptables --version" | grep -v nf_tables && echo "kube-proxy contains no nf_tables"
-      fi
-      # shellcheck disable=SC2181
-      if [[ $? != 0 ]]; then
-      echo "Hyperkube contains nf_tables, exiting..."
-      exit 99
-      fi
-      echo "  - ${CONTAINER_IMAGE}" >>${VHD_LOGS_FILEPATH}
-  fi
-done
-
 ADDON_IMAGES="
 mcr.microsoft.com/oss/open-policy-agent/gatekeeper:v3.1.3
 mcr.microsoft.com/oss/open-policy-agent/gatekeeper:v3.2.3
@@ -712,7 +571,149 @@ for SECRETS_STORE_PROVIDER_AZURE_VERSION in ${SECRETS_STORE_PROVIDER_AZURE_VERSI
   echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done
 
+# pull patched hyperkube image for AKS
+# this is used by kube-proxy and need to cover previously supported version for VMAS scale up scenario
+# So keeping as many versions as we can - those unsupported version can be removed when we don't have enough space
+# below are the required to support versions
+# v1.17.13
+# v1.17.16
+# v1.18.10
+# v1.18.14
+# v1.19.6
+# v1.19.7
+# v1.20.2
+# NOTE that we keep multiple files per k8s patch version as kubeproxy version is decided by CCP.
+PATCHED_HYPERKUBE_IMAGES="
+1.17.3-hotfix.20200601.1
+1.17.7-hotfix.20200714.2
+1.17.9-hotfix.20200824.1
+1.17.11-hotfix.20200901
+1.17.11-hotfix.20200901.1
+1.17.13
+1.17.16
+1.18.4-hotfix.20200626.1
+1.18.6-hotfix.20200723.1
+1.18.8-hotfix.20200924
+1.18.10-hotfix.20210118
+1.18.14-hotfix.20210118
+1.19.0
+1.19.1-hotfix.20200923
+1.19.3
+1.19.6-hotfix.20210118
+1.19.7-hotfix.20210122
+1.20.2
+"
+for KUBERNETES_VERSION in ${PATCHED_HYPERKUBE_IMAGES}; do
+  # Only need to store k8s components >= 1.19 for containerd VHDs
+  if (($(echo ${KUBERNETES_VERSION} | cut -d"." -f2) < 19)) && [[ ${CONTAINER_RUNTIME} == "containerd" ]]; then
+    continue
+  fi
+  # TODO: after CCP chart is done, change below to get hyperkube only for versions less than 1.17 only
+  if (($(echo ${KUBERNETES_VERSION} | cut -d"." -f2) < 19)); then
+      CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/hyperkube:v${KUBERNETES_VERSION}"
+      pullContainerImage ${cliTool} ${CONTAINER_IMAGE}
+      echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
+      if [[ ${cliTool} == "docker" ]]; then
+          docker run --rm --entrypoint "" ${CONTAINER_IMAGE} /bin/sh -c "iptables --version" | grep -v nf_tables && echo "Hyperkube contains no nf_tables"
+      else 
+          ctr --namespace k8s.io run --rm ${CONTAINER_IMAGE} checkTask /bin/sh -c "iptables --version" | grep -v nf_tables && echo "Hyperkube contains no nf_tables"
+      fi
+      # shellcheck disable=SC2181
+      if [[ $? != 0 ]]; then
+      echo "Hyperkube contains nf_tables, exiting..."
+      exit 99
+      fi
+  fi
+
+  # from 1.17 onwards start using kube-proxy as well
+  # strip the last .1 as that is for base image patch for hyperkube
+  if (($(echo ${KUBERNETES_VERSION} | cut -d"." -f2) >= 17)); then
+      if grep -iq hotfix <<< ${KUBERNETES_VERSION}; then
+      KUBERNETES_VERSION=`echo ${KUBERNETES_VERSION} | cut -d"." -f1,2,3,4`;
+      else
+      KUBERNETES_VERSION=`echo ${KUBERNETES_VERSION} | cut -d"." -f1,2,3`;
+      fi
+      CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/kube-proxy:v${KUBERNETES_VERSION}"
+      pullContainerImage ${cliTool} ${CONTAINER_IMAGE}
+      if [[ ${cliTool} == "docker" ]]; then
+          docker run --rm --entrypoint "" ${CONTAINER_IMAGE} /bin/sh -c "iptables --version" | grep -v nf_tables && echo "kube-proxy contains no nf_tables"
+      else
+          ctr --namespace k8s.io run --rm ${CONTAINER_IMAGE} checkTask /bin/sh -c "iptables --version" | grep -v nf_tables && echo "kube-proxy contains no nf_tables"
+      fi
+      # shellcheck disable=SC2181
+      if [[ $? != 0 ]]; then
+      echo "Hyperkube contains nf_tables, exiting..."
+      exit 99
+      fi
+      echo "  - ${CONTAINER_IMAGE}" >>${VHD_LOGS_FILEPATH}
+  fi
+done
+
+# kubelet and kubectl
+# need to cover previously supported version for VMAS scale up scenario
+# So keeping as many versions as we can - those unsupported version can be removed when we don't have enough space
+# below are the required to support versions
+# v1.17.13
+# v1.17.16
+# v1.18.10
+# v1.18.14
+# v1.19.6
+# v1.19.7
+# v1.20.2
+# NOTE that we only keep the latest one per k8s patch version as kubelet/kubectl is decided by VHD version
+K8S_VERSIONS="
+1.17.3-hotfix.20200601.1
+1.17.7-hotfix.20200817.1
+1.17.9-hotfix.20200824.1
+1.17.11-hotfix.20200901.1
+1.17.13
+1.17.16
+1.18.2-hotfix.20200624.1
+1.18.4-hotfix.20200626.1
+1.18.6-hotfix.20200723.1
+1.18.8-hotfix.20200924
+1.18.10-hotfix.20210118
+1.18.14-hotfix.20210118
+1.19.0
+1.19.1-hotfix.20200923
+1.19.3
+1.19.6-hotfix.20210118
+1.19.7-hotfix.20210122
+1.20.2
+"
+for PATCHED_KUBERNETES_VERSION in ${K8S_VERSIONS}; do
+  # Only need to store k8s components >= 1.19 for containerd VHDs
+  if (($(echo ${PATCHED_KUBERNETES_VERSION} | cut -d"." -f2) < 19)) && [[ ${CONTAINER_RUNTIME} == "containerd" ]]; then
+    continue
+  fi
+  if (($(echo ${PATCHED_KUBERNETES_VERSION} | cut -d"." -f2) < 17)); then
+    HYPERKUBE_URL="mcr.microsoft.com/oss/kubernetes/hyperkube:v${PATCHED_KUBERNETES_VERSION}"
+    # NOTE: the KUBERNETES_VERSION will be used to tag the extracted kubelet/kubectl in /usr/local/bin
+    # it should match the KUBERNETES_VERSION format(just version number, e.g. 1.15.7, no prefix v)
+    # in installKubeletAndKubectl() executed by cse, otherwise cse will need to download the kubelet/kubectl again
+    KUBERNETES_VERSION=$(echo ${PATCHED_KUBERNETES_VERSION} | cut -d"_" -f1 | cut -d"-" -f1 | cut -d"." -f1,2,3)
+    # extractHyperkube will extract the kubelet/kubectl binary from the image: ${HYPERKUBE_URL}
+    # and put them to /usr/local/bin/kubelet-${KUBERNETES_VERSION}
+    extractHyperkube ${cliTool}
+    # remove hyperkube here as the one that we really need is pulled later
+    removeContainerImage ${cliTool} $HYPERKUBE_URL
+  else
+    # strip the last .1 as that is for base image patch for hyperkube
+    if grep -iq hotfix <<< ${PATCHED_KUBERNETES_VERSION}; then
+      # shellcheck disable=SC2006
+      PATCHED_KUBERNETES_VERSION=`echo ${PATCHED_KUBERNETES_VERSION} | cut -d"." -f1,2,3,4`;
+    else
+      PATCHED_KUBERNETES_VERSION=`echo ${PATCHED_KUBERNETES_VERSION} | cut -d"." -f1,2,3`;
+    fi
+    KUBERNETES_VERSION=$(echo ${PATCHED_KUBERNETES_VERSION} | cut -d"_" -f1 | cut -d"-" -f1 | cut -d"." -f1,2,3)
+    extractKubeBinaries $KUBERNETES_VERSION "https://acs-mirror.azureedge.net/kubernetes/v${PATCHED_KUBERNETES_VERSION}/binaries/kubernetes-node-linux-amd64.tar.gz"
+  fi
+done
+echo "kubelet/kubectl downloaded:" >> ${VHD_LOGS_FILEPATH}
+ls -ltr /usr/local/bin/* >> ${VHD_LOGS_FILEPATH}
+
 # shellcheck disable=SC2010
+echo "Disk usage:" >> ${VHD_LOGS_FILEPATH}
 ls -ltr /dev/* | grep sgx >>  ${VHD_LOGS_FILEPATH} 
 
 df -h

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -710,6 +710,7 @@ for PATCHED_KUBERNETES_VERSION in ${K8S_VERSIONS}; do
   fi
 done
 
+# shellcheck disable=SC2129
 echo "kubelet/kubectl downloaded:" >> ${VHD_LOGS_FILEPATH}
 ls -ltr /usr/local/bin/* >> ${VHD_LOGS_FILEPATH}
 


### PR DESCRIPTION
Move kubelet/kubectl logging to bottom so that it doesn't appear in middle of the images pulled.
Also moved hyperkube since they usually updated together with kubelet/kubectl.