### PR TITLE
Remove unused fields from AgentPoolProfile.

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -29,12 +29,8 @@ const (
 			},
 			"agentPoolProfiles": [
 				{
-					"availabilityZones": null,
 					"name": "nodepool1",
-					"osDiskSizeGb": 128,
 					"osType": "Linux",
-					"scaleSetEvictionPolicy": null,
-					"scaleSetPriority": null,
 					"vmSize": "Standard_DS2_v2"
 				}
 			],

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -618,7 +618,6 @@ var _ = Describe("Assert generated customData and cseCmd for Windows", func() {
 			config.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet = "172.17.0.0/24"
 			config.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.ServiceCIDR = "172.17.255.0/24"
 			config.ContainerService.Properties.AgentPoolProfiles[0].VnetCidrs = []string{"172.17.0.0/16"}
-			config.ContainerService.Properties.AgentPoolProfiles[0].Subnet = "172.17.2.0/24"
 			config.ContainerService.Properties.AgentPoolProfiles[0].VnetSubnetID = "/subscriptions/359833f5/resourceGroups/MC_rg/providers/Microsoft.Network/virtualNetworks/aks-vnet-07752737/subnet/subnet2"
 			config.KubeletConfig["--cluster-dns"] = "172.17.255.10"
 		}),

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -616,29 +616,23 @@ type SysctlConfig struct {
 
 // AgentPoolProfile represents an agent pool definition
 type AgentPoolProfile struct {
-	Name                   string               `json:"name"`
-	VMSize                 string               `json:"vmSize"`
-	OSDiskSizeGB           int                  `json:"osDiskSizeGB,omitempty"`
-	KubeletDiskType        KubeletDiskType      `json:"kubeletDiskType,omitempty"`
-	DNSPrefix              string               `json:"dnsPrefix,omitempty"`
-	OSType                 OSType               `json:"osType,omitempty"`
-	Ports                  []int                `json:"ports,omitempty"`
-	AvailabilityProfile    string               `json:"availabilityProfile"`
-	ScaleSetPriority       string               `json:"scaleSetPriority,omitempty"`
-	ScaleSetEvictionPolicy string               `json:"scaleSetEvictionPolicy,omitempty"`
-	StorageProfile         string               `json:"storageProfile,omitempty"`
-	DiskSizesGB            []int                `json:"diskSizesGB,omitempty"`
-	VnetSubnetID           string               `json:"vnetSubnetID,omitempty"`
-	Subnet                 string               `json:"subnet"`
-	Distro                 Distro               `json:"distro,omitempty"`
-	CustomNodeLabels       map[string]string    `json:"customNodeLabels,omitempty"`
-	PreprovisionExtension  *Extension           `json:"preProvisionExtension"`
-	KubernetesConfig       *KubernetesConfig    `json:"kubernetesConfig,omitempty"`
-	AvailabilityZones      []string             `json:"availabilityZones,omitempty"`
-	VnetCidrs              []string             `json:"vnetCidrs,omitempty"`
-	WindowsNameVersion     string               `json:"windowsNameVersion,omitempty"`
-	CustomKubeletConfig    *CustomKubeletConfig `json:"customKubeletConfig,omitempty"`
-	CustomLinuxOSConfig    *CustomLinuxOSConfig `json:"customLinuxOSConfig,omitempty"`
+	Name                  string               `json:"name"`
+	VMSize                string               `json:"vmSize"`
+	KubeletDiskType       KubeletDiskType      `json:"kubeletDiskType,omitempty"`
+	DNSPrefix             string               `json:"dnsPrefix,omitempty"`
+	OSType                OSType               `json:"osType,omitempty"`
+	Ports                 []int                `json:"ports,omitempty"`
+	AvailabilityProfile   string               `json:"availabilityProfile"`
+	StorageProfile        string               `json:"storageProfile,omitempty"`
+	VnetSubnetID          string               `json:"vnetSubnetID,omitempty"`
+	Distro                Distro               `json:"distro,omitempty"`
+	CustomNodeLabels      map[string]string    `json:"customNodeLabels,omitempty"`
+	PreprovisionExtension *Extension           `json:"preProvisionExtension"`
+	KubernetesConfig      *KubernetesConfig    `json:"kubernetesConfig,omitempty"`
+	VnetCidrs             []string             `json:"vnetCidrs,omitempty"`
+	WindowsNameVersion    string               `json:"windowsNameVersion,omitempty"`
+	CustomKubeletConfig   *CustomKubeletConfig `json:"customKubeletConfig,omitempty"`
+	CustomLinuxOSConfig   *CustomLinuxOSConfig `json:"customLinuxOSConfig,omitempty"`
 }
 
 // Properties represents the AKS cluster definition
@@ -722,20 +716,6 @@ func (p *Properties) HasWindows() bool {
 		}
 	}
 	return false
