### PR TITLE
Set CONTAINERD_VERSION for Mariner to match available version

### DIFF
--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -30,7 +30,7 @@ installSGXDrivers() {
 installStandaloneContainerd() {
     CONTAINERD_VERSION=$1
     #overwrite the passed containerd_version since mariner uses only 1 version now which is different than ubuntu's
-    CONTAINERD_VERSION="1.4.4"
+    CONTAINERD_VERSION="1.3.4"
     # azure-built runtimes have a "+azure" suffix in their version strings (i.e 1.4.1+azure). remove that here.
     CURRENT_VERSION=$(containerd -version | cut -d " " -f 3 | sed 's|v||' | cut -d "+" -f 1)
     # v1.4.1 is our lowest supported version of containerd

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -2664,7 +2664,7 @@ installSGXDrivers() {
 installStandaloneContainerd() {
     CONTAINERD_VERSION=$1
     #overwrite the passed containerd_version since mariner uses only 1 version now which is different than ubuntu's
-    CONTAINERD_VERSION="1.4.4"
+    CONTAINERD_VERSION="1.3.4"
     # azure-built runtimes have a "+azure" suffix in their version strings (i.e 1.4.1+azure). remove that here.
     CURRENT_VERSION=$(containerd -version | cut -d " " -f 3 | sed 's|v||' | cut -d "+" -f 1)
     # v1.4.1 is our lowest supported version of containerd


### PR DESCRIPTION
Updating the fixed value of CONTAINERD_VERSION in CBLMariner's version of installStandaloneContainerd to match the moby-containerd available in the Mariner package repository.

A value of 1.4.4 was causing CSE to uninstall moby-containerd-1.3.4 then reinstall moby-containerd-1.3.4 on Mariner. This caused unnecessary package repo access during CSE, since the VHD already has all required packages installed.

In the future when Mariner's moby-containerd version is incremented I'll revisit this logic.