### PR TITLE
Rename ParseVMSSCSEMessage to ParseCSE (#631)

### DIFF
--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -7,7 +7,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -713,26 +712,4 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.UserAssignedIDEnabled()
 		},
 	}
-}
-
-// ParseVMSSCSEMessage parses the raw VMSS CSE output
-func ParseVMSSCSEMessage(message string) (datamodel.VMSSInstanceViewCSEStatus, error) {
-	var cseStatus datamodel.VMSSInstanceViewCSEStatus
-	var rerr error
-	start := strings.Index(message, "[stdout]") + len("[stdout]")
-	end := strings.Index(message, "[stderr]")
-	if end > start {
-		rawInstanceViewInfo := message[start:end]
-		err := json.Unmarshal([]byte(rawInstanceViewInfo), &cseStatus)
-		if err != nil || cseStatus.ExitCode == "" {
-			// Regex "vmssInstanceErrorCode=" is part of contract to parse the error, please inform clients who are relying on it before change the regex.
-			rerr = fmt.Errorf("vmssCSE has invalid message=%s, %s=%s", message, VMSSInstanceErrorCode, InvalidCSEMessage)
-		} else {
-			cseStatus.ExitCode = strings.Trim(cseStatus.ExitCode, "\"")
-		}
-	} else {
-		// Regex "vmssInstanceErrorCode=" is part of contract to parse the error, please inform clients who are relying on it before change the regex.
-		rerr = fmt.Errorf("vmssCSE has invalid message=%s, %s=%s", message, VMSSInstanceErrorCode, InvalidCSEMessage)
-	}
-	return cseStatus, rerr
 }

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -639,29 +639,6 @@ var _ = Describe("Assert generated customData and cseCmd for Windows", func() {
 
 })
 
-var _ = Describe("Assert ParseVMSSCSEMessage", func() {
-	It("when cse output format is correct", func() {
-		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Enable failed:\n[stdout]\n{ \"ExitCode\": \"51\", \"Output\": \"test\", \"Error\": \"\"}\n\n[stderr]\n"
-		res, err := ParseVMSSCSEMessage(testMessage)
-		Expect(err).To(BeNil())
-		Expect(res.ExitCode).To(Equal("51"))
-	})
-
-	It("when cse output format is incorrect", func() {
-		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Enable failed:\n[stdout]\n"
-		_, err := ParseVMSSCSEMessage(testMessage)
-		Expect(err).NotTo(BeNil())
-		Expect(err.Error()).To(ContainSubstring("vmssInstanceErrorCode=InvalidCSEMessage"))
-	})
-
-	It("when cse output exitcode is empty", func() {
-		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Enable failed:\n[stdout]\n{ \"ExitCode\": , \"Output\": \"test\", \"Error\": \"\"}\n\n[stderr]\n"
-		_, err := ParseVMSSCSEMessage(testMessage)
-		Expect(err).NotTo(BeNil())
-		Expect(err.Error()).To(ContainSubstring("vmssInstanceErrorCode=InvalidCSEMessage"))
-	})
-})
-
 func backfillCustomData(folder, customData string) {
 	if _, err := os.Stat(fmt.Sprintf("./testdata/%s", folder)); os.IsNotExist(err) {
 		e := os.MkdirAll(fmt.Sprintf("./testdata/%s", folder), 0755)

--- a/pkg/agent/const.go
+++ b/pkg/agent/const.go
@@ -206,10 +206,3 @@ const (
 	// AppGwIngressAddonName appgw addon
 	AppGwIngressAddonName = "appgw-ingress"
 )
-
-const (
-	// VMSSInstanceErrorCode is used to parse vmss instance error code
-	VMSSInstanceErrorCode = "vmssInstanceErrorCode"
-	// InvalidCSEMessage is the error code for vmss cse invalid message
-	InvalidCSEMessage = "InvalidCSEMessage"
-)

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -1824,12 +1824,37 @@ type KubeletWebhookAuthorization struct {
 	// +optional
 	CacheUnauthorizedTTL Duration `json:"cacheUnauthorizedTTL,omitempty"`
 }
-
-type VMSSInstanceViewCSEStatus struct {
-	// ExitCode stores the exitCode from VMSS CSE output.
+type CSEStatus struct {
+	// ExitCode stores the exitCode from CSE output.
 	ExitCode string `json:"exitCode,omitempty"`
-	// Output stores the output from VMSS CSE output.
+	// Output stores the output from CSE output.
 	Output string `json:"output,omitempty"`
-	// Error stores the error from VMSS CSE output.
+	// Error stores the error from CSE output.
 	Error string `json:"error,omitempty"`
+	// ExecDuration stores the execDuration from CSE output.
+	ExecDuration int `json:"execDuration,omitempty"`
+}
+
+type CSEStatusParsingErrorCode string
+
+const (
+	// CSEMessageUnmarshalError is the error code for unmarshal cse message
+	CSEMessageUnmarshalError CSEStatusParsingErrorCode = "CSEMessageUnmarshalError"
+	// CSEMessageExitCodeEmptyError is the error code for empty cse message exit code
+	CSEMessageExitCodeEmptyError CSEStatusParsingErrorCode = "CSEMessageExitCodeEmptyError"
+	// InvalidCSEMessage is the error code for cse invalid message
+	InvalidCSEMessage CSEStatusParsingErrorCode = "InvalidCSEMessage"
+)
+
+type CSEStatusParsingError struct {
+	Code    CSEStatusParsingErrorCode
+	Message string
+}
+
+func NewError(code CSEStatusParsingErrorCode, message string) *CSEStatusParsingError {
+	return &CSEStatusParsingError{Code: code, Message: message}
+}
+
+func (err *CSEStatusParsingError) Error() string {
+	return fmt.Sprintf("CSE has invalid message=%q, InstanceErrorCode=%s", err.Message, err.Code)
 }


### PR DESCRIPTION
* rename ParseCSE

* change comment to ParseCSE

* make parseCSEMessage general

* fix some minor comments

* create a new error struct

* make error specific

Co-authored-by: Jianping Zeng <jizen@microsoft.com>