### PR TITLE
Add lsof and pstree tools to CBLMariner VHD

### DIFF
--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -9,7 +9,7 @@ removeContainerd() {
 installDeps() {
     dnf_makecache || exit $ERR_APT_UPDATE_TIMEOUT
     dnf_update || exit $ERR_APT_DIST_UPGRADE_TIMEOUT
-    for dnf_package in blobfuse ca-certificates cifs-utils conntrack-tools cracklib ebtables ethtool fuse git iotop iproute ipset iptables jq nmap-ncat nfs-utils pam pigz socat sysstat traceroute util-linux xz zip; do
+    for dnf_package in blobfuse ca-certificates cifs-utils conntrack-tools cracklib ebtables ethtool fuse git iotop iproute ipset iptables jq lsof nmap-ncat nfs-utils pam pigz psmisc socat sysstat traceroute util-linux xz zip; do
       if ! dnf_install 30 1 600 $dnf_package; then
         exit $ERR_APT_INSTALL_TIMEOUT
       fi

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -2677,7 +2677,7 @@ removeContainerd() {
 installDeps() {
     dnf_makecache || exit $ERR_APT_UPDATE_TIMEOUT
     dnf_update || exit $ERR_APT_DIST_UPGRADE_TIMEOUT
-    for dnf_package in blobfuse ca-certificates cifs-utils conntrack-tools cracklib ebtables ethtool fuse git iotop iproute ipset iptables jq nmap-ncat nfs-utils pam pigz socat sysstat traceroute util-linux xz zip; do
+    for dnf_package in blobfuse ca-certificates cifs-utils conntrack-tools cracklib ebtables ethtool fuse git iotop iproute ipset iptables jq lsof nmap-ncat nfs-utils pam pigz psmisc socat sysstat traceroute util-linux xz zip; do
       if ! dnf_install 30 1 600 $dnf_package; then
         exit $ERR_APT_INSTALL_TIMEOUT
       fi


### PR DESCRIPTION
lsof and pstree are missing on the current CBLMariner VHDs causing some log-collection scripts to fail.
This commit adds those two tools into the CBLMariner VHD.