### PR TITLE
fix: remove templated files from VHD

### DIFF
--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -45,8 +45,6 @@ copyPackerFiles() {
   CONTAINERD_MONITOR_SERVICE_DEST=/etc/systemd/system/containerd-monitor.service
   CONTAINERD_MONITOR_TIMER_SRC=/home/packer/containerd-monitor.timer
   CONTAINERD_MONITOR_TIMER_DEST=/etc/systemd/system/containerd-monitor.timer
-  KUBELET_SERVICE_SRC=/home/packer/kubelet.service
-  KUBELET_SERVICE_DEST=/etc/systemd/system/kubelet.service
   DOCKER_CLEAR_MOUNT_PROPAGATION_FLAGS_SRC=/home/packer/docker_clear_mount_propagation_flags.conf
   DOCKER_CLEAR_MOUNT_PROPAGATION_FLAGS_DEST=/etc/systemd/system/docker.service.d/clear_mount_propagation_flags.conf
   NVIDIA_MODPROBE_SERVICE_SRC=/home/packer/nvidia-modprobe.service
@@ -82,7 +80,6 @@ copyPackerFiles() {
   cpAndMode $KUBELET_MONITOR_SERVICE_SRC $KUBELET_MONITOR_SERVICE_DEST 644
   cpAndMode $CONTAINERD_MONITOR_SERVICE_SRC $CONTAINERD_MONITOR_SERVICE_DEST 644
   cpAndMode $CONTAINERD_MONITOR_TIMER_SRC $CONTAINERD_MONITOR_TIMER_DEST 644
-  cpAndMode $KUBELET_SERVICE_SRC $KUBELET_SERVICE_DEST 644
   if [[ $OS != $MARINER_OS_NAME ]]; then
     cpAndMode $DOCKER_MONITOR_SERVICE_SRC $DOCKER_MONITOR_SERVICE_DEST 644
     cpAndMode $DOCKER_MONITOR_TIMER_SRC $DOCKER_MONITOR_TIMER_DEST 644

--- a/vhdbuilder/packer/vhd-image-builder-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-gen2.json
@@ -239,11 +239,6 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/kubelet.service",
-      "destination": "/home/packer/kubelet.service"
-    },
-    {
-      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/docker_clear_mount_propagation_flags.conf",
       "destination": "/home/packer/docker_clear_mount_propagation_flags.conf"
     },

--- a/vhdbuilder/packer/vhd-image-builder-mariner-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-gen2.json
@@ -212,11 +212,6 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/kubelet.service",
-      "destination": "/home/packer/kubelet.service"
-    },
-    {
-      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/pam-d-common-auth",
       "destination": "/home/packer/pam-d-common-auth"
     },

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -199,11 +199,6 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/kubelet.service",
-      "destination": "/home/packer/kubelet.service"
-    },
-    {
-      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/pam-d-common-auth",
       "destination": "/home/packer/pam-d-common-auth"
     },

--- a/vhdbuilder/packer/vhd-image-builder-sig.json
+++ b/vhdbuilder/packer/vhd-image-builder-sig.json
@@ -243,11 +243,6 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/kubelet.service",
-      "destination": "/home/packer/kubelet.service"
-    },
-    {
-      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/docker_clear_mount_propagation_flags.conf",
       "destination": "/home/packer/docker_clear_mount_propagation_flags.conf"
     },

--- a/vhdbuilder/packer/vhd-image-builder.json
+++ b/vhdbuilder/packer/vhd-image-builder.json
@@ -232,11 +232,6 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/kubelet.service",
-      "destination": "/home/packer/kubelet.service"
-    },
-    {
-      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/docker_clear_mount_propagation_flags.conf",
       "destination": "/home/packer/docker_clear_mount_propagation_flags.conf"
     },


### PR DESCRIPTION
this file contains Go templates and cannot be baked into the VHD as-is. remove it. more to come.