### PR TITLE
tlsbootstrap: read TLS bootstrap token from `NodeBootstrappingConfiguration`

### DIFF
--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -304,7 +304,7 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 			return IsKubeletConfigFileEnabled(cs, profile, config.EnableKubeletConfigFile)
 		},
 		"IsKubeletClientTLSBootstrappingEnabled": func() bool {
-			return IsKubeletClientTLSBootstrappingEnabled(config.KubeletClientTLSBootstrapToken, config.EnableKubeletClientTLSBootstrapping)
+			return IsKubeletClientTLSBootstrappingEnabled(config.KubeletClientTLSBootstrapToken)
 		},
 		"GetTLSBootstrapTokenForKubeConfig": func() string {
 			return GetTLSBootstrapTokenForKubeConfig(config.KubeletClientTLSBootstrapToken)

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -304,10 +304,10 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 			return IsKubeletConfigFileEnabled(cs, profile, config.EnableKubeletConfigFile)
 		},
 		"IsKubeletClientTLSBootstrappingEnabled": func() bool {
-			return IsKubeletClientTLSBootstrappingEnabled(cs, profile, config.EnableKubeletClientTLSBootstrapping)
+			return IsKubeletClientTLSBootstrappingEnabled(config.KubeletClientTLSBootstrapToken, config.EnableKubeletClientTLSBootstrapping)
 		},
 		"GetTLSBootstrapTokenForKubeConfig": func() string {
-			return GetTLSBootstrapTokenForKubeConfig(profile)
+			return GetTLSBootstrapTokenForKubeConfig(config.KubeletClientTLSBootstrapToken)
 		},
 		"GetKubeletConfigKeyVals": func(kc *datamodel.KubernetesConfig) string {
 			if kc == nil {

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -364,7 +364,6 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 		}),
 
 		Entry("AKSUbuntu1804 with kubelet client TLS bootstrapping enabled", "AKSUbuntu1804+KubeletClientTLSBootstrapping", "1.18.3", func(config *datamodel.NodeBootstrappingConfiguration) {
-			config.EnableKubeletClientTLSBootstrapping = true
 			config.KubeletClientTLSBootstrapToken = to.StringPtr("07401b.f395accd246ae52d")
 		}))
 })

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -327,7 +327,6 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 			}
 		}),
 
-
 		Entry("AKSUbuntu1604 with Disable1804SystemdResolved=true", "AKSUbuntu1604+Disable1804SystemdResolved=true", "1.16.13", func(config *datamodel.NodeBootstrappingConfiguration) {
 			config.Disable1804SystemdResolved = true
 			config.ContainerService.Properties.AgentPoolProfiles[0].KubernetesConfig = &datamodel.KubernetesConfig{
@@ -366,10 +365,7 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 
 		Entry("AKSUbuntu1804 with kubelet client TLS bootstrapping enabled", "AKSUbuntu1804+KubeletClientTLSBootstrapping", "1.18.3", func(config *datamodel.NodeBootstrappingConfiguration) {
 			config.EnableKubeletClientTLSBootstrapping = true
-			config.ContainerService.Properties.AgentPoolProfiles[0].TLSBootstrapToken = &datamodel.TLSBootstrapToken{
-				TokenID:     "07401b",
-				TokenSecret: "f395accd246ae52d",
-			}
+			config.KubeletClientTLSBootstrapToken = to.StringPtr("07401b.f395accd246ae52d")
 		}))
 })
 

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -1444,13 +1444,10 @@ type NodeBootstrappingConfiguration struct {
 	EnableACRTeleportPlugin       bool
 	TeleportdPluginURL            string
 
-	// EnableKubeletClientTLSBootstrapping - feature flag for enabling kubelet client TLS bootstrapping.
-	//
+	// KubeletClientTLSBootstrapToken - kubelet client TLS bootstrap token to use.
 	// When this feature flag is enabled, we skip kubelet kubeconfig generation and replace it with bootstrap kubeconfig.
 	//
 	// ref: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping
-	EnableKubeletClientTLSBootstrapping bool
-	// KubeletClientTLSBootstrapToken - kubelet client TLS bootstrap token to use.
 	KubeletClientTLSBootstrapToken *string
 }
 

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -1450,6 +1450,8 @@ type NodeBootstrappingConfiguration struct {
 	//
 	// ref: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping
 	EnableKubeletClientTLSBootstrapping bool
+	// KubeletClientTLSBootstrapToken - kubelet client TLS bootstrap token to use.
+	KubeletClientTLSBootstrapToken *string
 }
 
 // AKSKubeletConfiguration contains the configuration for the Kubelet that AKS set

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -1438,8 +1438,7 @@ type NodeBootstrappingConfiguration struct {
 	TeleportdPluginURL            string
 
 	// KubeletClientTLSBootstrapToken - kubelet client TLS bootstrap token to use.
-	// When this feature flag is enabled, we skip kubelet kubeconfig generation and replace it with bootstrap kubeconfig.
-	//
+	// When this feature is enabled, we skip kubelet kubeconfig generation and replace it with bootstrap kubeconfig.
 	// ref: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping
 	KubeletClientTLSBootstrapToken *string
 }

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -626,12 +626,6 @@ type SysctlConfig struct {
 	VMVfsCachePressure             *int32 `json:"vmVfsCachePressure,omitempty"`
 }
 
