### PR TITLE
adding omsagnet image ciprod08052021-1

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -144,7 +144,8 @@
         "ciprod06112021",
         "ciprod05202021-hotfix",
         "ciprod06112021-1",
-        "ciprod08052021"
+        "ciprod08052021",
+        "ciprod08052021-1"
       ]
     },
     {


### PR DESCRIPTION
Title says it all. The only difference between ciprod08052021 and ciprod08052021-1 is the image tag

@ganga1980 @vishiy @rashmichandrashekar @gracewehner