### PR TITLE
Add sysctl IP forwarding config for Mariner

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -80,6 +80,7 @@ fi
 if [[ $OS == $MARINER_OS_NAME ]]; then
     disableSystemdResolvedCache
     disableSystemdIptables
+    forceEnableIpForward
 fi
 
 if [[ ${CONTAINER_RUNTIME:-""} == "containerd" ]]; then

--- a/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
+++ b/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
@@ -15,3 +15,13 @@ installBcc() {
 configGPUDrivers() {
     echo "Not installing GPU drivers on Mariner"
 }
+
+forceEnableIpForward() {
+    CONFIG_FILEPATH="/etc/sysctl.d/99-force-bridge-forward.conf"
+    touch ${CONFIG_FILEPATH}
+    cat << EOF >> ${CONFIG_FILEPATH}
+    net.ipv4.ip_forward = 1
+    net.ipv4.conf.all.forwarding = 1
+    net.bridge.bridge-nf-call-iptables = 1
+EOF
+}

--- a/vhdbuilder/scripts/linux/tool_installs.sh
+++ b/vhdbuilder/scripts/linux/tool_installs.sh
@@ -66,3 +66,13 @@ EOF
 disableSystemdIptables() {
     systemctlDisableAndStop iptables || exit $ERR_DISBALE_IPTABLES
 }
+
+forceEnableIpForward() {
+    CONFIG_FILEPATH="/etc/sysctl.d/99-force-bridge-forward.conf"
+    touch ${CONFIG_FILEPATH}
+    cat << EOF >> ${CONFIG_FILEPATH}
+    net.ipv4.ip_forward = 1
+    net.ipv4.conf.all.forwarding = 1
+    net.bridge.bridge-nf-call-iptables = 1
+EOF
+}

--- a/vhdbuilder/scripts/linux/tool_installs.sh
+++ b/vhdbuilder/scripts/linux/tool_installs.sh
@@ -66,13 +66,3 @@ EOF
 disableSystemdIptables() {
     systemctlDisableAndStop iptables || exit $ERR_DISBALE_IPTABLES
 }
-
-forceEnableIpForward() {
-    CONFIG_FILEPATH="/etc/sysctl.d/99-force-bridge-forward.conf"
-    touch ${CONFIG_FILEPATH}
-    cat << EOF >> ${CONFIG_FILEPATH}
-    net.ipv4.ip_forward = 1
-    net.ipv4.conf.all.forwarding = 1
-    net.bridge.bridge-nf-call-iptables = 1
-EOF
-}


### PR DESCRIPTION
CSE is successfully deploying 11-containerd.conf to Mariner nodepools, but the Mariner base image has a security hardening config at priority 50 that's explicitly setting `net.ipv4.ip_forward = 0`. Because ip_forward is disabled, Mariner nodepools with AzureCNI networking have DNS issues.

This change puts a priority 99 sysctl configuration into the Mariner VHD with the same settings as 11-containerd.conf. Because this config is a higher priority than the hardening config it ensures that the expected containerd sysctl settings are active.

Verified by building a test image and successfully deploying an AzureCNI cluster with it.