### PR TITLE
Add workaround for networkd config in CBLMariner

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -81,6 +81,7 @@ if [[ $OS == $MARINER_OS_NAME ]]; then
     disableSystemdResolvedCache
     disableSystemdIptables
     forceEnableIpForward
+    networkdWorkaround
 fi
 
 if [[ ${CONTAINER_RUNTIME:-""} == "containerd" ]]; then

--- a/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
+++ b/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
@@ -25,3 +25,7 @@ forceEnableIpForward() {
     net.bridge.bridge-nf-call-iptables = 1
 EOF
 }
+
+networkdWorkaround() {
+    sed -i "s/Name=e\*/Name=eth0/g" /etc/systemd/network/99-dhcp-en.network
+}

--- a/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
+++ b/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
@@ -26,6 +26,9 @@ forceEnableIpForward() {
 EOF
 }
 
+# The default 99-dhcp-en config on Mariner attempts to assign an IP address
+# to the eth1 virtual function device, which delays cluster setup by 2 minutes.
+# This workaround makes it so that dhcp is only enabled on eth0.
 networkdWorkaround() {
     sed -i "s/Name=e\*/Name=eth0/g" /etc/systemd/network/99-dhcp-en.network
 }


### PR DESCRIPTION
The default systemd-networkd configuration in CBLMariner is matching on the Mellanox virtual function and is waiting for a 2 minute timeout for DHCP to assign it an IP address. This virtual device isn't supposed to get an IP address so it's an unnecessary 2 minute delay during cluster provisioning.

This change updates the default 99-dhcp-en.network config to only match on eth0, which matches the behavior on Ubuntu.