### PR TITLE
Cache k8s versions: 1.19.13 and 1.20.9

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -316,9 +316,11 @@ done
 # v1.19.9
 # v1.19.11
 # v1.19.12
+# v1.19.13
 # v1.20.5
 # v1.20.7
 # v1.20.8
+# v1.20.9
 # v1.21.1
 # v1.21.2
 # NOTE that we keep multiple files per k8s patch version as kubeproxy version is decided by CCP.
@@ -355,9 +357,11 @@ done
 # v1.19.9
 # v1.19.11
 # v1.19.12
+# v1.19.13
 # v1.20.5
 # v1.20.7
 # v1.20.8
+# v1.20.9
 # v1.21.1
 # v1.21.2
 # NOTE that we only keep the latest one per k8s patch version as kubelet/kubectl is decided by VHD version
@@ -375,10 +379,12 @@ KUBE_BINARY_VERSIONS="
 1.19.9-hotfix.20210505
 1.19.11
 1.19.12
+1.19.13
 1.20.2-hotfix.20210310
 1.20.5-hotfix.20210505
 1.20.7
 1.20.8
+1.20.9
 1.21.1
 1.21.2
 "

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -202,9 +202,11 @@ testKubeBinariesPresent() {
   1.19.7-hotfix.20210310
   1.19.9-hotfix.20210322
   1.19.12
+  1.19.13
   1.20.2-hotfix.20210310
   1.20.5-hotfix.20210322
   1.20.8
+  1.20.9
   "
   for patchedK8sVersion in ${k8sVersions}; do
     # Only need to store k8s components >= 1.19 for containerd VHDs


### PR DESCRIPTION
Added patch versions to KUBE_BINARY_VERSIONS for caching. kube-proxy images are in kube-proxy-images.json.  