### PR TITLE
Install shellcheck for Darwin

### DIFF
--- a/.pipelines/scripts/verify_shell.sh
+++ b/.pipelines/scripts/verify_shell.sh
@@ -16,7 +16,7 @@ if [[ "${installed}" -ne 0 ]]; then
     if [[ "${DISTRO}" == "ubuntu" ]]; then
         sudo apt-get install shellcheck -y
     elif [[ "${DISTRO}" == "darwin" ]]; then
-        brew install cabal-install
+        brew install cabal-install shellcheck
     else 
         echo "distro ${DISTRO} not supported at this time. skipping shellcheck"
         exit 1


### PR DESCRIPTION
Running `make generate` on MacOS/Darwin leads to this error:
```
./.pipelines/scripts/verify_shell.sh: line 65: shellcheck: command not found

make[1]: *** [validate-shell] Error 127

make: *** [generate] Error 2
```
as shellcheck was not installed. 

This PR adds the installation of shellcheck and removes this error during the execution of `make generate`.
 