### PR TITLE
Update Azure CNI to v1.4.0

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -178,9 +178,8 @@ for imageToBePulled in ${ContainerImages[*]}; do
 done
 
 VNET_CNI_VERSIONS="
+1.4.0
 1.2.7
-1.2.6
-1.2.0_hotfix
 "
 for VNET_CNI_VERSION in $VNET_CNI_VERSIONS; do
     VNET_CNI_PLUGINS_URL="https://acs-mirror.azureedge.net/azure-cni/v${VNET_CNI_VERSION}/binaries/azure-vnet-cni-linux-amd64-v${VNET_CNI_VERSION}.tgz"
@@ -190,8 +189,8 @@ done
 
 # merge with above after two more version releases
 SWIFT_CNI_VERSIONS="
+1.4.0
 1.2.7
-1.2.6
 "
 
 for VNET_CNI_VERSION in $SWIFT_CNI_VERSIONS; do


### PR DESCRIPTION
Uses this release: https://github.com/Azure/azure-container-networking/releases/tag/v1.4.0
