### PR TITLE
doc: Add release notes for AKS Windows VHD with 4B

### DIFF
--- a/vhdbuilder/release-notes/AKSWindows/2019-containerd/17763.1879.20210414.txt
+++ b/vhdbuilder/release-notes/AKSWindows/2019-containerd/17763.1879.20210414.txt
@@ -1,0 +1,143 @@
+﻿Build Number: 20210414.2_master_41415967
+Build Id:     41415967
+Build Repo:   https://github.com/Azure/AgentBaker
+Build Branch: master
+Commit:       db3d80efc38b88c4188b5dec8947a26ea7d6c41f
+
+VHD ID:      84cdc748-7de0-483b-bf76-dd89e3eb7229
+
+System Info
+	OS Name        : Windows Server 2019 Datacenter
+	OS Version     : 17763.1879
+	OS InstallType : Server Core
+
+Allowed security protocols: Tls, Tls11, Tls12
+
+Installed Features
+
+Display Name                                            Name                       Install State
+------------                                            ----                       -------------
+[X] File and Storage Services                           FileAndStorage-Services        Installed
+    [X] Storage Services                                Storage-Services               Installed
+[X] Hyper-V                                             Hyper-V                        Installed
+[X] .NET Framework 4.7 Features                         NET-Framework-45-Fea...        Installed
+    [X] .NET Framework 4.7                              NET-Framework-45-Core          Installed
+    [X] WCF Services                                    NET-WCF-Services45             Installed
+        [X] TCP Port Sharing                            NET-WCF-TCP-PortShar...        Installed
+[X] BitLocker Drive Encryption                          BitLocker                      Installed
+[X] Containers                                          Containers                     Installed
+[X] Enhanced Storage                                    EnhancedStorage                Installed
+[X] Remote Server Administration Tools                  RSAT                           Installed
+    [X] Role Administration Tools                       RSAT-Role-Tools                Installed
+        [X] Hyper-V Management Tools                    RSAT-Hyper-V-Tools             Installed
+            [X] Hyper-V Module for Windows PowerShell   Hyper-V-PowerShell             Installed
+[X] System Data Archiver                                System-DataArchiver            Installed
+[X] Windows Defender Antivirus                          Windows-Defender               Installed
+[X] Windows PowerShell                                  PowerShellRoot                 Installed
+    [X] Windows PowerShell 5.1                          PowerShell                     Installed
+[X] WoW64 Support                                       WoW64-Support                  Installed
+
+
+
+Installed Packages
+	Language.Basic~~~en-US~0.0.1.0
+	Language.Handwriting~~~en-US~0.0.1.0
+	Language.OCR~~~en-US~0.0.1.0
+	Language.Speech~~~en-US~0.0.1.0
+	Language.TextToSpeech~~~en-US~0.0.1.0
+	MathRecognizer~~~~0.0.1.0
+	OpenSSH.Client~~~~0.0.1.0
+	OpenSSH.Server~~~~0.0.1.0
+
+Installed QFEs
+	KB4601060 : Update          : http://support.microsoft.com/?kbid=4601060
+	KB5000859 : Security Update : http://support.microsoft.com/?kbid=5000859
+	KB5001342 : Security Update : http://support.microsoft.com/?kbid=5001342
+
+Installed Updates
+	Update for Windows Defender Antivirus antimalware platform - KB4052623 (Version 4.18.2001.10)
+	2021-02 Cumulative Update for .NET Framework 3.5, 4.7.2 and 4.8 for Windows Server 2019 for x64 (KB4601887)
+	Update for Microsoft Defender Antivirus antimalware platform - KB4052623 (Version 4.18.2103.7)
+	Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.335.823.0)
+	2021-04 Cumulative Update for Windows Server 2019 (1809) for x64-based Systems (KB5001342)
+
+Windows Update Registry Settings
+	https://docs.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+		NoAutoUpdate : 1
+
+ContainerD Info
+Version: ctr github.com/containerd/containerd 1.4.4+unknown
+
+Images:
+REF                                                                                              TYPE                                                      DIGEST                                                                  SIZE      PLATFORMS                 LABELS                          
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.12                                  application/vnd.docker.distribution.manifest.list.v2+json sha256:6f67f3d0c7cdde5702f8ce7f101b6519daa0237f0c34fecb7c058b6af8c22ad1 197.2 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.14                                  application/vnd.docker.distribution.manifest.list.v2+json sha256:14a3992d2d2f75a2ff79220c795ea21b53b187b67dc0c05bf83a5106fbaafbcf 107.7 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.0.0                                        application/vnd.docker.distribution.manifest.list.v2+json sha256:dfe6f6bf8f0650483ef52608930901687040083af65ebb258aa1f0ca7d7353fc 120.1 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.1.0                                        application/vnd.docker.distribution.manifest.list.v2+json sha256:1e48027365bff72cbb03aa7476f09c4554926607e69f8177b5f2014a441597cc 120.1 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.1.1                                        application/vnd.docker.distribution.manifest.list.v2+json sha256:dcac9ab27e9dbfa9776fd53e6547ebd8644ee961392f667b6e28a47d057cf849 120.1 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.0.0                                        application/vnd.docker.distribution.manifest.list.v2+json sha256:c4ca65cf10edef544b4713bf0bc7ae55ac273c9aa19801329014e5b5631af140 111.0 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.2.1-alpha.1-windows-1809-amd64 application/vnd.docker.distribution.manifest.v2+json      sha256:92dd20279c1e36282bd52e3db2679297921d517ffe4e98025c0370ce25a03fac 103.1 MiB windows/amd64             io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.0.1                            application/vnd.docker.distribution.manifest.list.v2+json sha256:fc5d14e9f26fe9a014c1fa348c6632412424b834b8cbf9a968af5a9599a818c1 106.9 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.0.1-alpha.1-windows-1809-amd64             application/vnd.docker.distribution.manifest.v2+json      sha256:d07f92ef2517c99cd011391ab1182c995cdd04ec01e47324abf07ea502476409 102.8 MiB windows/amd64             io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.2.0                                        application/vnd.docker.distribution.manifest.list.v2+json sha256:b7d82802cca8523df1d5973332c64d558fe352617926fd01707b17e2f022755f 107.1 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.19                                application/vnd.docker.distribution.manifest.list.v2+json sha256:c0d040a1c4fbfceb65663e31c09ea40f4f78e356437610cbc3fbb4bb409bd6f1 119.4 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.21                                application/vnd.docker.distribution.manifest.list.v2+json sha256:a0528bd855b1a8246252d6850218efc705d00aaa73489820f5f0e458b92fa36f 119.5 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.5.1                                 application/vnd.docker.distribution.manifest.list.v2+json sha256:0f0c53b4d1231c7ff062ec4453fa6bb5fe1a9df81379207ad87c734eff635604 109.3 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.6.0                                 application/vnd.docker.distribution.manifest.list.v2+json sha256:6a32329628bdea3c6d75e98aad6155b65d2e2b98ca616eb33f9ac562912804c6 108.3 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.0                                 application/vnd.docker.distribution.manifest.list.v2+json sha256:dc9f5c9fc51e19ea27ed67237ce7e665376f4a6a06e175dac4a9963b45f4521c 111.9 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/pause:1.4.1                                                     application/vnd.docker.distribution.manifest.list.v2+json sha256:e075a40446ece06b77075d247bbf027c039c26b956418b1c5b605330be1217f9 102.3 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/nanoserver:1809                                                        application/vnd.docker.distribution.manifest.list.v2+json sha256:8746dc8b6726d53ba7176332580712c2c5622290b2b44345ded8e302356203ac 96.6 MiB  windows/amd64,windows/arm io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/servercore:ltsc2019                                                    application/vnd.docker.distribution.manifest.list.v2+json sha256:1bb6543a7fe87bb95d9adfa4c53ea3469c1c846ad63baf32729078062e8c1127 2.3 GiB   windows/amd64             io.cri-containerd.image=managed 
+sha256:077fe47c8702ab4f09ae9fbe6d11777dcdf7d0b111b9edf406c2c3c0c8f77058                          application/vnd.docker.distribution.manifest.list.v2+json sha256:fc5d14e9f26fe9a014c1fa348c6632412424b834b8cbf9a968af5a9599a818c1 106.9 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+sha256:0ac0b63922f868afcd5f5db1d25ca24a809550b54a1c6c4873155224df018732                          application/vnd.docker.distribution.manifest.list.v2+json sha256:e075a40446ece06b77075d247bbf027c039c26b956418b1c5b605330be1217f9 102.3 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+sha256:152749f71f8fd6004056d15c7fd5791563072703171eb8dbd3e66b2ee67f8287                          application/vnd.docker.distribution.manifest.list.v2+json sha256:1bb6543a7fe87bb95d9adfa4c53ea3469c1c846ad63baf32729078062e8c1127 2.3 GiB   windows/amd64             io.cri-containerd.image=managed 
+sha256:5513a3d12ed6ee8ff7a6c66b4992ae79bb5e0bd9c632721eb8947ea13929d83f                          application/vnd.docker.distribution.manifest.list.v2+json sha256:8746dc8b6726d53ba7176332580712c2c5622290b2b44345ded8e302356203ac 96.6 MiB  windows/amd64,windows/arm io.cri-containerd.image=managed 
+sha256:5da9b97692475de2cc717b91b6badc2ba5fce1ef4a992ec6c3a0d9987f4d1b95                          application/vnd.docker.distribution.manifest.list.v2+json sha256:a0528bd855b1a8246252d6850218efc705d00aaa73489820f5f0e458b92fa36f 119.5 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+sha256:5e6dfdfe4bea95d6b03f6661635c1e7712fb674fcf65d2cdbdb0fd171a4f9629                          application/vnd.docker.distribution.manifest.list.v2+json sha256:6a32329628bdea3c6d75e98aad6155b65d2e2b98ca616eb33f9ac562912804c6 108.3 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+sha256:6db76cecfbae97dda7d7f020f2e9f82882a085aaf0a7ed3b046812d4367d08a4                          application/vnd.docker.distribution.manifest.list.v2+json sha256:0f0c53b4d1231c7ff062ec4453fa6bb5fe1a9df81379207ad87c734eff635604 109.3 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+sha256:7c4afdb7e0d6815fdaeb0ce25a07a2e69137401e937eea875a3c9860664c39bb                          application/vnd.docker.distribution.manifest.v2+json      sha256:d07f92ef2517c99cd011391ab1182c995cdd04ec01e47324abf07ea502476409 102.8 MiB windows/amd64             io.cri-containerd.image=managed 
+sha256:84162105ffe3375bb0493c4026d85adeb16a658c3551310a8d5b4e4983ab40d9                          application/vnd.docker.distribution.manifest.list.v2+json sha256:14a3992d2d2f75a2ff79220c795ea21b53b187b67dc0c05bf83a5106fbaafbcf 107.7 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+sha256:86febeaaf8648c734eed70ae48f96d91b98d3063572f892b0ae1b1d6414a1b37                          application/vnd.docker.distribution.manifest.list.v2+json sha256:1e48027365bff72cbb03aa7476f09c4554926607e69f8177b5f2014a441597cc 120.1 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+sha256:927caec05c10d03cbb7a95d733980d7a5e02edbd79a95448c9a5bb582ddfa684                          application/vnd.docker.distribution.manifest.v2+json      sha256:92dd20279c1e36282bd52e3db2679297921d517ffe4e98025c0370ce25a03fac 103.1 MiB windows/amd64             io.cri-containerd.image=managed 
+sha256:978d75aa605732dd92a7cacc3dd8fa6087e7852b9e9843abccc666d0fcf9f5e2                          application/vnd.docker.distribution.manifest.list.v2+json sha256:b7d82802cca8523df1d5973332c64d558fe352617926fd01707b17e2f022755f 107.1 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+sha256:bc1b7c74446d06b36da6bedd570563aca939465edfaebbad43dcf30102dc95fe                          application/vnd.docker.distribution.manifest.list.v2+json sha256:6f67f3d0c7cdde5702f8ce7f101b6519daa0237f0c34fecb7c058b6af8c22ad1 197.2 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+sha256:ca273de9d00e285648a7aaf9ea70cd9aec841f27cb14fc705df7329be0507c6d                          application/vnd.docker.distribution.manifest.list.v2+json sha256:c0d040a1c4fbfceb65663e31c09ea40f4f78e356437610cbc3fbb4bb409bd6f1 119.4 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+sha256:cc6fa6a61f3147f7860268c50662a62cf55ec93e6de6ba72cc8d06bb5441ccbf                          application/vnd.docker.distribution.manifest.list.v2+json sha256:c4ca65cf10edef544b4713bf0bc7ae55ac273c9aa19801329014e5b5631af140 111.0 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+sha256:f401c064d0b828ba247c8dc3ba0cb396a82001d0a66a17cbc8830195639d8b87                          application/vnd.docker.distribution.manifest.list.v2+json sha256:dcac9ab27e9dbfa9776fd53e6547ebd8644ee961392f667b6e28a47d057cf849 120.1 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+sha256:fbbb262cc532a7b9c51d19c77c7727a04ed8c1a59ed0417d3dcf16910978c28d                          application/vnd.docker.distribution.manifest.list.v2+json sha256:dfe6f6bf8f0650483ef52608930901687040083af65ebb258aa1f0ca7d7353fc 120.1 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+sha256:fdcd17879102c0450b16a6ba7791a558fdceaa39c10a212304c1bd085ce44dcb                          application/vnd.docker.distribution.manifest.list.v2+json sha256:dc9f5c9fc51e19ea27ed67237ce7e665376f4a6a06e175dac4a9963b45f4521c 111.9 MiB linux/amd64,windows/amd64 io.cri-containerd.image=managed 
+
+Cached Files:
+
+File                                                                             Sha256                                                           SizeBytes
+----                                                                             ------                                                           ---------
+c:\akse-cache\collect-windows-logs.ps1                                           AE433C3BE3B5CB372EC868D9E81FE4BAFBBCABE578C8C5B6CA1317416AA2651B      6943
+c:\akse-cache\collectlogs.ps1                                                    D8DF35E2AB1DBA4B163F5EF0A6DB05EFD52E4FFF87FD3B2B2888C1548499AC71      8990
+c:\akse-cache\dumpVfpPolicies.ps1                                                02BFF0235421F1C8477E809B8EB354B313C348CE2732C4842B710239CD6FE665      1642
+c:\akse-cache\helper.psm1                                                        BC45AA98FA40D51C4E8640865C329BDC4B522EA53CC17A5F0B512B4D44058C8C     17945
+c:\akse-cache\hns.psm1                                                           A8A53ED4FAC2E27C7E4268DB069D4CF3129A56D466EF3BF9465FB52DCD76A29C     14733
+c:\akse-cache\microsoft.applicationinsights.2.11.0.nupkg                         4B0448F9640FCD84979D6CE736348EE9304A7A069F77E38FF411F3211E699C68    776442
+c:\akse-cache\portReservationTest.ps1                                            0940BA8A0A564E5937F60871F7F87C866C8617882D121FF33BBB0798B0C82AC0      4370
+c:\akse-cache\signedscripts-v0.0.10.zip                                          429A25ECB5CF2664033024BC9AEB49148F036D97E06C495CC8DC663531AC5F8C     69937
+c:\akse-cache\signedscripts-v0.0.12.zip                                          862D8ADEC368C83AC991448DD152CDAB657219BC1E0BA4D153A5943C72694303     70802
+c:\akse-cache\signedscripts-v0.0.8.zip                                           7ECB7708127D337F6F641ECFE7B9838E07B4E5EDB8D9BBD66728F07E296C9930     61725
+c:\akse-cache\starthnstrace.cmd                                                  2E0A5D9F8866BC2F3DAAF84AB8F166CCFF243D044E9C9121DF888ACE98033048       591
+c:\akse-cache\startpacketcapture.cmd                                             3E31690E507C8B18AC5CC569C89B51CE1901630A501472DA1BC1FBF2737AA5BC       756
+c:\akse-cache\stoppacketcapture.cmd                                              BD966D7738A3C0FC73E651BAF196C0FB60D889F1180B2D114F8EA3F8A8453C3D        17
+c:\akse-cache\VFP.psm1                                                           3F2F44BD4B3219E8BB29EB9F8958EC96F2C8DDCEF556E995790B6476231A92DB      9616
+c:\akse-cache\win-bridge.exe                                                     CA12506E55DF3E3428B29994AE1FC8131DDFBB6838A550DFA22287CDC6548634   9599488
+c:\akse-cache\calico\calico-windows-v3.17.2.zip                                  1112432007D25BE160A3CCA8594F231D96A554CC8218430E8860529236DF7C14  64457853
+c:\akse-cache\calico\calico-windows-v3.18.1.zip                                  00895B3F052AC69638EE287EDC279AB6D97EE6D87B669130A79A315F99EE54D3  65609273
+c:\akse-cache\containerd\containerd-v0.0.1-windows-amd64.tar.gz                  2F040594701D398D163D17E87928D40294465D6BF202C84C7CE56A8E3856C481  61578716
+c:\akse-cache\csi-proxy\csi-proxy-v0.2.2.tar.gz                                  60BF51D4FB425386C235ABC3BCBD50D70C23CACB94C32A77509DA91CF0F066AD   6481034
+c:\akse-cache\win-k8s\v1.20.2-hotfix.20210310-1int.zip                           553E8FC348578322E6CCB79B35656E922831F82ED5D7846E08FB7229E4A9FC93  56995444
+c:\akse-cache\win-k8s\v1.20.5-hotfix.20210322-1int.zip                           9B502F037A2F3AD6AD86475EDF5F5BC10885A7E3DF8CA5C715BCBE5F7041E9BA  57030477
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.2.2.zip 52306F546DCB87D266A6DFDBD545982E6292134DEB86B8F90E00485ACFD6B4A1  39555626
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.2.6.zip B2FF69608D97B963F8B0B0631F9E88329B006D954773566F019680DED75B8774  72629816
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.2.7.zip 9AB8FA4C3FBD31429F3D6E5F8D9CE2FF1B192F52F43C5FA1ABA97FEC9BEE9927  72631755
+
+
+
+

