### PR TITLE
cherrypick Change execDuration to correct type (#718)

### DIFF
--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -1809,8 +1809,8 @@ type CSEStatus struct {
 	Output string `json:"output,omitempty"`
 	// Error stores the error from CSE output.
 	Error string `json:"error,omitempty"`
-	// ExecDuration stores the execDuration from CSE output.
-	ExecDuration int `json:"execDuration,omitempty"`
+	// ExecDuration stores the execDuration in seconds from CSE output.
+	ExecDuration string `json:"execDuration,omitempty"`
 }
 
 type CSEStatusParsingErrorCode string

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -197,10 +197,13 @@ func TestGetTLSBootstrapTokenForKubeConfig(t *testing.T) {
 
 var _ = Describe("Assert ParseCSE", func() {
 	It("when cse output format is correct", func() {
-		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Enable failed:\n[stdout]\n{ \"ExitCode\": \"51\", \"Output\": \"test\", \"Error\": \"\"}\n\n[stderr]\n"
+		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Enable failed:\n[stdout]\n{ \"ExitCode\": \"51\", \"Output\": \"test\", \"Error\": \"\", \"ExecDuration\": \"39\"}\n\n[stderr]\n"
 		res, err := ParseCSEMessage(testMessage)
 		Expect(err).To(BeNil())
 		Expect(res.ExitCode).To(Equal("51"))
+		Expect(res.Output).To(Equal("test"))
+		Expect(res.Error).To(Equal(""))
+		Expect(res.ExecDuration).To(Equal("39"))
 	})
 
 	It("when cse output format is incorrect", func() {
@@ -218,7 +221,14 @@ var _ = Describe("Assert ParseCSE", func() {
 	})
 
 	It("when cse output exitcode is empty", func() {
-		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Enable failed:\n[stdout]\n{ \"ExitCode\": , \"Output\": \"test\", \"Error\": \"\"}\n\n[stderr]\n"
+		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Enable failed:\n[stdout]\n{ \"ExitCode\": , \"Output\": \"test\", \"Error\": \"\", \"ExecDuration\": \"39\"}\n\n[stderr]\n"
+		_, err := ParseCSEMessage(testMessage)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring("InstanceErrorCode=CSEMessageUnmarshalError"))
+	})
+
+	It("when ExecDuration is integer", func() {
+		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Enable failed:\n[stdout]\n{ \"ExitCode\": \"51\", \"Output\": \"test\", \"Error\": \"\", \"ExecDuration\": 39}\n\n[stderr]\n"
 		_, err := ParseCSEMessage(testMessage)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(ContainSubstring("InstanceErrorCode=CSEMessageUnmarshalError"))


### PR DESCRIPTION
* Change execDuration to correct type

* validate all fields in test

* update ExecDuration comment

* add another test when ExecDuration is int

Co-authored-by: Jianping Zeng <jizen@microsoft.com>