### PR TITLE
get us the newest cni plugins for kubenet

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -319,9 +319,8 @@
       "downloadLocation": "/opt/cni/downloads",
       "downloadURL": "https://acs-mirror.azureedge.net/cni",
       "versions": [
-        "0.7.6",
-        "0.7.5",
-        "0.7.1"
+        "0.9.1",
+        "0.7.6"
       ]
     },
     {


### PR DESCRIPTION
Cache latest cni plugins for kubenet in vhd. 

0.9.1 is both the lastest and what aks-engine currently uses. 