### PR TITLE
Update azure-cns image to v1.3.3

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -74,7 +74,8 @@
     {
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-cns:*",
       "versions": [
-        "v1.2.9"
+        "v1.2.9",
+        "v1.3.3"
       ]
     },
     {


### PR DESCRIPTION
Updating azure-cns to v1.3.3 because of a race found during pod scale up in SWIFT.