-}
-
-// HasAvailabilityZones returns true if the cluster contains a profile with zones
-func (p *Properties) HasAvailabilityZones() bool {
-	hasZones := false
-	if p.AgentPoolProfiles != nil {
-		for _, agentPoolProfile := range p.AgentPoolProfiles {
-			if agentPoolProfile.HasAvailabilityZones() {
-				hasZones = true
-				break
-			}
-		}
-	}
-	return hasZones
 }
 
 // IsAKSCustomCloud checks if it's in AKS custom cloud
@@ -989,11 +969,6 @@ func (a *AgentPoolProfile) IsVHDDistro() bool {
 	return a.Distro.IsVHDDistro()
 }
 
-// HasAvailabilityZones returns true if the agent pool has availability zones
-func (a *AgentPoolProfile) HasAvailabilityZones() bool {
-	return a.AvailabilityZones != nil && len(a.AvailabilityZones) > 0
-}
-
 // IsLinux returns true if the agent pool is linux
 func (a *AgentPoolProfile) IsLinux() bool {
 	return strings.EqualFold(string(a.OSType), string(Linux))
@@ -1017,11 +992,6 @@ func (a *AgentPoolProfile) IsVirtualMachineScaleSets() bool {
 // IsAvailabilitySets returns true if the customer specified disks
 func (a *AgentPoolProfile) IsAvailabilitySets() bool {
 	return strings.EqualFold(a.AvailabilityProfile, AvailabilitySet)
-}
-
-// IsSpotScaleSet returns true if the VMSS is Spot Scale Set
-func (a *AgentPoolProfile) IsSpotScaleSet() bool {
-	return strings.EqualFold(a.AvailabilityProfile, VirtualMachineScaleSets) && strings.EqualFold(a.ScaleSetPriority, ScaleSetPrioritySpot)
 }
 
 // GetKubernetesLabels returns a k8s API-compliant labels string for nodes in this profile
@@ -1057,11 +1027,6 @@ func (a *AgentPoolProfile) GetKubernetesLabels(rg string, deprecated bool, nvidi
 		buf.WriteString(fmt.Sprintf(",%s=%s", key, a.CustomNodeLabels[key]))
 	}
 	return buf.String()
-}
-
-// HasDisks returns true if the customer specified disks
-func (a *AgentPoolProfile) HasDisks() bool {
-	return len(a.DiskSizesGB) > 0
 }
 
 // HasSecrets returns true if the customer specified secrets to install

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -215,61 +215,6 @@ func TestOSType(t *testing.T) {
 	}
 }
 
-func TestHasAvailabilityZones(t *testing.T) {
-	cases := []struct {
-		p                Properties
-		expectedAgent    bool
-		expectedAllZones bool
-	}{
-		{
-			p: Properties{
-				AgentPoolProfiles: []*AgentPoolProfile{
-					{
-						AvailabilityZones: []string{"1", "2"},
-					},
-					{
-						AvailabilityZones: []string{"1", "2"},
-					},
-				},
-			},
-			expectedAgent:    true,
-			expectedAllZones: true,
-		},
-		{
-			p: Properties{
-				AgentPoolProfiles: []*AgentPoolProfile{
-					{},
-					{
-						AvailabilityZones: []string{"1", "2"},
-					},
-				},
-			},
-			expectedAgent:    false,
-			expectedAllZones: false,
-		},
-		{
-			p: Properties{
-				AgentPoolProfiles: []*AgentPoolProfile{
-					{
-						AvailabilityZones: []string{},
-					},
-					{
-						AvailabilityZones: []string{"1", "2"},
-					},
-				},
-			},
-			expectedAgent:    false,
-			expectedAllZones: false,
-		},
-	}
-
-	for _, c := range cases {
-		if c.p.AgentPoolProfiles[0].HasAvailabilityZones() != c.expectedAgent {
-			t.Fatalf("expected HasAvailabilityZones() to return %t but instead returned %t", c.expectedAgent, c.p.AgentPoolProfiles[0].HasAvailabilityZones())
-		}
-	}
-}
-
 func TestIsIPMasqAgentEnabled(t *testing.T) {
 	cases := []struct {
 		p                                            Properties
@@ -669,7 +614,6 @@ func TestAvailabilityProfile(t *testing.T) {
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
 						AvailabilityProfile: VirtualMachineScaleSets,
-						ScaleSetPriority:    ScaleSetPrioritySpot,
 					},
 				},
 			},
