### PR TITLE
Add CoreDNS 1.8.4 into VHD and cleanup the unused

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -64,10 +64,9 @@
     {
       "downloadURL": "mcr.microsoft.com/oss/kubernetes/coredns:*",
       "versions": [
+        "1.8.4",
         "1.8.3",
-        "1.7.1",
-        "1.6.6",
-        "1.6.5"
+        "1.6.6"
       ]
     },
     {


### PR DESCRIPTION
Fix https://github.com/Azure/AKS/issues/2426