### PR TITLE
chore: Remove old images and packages

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -119,9 +119,13 @@ function Get-FilesToCacheOnVHD {
 
         foreach ($URL in $map[$dir]) {
             $fileName = [IO.Path]::GetFileName($URL)
-
+            # Doesnot cache containerd package in docker image
+            if ($containerRuntime -ne 'containerd' -And $dir -eq "c:\akse-cache\containerd\") {
+                Write-Log "Skip to download $URL for docker image"
+                continue
+            }
             # Windows containerD supports Windows containerD, starting from Kubernetes 1.20
-            if ($containerRuntime -eq 'containerd' -And $dir -eq "c:\akse-cache\win-k8s\") {
+            elseif ($containerRuntime -eq 'containerd' -And $dir -eq "c:\akse-cache\win-k8s\") {
                 $k8sMajorVersion = $fileName.split(".",3)[0]
                 $k8sMinorVersion = $fileName.split(".",3)[1]
                 if ($k8sMinorVersion -lt "20" -And $k8sMajorVersion -eq "v1") {

--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -119,9 +119,9 @@ function Get-FilesToCacheOnVHD {
 
         foreach ($URL in $map[$dir]) {
             $fileName = [IO.Path]::GetFileName($URL)
-            # Doesnot cache containerd package in docker image
+            # Do not cache containerd package on docker VHD
             if ($containerRuntime -ne 'containerd' -And $dir -eq "c:\akse-cache\containerd\") {
-                Write-Log "Skip to download $URL for docker image"
+                Write-Log "Skip to download $URL for docker VHD"
                 continue
             }
             # Windows containerD supports Windows containerD, starting from Kubernetes 1.20

--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -124,8 +124,9 @@ function Get-FilesToCacheOnVHD {
                 Write-Log "Skip to download $URL for docker VHD"
                 continue
             }
+
             # Windows containerD supports Windows containerD, starting from Kubernetes 1.20
-            elseif ($containerRuntime -eq 'containerd' -And $dir -eq "c:\akse-cache\win-k8s\") {
+            if ($containerRuntime -eq 'containerd' -And $dir -eq "c:\akse-cache\win-k8s\") {
                 $k8sMajorVersion = $fileName.split(".",3)[0]
                 $k8sMinorVersion = $fileName.split(".",3)[1]
                 if ($k8sMinorVersion -lt "20" -And $k8sMajorVersion -eq "v1") {

--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -34,23 +34,14 @@ switch ($windowsSKU) {
             "mcr.microsoft.com/windows/servercore:ltsc2019",
             "mcr.microsoft.com/windows/nanoserver:1809",
             "mcr.microsoft.com/oss/kubernetes/pause:3.4.1",
-            "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.2.0",
             "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.3.0",
-            "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.1.0",
             "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.2.0",
-            "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.2.0",
             "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.4.0",
-            "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.2.0",
             "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.4.0",
-            "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.19",
             "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.21",
-            "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.12",
             "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.14",
-            "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.5.1", # for k8s 1.18.x
             "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.6.0", # for k8s 1.19.x
-            "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.4", # for k8s 1.20.x
             "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.5", # for k8s 1.20.x
-            "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.1", # for k8s 1.21.x
             "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.2", # for k8s 1.21.x
             "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod06112021",
             "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod06112021-2")
@@ -60,19 +51,13 @@ switch ($windowsSKU) {
             "mcr.microsoft.com/windows/servercore:ltsc2019",
             "mcr.microsoft.com/windows/nanoserver:1809",
             "mcr.microsoft.com/oss/kubernetes/pause:3.4.1",
-            "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.2.0",
             "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.3.0",
-            "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.1.0",
             "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.2.0",
-            "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.2.0",
             "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.4.0",
-            "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.2.0",
             "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.4.0",
             "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.21",
             "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.14",
-            "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.4", # for k8s 1.20.x
             "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.5", # for k8s 1.20.x
-            "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.1", # for k8s 1.21.x
             "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.2", # for k8s 1.21.x
             "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod06112021-2")
     }
@@ -95,7 +80,6 @@ $global:map = @{
         "https://github.com/microsoft/SDN/raw/master/Kubernetes/windows/helper.psm1",
         "https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1",
         "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg",
-        "https://acs-mirror.azureedge.net/aks-engine/windows/provisioning/signedscripts-v0.0.12.zip",
         "https://acs-mirror.azureedge.net/aks-engine/windows/provisioning/signedscripts-v0.0.13.zip",
         "https://acs-mirror.azureedge.net/aks-engine/windows/provisioning/signedscripts-v0.0.14.zip"
     );
@@ -153,7 +137,6 @@ $global:map = @{
         "https://acs-mirror.azureedge.net/kubernetes/v1.21.2/windowszip/v1.21.2-1int.zip"
     );
     "c:\akse-cache\win-vnet-cni\" = @(
-        "https://acs-mirror.azureedge.net/azure-cni/v1.2.6/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.6.zip",
         "https://acs-mirror.azureedge.net/azure-cni/v1.2.7/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.2.7.zip",
         "https://acs-mirror.azureedge.net/azure-cni/v1.4.0/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.4.0.zip",
         "https://acs-mirror.azureedge.net/azure-cni/v1.4.7/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.4.7.zip"

--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -52,7 +52,7 @@ function Test-FilesToCacheOnVHD
 
             # Do not validate containerd package on docker VHD
             if ($containerRuntime -ne 'containerd' -And $dir -eq "c:\akse-cache\containerd\") {
-                Write-Log "Skip to validate $URL for docker VHD"
+                Write-Output "Skip to validate $URL for docker VHD"
                 continue
             }
 

--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -56,7 +56,7 @@ function Test-FilesToCacheOnVHD
                 continue
             }
             # Windows containerD supports Windows containerD, starting from Kubernetes 1.20
-            elseif if ($containerRuntime -eq "containerd" -And $fakeDir -eq "c:\akse-cache\win-k8s\") {
+            elseif ($containerRuntime -eq "containerd" -And $fakeDir -eq "c:\akse-cache\win-k8s\") {
                 $k8sMajorVersion = $fileName.split(".",3)[0]
                 $k8sMinorVersion = $fileName.split(".",3)[1]
                 if ($k8sMinorVersion -lt "20" -And $k8sMajorVersion -eq "v1") {

--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -55,8 +55,9 @@ function Test-FilesToCacheOnVHD
                 Write-Log "Skip to validate $URL for docker VHD"
                 continue
             }
+
             # Windows containerD supports Windows containerD, starting from Kubernetes 1.20
-            elseif ($containerRuntime -eq "containerd" -And $fakeDir -eq "c:\akse-cache\win-k8s\") {
+            if ($containerRuntime -eq "containerd" -And $fakeDir -eq "c:\akse-cache\win-k8s\") {
                 $k8sMajorVersion = $fileName.split(".",3)[0]
                 $k8sMinorVersion = $fileName.split(".",3)[1]
                 if ($k8sMinorVersion -lt "20" -And $k8sMajorVersion -eq "v1") {
@@ -70,9 +71,9 @@ function Test-FilesToCacheOnVHD
                 $invalidFiles = $invalidFiles + $dest
                 continue
             }
+
             $remoteFileSize = (Invoke-WebRequest $URL -UseBasicParsing -Method Head).Headers.'Content-Length'
             $localFileSize = (Get-Item $dest).length
-
             if ($localFileSize -ne $remoteFileSize) {
                 Write-Error "$dest : Local file size is $localFileSize but remote file size is $remoteFileSize"
                 $invalidFiles = $invalidFiles + $dest

--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -50,7 +50,13 @@ function Test-FilesToCacheOnVHD
             $fileName = [IO.Path]::GetFileName($URL)
             $dest = [IO.Path]::Combine($dir, $fileName)
 
-            if ($containerRuntime -eq "containerd" -And $fakeDir -eq "c:\akse-cache\win-k8s\") {
+            # Do not validate containerd package on docker VHD
+            if ($containerRuntime -ne 'containerd' -And $dir -eq "c:\akse-cache\containerd\") {
+                Write-Log "Skip to validate $URL for docker VHD"
+                continue
+            }
+            # Windows containerD supports Windows containerD, starting from Kubernetes 1.20
+            elseif if ($containerRuntime -eq "containerd" -And $fakeDir -eq "c:\akse-cache\win-k8s\") {
                 $k8sMajorVersion = $fileName.split(".",3)[0]
                 $k8sMinorVersion = $fileName.split(".",3)[1]
                 if ($k8sMinorVersion -lt "20" -And $k8sMajorVersion -eq "v1") {


### PR DESCRIPTION
Disk is not enough in building Windows 2019 docker image. https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=45352208&view=logs&j=15a94705-2dfe-51ff-b195-e5f5cdf037b6&t=12803780-4248-5d28-29fb-fc69ebac29b6&l=1403

1. Remove old images
2. Do not download containerd package when building docker image
