### PR TITLE
Increase SIG publish timeout to 90m in packer

### DIFF
--- a/vhdbuilder/packer/vhd-image-builder-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-gen2.json
@@ -46,7 +46,8 @@
         "replication_regions": [
           "{{user `location`}}"
         ]
-      }
+      },
+      "shared_image_gallery_timeout": "90m"
     }
   ],
   "provisioners": [

--- a/vhdbuilder/packer/vhd-image-builder-mariner-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-gen2.json
@@ -49,7 +49,8 @@
         "replication_regions": [
           "{{user `location`}}"
         ]
-      }
+      },
+      "shared_image_gallery_timeout": "90m"
     }
   ],
   "provisioners": [

--- a/vhdbuilder/packer/vhd-image-builder-sig.json
+++ b/vhdbuilder/packer/vhd-image-builder-sig.json
@@ -50,7 +50,8 @@
         "replication_regions": [
           "{{user `location`}}"
         ]
-      }
+      },
+      "shared_image_gallery_timeout": "90m"
     }
   ],
   "provisioners": [

--- a/vhdbuilder/packer/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows-vhd-builder-sig.json
@@ -44,6 +44,7 @@
                     "{{user `location`}}"
                 ]
             },
+            "shared_image_gallery_timeout": "90m",
             "polling_duration_timeout": "1h",
             "communicator": "winrm",
             "winrm_use_ssl": true,


### PR DESCRIPTION
As sometimes creating sig image will take more than the default value 60m

https://www.packer.io/docs/builders/azure/arm#shared_image_gallery_timeout