### PR TITLE
chore: enlarge sig timout

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -31,7 +31,7 @@ function DownloadFileWithRetry {
     )
     curl.exe -f --retry $retryCount --retry-delay $retryDelay -L $URL -o $Dest
     if (-not $?) {
-        throw "Curl exited with '$LASTEXITCODE' while attemping to downlaod '$URL'"
+        throw "Curl exited with '$LASTEXITCODE' while attemping to download '$URL'"
     }
 }
 

--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -91,7 +91,7 @@ fi
 
 # considerations to also add the windows support here instead of an extra script to initialize windows variables:
 # 1. we can demonstrate the whole user defined parameters all at once
-# 2. help us keep in mind that changes of this variables will influence both windows and linux VHD building
+# 2. help us keep in mind that changes of these variables will influence both windows and linux VHD building
 
 # windows image sku and windows image version are recorded in code instead of pipeline variables
 # because a pr gives a better chance to take a review of the version changes.

--- a/vhdbuilder/packer/vhd-image-builder-sig.json
+++ b/vhdbuilder/packer/vhd-image-builder-sig.json
@@ -41,6 +41,7 @@
       "vm_size": "{{user `vm_size`}}",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_name": "{{user `sig_image_name`}}",
+      "polling_duration_timeout": "1h",
       "shared_image_gallery_destination": {
         "resource_group": "{{user `resource_group_name`}}",
         "gallery_name": "{{user `sig_gallery_name`}}",

--- a/vhdbuilder/packer/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows-vhd-builder-sig.json
@@ -44,7 +44,7 @@
                     "{{user `location`}}"
                 ]
             },
-            "shared_image_gallery_timeout": "2h",
+            "polling_duration_timeout": "1h",
             "communicator": "winrm",
             "winrm_use_ssl": true,
             "winrm_insecure": true,

--- a/vhdbuilder/packer/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows-vhd-builder-sig.json
@@ -105,7 +105,8 @@
                 "BUILD_COMMIT={{user `build_commit`}}",
                 "BUILD_ID={{user `build_id`}}",
                 "BUILD_NUMBER={{user `build_number`}}",
-                "BUILD_REPO={{user `build_repo`}}"
+                "BUILD_REPO={{user `build_repo`}}",
+                "ContainerRuntime={{user `container_runtime`}}"
             ],
             "type": "powershell",
             "script": "vhdbuilder/packer/write-release-notes-windows.ps1"

--- a/vhdbuilder/packer/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows-vhd-builder-sig.json
@@ -1,4 +1,3 @@
-
 {
     "variables": {
         "build_branch": "{{env `GIT_BRANCH`}}",
@@ -37,13 +36,15 @@
             "managed_image_resource_group_name": "{{user `resource_group_name`}}",
             "managed_image_name": "{{user `sig_image_name`}}",
             "shared_image_gallery_destination": {
-              "resource_group": "{{user `resource_group_name`}}",
-              "gallery_name": "{{user `sig_gallery_name`}}",
-              "image_name": "{{user `sig_image_name`}}",
-              "image_version": "{{user `sig_image_version`}}",
-              "replication_regions": ["{{user `location`}}"]
+                "resource_group": "{{user `resource_group_name`}}",
+                "gallery_name": "{{user `sig_gallery_name`}}",
+                "image_name": "{{user `sig_image_name`}}",
+                "image_version": "{{user `sig_image_version`}}",
+                "replication_regions": [
+                    "{{user `location`}}"
+                ]
             },
-	    "shared_image_gallery_timeout": "1h30m",
+            "shared_image_gallery_timeout": "2h",
             "communicator": "winrm",
             "winrm_use_ssl": true,
             "winrm_insecure": true,
@@ -100,7 +101,7 @@
         {
             "elevated_user": "packer",
             "elevated_password": "{{.WinRMPassword}}",
-            "environment_vars" : [
+            "environment_vars": [
                 "BUILD_BRANCH={{user `build_branch`}}",
                 "BUILD_COMMIT={{user `build_commit`}}",
                 "BUILD_ID={{user `build_id`}}",

--- a/vhdbuilder/packer/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows-vhd-builder-sig.json
@@ -43,6 +43,7 @@
               "image_version": "{{user `sig_image_version`}}",
               "replication_regions": ["{{user `location`}}"]
             },
+	    "shared_image_gallery_timeout": "1h30m",
             "communicator": "winrm",
             "winrm_use_ssl": true,
             "winrm_insecure": true,


### PR DESCRIPTION
When building SIG image in our SIG mode pipeline,  sig image creation time out occurs frequently. The answer to this is that `shared_image_gallery_timeout` with default value 1hour is overwritten by `polling_duration_timeout` which actually defaults to 15 minutes, and the sig image creation is normally more than 15 minutes, but 30 minutes or so.
I have a [fix of this issue in packer](https://github.com/hashicorp/packer/pull/10816), but to not block our more incoming sig image test, I here use polling_duration_timeout instead. Also, as the SIG image pipeline is for testing, not for production, the influence is limited.