--- a/vhdbuilder/release-notes/AKSWindows/2019/17763.1879.20210414.txt
+++ b/vhdbuilder/release-notes/AKSWindows/2019/17763.1879.20210414.txt
@@ -1,0 +1,146 @@
+﻿Build Number: 20210414.2_master_41415967
+Build Id:     41415967
+Build Repo:   https://github.com/Azure/AgentBaker
+Build Branch: master
+Commit:       db3d80efc38b88c4188b5dec8947a26ea7d6c41f
+
+VHD ID:      54e85000-04b6-4d71-badf-5d9339a8eb1b
+
+System Info
+	OS Name        : Windows Server 2019 Datacenter
+	OS Version     : 17763.1879
+	OS InstallType : Server Core
+
+Allowed security protocols: Tls, Tls11, Tls12
+
+Installed Features
+
+Display Name                                            Name                       Install State
+------------                                            ----                       -------------
+[X] File and Storage Services                           FileAndStorage-Services        Installed
+    [X] Storage Services                                Storage-Services               Installed
+[X] Hyper-V                                             Hyper-V                        Installed
+[X] .NET Framework 4.7 Features                         NET-Framework-45-Fea...        Installed
+    [X] .NET Framework 4.7                              NET-Framework-45-Core          Installed
+    [X] WCF Services                                    NET-WCF-Services45             Installed
+        [X] TCP Port Sharing                            NET-WCF-TCP-PortShar...        Installed
+[X] BitLocker Drive Encryption                          BitLocker                      Installed
+[X] Containers                                          Containers                     Installed
+[X] Enhanced Storage                                    EnhancedStorage                Installed
+[X] Remote Server Administration Tools                  RSAT                           Installed
+    [X] Role Administration Tools                       RSAT-Role-Tools                Installed
+        [X] Hyper-V Management Tools                    RSAT-Hyper-V-Tools             Installed
+            [X] Hyper-V Module for Windows PowerShell   Hyper-V-PowerShell             Installed
+[X] System Data Archiver                                System-DataArchiver            Installed
+[X] Windows Defender Antivirus                          Windows-Defender               Installed
+[X] Windows PowerShell                                  PowerShellRoot                 Installed
+    [X] Windows PowerShell 5.1                          PowerShell                     Installed
+[X] WoW64 Support                                       WoW64-Support                  Installed
+
+
+
+Installed Packages
+	Language.Basic~~~en-US~0.0.1.0
+	Language.Handwriting~~~en-US~0.0.1.0
+	Language.OCR~~~en-US~0.0.1.0
+	Language.Speech~~~en-US~0.0.1.0
+	Language.TextToSpeech~~~en-US~0.0.1.0
+	MathRecognizer~~~~0.0.1.0
+	OpenSSH.Client~~~~0.0.1.0
+	OpenSSH.Server~~~~0.0.1.0
+
+Installed QFEs
+	KB4601060 : Update          : http://support.microsoft.com/?kbid=4601060
+	KB5000859 : Security Update : http://support.microsoft.com/?kbid=5000859
+	KB5001342 : Security Update : http://support.microsoft.com/?kbid=5001342
+
+Installed Updates
+	Update for Windows Defender Antivirus antimalware platform - KB4052623 (Version 4.18.2001.10)
+	2021-02 Cumulative Update for .NET Framework 3.5, 4.7.2 and 4.8 for Windows Server 2019 for x64 (KB4601887)
+	Update for Microsoft Defender Antivirus antimalware platform - KB4052623 (Version 4.18.2103.7)
+	Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.335.823.0)
+	2021-04 Cumulative Update for Windows Server 2019 (1809) for x64-based Systems (KB5001342)
+
+Windows Update Registry Settings
+	https://docs.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+		NoAutoUpdate : 1
+
+Docker Info
+Version: Docker version 19.03.14, build e820475
+
+Images:
+
+Repository                                                     Tag                               ID          
+----------                                                     ---                               --          
+mcr.microsoft.com/windows/servercore                           ltsc2019                          152749f71f8f
+mcr.microsoft.com/windows/nanoserver                           1809                              5513a3d12ed6
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure       0.0.14                            84162105ffe3
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver      v0.0.21                           5da9b9769247
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi             v1.1.1                            f401c064d0b8
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi             v1.1.0                            86febeaaf864
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi             v1.0.0                            fbbb262cc532
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi             v1.0.0                            cc6fa6a61f31
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure       0.0.12                            bc1b7c74446d
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver      v0.0.19                           ca273de9d00e
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager      v0.7.0                            fdcd17879102
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe             v2.2.0                            978d75aa6057
+mcr.microsoft.com/oss/kubernetes/pause                         1.4.1                             0ac0b63922f8
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar v2.0.1                            077fe47c8702
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager      v0.6.0                            5e6dfdfe4bea
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager      v0.5.1                            6db76cecfbae
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar v1.2.1-alpha.1-windows-1809-amd64 927caec05c10
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe             v2.0.1-alpha.1-windows-1809-amd64 7c4afdb7e0d6
+
+
+
+Cached Files:
+
+File                                                                             Sha256                                                           SizeBytes
+----                                                                             ------                                                           ---------
+c:\akse-cache\collect-windows-logs.ps1                                           AE433C3BE3B5CB372EC868D9E81FE4BAFBBCABE578C8C5B6CA1317416AA2651B      6943
+c:\akse-cache\collectlogs.ps1                                                    D8DF35E2AB1DBA4B163F5EF0A6DB05EFD52E4FFF87FD3B2B2888C1548499AC71      8990
+c:\akse-cache\dumpVfpPolicies.ps1                                                02BFF0235421F1C8477E809B8EB354B313C348CE2732C4842B710239CD6FE665      1642
+c:\akse-cache\helper.psm1                                                        BC45AA98FA40D51C4E8640865C329BDC4B522EA53CC17A5F0B512B4D44058C8C     17945
+c:\akse-cache\hns.psm1                                                           A8A53ED4FAC2E27C7E4268DB069D4CF3129A56D466EF3BF9465FB52DCD76A29C     14733
+c:\akse-cache\microsoft.applicationinsights.2.11.0.nupkg                         4B0448F9640FCD84979D6CE736348EE9304A7A069F77E38FF411F3211E699C68    776442
+c:\akse-cache\portReservationTest.ps1                                            0940BA8A0A564E5937F60871F7F87C866C8617882D121FF33BBB0798B0C82AC0      4370
+c:\akse-cache\signedscripts-v0.0.10.zip                                          429A25ECB5CF2664033024BC9AEB49148F036D97E06C495CC8DC663531AC5F8C     69937
+c:\akse-cache\signedscripts-v0.0.12.zip                                          862D8ADEC368C83AC991448DD152CDAB657219BC1E0BA4D153A5943C72694303     70802
+c:\akse-cache\signedscripts-v0.0.8.zip                                           7ECB7708127D337F6F641ECFE7B9838E07B4E5EDB8D9BBD66728F07E296C9930     61725
+c:\akse-cache\starthnstrace.cmd                                                  2E0A5D9F8866BC2F3DAAF84AB8F166CCFF243D044E9C9121DF888ACE98033048       591
+c:\akse-cache\startpacketcapture.cmd                                             3E31690E507C8B18AC5CC569C89B51CE1901630A501472DA1BC1FBF2737AA5BC       756
+c:\akse-cache\stoppacketcapture.cmd                                              BD966D7738A3C0FC73E651BAF196C0FB60D889F1180B2D114F8EA3F8A8453C3D        17
+c:\akse-cache\VFP.psm1                                                           3F2F44BD4B3219E8BB29EB9F8958EC96F2C8DDCEF556E995790B6476231A92DB      9616
+c:\akse-cache\win-bridge.exe                                                     CA12506E55DF3E3428B29994AE1FC8131DDFBB6838A550DFA22287CDC6548634   9599488
+c:\akse-cache\calico\calico-windows-v3.17.2.zip                                  1112432007D25BE160A3CCA8594F231D96A554CC8218430E8860529236DF7C14  64457853
+c:\akse-cache\calico\calico-windows-v3.18.1.zip                                  00895B3F052AC69638EE287EDC279AB6D97EE6D87B669130A79A315F99EE54D3  65609273
+c:\akse-cache\containerd\containerd-v0.0.1-windows-amd64.tar.gz                  2F040594701D398D163D17E87928D40294465D6BF202C84C7CE56A8E3856C481  61578716
+c:\akse-cache\csi-proxy\csi-proxy-v0.2.2.tar.gz                                  60BF51D4FB425386C235ABC3BCBD50D70C23CACB94C32A77509DA91CF0F066AD   6481034
+c:\akse-cache\win-k8s\v1.17.11-hotfix.20200901-1int.zip                          CA7CECB05A5081E65195BCE11A2D4F4EC212D2D9DAA2961EC5FA167D5B9E24CC  98390423
+c:\akse-cache\win-k8s\v1.17.13-hotfix.20210118-1int.zip                          068BED7B34237DCD310BC82EFF2EBD85AFF353AED8C4636EBE7DC5AB7A13CBCC  98401405
+c:\akse-cache\win-k8s\v1.17.16-hotfix.20210118-1int.zip                          B37760F94EEC3FB406A8B42CE41E5AAACD63EF302E4B172580E0456FAE15A3C5  98417816
+c:\akse-cache\win-k8s\v1.17.7-hotfix.20200817-1int.zip                           7823108C804EA27E3315E7DE7003C057635B57D54ECCA9FF24FFDC02F9454699  98365082
+c:\akse-cache\win-k8s\v1.17.9-hotfix.20200824-1int.zip                           E788E11994D3283C5C466A7725EFF7E159C193B9C0F3D0BB9DBB60866D8A4C19  98368709
+c:\akse-cache\win-k8s\v1.18.10-hotfix.20210118-1int.zip                          13DE7E2E6C7338DACA8156FBAE4406D9A81697FFE82F80CD789C9738C97E95A8  99547440
+c:\akse-cache\win-k8s\v1.18.14-hotfix.20210322-1int.zip                          A98BAF74D2FFB14089A6E9E531D60CB8442790BF051461A2D61A43C2917B1684  99567186
+c:\akse-cache\win-k8s\v1.18.17-hotfix.20210322-1int.zip                          75A33B623827EF9745DB23094074A65060B9DB39D0DC0DCCC8F09360FA4CBC55  58090328
+c:\akse-cache\win-k8s\v1.18.4-hotfix.20200626-1int.zip                           2F39F5E9EEEB9B5C2ED4063CC680D2D92BA714181635FB09C13EC72B51E5D32A  58027424
+c:\akse-cache\win-k8s\v1.18.6-hotfix.20200723-1int.zip                           477FBB5C80AC088A574C5B7585E2C2520439E50DB9ED09CD68E068C785A21FAE  58037109
+c:\akse-cache\win-k8s\v1.18.8-hotfix.20200924-1int.zip                           D669FB1F50744C668250C40999B27CD2155802F6FEB2479836ABCB7E115B05DC  99526379
+c:\akse-cache\win-k8s\v1.19.0-1int.zip                                           9410B24188379D34EDEB78215DB97F1D4C1202A2CBEB453C6428A0D2C7CE9D4D 102808635
+c:\akse-cache\win-k8s\v1.19.1-hotfix.20200923-1int.zip                           04F57C9AB7C9AA482CB870D00340B8BF9E33C14A1E2EBAD1A50DC077858B7F1A 102810662
+c:\akse-cache\win-k8s\v1.19.3-hotfix.20210118-1int.zip                           4881CE4A01D96B9BB37C91F79FE00B6CF677A89ED394A1E9A499DB9D4826B127 102840495
+c:\akse-cache\win-k8s\v1.19.6-hotfix.20210118-1int.zip                           B0D6258B0AD8456EEF07B573E92601A2597BDCA7932371049387152077B3AB46 102435304
+c:\akse-cache\win-k8s\v1.19.7-hotfix.20210310-1int.zip                           36A052B7F8710F9CE3FE74C2DFB1DAB8DBFC7121795E10233F5273F676246379  56472821
+c:\akse-cache\win-k8s\v1.19.9-hotfix.20210322-1int.zip                           C1E5021CFBC9CCC66B52D9E3087D2B17F3A0FFCEA0CE91C98180867F2B522758  56500356
+c:\akse-cache\win-k8s\v1.20.2-hotfix.20210310-1int.zip                           553E8FC348578322E6CCB79B35656E922831F82ED5D7846E08FB7229E4A9FC93  56995444
+c:\akse-cache\win-k8s\v1.20.5-hotfix.20210322-1int.zip                           9B502F037A2F3AD6AD86475EDF5F5BC10885A7E3DF8CA5C715BCBE5F7041E9BA  57030477
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.2.2.zip 52306F546DCB87D266A6DFDBD545982E6292134DEB86B8F90E00485ACFD6B4A1  39555626
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.2.6.zip B2FF69608D97B963F8B0B0631F9E88329B006D954773566F019680DED75B8774  72629816
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.2.7.zip 9AB8FA4C3FBD31429F3D6E5F8D9CE2FF1B192F52F43C5FA1ABA97FEC9BEE9927  72631755
+
+
+
+


### PR DESCRIPTION
Add release notes for AKS Windows VHD with 4B for both docker and containerd.
Add a new folder for the release notes of 2019 with containerd 