### PR TITLE
Add Policy images containing CVE fixes CVE-2021-3711, CVE-2021-3712, CVE-2021-3121

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -289,14 +289,15 @@
       "downloadURL": "mcr.microsoft.com/azure-policy/policy-kubernetes-addon-prod:*",
       "versions": [
         "prod_20210719.1",
-        "prod_20210806.1"
+        "prod_20210909.1"
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/azure-policy/policy-kubernetes-webhook:*",
       "versions": [
         "prod_20210713.1",
-        "prod_20210806.1"
+        "prod_20210714.1",
+        "prod_20210909.1"
       ]
     },
     {


### PR DESCRIPTION
Add Policy images containing high severity CVE fixes CVE-2021-3711, CVE-2021-3712, CVE-2021-3121

Below 3 newly added images contains the security fixes...
mcr.microsoft.com/azure-policy/policy-kubernetes-addon-prod:prod_20210909.1
mcr.microsoft.com/azure-policy/policy-kubernetes-webhook:prod_20210714.1
mcr.microsoft.com/azure-policy/policy-kubernetes-webhook:prod_20210909.1

Policy webhook image prod_20210714.1 is used for clusters <1.18. This image supports v1beta1 version of validation webhook.
Policy webhook image prod_20210909.1 is used for clusters >=1.18. This image supports v1 version of validation webhook.