### PR TITLE
fix: Remove old omsagent image in Windows containerd VHD

### DIFF
--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -73,7 +73,6 @@ switch ($windowsSKU) {
             "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.5", # for k8s 1.20.x
             "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.1", # for k8s 1.21.x
             "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.2", # for k8s 1.21.x
-            "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod06112021",
             "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod06112021-2")
     }
     default {


### PR DESCRIPTION
Remove old omsagent image in Windows VHD since that it seems like that the disk is not enough
https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=44526225&view=logs&j=4cae91f8-9300-5d2a-325c-cec7e691ae6d&t=ba6e6658-3216-5a7b-1df5-e991efde6751