### PR TITLE
chore: Update Windows docker version to 20.10.6

### DIFF
--- a/pkg/agent/datamodel/const.go
+++ b/pkg/agent/datamodel/const.go
@@ -11,7 +11,7 @@ const (
 
 const (
 	// KubernetesWindowsDockerVersion is the default version for docker on Windows nodes in kubernetes
-	KubernetesWindowsDockerVersion = "19.03.14"
+	KubernetesWindowsDockerVersion = "20.10.5"
 	// KubernetesDefaultWindowsSku is the default SKU for Windows VMs in kubernetes
 	KubernetesDefaultWindowsSku = "Datacenter-Core-1809-with-Containers-smalldisk"
 	// KubernetesDefaultContainerdWindowsSandboxIsolation is the default containerd handler for windows pods

--- a/pkg/agent/datamodel/const.go
+++ b/pkg/agent/datamodel/const.go
@@ -11,7 +11,7 @@ const (
 
 const (
 	// KubernetesWindowsDockerVersion is the default version for docker on Windows nodes in kubernetes
-	KubernetesWindowsDockerVersion = "20.10.5"
+	KubernetesWindowsDockerVersion = "20.10.6"
 	// KubernetesDefaultWindowsSku is the default SKU for Windows VMs in kubernetes
 	KubernetesDefaultWindowsSku = "Datacenter-Core-1809-with-Containers-smalldisk"
 	// KubernetesDefaultContainerdWindowsSandboxIsolation is the default containerd handler for windows pods

--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -27,7 +27,7 @@ $global:patchIDs = @("KB5003646")
 
 $global:containerdPackageUrl = "https://acs-mirror.azureedge.net/containerd/windows/v0.0.41/binaries/containerd-v0.0.41-windows-amd64.tar.gz"
 
-$global:defaultDockerVersion = "19.03.14"
+$global:defaultDockerVersion = "20.10.5"
 
 switch ($windowsSKU) {
     "2019" {

--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -27,7 +27,7 @@ $global:patchIDs = @("KB5003646")
 
 $global:containerdPackageUrl = "https://acs-mirror.azureedge.net/containerd/windows/v0.0.41/binaries/containerd-v0.0.41-windows-amd64.tar.gz"
 
-$global:defaultDockerVersion = "20.10.5"
+$global:defaultDockerVersion = "20.10.6"
 
 switch ($windowsSKU) {
     "2019" {


### PR DESCRIPTION
The issue https://github.com/microsoft/Windows-Containers/issues/106 is fixed in the docker 20.10. Update Windows docker version to 20.10.6 which is the latest docker version in DockerMsftProvider 
I will merge this PR after https://github.com/Azure/aks-engine/pull/4556 is merged
