### PR TITLE
Update Azure CNI to v1.4.1

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -374,7 +374,8 @@
       "downloadURL": "https://acs-mirror.azureedge.net/azure-cni/v*/binaries",
       "versions": [
         "1.2.7",
-        "1.4.0"
+        "1.4.0",
+        "1.4.1"
       ]
     },
     {
@@ -383,7 +384,8 @@
       "downloadURL": "https://acs-mirror.azureedge.net/azure-cni/v*/binaries",
       "versions": [
         "1.2.7",
-        "1.4.0"
+        "1.4.0",
+        "1.4.1"
       ]
     },
     {

--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -136,9 +136,9 @@ $global:map = @{
         "https://acs-mirror.azureedge.net/kubernetes/v1.21.1-hotfix.20210526/windowszip/v1.21.1-hotfix.20210526-1int.zip"
     );
     "c:\akse-cache\win-vnet-cni\" = @(
-        "https://acs-mirror.azureedge.net/azure-cni/v1.2.6/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.6.zip",
         "https://acs-mirror.azureedge.net/azure-cni/v1.2.7/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.7.zip",
-        "https://acs-mirror.azureedge.net/azure-cni/v1.4.0/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.4.0.zip"
+        "https://acs-mirror.azureedge.net/azure-cni/v1.4.0/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.4.0.zip",
+        "https://acs-mirror.azureedge.net/azure-cni/v1.4.1/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.4.1.zip"
     );
     "c:\akse-cache\calico\" = @(
         "https://acs-mirror.azureedge.net/calico-node/v3.18.1/binaries/calico-windows-v3.18.1.zip",

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -178,6 +178,7 @@ for imageToBePulled in ${ContainerImages[*]}; do
 done
 
 VNET_CNI_VERSIONS="
+1.4.1
 1.4.0
 1.2.7
 "
@@ -189,6 +190,7 @@ done
 
 # merge with above after two more version releases
 SWIFT_CNI_VERSIONS="
+1.4.1
 1.4.0
 1.2.7
 "


### PR DESCRIPTION
Caching this release: https://github.com/Azure/azure-container-networking/releases/tag/v1.4.1 for linux and windows.

The pipelines: [Networking-Aquarius-Linux-Official-master](https://msazure.visualstudio.com/One/_build?definitionId=144451&_a=summary) and [Azure CNI (signed+unsigned)](https://dev.azure.com/AzureContainerUpstream/Kubernetes/_build?definitionId=74&_a=summary) need to be ran with this release  as well before this goes in.