### PR TITLE
chore: Update Azure CNI to v1.2.7

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -148,10 +148,9 @@ function Get-FilesToCacheOnVHD {
             "https://acs-mirror.azureedge.net/kubernetes/v1.20.2/windowszip/v1.20.2-1int.zip"
         );
         "c:\akse-cache\win-vnet-cni\" = @(
-            "https://acs-mirror.azureedge.net/azure-cni/v1.2.0/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.0.zip",
-            "https://acs-mirror.azureedge.net/azure-cni/v1.2.0_hotfix/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.0_hotfix.zip",
             "https://acs-mirror.azureedge.net/azure-cni/v1.2.2/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.2.zip",
-            "https://acs-mirror.azureedge.net/azure-cni/v1.2.6/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.6.zip"
+            "https://acs-mirror.azureedge.net/azure-cni/v1.2.6/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.6.zip",
+            "https://acs-mirror.azureedge.net/azure-cni/v1.2.7/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.7.zip"
         );
         "c:\akse-cache\calico\" = @(
             "https://acs-mirror.azureedge.net/calico-node/v3.17.1/binaries/calico-windows-v3.17.1.zip",

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -105,6 +105,7 @@ cat << EOF >> ${VHD_LOGS_FILEPATH}
 EOF
 
 VNET_CNI_VERSIONS="
+1.2.7
 1.2.6
 1.2.0_hotfix
 1.2.0

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -108,7 +108,6 @@ VNET_CNI_VERSIONS="
 1.2.7
 1.2.6
 1.2.0_hotfix
-1.2.0
 "
 for VNET_CNI_VERSION in $VNET_CNI_VERSIONS; do
     VNET_CNI_PLUGINS_URL="https://acs-mirror.azureedge.net/azure-cni/v${VNET_CNI_VERSION}/binaries/azure-vnet-cni-linux-amd64-v${VNET_CNI_VERSION}.tgz"
@@ -118,6 +117,7 @@ done
 
 # merge with above after two more version releases
 SWIFT_CNI_VERSIONS="
+1.2.7
 1.2.6
 "
 

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -116,7 +116,7 @@ filesToDownload='
   "fileName":"azure-vnet-cni-linux-amd64-v*.tgz",
   "downloadLocation":"/opt/cni/downloads",
   "downloadURL":"https://acs-mirror.azureedge.net/azure-cni/v*/binaries",
-  "versions":["1.2.6", "1.2.0_hotfix","1.2.0"]
+  "versions":["1.2.7", "1.2.6", "1.2.0_hotfix","1.2.0"]
 },
 {
   "fileName":"azure-vnet-cni-swift-linux-amd64-v*.tgz",

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -116,13 +116,13 @@ filesToDownload='
   "fileName":"azure-vnet-cni-linux-amd64-v*.tgz",
   "downloadLocation":"/opt/cni/downloads",
   "downloadURL":"https://acs-mirror.azureedge.net/azure-cni/v*/binaries",
-  "versions":["1.2.7", "1.2.6", "1.2.0_hotfix","1.2.0"]
+  "versions":["1.2.7", "1.2.6", "1.2.0_hotfix"]
 },
 {
   "fileName":"azure-vnet-cni-swift-linux-amd64-v*.tgz",
   "downloadLocation":"/opt/cni/downloads",
   "downloadURL":"https://acs-mirror.azureedge.net/azure-cni/v*/binaries",
-  "versions":["1.2.6"]
+  "versions":["1.2.7", "1.2.6"]
 },
 {
   "fileName":"v*/bpftrace-tools.tar",

--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -89,10 +89,9 @@ function Test-FilesToCacheOnVHD
             "https://acs-mirror.azureedge.net/kubernetes/v1.20.2/windowszip/v1.20.2-1int.zip"
         );
         "c:\akse-cache\win-vnet-cni\" = @(
-            "https://acs-mirror.azureedge.net/azure-cni/v1.2.0/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.0.zip",
-            "https://acs-mirror.azureedge.net/azure-cni/v1.2.0_hotfix/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.0_hotfix.zip",
             "https://acs-mirror.azureedge.net/azure-cni/v1.2.2/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.2.zip",
-            "https://acs-mirror.azureedge.net/azure-cni/v1.2.6/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.6.zip"
+            "https://acs-mirror.azureedge.net/azure-cni/v1.2.6/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.6.zip",
+            "https://acs-mirror.azureedge.net/azure-cni/v1.2.7/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.7.zip"
         );
         "c:\akse-cache\calico\" = @(
             "https://acs-mirror.azureedge.net/calico-node/v3.17.1/binaries/calico-windows-v3.17.1.zip",


### PR DESCRIPTION
Update Azure CNI to [v1.2.7](https://github.com/Azure/azure-container-networking/releases/tag/v1.2.7)