### PR TITLE
Remove k8s version: 1.18.8

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -363,7 +363,6 @@ done
 # NOTE that we only keep the latest one per k8s patch version as kubelet/kubectl is decided by VHD version
 # Please do not use the .1 suffix, because that's only for the base image patches
 KUBE_BINARY_VERSIONS="
-1.18.8-hotfix.20200924
 1.18.10-hotfix.20210118
 1.18.14-hotfix.20210322
 1.18.17-hotfix.20210505

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -192,7 +192,6 @@ testKubeBinariesPresent() {
   containerRuntime=$1
   binaryDir=/usr/local/bin
   k8sVersions="
-  1.18.8-hotfix.20200924
   1.18.10-hotfix.20210118
   1.18.14-hotfix.20210322
   1.18.17-hotfix.20210322


### PR DESCRIPTION
Removing k8s version 1.18.8's kube binary for additional space. Currently 99% of the disk space is full for the `1804_fips_gen2_gpu_containerd` sku.