### PR TITLE
Remove the "Count" field from AgentPoolProfile as it is not used

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -30,7 +30,6 @@ const (
 			"agentPoolProfiles": [
 				{
 					"availabilityZones": null,
-					"count": 1,
 					"name": "nodepool1",
 					"osDiskSizeGb": 128,
 					"osType": "Linux",

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -89,7 +89,6 @@ func TestE2EBasic(t *testing.T) {
 			AgentPoolProfiles: []*datamodel.AgentPoolProfile{
 				{
 					Name:                values.Name,
-					Count:               1,
 					VMSize:              "Standard_DS1_v2",
 					StorageProfile:      "ManagedDisks",
 					OSType:              datamodel.Linux,

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -28,9 +28,7 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 				OrchestratorProfile: &datamodel.OrchestratorProfile{
 					OrchestratorType:    datamodel.Kubernetes,
 					OrchestratorVersion: k8sVersion,
-					KubernetesConfig: &datamodel.KubernetesConfig{
-
-					},
+					KubernetesConfig:    &datamodel.KubernetesConfig{},
 				},
 				HostedMasterProfile: &datamodel.HostedMasterProfile{
 					DNSPrefix: "uttestdom",
@@ -38,13 +36,12 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 				AgentPoolProfiles: []*datamodel.AgentPoolProfile{
 					{
 						Name:                "agent2",
-						Count:               3,
 						VMSize:              "Standard_DS1_v2",
 						StorageProfile:      "ManagedDisks",
 						OSType:              datamodel.Linux,
 						VnetSubnetID:        "/subscriptions/359833f5/resourceGroups/MC_rg/providers/Microsoft.Network/virtualNetworks/aks-vnet-07752737/subnet/subnet1",
 						AvailabilityProfile: datamodel.VirtualMachineScaleSets,
-						Distro: datamodel.AKSUbuntu1604,
+						Distro:              datamodel.AKSUbuntu1604,
 					},
 				},
 				LinuxProfile: &datamodel.LinuxProfile{
@@ -133,7 +130,7 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 			EnableKubeletConfigFile:       false,
 			EnableNvidia:                  false,
 			FIPSEnabled:                   false,
-			KubeletConfig:				   kubeletConfig,
+			KubeletConfig:                 kubeletConfig,
 		}
 
 		if configUpdator != nil {
@@ -442,8 +439,8 @@ var _ = Describe("Assert generated customData and cseCmd for Windows", func() {
 						ServiceCIDR:          "10.0.0.0/16",
 						EnableRbac:           to.BoolPtr(true),
 						EnableSecureKubelet:  to.BoolPtr(true),
-						UseInstanceMetadata: to.BoolPtr(true),
-						DNSServiceIP:        "10.0.0.10",
+						UseInstanceMetadata:  to.BoolPtr(true),
+						DNSServiceIP:         "10.0.0.10",
 					},
 				},
 				HostedMasterProfile: &datamodel.HostedMasterProfile{
@@ -455,7 +452,6 @@ var _ = Describe("Assert generated customData and cseCmd for Windows", func() {
 				AgentPoolProfiles: []*datamodel.AgentPoolProfile{
 					{
 						Name:                "wpool2",
-						Count:               3,
 						VMSize:              "Standard_D2s_v3",
 						StorageProfile:      "ManagedDisks",
 						OSType:              datamodel.Windows,
@@ -463,7 +459,7 @@ var _ = Describe("Assert generated customData and cseCmd for Windows", func() {
 						WindowsNameVersion:  "v2",
 						AvailabilityProfile: datamodel.VirtualMachineScaleSets,
 						CustomNodeLabels:    map[string]string{"kubernetes.azure.com/node-image-version": "AKSWindows-2019-17763.1577.201111"},
-						Distro: datamodel.Distro("aks-windows-2019"),
+						Distro:              datamodel.Distro("aks-windows-2019"),
 					},
 				},
 				LinuxProfile: &datamodel.LinuxProfile{
@@ -521,7 +517,7 @@ var _ = Describe("Assert generated customData and cseCmd for Windows", func() {
 			HyperkubeImageURL:         hyperkubeImage,
 			WindowsPackageURL:         windowsPackage,
 		}
-		
+
 		kubeletConfig := map[string]string{
 			"--address":                           "0.0.0.0",
 			"--anonymous-auth":                    "false",
@@ -572,7 +568,7 @@ var _ = Describe("Assert generated customData and cseCmd for Windows", func() {
 			EnableGPUDevicePluginIfNeeded: false,
 			EnableKubeletConfigFile:       false,
 			EnableNvidia:                  false,
-			KubeletConfig:				   kubeletConfig,
+			KubeletConfig:                 kubeletConfig,
 		}
 
 		if configUpdator != nil {

--- a/pkg/agent/datamodel/mocks.go
+++ b/pkg/agent/datamodel/mocks.go
@@ -19,7 +19,6 @@ func CreateMockContainerService(containerServiceName, orchestratorVersion string
 
 	cs.Properties.AgentPoolProfiles = []*AgentPoolProfile{}
 	agentPool := &AgentPoolProfile{}
-	agentPool.Count = agentCount
 	agentPool.Name = "agentpool1"
 	agentPool.VMSize = "Standard_D2_v2"
 	agentPool.OSType = Linux
@@ -88,7 +87,6 @@ func GetK8sDefaultProperties(hasWindows bool) *Properties {
 			{
 				Name:                "agentpool",
 				VMSize:              "Standard_D2_v2",
-				Count:               1,
 				AvailabilityProfile: AvailabilitySet,
 			},
 		},
@@ -103,7 +101,6 @@ func GetK8sDefaultProperties(hasWindows bool) *Properties {
 			{
 				Name:                "agentpool",
 				VMSize:              "Standard_D2_v2",
-				Count:               1,
 				AvailabilityProfile: AvailabilitySet,
 				OSType:              Windows,
 			},
@@ -190,13 +187,13 @@ var (
 		},
 		//KubernetesSpecConfig is the default kubernetes container image url.
 		KubernetesSpecConfig: KubernetesSpecConfig{
-			KubernetesImageBase:                  "k8s.gcr.io/",
-			TillerImageBase:                      "gcr.io/kubernetes-helm/",
-			ACIConnectorImageBase:                "microsoft/",
-			NVIDIAImageBase:                      "nvidia/",
-			CalicoImageBase:                      "calico/",
-			AzureCNIImageBase:                    "mcr.microsoft.com/containernetworking/",
-			MCRKubernetesImageBase:               "mcr.microsoft.com/",
+			KubernetesImageBase:    "k8s.gcr.io/",
+			TillerImageBase:        "gcr.io/kubernetes-helm/",
+			ACIConnectorImageBase:  "microsoft/",
+			NVIDIAImageBase:        "nvidia/",
+			CalicoImageBase:        "calico/",
+			AzureCNIImageBase:      "mcr.microsoft.com/containernetworking/",
+			MCRKubernetesImageBase: "mcr.microsoft.com/",
 
 			KubeBinariesSASURLBase:               "https://acs-mirror.azureedge.net/kubernetes/",
 			WindowsTelemetryGUID:                 "fb801154-36b9-41bc-89c2-f4d4f05472b0",

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -617,7 +617,6 @@ type SysctlConfig struct {
 // AgentPoolProfile represents an agent pool definition
 type AgentPoolProfile struct {
 	Name                   string               `json:"name"`
-	Count                  int                  `json:"count"`
 	VMSize                 string               `json:"vmSize"`
 	OSDiskSizeGB           int                  `json:"osDiskSizeGB,omitempty"`
 	KubeletDiskType        KubeletDiskType      `json:"kubeletDiskType,omitempty"`
@@ -723,15 +722,6 @@ func (p *Properties) HasWindows() bool {
 		}
 	}
 	return false
-}
-
-// TotalNodes returns the total number of nodes in the cluster configuration
-func (p *Properties) TotalNodes() int {
-	var totalNodes int
-	for _, pool := range p.AgentPoolProfiles {
-		totalNodes += pool.Count
-	}
-	return totalNodes
 }
 
 // HasAvailabilityZones returns true if the cluster contains a profile with zones

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -215,39 +215,6 @@ func TestOSType(t *testing.T) {
 	}
 }
 
-func TestTotalNodes(t *testing.T) {
-	cases := []struct {
-		name     string
-		p        Properties
-		expected int
-	}{
-		{
-			name: "7 total nodes between 2 pools",
-			p: Properties{
-				AgentPoolProfiles: []*AgentPoolProfile{
-					{
-						Count: 3,
-					},
-					{
-						Count: 4,
-					},
-				},
-			},
-			expected: 7,
-		},
-	}
-
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-			if c.p.TotalNodes() != c.expected {
-				t.Fatalf("expected TotalNodes() to return %d but instead returned %d", c.expected, c.p.TotalNodes())
-			}
-		})
-	}
-}
-
 func TestHasAvailabilityZones(t *testing.T) {
 	cases := []struct {
 		p                Properties
@@ -258,11 +225,9 @@ func TestHasAvailabilityZones(t *testing.T) {
 			p: Properties{
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
-						Count:             1,
 						AvailabilityZones: []string{"1", "2"},
 					},
 					{
-						Count:             1,
 						AvailabilityZones: []string{"1", "2"},
 					},
 				},
@@ -273,11 +238,8 @@ func TestHasAvailabilityZones(t *testing.T) {
 		{
 			p: Properties{
 				AgentPoolProfiles: []*AgentPoolProfile{
+					{},
 					{
-						Count: 1,
-					},
-					{
-						Count:             1,
 						AvailabilityZones: []string{"1", "2"},
 					},
 				},
@@ -289,11 +251,9 @@ func TestHasAvailabilityZones(t *testing.T) {
 			p: Properties{
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
-						Count:             1,
 						AvailabilityZones: []string{},
 					},
 					{
-						Count:             1,
 						AvailabilityZones: []string{"1", "2"},
 					},
 				},
@@ -531,7 +491,6 @@ func TestAnyAgentIsLinux(t *testing.T) {
 					{
 						Name:   "agentpool1",
 						VMSize: "Standard_D2_v2",
-						Count:  2,
 						OSType: Linux,
 					},
 				},
@@ -545,7 +504,6 @@ func TestAnyAgentIsLinux(t *testing.T) {
 					{
 						Name:   "agentpool1",
 						VMSize: "Standard_D2_v2",
-						Count:  2,
 						OSType: Windows,
 					},
 					{
@@ -564,12 +522,10 @@ func TestAnyAgentIsLinux(t *testing.T) {
 					{
 						Name:   "agentpool1",
 						VMSize: "Standard_D2_v2",
-						Count:  2,
 					},
 					{
 						Name:   "agentpool1",
 						VMSize: "Standard_D2_v2",
-						Count:  100,
 					},
 				},
 			},
@@ -582,12 +538,10 @@ func TestAnyAgentIsLinux(t *testing.T) {
 					{
 						Name:   "agentpool1",
 						VMSize: "Standard_D2_v2",
-						Count:  2,
 					},
 					{
 						Name:   "agentpool1",
 						VMSize: "Standard_D2_v2",
-						Count:  100,
 						OSType: Windows,
 					},
 				},
@@ -652,7 +606,6 @@ func TestPropertiesHasDCSeriesSKU(t *testing.T) {
 				{
 					Name:   "agentpool",
 					VMSize: c.VMSKU,
-					Count:  1,
 				},
 			},
 			OrchestratorProfile: &OrchestratorProfile{
@@ -676,7 +629,6 @@ func TestIsVHDDistroForAllNodes(t *testing.T) {
 			p: Properties{
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
-						Count:  1,
 						Distro: AKSUbuntu1604,
 					},
 				},
@@ -687,7 +639,6 @@ func TestIsVHDDistroForAllNodes(t *testing.T) {
 			p: Properties{
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
-						Count:  1,
 						OSType: Windows,
 					},
 				},
@@ -821,7 +772,6 @@ func TestGetSubnetName(t *testing.T) {
 					{
 						Name:                "agentpool",
 						VMSize:              "Standard_D2_v2",
-						Count:               1,
 						AvailabilityProfile: VirtualMachineScaleSets,
 					},
 				},
@@ -843,7 +793,6 @@ func TestGetSubnetName(t *testing.T) {
 					{
 						Name:                "agentpool",
 						VMSize:              "Standard_D2_v2",
-						Count:               1,
 						AvailabilityProfile: VirtualMachineScaleSets,
 						VnetSubnetID:        "/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Network/virtualNetworks/ExampleCustomVNET/subnets/BazAgentSubnet",
 					},
@@ -880,7 +829,6 @@ func TestGetRouteTableName(t *testing.T) {
 			{
 				Name:                "agentpool",
 				VMSize:              "Standard_D2_v2",
-				Count:               1,
 				AvailabilityProfile: VirtualMachineScaleSets,
 			},
 		},
@@ -919,7 +867,6 @@ func TestProperties_GetVirtualNetworkName(t *testing.T) {
 					{
 						Name:                "agentpool",
 						VMSize:              "Standard_D2_v2",
-						Count:               1,
 						AvailabilityProfile: VirtualMachineScaleSets,
 						VnetSubnetID:        "/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Network/virtualNetworks/ExampleCustomVNET/subnets/BazAgentSubnet",
 					},
@@ -942,7 +889,6 @@ func TestProperties_GetVirtualNetworkName(t *testing.T) {
 					{
 						Name:                "agentpool",
 						VMSize:              "Standard_D2_v2",
-						Count:               1,
 						AvailabilityProfile: VirtualMachineScaleSets,
 					},
 				},
@@ -975,7 +921,6 @@ func TestProperties_GetVNetResourceGroupName(t *testing.T) {
 			{
 				Name:                "agentpool",
 				VMSize:              "Standard_D2_v2",
-				Count:               1,
 				AvailabilityProfile: VirtualMachineScaleSets,
 				VnetSubnetID:        "/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.Network/virtualNetworks/ExampleCustomVNET/subnets/BazAgentSubnet",
 			},
@@ -1003,7 +948,6 @@ func TestGetPrimaryAvailabilitySetName(t *testing.T) {
 			{
 				Name:                "agentpool",
 				VMSize:              "Standard_D2_v2",
-				Count:               1,
 				AvailabilityProfile: AvailabilitySet,
 			},
 		},
@@ -1019,7 +963,6 @@ func TestGetPrimaryAvailabilitySetName(t *testing.T) {
 		{
 			Name:                "agentpool",
 			VMSize:              "Standard_D2_v2",
-			Count:               1,
 			AvailabilityProfile: VirtualMachineScaleSets,
 		},
 	}
@@ -1105,19 +1048,6 @@ func TestIsCustomVNET(t *testing.T) {
 				},
 			},
 			expectedAgent: true,
-		},
-		{
-			p: Properties{
-				AgentPoolProfiles: []*AgentPoolProfile{
-					{
-						Count: 1,
-					},
-					{
-						Count: 1,
-					},
-				},
-			},
-			expectedAgent: false,
 		},
 	}
 

--- a/pkg/agent/params.go
+++ b/pkg/agent/params.go
@@ -63,7 +63,6 @@ func getParameters(config *datamodel.NodeBootstrappingConfiguration, generatorCo
 	// Agent parameters
 	isSetVnetCidrs := false
 	for _, agentProfile := range properties.AgentPoolProfiles {
-		addValue(parametersMap, fmt.Sprintf("%sCount", agentProfile.Name), agentProfile.Count)
 		addValue(parametersMap, fmt.Sprintf("%sVMSize", agentProfile.Name), agentProfile.VMSize)
 		if agentProfile.HasAvailabilityZones() {
 			addValue(parametersMap, fmt.Sprintf("%sAvailabilityZones", agentProfile.Name), agentProfile.AvailabilityZones)

--- a/pkg/aks-engine/api/apiloader.go
+++ b/pkg/aks-engine/api/apiloader.go
@@ -21,7 +21,6 @@ const (
 	defaultVMSize        = "Standard_DS2_v2"
 	defaultOSDiskSizeGB  = 200
 	defaultAgentPoolName = "agent"
-	defaultAgentCount    = 3
 	defaultAdminUser     = "azureuser"
 )
 
@@ -99,7 +98,6 @@ func LoadDefaultContainerServiceProperties() (datamodel.TypeMeta, *datamodel.Pro
 		AgentPoolProfiles: []*datamodel.AgentPoolProfile{
 			{
 				Name:         defaultAgentPoolName,
-				Count:        defaultAgentCount,
 				VMSize:       defaultVMSize,
 				OSDiskSizeGB: defaultOSDiskSizeGB,
 			},

--- a/pkg/aks-engine/api/apiloader_test.go
+++ b/pkg/aks-engine/api/apiloader_test.go
@@ -30,7 +30,7 @@ const exampleAPIModel = `{
 			}
 		},
 		"hostedMasterProfile": { "dnsPrefix": "" },
-		"agentPoolProfiles": [ { "name": "linuxpool1", "count": 2, "vmSize": "Standard_D2_v2", "availabilityProfile": "AvailabilitySet" } ],
+		"agentPoolProfiles": [ { "name": "linuxpool1", "vmSize": "Standard_D2_v2", "availabilityProfile": "AvailabilitySet" } ],
 		"windowsProfile": { "adminUsername": "azureuser", "adminPassword": "replacepassword1234$" },
 		"linuxProfile": { "adminUsername": "azureuser", "ssh": { "publicKeys": [ { "keyData": "" } ] }
 		},
@@ -73,7 +73,6 @@ func TestLoadContainerServiceWithEmptyLocationPublicCloud(t *testing.T) {
 				{
 					"name": "linuxpool",
 					"osDiskSizeGB": 200,
-					"count": 3,
 					"vmSize": "Standard_D2_v2",
 					"distro": "ubuntu",
 					"availabilityProfile": "AvailabilitySet"
@@ -272,7 +271,6 @@ func getDefaultContainerService() *datamodel.ContainerService {
 			AgentPoolProfiles: []*datamodel.AgentPoolProfile{
 				{
 					Name:      "sampleAgent",
-					Count:     2,
 					VMSize:    "sampleVM",
 					DNSPrefix: "blueorange",
 					OSType:    "Linux",
@@ -280,7 +278,6 @@ func getDefaultContainerService() *datamodel.ContainerService {
 				},
 				{
 					Name:      "sampleAgent-public",
-					Count:     2,
 					VMSize:    "sampleVM",
 					DNSPrefix: "blueorange",
 					OSType:    "Linux",
@@ -310,10 +307,6 @@ func TestLoadDefaultContainerServiceProperties(t *testing.T) {
 
 	if p.AgentPoolProfiles[0].Name != defaultAgentPoolName {
 		t.Errorf("Expected LoadDefaultContainerServiceProperties() to return %s AgentPoolProfiles[0].Name, instead got %s", defaultAgentPoolName, p.AgentPoolProfiles[0].Name)
-	}
-
-	if p.AgentPoolProfiles[0].Count != defaultAgentCount {
-		t.Errorf("Expected LoadDefaultContainerServiceProperties() to return %d AgentPoolProfiles[0].Count, instead got %d", defaultAgentCount, p.AgentPoolProfiles[0].Count)
 	}
 
 	if p.AgentPoolProfiles[0].VMSize != defaultVMSize {

--- a/pkg/aks-engine/api/testdata/simple/kubernetes.json
+++ b/pkg/aks-engine/api/testdata/simple/kubernetes.json
@@ -10,13 +10,11 @@
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
-        "count": 3,
         "vmSize": "Standard_D2_v2",
         "availabilityProfile": "AvailabilitySet"
       },
       {
         "name": "agentpool2",
-        "count": 3,
         "vmSize": "Standard_D2_v2",
         "availabilityProfile": "AvailabilitySet"
       }

--- a/pkg/aks-engine/engine/testdata/simple/kubernetes.json
+++ b/pkg/aks-engine/engine/testdata/simple/kubernetes.json
@@ -10,13 +10,11 @@
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
-        "count": 3,
         "vmSize": "Standard_D2_v2",
         "availabilityProfile": "AvailabilitySet"
       },
       {
         "name": "agentpool2",
-        "count": 3,
         "vmSize": "Standard_D2_v2",
         "availabilityProfile": "AvailabilitySet"
       }


### PR DESCRIPTION
Remove the "Count" field from AgentPoolProfile as it is not used by our templates.

The count value is put into a parameter <agentPoolName>Count, but that parameter is not used anywhere.