### PR TITLE
Update CNI plugins to v0.9.1

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -372,7 +372,8 @@
       "downloadLocation": "/opt/cni/downloads",
       "downloadURL": "https://acs-mirror.azureedge.net/cni-plugins/v*/binaries",
       "versions": [
-        "0.8.6"
+        "0.8.6",
+        "0.9.1"
       ]
     },
     {

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -213,6 +213,7 @@ done
 
 CNI_PLUGIN_VERSIONS="
 0.8.6
+0.9.1
 "
 for CNI_PLUGIN_VERSION in $CNI_PLUGIN_VERSIONS; do
     CNI_PLUGINS_URL="https://acs-mirror.azureedge.net/cni-plugins/v${CNI_PLUGIN_VERSION}/binaries/cni-plugins-linux-amd64-v${CNI_PLUGIN_VERSION}.tgz"


### PR DESCRIPTION
AKS VHD is currently using v0.7.x, need to replicate to acs-mirror