### PR TITLE
Change execDuration to correct type

### DIFF
--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -1810,7 +1810,7 @@ type CSEStatus struct {
 	// Error stores the error from CSE output.
 	Error string `json:"error,omitempty"`
 	// ExecDuration stores the execDuration from CSE output.
-	ExecDuration int `json:"execDuration,omitempty"`
+	ExecDuration string `json:"execDuration,omitempty"`
 }
 
 type CSEStatusParsingErrorCode string

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -197,7 +197,7 @@ func TestGetTLSBootstrapTokenForKubeConfig(t *testing.T) {
 
 var _ = Describe("Assert ParseCSE", func() {
 	It("when cse output format is correct", func() {
-		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Enable failed:\n[stdout]\n{ \"ExitCode\": \"51\", \"Output\": \"test\", \"Error\": \"\"}\n\n[stderr]\n"
+		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Enable failed:\n[stdout]\n{ \"ExitCode\": \"51\", \"Output\": \"test\", \"Error\": \"\", \"ExecDuration\": \"39\"}\n\n[stderr]\n"
 		res, err := ParseCSEMessage(testMessage)
 		Expect(err).To(BeNil())
 		Expect(res.ExitCode).To(Equal("51"))
@@ -218,7 +218,7 @@ var _ = Describe("Assert ParseCSE", func() {
 	})
 
 	It("when cse output exitcode is empty", func() {
-		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Enable failed:\n[stdout]\n{ \"ExitCode\": , \"Output\": \"test\", \"Error\": \"\"}\n\n[stderr]\n"
+		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Enable failed:\n[stdout]\n{ \"ExitCode\": \"51\", \"Output\": \"test\", \"Error\": \"\", \"ExecDuration\": 39}\n\n[stderr]\n"
 		_, err := ParseCSEMessage(testMessage)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(ContainSubstring("InstanceErrorCode=CSEMessageUnmarshalError"))


### PR DESCRIPTION
Have CSEMessageUnmarshalError for message { "ExitCode": "0", "Output": "test", "Error": "", "ExecDuration": "39" }. Change ExecDuration type from int to string to fix this.