### PR TITLE
updating omsagent for April release

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -136,9 +136,9 @@
     {
       "downloadURL": "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:*",
       "versions": [
-        "ciprod01112021",
         "ciprod02232021",
-        "ciprod03262021"
+        "ciprod03262021",
+        "ciprod04222021"
       ]
     },
     {


### PR DESCRIPTION
This is for the April OMS agent release (Container Insights)

pkg/agent/k8s_versions_for_baker_test.go also has a reference to omsagent, but it doesn't look like that file should be updated to have the newest agent (please correct me if I'm wrong)

/assign @ganga1980