### PR TITLE
kubenet and azure cni both run ipmasqagent. swift does it's own thing…

### DIFF
--- a/parts/linux/cloud-init/nodecustomdata.yml
+++ b/parts/linux/cloud-init/nodecustomdata.yml
@@ -531,11 +531,6 @@ write_files:
   owner: root
   content: |
     #!/bin/bash
-{{if not IsIPMasqAgentEnabled}}
-    {{if IsAzureCNI}}
-    iptables -t nat -A POSTROUTING -m iprange ! --dst-range 168.63.129.16 -m addrtype ! --dst-type local ! -d {{GetParameter "vnetCidr"}} -j MASQUERADE
-    {{end}}
-{{end}}
 
     # Disallow container from reaching out to the special IP address 168.63.129.16
     # for TCP protocol (which http uses)


### PR DESCRIPTION
…. This logic just gets in the way. Maybe calico depends on it but we don't think so