@@ -685,7 +629,6 @@ func TestAvailabilityProfile(t *testing.T) {
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
 						AvailabilityProfile: VirtualMachineScaleSets,
-						ScaleSetPriority:    ScaleSetPriorityLow,
 					},
 				},
 			},
@@ -701,7 +644,6 @@ func TestAvailabilityProfile(t *testing.T) {
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
 						AvailabilityProfile: VirtualMachineScaleSets,
-						ScaleSetPriority:    ScaleSetPriorityRegular,
 					},
 					{
 						AvailabilityProfile: AvailabilitySet,
@@ -741,9 +683,6 @@ func TestAvailabilityProfile(t *testing.T) {
 		}
 		if c.p.AgentPoolProfiles[0].IsAvailabilitySets() != c.expectedIsAS {
 			t.Fatalf("expected IsAvailabilitySets() to return %t but instead returned %t", c.expectedIsAS, c.p.AgentPoolProfiles[0].IsAvailabilitySets())
-		}
-		if c.p.AgentPoolProfiles[0].IsSpotScaleSet() != c.expectedSpot {
-			t.Fatalf("expected IsSpotScaleSet() to return %t but instead returned %t", c.expectedSpot, c.p.AgentPoolProfiles[0].IsSpotScaleSet())
 		}
 		if c.p.GetVMType() != c.expectedVMType {
 			t.Fatalf("expected GetVMType() to return %s but instead returned %s", c.expectedVMType, c.p.GetVMType())
@@ -1212,7 +1151,6 @@ func TestHasStorageProfile(t *testing.T) {
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
 						StorageProfile: StorageAccount,
-						DiskSizesGB:    []int{5},
 					},
 					{
 						StorageProfile: StorageAccount,
@@ -1411,9 +1349,6 @@ func TestHasStorageProfile(t *testing.T) {
 			t.Parallel()
 			if c.p.OrchestratorProfile != nil && c.p.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision() != c.expectedPrivateJB {
 				t.Fatalf("expected PrivateJumpboxProvision() to return %t but instead returned %t", c.expectedPrivateJB, c.p.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision())
-			}
-			if c.p.AgentPoolProfiles[0].HasDisks() != c.expectedHasDisks {
-				t.Fatalf("expected HasDisks() to return %t but instead returned %t", c.expectedHasDisks, c.p.AgentPoolProfiles[0].HasDisks())
 			}
 		})
 	}

--- a/pkg/agent/params.go
+++ b/pkg/agent/params.go
@@ -64,21 +64,11 @@ func getParameters(config *datamodel.NodeBootstrappingConfiguration, generatorCo
 	isSetVnetCidrs := false
 	for _, agentProfile := range properties.AgentPoolProfiles {
 		addValue(parametersMap, fmt.Sprintf("%sVMSize", agentProfile.Name), agentProfile.VMSize)
-		if agentProfile.HasAvailabilityZones() {
-			addValue(parametersMap, fmt.Sprintf("%sAvailabilityZones", agentProfile.Name), agentProfile.AvailabilityZones)
-		}
 		if agentProfile.IsCustomVNET() {
 			addValue(parametersMap, fmt.Sprintf("%sVnetSubnetID", agentProfile.Name), agentProfile.VnetSubnetID)
-		} else {
-			addValue(parametersMap, fmt.Sprintf("%sSubnet", agentProfile.Name), agentProfile.Subnet)
 		}
 		if len(agentProfile.Ports) > 0 {
 			addValue(parametersMap, fmt.Sprintf("%sEndpointDNSNamePrefix", agentProfile.Name), agentProfile.DNSPrefix)
-		}
-
-		if !agentProfile.IsAvailabilitySets() && agentProfile.IsSpotScaleSet() {
-			addValue(parametersMap, fmt.Sprintf("%sScaleSetPriority", agentProfile.Name), agentProfile.ScaleSetPriority)
-			addValue(parametersMap, fmt.Sprintf("%sScaleSetEvictionPolicy", agentProfile.Name), agentProfile.ScaleSetEvictionPolicy)
 		}
 
 		if !isSetVnetCidrs && len(agentProfile.VnetCidrs) != 0 {

--- a/pkg/aks-engine/api/apiloader.go
+++ b/pkg/aks-engine/api/apiloader.go
@@ -19,7 +19,6 @@ const (
 	defaultAPIVersion    = VlabsAPIVersion
 	defaultMasterCount   = 3
 	defaultVMSize        = "Standard_DS2_v2"
-	defaultOSDiskSizeGB  = 200
 	defaultAgentPoolName = "agent"
 	defaultAdminUser     = "azureuser"
 )
@@ -97,9 +96,8 @@ func LoadDefaultContainerServiceProperties() (datamodel.TypeMeta, *datamodel.Pro
 		HostedMasterProfile: &datamodel.HostedMasterProfile{},
 		AgentPoolProfiles: []*datamodel.AgentPoolProfile{
 			{
-				Name:         defaultAgentPoolName,
-				VMSize:       defaultVMSize,
-				OSDiskSizeGB: defaultOSDiskSizeGB,
+				Name:   defaultAgentPoolName,
+				VMSize: defaultVMSize,
 			},
 		},
 		LinuxProfile: &datamodel.LinuxProfile{AdminUsername: defaultAdminUser},

--- a/pkg/aks-engine/api/apiloader_test.go
+++ b/pkg/aks-engine/api/apiloader_test.go
@@ -72,7 +72,6 @@ func TestLoadContainerServiceWithEmptyLocationPublicCloud(t *testing.T) {
 			"agentPoolProfiles": [
 				{
 					"name": "linuxpool",
-					"osDiskSizeGB": 200,
 					"vmSize": "Standard_D2_v2",
 					"distro": "ubuntu",
 					"availabilityProfile": "AvailabilitySet"
@@ -274,14 +273,12 @@ func getDefaultContainerService() *datamodel.ContainerService {
 					VMSize:    "sampleVM",
 					DNSPrefix: "blueorange",
 					OSType:    "Linux",
-					Subnet:    "sampleSubnet",
 				},
 				{
 					Name:      "sampleAgent-public",
 					VMSize:    "sampleVM",
 					DNSPrefix: "blueorange",
 					OSType:    "Linux",
-					Subnet:    "sampleSubnet",
 				},
 			},
 		},
@@ -311,10 +308,6 @@ func TestLoadDefaultContainerServiceProperties(t *testing.T) {
 
 	if p.AgentPoolProfiles[0].VMSize != defaultVMSize {
 		t.Errorf("Expected LoadDefaultContainerServiceProperties() to return %s AgentPoolProfiles[0].VMSize, instead got %s", defaultVMSize, p.AgentPoolProfiles[0].VMSize)
-	}
-
-	if p.AgentPoolProfiles[0].OSDiskSizeGB != defaultOSDiskSizeGB {
-		t.Errorf("Expected LoadDefaultContainerServiceProperties() to return %d AgentPoolProfiles[0].OSDiskSizeGB, instead got %d", defaultOSDiskSizeGB, p.AgentPoolProfiles[0].OSDiskSizeGB)
 	}
 
 	if p.LinuxProfile.AdminUsername != defaultAdminUser {


### PR DESCRIPTION
Removed the following fields:
    AvailabilityZones, Subnet, DiskSizesGB, ScaleSetEvictionPolicy, ScaleSetPriority, and OSDiskSizeGB.
Some of them were put into the parameters or variables map, but those parameters or variables were never used.