### PR TITLE
fix empty dnsprefix in windows cse

### DIFF
--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -283,6 +283,8 @@ type HostedMasterProfile struct {
 	// Not used during PUT, returned as part of GETFQDN
 	FQDN      string `json:"fqdn,omitempty"`
 	DNSPrefix string `json:"dnsPrefix"`
+	// FQDNSubdomain is used by private cluster without dnsPrefix so they have fixed FQDN
+	FQDNSubdomain string `json:"fqdnSubdomain"`
 	// Subnet holds the CIDR which defines the Azure Subnet in which
 	// Agents will be provisioned. This is stored on the HostedMasterProfile
 	// and will become `masterSubnet` in the compiled template.
@@ -413,9 +415,9 @@ type LinuxProfile struct {
 	SSH           struct {
 		PublicKeys []PublicKey `json:"publicKeys"`
 	} `json:"ssh"`
-	Secrets               []KeyVaultSecrets   `json:"secrets,omitempty"`
-	Distro                Distro              `json:"distro,omitempty"`
-	CustomSearchDomain    *CustomSearchDomain `json:"customSearchDomain,omitempty"`
+	Secrets            []KeyVaultSecrets   `json:"secrets,omitempty"`
+	Distro             Distro              `json:"distro,omitempty"`
+	CustomSearchDomain *CustomSearchDomain `json:"customSearchDomain,omitempty"`
 }
 
 // Extension represents an extension definition in the master or agentPoolProfile

--- a/pkg/agent/params.go
+++ b/pkg/agent/params.go
@@ -23,9 +23,19 @@ func getParameters(config *datamodel.NodeBootstrappingConfiguration, generatorCo
 		addValue(parametersMap, "linuxAdminUsername", linuxProfile.AdminUsername)
 	}
 	// masterEndpointDNSNamePrefix is the basis for storage account creation across dcos, swarm, and k8s
+	// looks like masterEndpointDNSNamePrefix is only used in windows cse kubeconfig cluster/context name and it's not
+	// required since linux uses static value for that.
 	if properties.HostedMasterProfile != nil {
 		// Agents only, use cluster DNS prefix
-		addValue(parametersMap, "masterEndpointDNSNamePrefix", properties.HostedMasterProfile.DNSPrefix)
+		if properties.HostedMasterProfile.DNSPrefix != "" {
+			addValue(parametersMap, "masterEndpointDNSNamePrefix", properties.HostedMasterProfile.DNSPrefix)
+		} else if properties.HostedMasterProfile.FQDNSubdomain != "" {
+			addValue(parametersMap, "masterEndpointDNSNamePrefix", properties.HostedMasterProfile.FQDNSubdomain)
+		} else {
+			// should not happen but just in case, we fill in value "localcluster" just like linux
+			addValue(parametersMap, "masterEndpointDNSNamePrefix", "localcluster")
+		}
+
 	}
 	if properties.HostedMasterProfile != nil {
 		addValue(parametersMap, "vnetCidr", DefaultVNETCIDR)


### PR DESCRIPTION
Fix windows node provision failure using feature combination: windows + private cluster + byo private dns zone + fqdnSubdomain.
When fqdnSubdomain is used, the dnsPrefix will be empty. This is by design. 

Tested in standalone env with this fix.