### PR TITLE
feat: Collect CCGPlugin logs for Windows gMSAv2

### DIFF
--- a/vhdbuilder/scripts/windows/collect-windows-logs.ps1
+++ b/vhdbuilder/scripts/windows/collect-windows-logs.ps1
@@ -84,6 +84,16 @@ if ([System.Diagnostics.EventLog]::SourceExists("Docker")) {
 else {
   Write-Host "Docker events are not available"
 }
+
+# CCGPlugin (Windows gMSAv2)
+if ([System.Diagnostics.EventLog]::SourceExists("Containers-CCG")) {
+  get-eventlog -LogName Application -Source Containers-CCG | Select-Object Index, TimeGenerated, EntryType, Message | Sort-Object Index | Export-CSV -Path "$ENV:TEMP\\$($timeStamp)_containers-ccg.csv"
+  $paths += "$ENV:TEMP\\$($timeStamp)_containers-ccg.csv"
+}
+else {
+  Write-Host "Containers-CCG events are not available"
+}
+
 Get-CimInstance win32_pagefileusage | Format-List * | Out-File -Append "$ENV:TEMP\\$($timeStamp)_pagefile.txt"
 Get-CimInstance win32_computersystem | Format-List AutomaticManagedPagefile | Out-File -Append "$ENV:TEMP\\$($timeStamp)_pagefile.txt"
 $paths += "$ENV:TEMP\\$($timeStamp)_pagefile.txt"


### PR DESCRIPTION
Collect CCGPlugin logs for Windows gMSAv2
C:/windows/system32/winevt/Logs/Microsoft-Windows-Containers-CCG%4Admin.evtx
![image](https://user-images.githubusercontent.com/6416187/130013453-6bfcfac2-0ffa-4a85-a614-fa2a40c9aec3.png)

disk inspector: https://github.com/Azure/azure-diskinspect-service/pull/202
