### PR TITLE
Remove IsUbuntu OSSKU check

### DIFF
--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -390,9 +390,6 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 		"IsMariner": func() bool {
 			return strings.EqualFold(string(config.OSSKU), string("CBLMariner"))
 		},
-		"IsUbuntu": func() bool {
-			return strings.EqualFold(string(config.OSSKU), string("Ubuntu"))
-		},
 		"IsPrivateCluster": func() bool {
 			return cs.Properties.OrchestratorProfile.IsPrivateCluster()
 		},


### PR DESCRIPTION
Currently most clusters do not have an OSSKU property set, so checking OSSKU=Ubuntu isnt a good indicator of IsUbuntu. Since the function is not used anywhere yet, remove it for now to avoid confusion.