### PR TITLE
new cve fix fo networkmanger

### DIFF
--- a/pkg/agent/k8s_versions_for_baker_test.go
+++ b/pkg/agent/k8s_versions_for_baker_test.go
@@ -23,7 +23,7 @@ const (
 	reschedulerImageReference                         string = "rescheduler:v0.4.0"
 	virtualKubeletImageReference                      string = "virtual-kubelet:latest"
 	omsImageReference                                 string = "oms:ciprod01072020"
-	azureCNINetworkMonitorImageReference              string = "networkmonitor:v1.1.8"
+	azureCNINetworkMonitorImageReference              string = "networkmonitor:v1.1.8post2"
 	nvidiaDevicePluginImageReference                  string = "k8s-device-plugin:1.11"
 	blobfuseFlexVolumeImageReference                  string = "mcr.microsoft.com/k8s/flexvolume/blobfuse-flexvolume:1.0.8"
 	smbFlexVolumeImageReference                       string = "mcr.microsoft.com/k8s/flexvolume/smb-flexvolume:1.0.2"

--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -74,10 +74,8 @@
     {
       "downloadURL": "mcr.microsoft.com/containernetworking/networkmonitor:*",
       "versions": [
-        "v1.1.8",
-        "v0.0.7",
-        "v0.0.6",
-        "v0.0.6_v0.0.5"
+        "v1.1.8post2",
+        "v1.1.8"
       ]
     },
     {


### PR DESCRIPTION
Cache Image to fix egress test/not pull for new clusters.


Hoping we can actually remove network monitor soon. 