### PR TITLE
Don't pin blobfuse apparently we need at least 1.3.8 to work with k8s…

### DIFF
--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
@@ -18,7 +18,7 @@ installDeps() {
     aptmarkWALinuxAgent hold
     apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT
     apt_get_dist_upgrade || exit $ERR_APT_DIST_UPGRADE_TIMEOUT
-    for apt_package in apache2-utils apt-transport-https blobfuse=1.3.7 ca-certificates ceph-common cgroup-lite cifs-utils conntrack cracklib-runtime ebtables ethtool fuse git glusterfs-client htop iftop init-system-helpers iotop iproute2 ipset iptables jq libpam-pwquality libpwquality-tools mount nfs-common pigz socat sysfsutils sysstat traceroute util-linux xz-utils zip; do
+    for apt_package in apache2-utils apt-transport-https blobfuse ca-certificates ceph-common cgroup-lite cifs-utils conntrack cracklib-runtime ebtables ethtool fuse git glusterfs-client htop iftop init-system-helpers iotop iproute2 ipset iptables jq libpam-pwquality libpwquality-tools mount nfs-common pigz socat sysfsutils sysstat traceroute util-linux xz-utils zip; do
       if ! apt_get_install 30 1 600 $apt_package; then
         journalctl --no-pager -u $apt_package
         exit $ERR_APT_INSTALL_TIMEOUT


### PR DESCRIPTION
… 1.19

[10:39 PM] Paul Miller (AWESOME)
[10:37 PM] Paul Miller (AWESOME)[4:59 PM] Paul Miller (AWESOME)SystemD .50 install
 borks networking. [S500 - PWC] CRI-AKS | AKS cluster was down after image upgrade | 2107230040004895 -  CustomerAPIServerAuthorizationError + USign In Sign In [10:37 PM] Paul Miller (AWESOME)Nara V (narven) edited at 2021-07-28 19:00:32 PDTOnly Blobfuse 1.3.8 and above will work with AKS 1.19. Please upgrade to Blobfuse 1.3.8. AKS 1.19 had a breaking change to identify if the directory is mounted, so only release 1.3.8 is compatible with AKS 1.19

	
    Sign In