### PR TITLE
remove stateful directories from tmp disk

### DIFF
--- a/parts/linux/cloud-init/artifacts/bind-mount.sh
+++ b/parts/linux/cloud-init/artifacts/bind-mount.sh
@@ -18,7 +18,7 @@ MOUNT_POINT="/mnt/aks"
 {{end}}
 
 KUBELET_MOUNT_POINT="${MOUNT_POINT}/kubelet"
-KUBELET_DIR="/var/lib/kubelet"
+KUBELET_DIR="/var/lib/kubelet/pods"
 
 mkdir -p "${MOUNT_POINT}"
 


### PR DESCRIPTION
this removes kubeconfig, bootstrap kubeconfig, kubelet socket, device plugins, checkpoints from temp disk bind mounts. 

only pods and ephemeral volumes should go here. 

TBD: will this mess up how kubelet handles calculation of ephemeral pod volume 