### PR TITLE
chore: remove old Windows images

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -102,29 +102,41 @@ function Get-ContainerImages {
     $imagesToPull = @()
 
     switch ($windowsSKU) {
-        { '2019', '2019-containerd'} {
+        '2019' {
             $imagesToPull = @(
                 "mcr.microsoft.com/windows/servercore:ltsc2019",
                 "mcr.microsoft.com/windows/nanoserver:1809",
-                "mcr.microsoft.com/oss/kubernetes/pause:1.4.1",
                 "mcr.microsoft.com/oss/kubernetes/pause:3.4.1",
                 "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.2.0",
                 "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.0.1",
                 "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.1.0",
-                "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.5.1",
-                "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.6.0",
-                "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.4",
-                "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.0",
-                "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.19",
-                "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.12",
                 "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.1.1",
                 "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.2.0",
                 "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.0.0",
                 "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.2.0",
+                "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.19",
+                "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.21",
+                "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.12",
+                "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.14",
+                "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.4",
+                "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.0",
+                "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod04222021")
+            Write-Output "Pulling images for windows server 2019 with docker"
+        }
+        '2019-containerd' {
+            $imagesToPull = @(
+                "mcr.microsoft.com/windows/servercore:ltsc2019",
+                "mcr.microsoft.com/windows/nanoserver:1809",
+                "mcr.microsoft.com/oss/kubernetes/pause:3.4.1",
+                "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.2.0",
+                "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.1.0",
+                "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.2.0",
+                "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.2.0",
                 "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.21",
                 "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.14",
+                "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.0",
                 "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod04222021")
-            Write-Log "Pulling images for windows server 2019"
+            Write-Output "Pulling images for windows server 2019 with containerd"
         }
         '2004' {
             $imagesToPull = @(

--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -169,29 +169,41 @@ function Test-ImagesPulled {
     )
     $imagesToPull = @()
     switch ($WindowsSKU) {
-        {'2019', '2019-containerd'} {
+        '2019' {
             $imagesToPull = @(
                 "mcr.microsoft.com/windows/servercore:ltsc2019",
                 "mcr.microsoft.com/windows/nanoserver:1809",
-                "mcr.microsoft.com/oss/kubernetes/pause:1.4.1",
                 "mcr.microsoft.com/oss/kubernetes/pause:3.4.1",
                 "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.2.0",
                 "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.0.1",
                 "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.1.0",
-                "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.5.1",
-                "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.6.0",
-                "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.4",
-                "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.0",
-                "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.19",
-                "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.12",
                 "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.1.1",
                 "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.2.0",
                 "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.0.0",
                 "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.2.0",
+                "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.19",
+                "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.21",
+                "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.12",
+                "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.14",
+                "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.4",
+                "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.0",
+                "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod04222021")
+            Write-Output "Pulling images for windows server 2019 with docker"
+        }
+        '2019-containerd' {
+            $imagesToPull = @(
+                "mcr.microsoft.com/windows/servercore:ltsc2019",
+                "mcr.microsoft.com/windows/nanoserver:1809",
+                "mcr.microsoft.com/oss/kubernetes/pause:3.4.1",
+                "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.2.0",
+                "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.1.0",
+                "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.2.0",
+                "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.2.0",
                 "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.21",
                 "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.14",
+                "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.0",
                 "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod04222021")
-            Write-Output "Pulling images for windows server 2019"
+            Write-Output "Pulling images for windows server 2019 with containerd"
         }
         '2004' {
             $imagesToPull = @(


### PR DESCRIPTION
1. Separate images for containerd from docker's.
2. Remove PauseImage 1.4.1 since we have updated it to 3.4.1 with last Windows VHD in AKS
3. Remove old versions v0.5.1, v0.6.0, for azure-cloud-node-manager
3. Only keep one latest version for each image for containerd as a workaround for the issue that disk space is not enough in the VHD since containerd is in public preview