### PR TITLE
added linux container insights agent image 05202021

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -141,8 +141,7 @@
       "downloadURL": "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:*",
       "versions": [
         "ciprod03262021",
-        "ciprod04222021",
-        "ciprod05122021"
+        "ciprod05202021"
       ]
     },
     {


### PR DESCRIPTION
Adding the Container Insights 5-20-2021 release. This release is also Linux only, so there is no updated Windows image to add.

I left the 03262021 image and removed the other two newer images because CI rolled back to 03262021 in production. We discovered an issue in the following two images and abandon those two releases. They will never be deployed again, so no need to have them in the agent baker.

@microsoft/docker-provider-devs