### PR TITLE
Tienle/confcom air gapped

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -290,7 +290,7 @@ if grep -q "fullgpu" <<< "$FEATURE_FLAGS" && grep -q "gpudaemon" <<< "$FEATURE_F
   systemctlEnableAndStart nvidia-device-plugin || exit 1
 fi
 
-installSGX=${SGX_DEVICE_PLUGIN_INSTALL:-"False"}
+installSGX=${SGX_INSTALL:-"False"}
 if [[ ${installSGX} == "True" ]]; then
     SGX_DEVICE_PLUGIN_VERSIONS="1.0"
     for SGX_DEVICE_PLUGIN_VERSION in ${SGX_DEVICE_PLUGIN_VERSIONS}; do
@@ -309,6 +309,13 @@ if [[ ${installSGX} == "True" ]]; then
     SGX_WEBHOOK_VERSIONS="0.1"
     for SGX_WEBHOOK_VERSION in ${SGX_WEBHOOK_VERSIONS}; do
         CONTAINER_IMAGE="mcr.microsoft.com/aks/acc/sgx-webhook:${SGX_WEBHOOK_VERSION}"
+        pullContainerImage ${cliTool} ${CONTAINER_IMAGE}
+        echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
+    done
+
+    SGX_QUOTE_HELPER_VERSIONS="1.0"
+    for SGX_QUOTE_HELPER_VERSION in ${SGX_QUOTE_HELPER_VERSIONS}; do
+        CONTAINER_IMAGE="mcr.microsoft.com/aks/acc/sgx-attestation:${SGX_QUOTE_HELPER_VERSION}"
         pullContainerImage ${cliTool} ${CONTAINER_IMAGE}
         echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
     done

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -295,22 +295,6 @@ imagesToBePulled='
   {
     "downloadURL": "mcr.microsoft.com/oss/azure/aad-pod-identity/nmi:v*",
     "versions": ["1.7.0","1.7.4"]
-  },
-  {
-    "downloadURL": "mcr.microsoft.com/aks/acc/sgx-device-plugin:*",
-    "versions": ["1.0"]
-  },
-  {
-    "downloadURL": "mcr.microsoft.com/aks/acc/sgx-plugin:*",
-    "versions": ["0.1"]
-  },
-  {
-    "downloadURL": "mcr.microsoft.com/aks/acc/sgx-webhook:*",
-    "versions": ["0.1"]
-  },
-  {
-    "downloadURL": "mcr.microsoft.com/aks/acc/sgx-attestation:*",
-    "versions": ["1.0"]
   }
 ]
 '

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -295,6 +295,22 @@ imagesToBePulled='
   {
     "downloadURL": "mcr.microsoft.com/oss/azure/aad-pod-identity/nmi:v*",
     "versions": ["1.7.0","1.7.4"]
+  },
+  {
+    "downloadURL": "mcr.microsoft.com/aks/acc/sgx-device-plugin:*",
+    "versions": ["1.0"]
+  },
+  {
+    "downloadURL": "mcr.microsoft.com/aks/acc/sgx-plugin:*",
+    "versions": ["0.1"]
+  },
+  {
+    "downloadURL": "mcr.microsoft.com/aks/acc/sgx-webhook:*",
+    "versions": ["0.1"]
+  },
+  {
+    "downloadURL": "mcr.microsoft.com/aks/acc/sgx-attestation:*",
+    "versions": ["1.0"]
   }
 ]
 '

--- a/vhdbuilder/packer/vhd-image-builder-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-gen2.json
@@ -254,7 +254,7 @@
     {
       "type": "shell",
       "inline": [
-        "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} HYPERV_GENERATION={{user `hyperv_generation`}} CONTAINER_RUNTIME={{user `container_runtime`}} TELEPORTD_PLUGIN_DOWNLOAD_URL={{user `teleportd_plugin_download_url`}} SGX_DEVICE_PLUGIN_INSTALL=True /bin/bash -ux /home/packer/install-dependencies.sh"
+        "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} HYPERV_GENERATION={{user `hyperv_generation`}} CONTAINER_RUNTIME={{user `container_runtime`}} TELEPORTD_PLUGIN_DOWNLOAD_URL={{user `teleportd_plugin_download_url`}} SGX_INSTALL=True /bin/bash -ux /home/packer/install-dependencies.sh"
       ]
     },
     {


### PR DESCRIPTION
There are two components of our confcom AKS addon: device-plugin and quote-helper. Device-plugin has been baked in VHD, this RP is to bake quote-helper. This comes as the requirement for onboarding confcom to air-gapped regions.