-// TLSBootstrapToken defines the agent node TLS bootstrap token to use.
-type TLSBootstrapToken struct {
-	TokenID     string `json:"tokenId"`
-	TokenSecret string `json:"tokenSecret"`
-}
-
 // AgentPoolProfile represents an agent pool definition
 type AgentPoolProfile struct {
 	Name                                string               `json:"name"`
@@ -683,7 +677,6 @@ type AgentPoolProfile struct {
 	ProximityPlacementGroupID           string               `json:"proximityPlacementGroupID,omitempty"`
 	CustomKubeletConfig                 *CustomKubeletConfig `json:"customKubeletConfig,omitempty"`
 	CustomLinuxOSConfig                 *CustomLinuxOSConfig `json:"customLinuxOSConfig,omitempty"`
-	TLSBootstrapToken                   *TLSBootstrapToken   `json:"tlsBootstrapToken,omitempty"`
 }
 
 // Properties represents the AKS cluster definition

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -379,18 +379,8 @@ func IsKubeletConfigFileEnabled(cs *datamodel.ContainerService, profile *datamod
 }
 
 // IsKubeletClientTLSBootstrappingEnabled get if kubelet client TLS bootstrapping is enabled
-func IsKubeletClientTLSBootstrappingEnabled(tlsBootstrapToken *string, kubeletClientTLSBootstrappingEnabled bool) bool {
-	if !kubeletClientTLSBootstrappingEnabled {
-		// toggle is off, we don't enable it
-		return false
-	}
-
-	if tlsBootstrapToken == nil {
-		// agent node's TLS bootstrap token is not set
-		return false
-	}
-
-	return true
+func IsKubeletClientTLSBootstrappingEnabled(tlsBootstrapToken *string) bool {
+	return tlsBootstrapToken != nil
 }
 
 // GetTLSBootstrapTokenForKubeConfig returns the TLS bootstrap token for kubeconfig usage.

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -379,13 +379,13 @@ func IsKubeletConfigFileEnabled(cs *datamodel.ContainerService, profile *datamod
 }
 
 // IsKubeletClientTLSBootstrappingEnabled get if kubelet client TLS bootstrapping is enabled
-func IsKubeletClientTLSBootstrappingEnabled(cs *datamodel.ContainerService, profile *datamodel.AgentPoolProfile, kubeletClientTLSBootstrappingEnabled bool) bool {
+func IsKubeletClientTLSBootstrappingEnabled(tlsBootstrapToken *string, kubeletClientTLSBootstrappingEnabled bool) bool {
 	if !kubeletClientTLSBootstrappingEnabled {
 		// toggle is off, we don't enable it
 		return false
 	}
 
-	if profile.TLSBootstrapToken == nil {
+	if tlsBootstrapToken == nil {
 		// agent node's TLS bootstrap token is not set
 		return false
 	}
@@ -397,14 +397,13 @@ func IsKubeletClientTLSBootstrappingEnabled(cs *datamodel.ContainerService, prof
 // It returns empty string if TLS bootstrap token is not enabled.
 //
 // ref: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#kubelet-configuration
-func GetTLSBootstrapTokenForKubeConfig(profile *datamodel.AgentPoolProfile) string {
-	t := profile.TLSBootstrapToken
-	if t == nil {
+func GetTLSBootstrapTokenForKubeConfig(tlsBootstrapToken *string) string {
+	if tlsBootstrapToken == nil {
 		// not set
 		return ""
 	}
 
-	return fmt.Sprintf("%s.%s", t.TokenID, t.TokenSecret)
+	return *tlsBootstrapToken
 }
 
 // GetKubeletConfigFileContent converts kubelet flags we set to a file, and return the json content

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -144,54 +144,25 @@ var expectedKubeletJSON string = `{
 
 func TestIsKubeletClientTLSBootstrappingEnabled(t *testing.T) {
 	cases := []struct {
-		cs                                   *datamodel.ContainerService
-		profile                              *datamodel.AgentPoolProfile
+		tlsBootstrapToken                    *string
 		kubeletClientTLSBootstrappingEnabled bool
 		expected                             bool
 		reason                               string
 	}{
 		{
-			cs: &datamodel.ContainerService{
-				Properties: &datamodel.Properties{
-					OrchestratorProfile: &datamodel.OrchestratorProfile{
-						OrchestratorVersion: "1.18.3",
-					},
-				},
-			},
-			profile:                              &datamodel.AgentPoolProfile{},
+			tlsBootstrapToken:                    nil,
 			kubeletClientTLSBootstrappingEnabled: false,
 			expected:                             false,
 			reason:                               "toggle disabled",
 		},
 		{
-			cs: &datamodel.ContainerService{
-				Properties: &datamodel.Properties{
-					OrchestratorProfile: &datamodel.OrchestratorProfile{
-						OrchestratorVersion: "1.18.3",
-					},
-				},
-			},
-			profile: &datamodel.AgentPoolProfile{
-				TLSBootstrapToken: nil,
-			},
+			tlsBootstrapToken:                    nil,
 			kubeletClientTLSBootstrappingEnabled: true,
 			expected:                             false,
 			reason:                               "agent pool TLS bootstrap token not set",
 		},
 		{
-			cs: &datamodel.ContainerService{
-				Properties: &datamodel.Properties{
-					OrchestratorProfile: &datamodel.OrchestratorProfile{
-						OrchestratorVersion: "1.18.3",
-					},
-				},
-			},
-			profile: &datamodel.AgentPoolProfile{
-				TLSBootstrapToken: &datamodel.TLSBootstrapToken{
-					TokenID:     "foobar",
-					TokenSecret: "foobar",
-				},
-			},
+			tlsBootstrapToken:                    to.StringPtr("foobar.foobar"),
 			kubeletClientTLSBootstrappingEnabled: true,
 			expected:                             true,
 			reason:                               "supported",
@@ -199,7 +170,7 @@ func TestIsKubeletClientTLSBootstrappingEnabled(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		actual := IsKubeletClientTLSBootstrappingEnabled(c.cs, c.profile, c.kubeletClientTLSBootstrappingEnabled)
+		actual := IsKubeletClientTLSBootstrappingEnabled(c.tlsBootstrapToken, c.kubeletClientTLSBootstrappingEnabled)
 		if actual != c.expected {
 			t.Errorf("%s: expected=%t, actual=%t", c.reason, c.expected, actual)
 		}
@@ -208,26 +179,21 @@ func TestIsKubeletClientTLSBootstrappingEnabled(t *testing.T) {
 
 func TestGetTLSBootstrapTokenForKubeConfig(t *testing.T) {
 	cases := []struct {
-		profile  *datamodel.AgentPoolProfile
+		token    *string
 		expected string
 	}{
 		{
-			profile:  &datamodel.AgentPoolProfile{},
+			token:    nil,
 			expected: "",
 		},
 		{
-			profile: &datamodel.AgentPoolProfile{
-				TLSBootstrapToken: &datamodel.TLSBootstrapToken{
-					TokenID:     "foo",
-					TokenSecret: "bar",
-				},
-			},
+			token:    to.StringPtr("foo.bar"),
 			expected: "foo.bar",
 		},
 	}
 
 	for _, c := range cases {
-		actual := GetTLSBootstrapTokenForKubeConfig(c.profile)
+		actual := GetTLSBootstrapTokenForKubeConfig(c.token)
 		if actual != c.expected {
 			t.Errorf("GetTLSBootstrapTokenForKubeConfig: expected=%s, actual=%s", c.expected, actual)
 		}

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -144,33 +144,24 @@ var expectedKubeletJSON string = `{
 
 func TestIsKubeletClientTLSBootstrappingEnabled(t *testing.T) {
 	cases := []struct {
-		tlsBootstrapToken                    *string
-		kubeletClientTLSBootstrappingEnabled bool
-		expected                             bool
-		reason                               string
+		tlsBootstrapToken *string
+		expected          bool
+		reason            string
 	}{
 		{
-			tlsBootstrapToken:                    nil,
-			kubeletClientTLSBootstrappingEnabled: false,
-			expected:                             false,
-			reason:                               "toggle disabled",
+			tlsBootstrapToken: nil,
+			expected:          false,
+			reason:            "agent pool TLS bootstrap token not set",
 		},
 		{
-			tlsBootstrapToken:                    nil,
-			kubeletClientTLSBootstrappingEnabled: true,
-			expected:                             false,
-			reason:                               "agent pool TLS bootstrap token not set",
-		},
-		{
-			tlsBootstrapToken:                    to.StringPtr("foobar.foobar"),
-			kubeletClientTLSBootstrappingEnabled: true,
-			expected:                             true,
-			reason:                               "supported",
+			tlsBootstrapToken: to.StringPtr("foobar.foobar"),
+			expected:          true,
+			reason:            "supported",
 		},
 	}
 
 	for _, c := range cases {
-		actual := IsKubeletClientTLSBootstrappingEnabled(c.tlsBootstrapToken, c.kubeletClientTLSBootstrappingEnabled)
+		actual := IsKubeletClientTLSBootstrappingEnabled(c.tlsBootstrapToken)
 		if actual != c.expected {
 			t.Errorf("%s: expected=%t, actual=%t", c.reason, c.expected, actual)
 		}


### PR DESCRIPTION
To avoid depending on agent profile, this pull request decoupled the TLS bootstrap token to set in the `NodeBootstrappingConfiguration`. I also removed the unused `TLSBootstrapToken` struct from agent pool profile.