### PR TITLE
Update calico images for CVE

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -168,7 +168,7 @@
     {
       "downloadURL": "mcr.microsoft.com/oss/calico/pod2daemon-flexvol:*",
       "versions": [
-        "v3.8.9"
+        "v3.8.9.1"
       ]
     },
     {
@@ -180,7 +180,7 @@
     {
       "downloadURL": "mcr.microsoft.com/oss/tigera/operator:*",
       "versions": [
-        "v1.13.5"
+        "v1.17.1"
       ]
     },
     {

--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -154,6 +154,7 @@
       "downloadURL": "mcr.microsoft.com/oss/calico/node:*",
       "versions": [
         "v3.17.2",
+        "v3.18.1",
         "v3.19.0",
         "v3.8.9.2",
         "v3.8.9.5"
@@ -163,6 +164,7 @@
       "downloadURL": "mcr.microsoft.com/oss/calico/typha:*",
       "versions": [
         "v3.17.2",
+        "v3.18.1",
         "v3.19.0",
         "v3.8.9"
       ]
@@ -177,6 +179,7 @@
       "downloadURL": "mcr.microsoft.com/oss/calico/kube-controllers:*",
       "versions": [
         "v3.17.2",
+        "v3.18.1",
         "v3.19.0"
       ]
     },
@@ -184,6 +187,7 @@
       "downloadURL": "mcr.microsoft.com/oss/tigera/operator:*",
       "versions": [
         "v1.13.5",
+        "v1.15.1",
         "v1.17.1"
       ]
     },

--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -154,6 +154,7 @@
       "downloadURL": "mcr.microsoft.com/oss/calico/node:*",
       "versions": [
         "v3.17.2",
+        "v3.19.0",
         "v3.8.9.2",
         "v3.8.9.5"
       ]
@@ -162,6 +163,7 @@
       "downloadURL": "mcr.microsoft.com/oss/calico/typha:*",
       "versions": [
         "v3.17.2",
+        "v3.19.0",
         "v3.8.9"
       ]
     },
@@ -174,12 +176,14 @@
     {
       "downloadURL": "mcr.microsoft.com/oss/calico/kube-controllers:*",
       "versions": [
-        "v3.17.2"
+        "v3.17.2",
+        "v3.19.0"
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/oss/tigera/operator:*",
       "versions": [
+        "v1.13.5",
         "v1.17.1"
       ]
     },


### PR DESCRIPTION
CVE's in found in pod2daemon-flexvol so we need to go from v3.8.9 -> v3.8.9.1

Tigera-operator also needs updating so adding that in with the relevant Calico images. I will list what images tigera-operator pulls below:
```
Calico v3.17.2 via tigera-operator v1.13.5
Calico v3.18.1 via tigera-operator v1.15.1
Calico v3.19.0 via tigera-operator v1.17.1
```