### PR TITLE
chore: update secrets store csi driver related images

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -119,13 +119,15 @@
     {
       "downloadURL": "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:*",
       "versions": [
-        "v0.0.19"
+        "v0.0.19",
+        "v0.0.21"
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:*",
       "versions": [
-        "0.0.12"
+        "0.0.12",
+        "0.0.14"
       ]
     },
     {

--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -78,7 +78,9 @@ function Get-ContainerImages {
                 "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.0.0",
                 "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.1.0",
                 "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.1.1",
-                "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.0.0")
+                "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.0.0",
+                "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.21",
+                "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.14")
             Write-Log "Pulling images for windows server 2019"
         }
         '2004' {

--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -186,7 +186,9 @@ function Test-ImagesPulled {
                 "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.0.0",
                 "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.1.0",
                 "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.1.1",
-                "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.0.0")
+                "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.0.0",
+                "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.21",
+                "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.14")
             Write-Output "Pulling images for windows server 2019"
         }
         '2004' {


### PR DESCRIPTION
update secrets-store-provider-azure to 0.0.14 and secrets-store-csi-driver to v0.0.21