### PR TITLE
remove unuseful code Set-AllowedSecurityProtocols

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -233,20 +233,6 @@ function Install-WindowsPatches {
     }
 }
 
-function Set-AllowedSecurityProtocols {
-    $allowedProtocols = @()
-    $insecureProtocols = @([System.Net.SecurityProtocolType]::SystemDefault, [System.Net.SecurityProtocolType]::Ssl3)
-
-    foreach ($protocol in [System.Enum]::GetValues([System.Net.SecurityProtocolType])) {
-        if ($insecureProtocols -notcontains $protocol) {
-            $allowedProtocols += $protocol
-        }
-    }
-
-    Write-Log "Settings allowed security protocols to: $allowedProtocols"
-    [System.Net.ServicePointManager]::SecurityProtocol = $allowedProtocols
-}
-
 function Set-WinRmServiceAutoStart {
     Write-Log "Setting WinRM service start to auto"
     sc.exe config winrm start=auto
@@ -317,7 +303,6 @@ try{
             Disable-WindowsUpdates
             Set-WinRmServiceDelayedStart
             Update-DefenderSignatures
-            Set-AllowedSecurityProtocols
             Install-WindowsPatches
             Install-OpenSSH
             Update-WindowsFeatures

--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -16,21 +16,6 @@ $env:WindowsSKU=$windowsSKU
 
 . c:\windows-vhd-configuration.ps1
 
-function Compare-AllowedSecurityProtocols {
-    $allowedProtocols = @()
-    $insecureProtocols = @([System.Net.SecurityProtocolType]::SystemDefault, [System.Net.SecurityProtocolType]::Ssl3)
-
-    foreach ($protocol in [System.Enum]::GetValues([System.Net.SecurityProtocolType])) {
-        if ($insecureProtocols -notcontains $protocol) {
-            $allowedProtocols += $protocol
-        }
-    }
-    if([System.Net.ServicePointManager]::SecurityProtocol -ne $allowedProtocols) {
-        Write-Error "allowedSecurityProtocols '$([System.Net.ServicePointManager]::SecurityProtocol)', expecting '$allowedProtocols'"
-        exit 1
-    }
-}
-
 function Test-FilesToCacheOnVHD
 {
     $invalidFiles = @()
@@ -155,7 +140,6 @@ function Test-RegistryAdded {
     }
 }
 
-Compare-AllowedSecurityProtocols
 Test-FilesToCacheOnVHD
 Test-PatchInstalled
 Test-ImagesPulled


### PR DESCRIPTION
Actually the tls configuration in building Windows VHD does not work as expected. We have disabled insecure TLS protocols in node provisioning so I think that we can remove these code now.