### PR TITLE
fix: don't publish artifacts if previous steps fail

### DIFF
--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -121,7 +121,7 @@ phases:
           -e OS_DISK_SAS=${OS_DISK_SAS} \
           ${CONTAINER_IMAGE} make -f packer.mk az-copy
         displayName: Copying resource to Classic Storage Account
-        condition: and(eq(variables.DRY_RUN, 'False'), eq(variables['MODE'], 'default'))
+        condition: and(succeeded(), eq(variables.DRY_RUN, 'False'), eq(variables['MODE'], 'default'))
       - bash: |
           echo MODE=$(MODE) && \
           PKR_RG_NAME="$(cat packer-output | grep "ResourceGroupName" | cut -d "'" -f 2 | head -1)" && \
@@ -166,7 +166,7 @@ phases:
           -e SIG_IMAGE_NAME=${SIG_IMAGE_NAME} \
           ${CONTAINER_IMAGE} make -f packer.mk convert-sig-to-classic-storage-account-blob
         displayName: Convert Shared Image Gallery To VHD Blob In Classic Storage Account
-        condition: and(eq(variables.DRY_RUN, 'False'), eq(variables['MODE'], 'gen2Mode'))
+        condition: and(succeeded(), eq(variables.DRY_RUN, 'False'), eq(variables['MODE'], 'gen2Mode'))
       - bash: |
           echo MODE=$(MODE) && \
           if [[ $(MODE) == "gen2Mode" ]]; then create_time="$(cat vhdbuilder/packer/settings.json | grep "create_time" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')"; \
@@ -194,9 +194,9 @@ phases:
           -e IMAGE_VERSION=${IMAGE_VERSION} \
           ${CONTAINER_IMAGE} make -f packer.mk generate-sas
         displayName: Getting Shared Access Signature URI
-        condition: and(eq(variables.DRY_RUN, 'False'), or(eq(variables['MODE'], 'gen2Mode'), eq(variables['MODE'], 'default')))
+        condition: and(succeeded(), eq(variables.DRY_RUN, 'False'), or(eq(variables['MODE'], 'gen2Mode'), eq(variables['MODE'], 'default')))
       - task: PublishPipelineArtifact@1
         inputs:
           artifactName: 'publishing-info'
           targetPath: 'vhd-publishing-info.json'
-        condition: and(eq(variables.DRY_RUN, 'False'), ne(variables['MODE'], 'sigMode'))
+        condition: and(succeeded(), eq(variables.DRY_RUN, 'False'), ne(variables['MODE'], 'sigMode'))

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -85,7 +85,7 @@ steps:
       -e VHD_NAME=${VHD_NAME} \
       ${CONTAINER_IMAGE} make -f packer.mk az-copy
     displayName: Copying resource to Classic Storage Account
-    condition: and(eq(variables.DRY_RUN, 'False'), eq(variables['MODE'], 'default'))
+    condition: and(succeeded(), eq(variables.DRY_RUN, 'False'), eq(variables['MODE'], 'default'))
   - bash: |
       echo MODE=$(MODE) && \
       PKR_RG_NAME="$(cat packer-output | grep "ResourceGroupName" | cut -d "'" -f 2 | head -1)" && \
@@ -129,9 +129,9 @@ steps:
       -e HYPERV_GENERATION="V1" \
       ${CONTAINER_IMAGE} make -f packer.mk generate-sas
     displayName: Getting Shared Access Signature URI
-    condition: and(eq(variables.DRY_RUN, 'False'), eq(variables['MODE'], 'default'))
+    condition: and(succeeded(), eq(variables.DRY_RUN, 'False'), eq(variables['MODE'], 'default'))
   - task: PublishPipelineArtifact@1
     inputs:
         artifactName: 'publishing-info-${{ parameters.artifactName }}'
         targetPath: 'vhd-publishing-info.json'
-    condition: and(eq(variables.DRY_RUN, 'False'), ne(variables['MODE'], 'sigMode'))
+    condition: and(succeeded(), eq(variables.DRY_RUN, 'False'), ne(variables['MODE'], 'sigMode'))

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -96,7 +96,7 @@ steps:
         -e OS_DISK_SAS=${OS_DISK_SAS} \
         ${CONTAINER_IMAGE} make -f packer.mk az-copy
     displayName: Copying resource to Classic Storage Account
-    condition: and(eq(variables.DRY_RUN, 'False'), eq(variables['MODE'], 'default'))
+    condition: and(succeeded(), eq(variables.DRY_RUN, 'False'), eq(variables['MODE'], 'default'))
   - bash: |
       echo MODE=$(MODE) && \
       PKR_RG_NAME="$(cat packer-output | grep "ResourceGroupName" | cut -d "'" -f 2 | head -1)" && \
@@ -171,12 +171,12 @@ steps:
         -e IMAGE_VERSION=${IMAGE_VERSION} \
         ${CONTAINER_IMAGE} make -f packer.mk generate-sas
     displayName: Getting Shared Access Signature URI
-    condition: and(eq(variables.DRY_RUN, 'False'), or(eq(variables['MODE'], 'gen2Mode'), eq(variables['MODE'], 'default')))
+    condition: and(succeeded(), eq(variables.DRY_RUN, 'False'), or(eq(variables['MODE'], 'gen2Mode'), eq(variables['MODE'], 'default')))
   - task: PublishPipelineArtifact@1
     inputs:
         artifactName: 'publishing-info-${{ parameters.artifactName }}'
         targetPath: 'vhd-publishing-info.json'
-    condition: and(eq(variables.DRY_RUN, 'False'), ne(variables['MODE'], 'sigMode'))
+    condition: and(succeeded(), eq(variables.DRY_RUN, 'False'), ne(variables['MODE'], 'sigMode'))
   - task: UniversalPackages@0
     displayName: Universal Publish
     inputs:

--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -eux
-
+exit 1
 LINUX_SCRIPT_PATH="linux-vhd-content-test.sh"
 WIN_SCRIPT_PATH="windows-vhd-content-test.ps1"
 TEST_RESOURCE_PREFIX="vhd-test"

--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -eux
-exit 1
 LINUX_SCRIPT_PATH="linux-vhd-content-test.sh"
 WIN_SCRIPT_PATH="windows-vhd-content-test.ps1"
 TEST_RESOURCE_PREFIX="vhd-test"


### PR DESCRIPTION
Currently, if the previous step fails, still some of the steps to publish artifacts continue. 
This may break a re-run of the failed step caused by the existing published artifact, like the error below:
`##[error]Artifact publishing-info-2019 already exists for build 41753757.`

We can benefit from re-running the failed job considering we have multiple jobs in one build, and the failure is caused by intermittent and recoverable errors.

tests have been done:
- Linux check-in pipeline
https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=41831847&view=results
- [TEST All VHDs] AKS Linux VHD Build - Msft Tenant
https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=41831846&view=logs&jobId=35680035-4ba4-5771-0c56-b9253365da62&j=35680035-4ba4-5771-0c56-b9253365da62&t=5b6fac9c-c1fb-58c1-e2ed-8c59f4e18e63
- Windows check-in pipeline, this pipeline yaml is shared with the one to build VHD for production.
https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=41831843&view=results