### PR TITLE
Update image - removes owner references for cluster v1.20 compatibility

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -287,7 +287,8 @@
       "downloadURL": "mcr.microsoft.com/azure-policy/policy-kubernetes-addon-prod:*",
       "versions": [
         "prod_20201015.1",
-        "prod_20210216.1"
+        "prod_20210216.1",
+        "prod_20210325.1"
       ]
     },
     {


### PR DESCRIPTION
This new image removes owner references from resources created by the addon because v1.20 clusters have conflicts with cross-namespaced owner references. They are not needed anymore as root issue with gatekeeper has been fixed.