### PR TITLE
bump SIG image versions to align with the latest used (#1021)

### DIFF
--- a/pkg/agent/bakerapi_test.go
+++ b/pkg/agent/bakerapi_test.go
@@ -160,12 +160,12 @@ var _ = Describe("AgentBaker API implementation tests", func() {
 			Expect(nodeBootStrapping.OSImageConfig.ImageOffer).To(Equal("aks"))
 			Expect(nodeBootStrapping.OSImageConfig.ImageSku).To(Equal("aks-ubuntu-1604-2021-q3"))
 			Expect(nodeBootStrapping.OSImageConfig.ImagePublisher).To(Equal("microsoft-aks"))
-			Expect(nodeBootStrapping.OSImageConfig.ImageVersion).To(Equal("2021.07.10"))
+			Expect(nodeBootStrapping.OSImageConfig.ImageVersion).To(Equal("2021.08.14"))
 
 			Expect(nodeBootStrapping.SigImageConfig.ResourceGroup).To(Equal("resourcegroup"))
 			Expect(nodeBootStrapping.SigImageConfig.Gallery).To(Equal("aksubuntu"))
 			Expect(nodeBootStrapping.SigImageConfig.Definition).To(Equal("1604"))
-			Expect(nodeBootStrapping.SigImageConfig.Version).To(Equal("2021.07.10"))
+			Expect(nodeBootStrapping.SigImageConfig.Version).To(Equal("2021.08.14"))
 		})
 
 		It("should return an error if cloud is not found", func() {
@@ -198,7 +198,7 @@ var _ = Describe("AgentBaker API implementation tests", func() {
 			Expect(sigImageConfig.ResourceGroup).To(Equal("resourcegroup"))
 			Expect(sigImageConfig.Gallery).To(Equal("aksubuntu"))
 			Expect(sigImageConfig.Definition).To(Equal("1604"))
-			Expect(sigImageConfig.Version).To(Equal("2021.07.10"))
+			Expect(sigImageConfig.Version).To(Equal("2021.08.14"))
 		})
 
 		It("should return error if image config not found for distro", func() {

--- a/pkg/agent/datamodel/osimageconfig.go
+++ b/pkg/agent/datamodel/osimageconfig.go
@@ -22,7 +22,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-ubuntu-1804-gen2-2021-q3",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2021.07.10",
+		ImageVersion:   "2021.08.14",
 	}
 
 	RHELOSImageConfig = AzureOSImageConfig{
@@ -36,14 +36,14 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-ubuntu-1604-2021-q3",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2021.07.10",
+		ImageVersion:   "2021.08.14",
 	}
 
 	AKSUbuntu1804OSImageConfig = AzureOSImageConfig{
 		ImageOffer:     "aks",
 		ImageSku:       "aks-ubuntu-1804-2021-q3",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2021.07.10",
+		ImageVersion:   "2021.08.14",
 	}
 
 	AKSWindowsServer2019OSImageConfig = AzureOSImageConfig{

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -200,7 +200,8 @@ const (
 )
 
 const (
-	LinuxSIGImageVersion string = "2021.07.10"
+	LinuxSIGImageVersion   string = "2021.08.14"
+	WindowsSIGImageVersion string = "17763.2114.210811"
 )
 
 // SIG config Template
@@ -306,13 +307,13 @@ var (
 		ResourceGroup: AKSWindowsResourceGroup,
 		Gallery:       AKSWindowsGalleryName,
 		Definition:    "windows-2019",
-		Version:       "17763.2061.210714",
+		Version:       WindowsSIGImageVersion,
 	}
 	SIGWindows2019ContainerdImageConfigTemplate = SigImageConfigTemplate{
 		ResourceGroup: AKSWindowsResourceGroup,
 		Gallery:       AKSWindowsGalleryName,
 		Definition:    "windows-2019-containerd",
-		Version:       "17763.2061.210714",
+		Version:       WindowsSIGImageVersion,
 	}
 )
 

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -45,7 +45,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(aksUbuntuGPU1804Gen2.ResourceGroup).To(Equal("resourcegroup"))
 		Expect(aksUbuntuGPU1804Gen2.Gallery).To(Equal("aksubuntu"))
 		Expect(aksUbuntuGPU1804Gen2.Definition).To(Equal("1804gen2gpu"))
-		Expect(aksUbuntuGPU1804Gen2.Version).To(Equal("2021.07.10"))
+		Expect(aksUbuntuGPU1804Gen2.Version).To(Equal("2021.08.14"))
 
 		Expect(len(sigConfig.SigCBLMarinerImageConfig)).To(Equal(1))
 
@@ -53,7 +53,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(mariner.ResourceGroup).To(Equal("resourcegroup"))
 		Expect(mariner.Gallery).To(Equal("akscblmariner"))
 		Expect(mariner.Definition).To(Equal("V1"))
-		Expect(mariner.Version).To(Equal("2021.07.10"))
+		Expect(mariner.Version).To(Equal("2021.08.14"))
 
 		Expect(len(sigConfig.SigWindowsImageConfig)).To(Equal(2))
 
@@ -61,6 +61,6 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(windows2019Containerd.ResourceGroup).To(Equal("resourcegroup"))
 		Expect(windows2019Containerd.Gallery).To(Equal("akswindows"))
 		Expect(windows2019Containerd.Definition).To(Equal("windows-2019-containerd"))
-		Expect(windows2019Containerd.Version).To(Equal("17763.2061.210714"))
+		Expect(windows2019Containerd.Version).To(Equal("17763.2114.210811"))
 	})
 })


### PR DESCRIPTION
Cherry-picks #1021 onto the release branch 