### PR TITLE
AgentPoolProfile Remodel Pt1 (Move KubeletDiskType, PreprovisionExtension out of APP)

### DIFF
--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -77,8 +77,8 @@ func (t *TemplateGenerator) getWindowsNodeCustomDataJSONObject(config *datamodel
 
 	preprovisionCmd := ""
 
-	if profile.PreprovisionExtension != nil {
-		preprovisionCmd = makeAgentExtensionScriptCommands(cs, profile)
+	if config.CSEConfiguration.PreprovisionExtension != nil {
+		preprovisionCmd = makeAgentExtensionScriptCommands(cs, profile, config.CSEConfiguration)
 	}
 
 	str = strings.Replace(str, "PREPROVISION_EXTENSION", escapeSingleLine(strings.TrimSpace(preprovisionCmd)), -1)
@@ -393,9 +393,9 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 		},
 		"GetKubernetesAgentPreprovisionYaml": func(profile *datamodel.AgentPoolProfile) string {
 			str := ""
-			if profile.PreprovisionExtension != nil {
+			if config.CSEConfiguration.PreprovisionExtension != nil {
 				str += "\n"
-				str += makeAgentExtensionScriptCommands(cs, profile)
+				str += makeAgentExtensionScriptCommands(cs, profile, config.CSEConfiguration)
 			}
 			return str
 		},

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -77,7 +77,7 @@ func (t *TemplateGenerator) getWindowsNodeCustomDataJSONObject(config *datamodel
 
 	preprovisionCmd := ""
 
-	if config.CSEConfiguration.PreprovisionExtension != nil {
+	if config.CSEConfiguration != nil && config.CSEConfiguration.PreprovisionExtension != nil {
 		preprovisionCmd = makeAgentExtensionScriptCommands(cs, profile, config.CSEConfiguration)
 	}
 
@@ -393,7 +393,7 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 		},
 		"GetKubernetesAgentPreprovisionYaml": func(profile *datamodel.AgentPoolProfile) string {
 			str := ""
-			if config.CSEConfiguration.PreprovisionExtension != nil {
+			if config.CSEConfiguration != nil && config.CSEConfiguration.PreprovisionExtension != nil {
 				str += "\n"
 				str += makeAgentExtensionScriptCommands(cs, profile, config.CSEConfiguration)
 			}

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -520,7 +520,7 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 			if profile != nil && profile.KubernetesConfig != nil && profile.KubernetesConfig.ContainerRuntimeConfig != nil && profile.KubernetesConfig.ContainerRuntimeConfig[datamodel.ContainerDataDirKey] != "" {
 				return true
 			}
-			if profile.KubeletDiskType == datamodel.TempDisk {
+			if config.Storage != nil && config.Storage.KubeletDiskType == datamodel.TempDisk {
 				return true
 			}
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.ContainerRuntimeConfig != nil && cs.Properties.OrchestratorProfile.KubernetesConfig.ContainerRuntimeConfig[datamodel.ContainerDataDirKey] != ""
@@ -529,17 +529,17 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 			if profile != nil && profile.KubernetesConfig != nil && profile.KubernetesConfig.ContainerRuntimeConfig != nil && profile.KubernetesConfig.ContainerRuntimeConfig[datamodel.ContainerDataDirKey] != "" {
 				return profile.KubernetesConfig.ContainerRuntimeConfig[datamodel.ContainerDataDirKey]
 			}
-			if profile.KubeletDiskType == datamodel.TempDisk {
+			if config.Storage != nil && config.Storage.KubeletDiskType == datamodel.TempDisk {
 				return datamodel.TempDiskContainerDataDir
 			}
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.ContainerRuntimeConfig[datamodel.ContainerDataDirKey]
 		},
 		"HasKubeletDiskType": func() bool {
-			return profile != nil && profile.KubeletDiskType != ""
+			return config.Storage != nil && config.Storage.KubeletDiskType != ""
 		},
 		"GetKubeletDiskType": func() string {
-			if profile != nil && profile.KubeletDiskType != "" {
-				return string(profile.KubeletDiskType)
+			if config.Storage != nil && config.Storage.KubeletDiskType != "" {
+				return string(config.Storage.KubeletDiskType)
 			}
 			return ""
 		},

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 		Entry("AKSUbuntu1604 with temp disk (toggle)", "AKSUbuntu1604+TempDiskToggle", "1.15.7", func(config *datamodel.NodeBootstrappingConfiguration) {
 			// this tests prioritization of the new api property vs the old property i'd like to remove.
 			// ContainerRuntimeConfig should take priority until we remove it entirely
-			config.AgentPoolProfile.KubeletDiskType = datamodel.OSDisk
+			config.Storage.KubeletDiskType = datamodel.OSDisk
 			config.ContainerService.Properties.AgentPoolProfiles[0].KubernetesConfig = &datamodel.KubernetesConfig{
 				ContainerRuntimeConfig: map[string]string{
 					datamodel.ContainerDataDirKey: "/mnt/containers",
@@ -182,11 +182,11 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 		}),
 		Entry("AKSUbuntu1604 with temp disk (api field)", "AKSUbuntu1604+TempDiskExplicit", "1.15.7", func(config *datamodel.NodeBootstrappingConfiguration) {
 			// also tests prioritization, but now the API property should take precedence
-			config.AgentPoolProfile.KubeletDiskType = datamodel.TempDisk
+			config.Storage.KubeletDiskType = datamodel.TempDisk
 		}),
 		Entry("AKSUbuntu1604 with OS disk", "AKSUbuntu1604+OSKubeletDisk", "1.15.7", func(config *datamodel.NodeBootstrappingConfiguration) {
 			// also tests prioritization, but now the API property should take precedence
-			config.AgentPoolProfile.KubeletDiskType = datamodel.OSDisk
+			config.Storage.KubeletDiskType = datamodel.OSDisk
 		}),
 		Entry("AKSUbuntu1604 with Temp Disk and containerd", "AKSUbuntu1604+TempDisk+Containerd", "1.15.7", func(config *datamodel.NodeBootstrappingConfiguration) {
 			config.ContainerService.Properties.OrchestratorProfile.KubernetesConfig = &datamodel.KubernetesConfig{
@@ -427,7 +427,7 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 			config.EnableNvidia = true
 			config.GPUInstanceProfile = "mig-3g"
 		}),
-		
+
 		Entry("AKSUbuntu1804 with krustlet", "AKSUbuntu1804+krustlet", "1.20.7", func(config *datamodel.NodeBootstrappingConfiguration) {
 			config.ContainerService.Properties.AgentPoolProfiles[0].WorkloadRuntime = datamodel.WasmWasi
 			config.ContainerService.Properties.AgentPoolProfiles[0].KubernetesConfig = &datamodel.KubernetesConfig{

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -82,6 +82,10 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 			WindowsPackageURL:         windowsPackage,
 		}
 
+		storage := &datamodel.Storage{
+			KubeletDiskType: "",
+		}
+
 		kubeletConfig := map[string]string{
 			"--address":                           "0.0.0.0",
 			"--pod-manifest-path":                 "/etc/kubernetes/manifests",
@@ -132,6 +136,7 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 			FIPSEnabled:                   false,
 			KubeletConfig:                 kubeletConfig,
 			PrimaryScaleSetName:           "aks-agent2-36873793-vmss",
+			Storage:                       storage,
 		}
 
 		if configUpdator != nil {

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -612,12 +612,15 @@ type AgentPoolProfile struct {
 	VnetSubnetID          string               `json:"vnetSubnetID,omitempty"`
 	Distro                Distro               `json:"distro,omitempty"`
 	CustomNodeLabels      map[string]string    `json:"customNodeLabels,omitempty"`
-	PreprovisionExtension *Extension           `json:"preProvisionExtension"`
 	KubernetesConfig      *KubernetesConfig    `json:"kubernetesConfig,omitempty"`
 	VnetCidrs             []string             `json:"vnetCidrs,omitempty"`
 	WindowsNameVersion    string               `json:"windowsNameVersion,omitempty"`
 	CustomKubeletConfig   *CustomKubeletConfig `json:"customKubeletConfig,omitempty"`
 	CustomLinuxOSConfig   *CustomLinuxOSConfig `json:"customLinuxOSConfig,omitempty"`
+}
+
+type CSEConfiguration struct {
+	PreprovisionExtension *Extension           `json:"preProvisionExtension"`
 }
 
 // Properties represents the AKS cluster definition
@@ -1272,6 +1275,7 @@ type NodeBootstrappingConfiguration struct {
 	CloudSpecConfig               *AzureEnvironmentSpecConfig
 	K8sComponents                 *K8sComponents
 	AgentPoolProfile              *AgentPoolProfile
+	CSEConfiguration              *CSEConfiguration
 	TenantID                      string
 	SubscriptionID                string
 	ResourceGroupName             string

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -413,9 +413,9 @@ type LinuxProfile struct {
 	SSH           struct {
 		PublicKeys []PublicKey `json:"publicKeys"`
 	} `json:"ssh"`
-	Secrets               []KeyVaultSecrets   `json:"secrets,omitempty"`
-	Distro                Distro              `json:"distro,omitempty"`
-	CustomSearchDomain    *CustomSearchDomain `json:"customSearchDomain,omitempty"`
+	Secrets            []KeyVaultSecrets   `json:"secrets,omitempty"`
+	Distro             Distro              `json:"distro,omitempty"`
+	CustomSearchDomain *CustomSearchDomain `json:"customSearchDomain,omitempty"`
 }
 
 // Extension represents an extension definition in the master or agentPoolProfile
@@ -600,27 +600,30 @@ type SysctlConfig struct {
 
 // AgentPoolProfile represents an agent pool definition
 type AgentPoolProfile struct {
-	Name                  string               `json:"name"`
-	VMSize                string               `json:"vmSize"`
-	KubeletDiskType       KubeletDiskType      `json:"kubeletDiskType,omitempty"`
-	WorkloadRuntime       WorkloadRuntime      `json:"workloadRuntime,omitempty"`
-	DNSPrefix             string               `json:"dnsPrefix,omitempty"`
-	OSType                OSType               `json:"osType,omitempty"`
-	Ports                 []int                `json:"ports,omitempty"`
-	AvailabilityProfile   string               `json:"availabilityProfile"`
-	StorageProfile        string               `json:"storageProfile,omitempty"`
-	VnetSubnetID          string               `json:"vnetSubnetID,omitempty"`
-	Distro                Distro               `json:"distro,omitempty"`
-	CustomNodeLabels      map[string]string    `json:"customNodeLabels,omitempty"`
-	KubernetesConfig      *KubernetesConfig    `json:"kubernetesConfig,omitempty"`
-	VnetCidrs             []string             `json:"vnetCidrs,omitempty"`
-	WindowsNameVersion    string               `json:"windowsNameVersion,omitempty"`
-	CustomKubeletConfig   *CustomKubeletConfig `json:"customKubeletConfig,omitempty"`
-	CustomLinuxOSConfig   *CustomLinuxOSConfig `json:"customLinuxOSConfig,omitempty"`
+	Name                string               `json:"name"`
+	VMSize              string               `json:"vmSize"`
+	WorkloadRuntime     WorkloadRuntime      `json:"workloadRuntime,omitempty"`
+	DNSPrefix           string               `json:"dnsPrefix,omitempty"`
+	OSType              OSType               `json:"osType,omitempty"`
+	Ports               []int                `json:"ports,omitempty"`
+	AvailabilityProfile string               `json:"availabilityProfile"`
+	StorageProfile      string               `json:"storageProfile,omitempty"`
+	VnetSubnetID        string               `json:"vnetSubnetID,omitempty"`
+	Distro              Distro               `json:"distro,omitempty"`
+	CustomNodeLabels    map[string]string    `json:"customNodeLabels,omitempty"`
+	KubernetesConfig    *KubernetesConfig    `json:"kubernetesConfig,omitempty"`
+	VnetCidrs           []string             `json:"vnetCidrs,omitempty"`
+	WindowsNameVersion  string               `json:"windowsNameVersion,omitempty"`
+	CustomKubeletConfig *CustomKubeletConfig `json:"customKubeletConfig,omitempty"`
+	CustomLinuxOSConfig *CustomLinuxOSConfig `json:"customLinuxOSConfig,omitempty"`
+}
+
+type Storage struct {
+	KubeletDiskType KubeletDiskType `json:"kubeletDiskType,omitempty"`
 }
 
 type CSEConfiguration struct {
-	PreprovisionExtension *Extension           `json:"preProvisionExtension"`
+	PreprovisionExtension *Extension `json:"preProvisionExtension"`
 }
 
 // Properties represents the AKS cluster definition
@@ -1275,7 +1278,6 @@ type NodeBootstrappingConfiguration struct {
 	CloudSpecConfig               *AzureEnvironmentSpecConfig
 	K8sComponents                 *K8sComponents
 	AgentPoolProfile              *AgentPoolProfile
-	CSEConfiguration              *CSEConfiguration
 	TenantID                      string
 	SubscriptionID                string
 	ResourceGroupName             string
@@ -1301,6 +1303,8 @@ type NodeBootstrappingConfiguration struct {
 	GPUInstanceProfile             string
 	PrimaryScaleSetName            string
 	SIGConfig                      SIGConfig
+	CSEConfiguration              *CSEConfiguration
+	Storage                       *Storage
 }
 
 // NodeBootstrapping represents the custom data, CSE, and OS image info needed for node bootstrapping.

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -128,12 +128,12 @@ func addSecret(m paramsMap, k string, v interface{}, encode bool) {
 	addKeyvaultReference(m, k, parts[1], parts[2], parts[4])
 }
 
-func makeAgentExtensionScriptCommands(cs *datamodel.ContainerService, profile *datamodel.AgentPoolProfile) string {
+func makeAgentExtensionScriptCommands(cs *datamodel.ContainerService, profile *datamodel.AgentPoolProfile, cseconfig *datamodel.CSEConfiguration) string {
 	if profile.OSType == datamodel.Windows {
-		return makeWindowsExtensionScriptCommands(profile.PreprovisionExtension,
+		return makeWindowsExtensionScriptCommands(cseconfig.PreprovisionExtension,
 			cs.Properties.ExtensionProfiles)
 	}
-	return makeExtensionScriptCommands(profile.PreprovisionExtension,
+	return makeExtensionScriptCommands(cseconfig.PreprovisionExtension,
 		"", cs.Properties.ExtensionProfiles)
 }
 


### PR DESCRIPTION
This is the first PR in the effort to clean up AgentPoolProfile. It moves KubeletDiskType(to new Storage Struct) and PreprovisionExtension(to CSEConfiguration struct)