### PR TITLE
Use metrics-server v0.4.4 and remove unused version

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -43,8 +43,7 @@
       "downloadURL": "mcr.microsoft.com/oss/kubernetes/metrics-server:*",
       "versions": [
         "v0.3.6",
-        "v0.3.5",
-        "v0.4.2"
+        "v0.4.4"
       ]
     },
     {


### PR DESCRIPTION
Use metrics-server v0.4.4 and remove unused version v0.3.5.