### PR TITLE
Stop caching azure npm its only in .4% of linux deployments

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -86,16 +86,6 @@
       ]
     },
     {
-      "downloadURL": "mcr.microsoft.com/containernetworking/azure-npm:*",
-      "versions": [
-        "v1.2.8",
-        "v1.2.2_hotfix",
-        "v1.2.1",
-        "v1.1.8",
-        "v1.3.1"
-      ]
-    },
-    {
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-vnet-telemetry:*",
       "versions": [
         "v1.0.30"


### PR DESCRIPTION
Alternatively we could keep caching and bumpt to 1.4.2. 