### PR TITLE
Remove telemetry code in Windows CSE code

### DIFF
--- a/parts/windows/kuberneteswindowssetup.ps1
+++ b/parts/windows/kuberneteswindowssetup.ps1
@@ -153,10 +153,6 @@ $global:NetworkPlugin = "{{GetParameter "networkPlugin"}}"
 $global:VNetCNIPluginsURL = "{{GetParameter "vnetCniWindowsPluginsURL"}}"
 $global:IsDualStackEnabled = {{if IsIPv6DualStackFeatureEnabled}}$true{{else}}$false{{end}}
 
-# Telemetry settings
-$global:EnableTelemetry = [System.Convert]::ToBoolean("{{GetVariable "enableTelemetry" }}");
-$global:TelemetryKey = "{{GetVariable "applicationInsightsKey" }}";
-
 # CSI Proxy settings
 $global:EnableCsiProxy = [System.Convert]::ToBoolean("{{GetVariable "windowsEnableCSIProxy" }}");
 $global:CsiProxyUrl = "{{GetVariable "windowsCSIProxyURL" }}";
@@ -214,77 +210,19 @@ try
 
         Write-Log ".\CustomDataSetupScript.ps1 -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp -MasterFQDNPrefix $MasterFQDNPrefix -Location $Location -AADClientId $AADClientId -NetworkAPIVersion $NetworkAPIVersion -TargetEnvironment $TargetEnvironment"
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
-
-            $configAppInsightsClientTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            # Get app insights binaries and set up app insights client
-            Create-Directory -FullPath c:\k\appinsights -DirectoryUsage "storing appinsights"
-            DownloadFileOverHttp -Url "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg" -DestinationPath "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip"
-            Expand-Archive -Path "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip" -DestinationPath "c:\k\appinsights"
-            $appInsightsDll = "c:\k\appinsights\lib\net46\Microsoft.ApplicationInsights.dll"
-            [Reflection.Assembly]::LoadFile($appInsightsDll)
-            $conf = New-Object "Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration"
-            $conf.DisableTelemetry = -not $global:EnableTelemetry
-            $conf.InstrumentationKey = $global:TelemetryKey
-            $global:AppInsightsClient = New-Object "Microsoft.ApplicationInsights.TelemetryClient"($conf)
-
-            $global:AppInsightsClient.Context.Properties["correlation_id"] = New-Guid
-            $global:AppInsightsClient.Context.Properties["cri"] = $global:ContainerRuntime
-            # TODO: Update once containerd versioning story is decided
-            $global:AppInsightsClient.Context.Properties["cri_version"] = if ($global:ContainerRuntime -eq "docker") { $global:DockerVersion } else { "" }
-            $global:AppInsightsClient.Context.Properties["k8s_version"] = $global:KubeBinariesVersion
-            $global:AppInsightsClient.Context.Properties["lb_sku"] = $global:LoadBalancerSku
-            $global:AppInsightsClient.Context.Properties["location"] = $Location
-            $global:AppInsightsClient.Context.Properties["os_type"] = "windows"
-            $global:AppInsightsClient.Context.Properties["os_version"] = Get-WindowsVersion
-            $global:AppInsightsClient.Context.Properties["network_plugin"] = $global:NetworkPlugin
-            $global:AppInsightsClient.Context.Properties["network_plugin_version"] = Get-CniVersion
-            $global:AppInsightsClient.Context.Properties["network_mode"] = $global:NetworkMode
-            $global:AppInsightsClient.Context.Properties["subscription_id"] = $global:SubscriptionId
-
-            $vhdId = ""
-            if (Test-Path "c:\vhd-id.txt") {
-                $vhdId = Get-Content "c:\vhd-id.txt"
-            }
-            $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
-
-            $imdsProperties = Get-InstanceMetadataServiceTelemetry
-            foreach ($key in $imdsProperties.keys) {
-                $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-            }
-
-            $configAppInsightsClientTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Config-AppInsightsClient", $configAppInsightsClientTimer.Elapsed.TotalSeconds)
-        }
-
         # Install OpenSSH if SSH enabled
         $sshEnabled = [System.Convert]::ToBoolean("{{ WindowsSSHEnabled }}")
 
         if ( $sshEnabled ) {
             Write-Log "Install OpenSSH"
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-OpenSSH -SSHKeys $SSHKeys
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-OpenSSH", $installOpenSSHTimer.Elapsed.TotalSeconds)
-            }
         }
 
         Write-Log "Apply telemetry data setting"
         Set-TelemetrySetting -WindowsTelemetryGUID $global:WindowsTelemetryGUID
 
         Write-Log "Resize os drive if possible"
-        if ($global:EnableTelemetry) {
-            $resizeTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         Resize-OSDrive
-        if ($global:EnableTelemetry) {
-            $resizeTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Resize-OSDrive", $resizeTimer.Elapsed.TotalSeconds)
-        }
 
         Write-Log "Initialize data disks"
         Initialize-DataDisks
@@ -318,9 +256,6 @@ try
 
         if ($useContainerD) {
             Write-Log "Installing ContainerD"
-            if ($global:EnableTelemetry) {
-                $containerdTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             $cniBinPath = $global:AzureCNIBinDir
             $cniConfigPath = $global:AzureCNIConfDir
             if ($global:NetworkPlugin -eq "kubenet") {
@@ -328,21 +263,10 @@ try
                 $cniConfigPath = $global:CNIConfigPath
             }
             Install-Containerd -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir
-            if ($global:EnableTelemetry) {
-                $containerdTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-ContainerD", $containerdTimer.Elapsed.TotalSeconds)
-            }
         } else {
             Write-Log "Install docker"
-            if ($global:EnableTelemetry) {
-                $dockerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-Docker -DockerVersion $global:DockerVersion
             Set-DockerLogFileOptions
-            if ($global:EnableTelemetry) {
-                $dockerTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-Docker", $dockerTimer.Elapsed.TotalSeconds)
-            }
         }
 
         # For AKSClustomCloud, TargetEnvironment must be set to AzureStackCloud
@@ -416,14 +340,7 @@ try
          }
 
         Write-Log "Create the Pause Container kubletwin/pause"
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         New-InfraContainer -KubeDir $global:KubeDir -ContainerRuntime $global:ContainerRuntime
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("New-InfraContainer", $infraContainerTimer.Elapsed.TotalSeconds)
-        }
 
         if (-not (Test-ContainerImageExists -Image "kubletwin/pause" -ContainerRuntime $global:ContainerRuntime)) {
             Write-Log "Could not find container with name kubletwin/pause"
@@ -522,12 +439,6 @@ try
             Remove-Item $CacheDir -Recurse -Force
         }
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("TotalDuration", $global:globalTimer.Elapsed.TotalSeconds)
-            $global:AppInsightsClient.Flush()
-        }
-
         if ($global:TLSBootstrapToken) {
             Write-Log "Removing temporary kube config"
             $kubeConfigFile = [io.path]::Combine($KubeDir, "config")
@@ -540,13 +451,6 @@ try
 }
 catch
 {
-    if ($global:EnableTelemetry) {
-        $exceptionTelemtry = New-Object "Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry"
-        $exceptionTelemtry.Exception = $_.Exception
-        $global:AppInsightsClient.TrackException($exceptionTelemtry)
-        $global:AppInsightsClient.Flush()
-    }
-
     # Set-ExitCode will exit with the specified ExitCode immediately and not be caught by this catch block
     # Ideally all exceptions will be handled and no exception will be thrown.
     Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_UNKNOWN -ErrorMessage $_

--- a/pkg/agent/testdata/AKSWindows2019+CustomCloud/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+CustomCloud/CustomData
@@ -149,10 +149,6 @@ $global:NetworkPlugin = "azure"
 $global:VNetCNIPluginsURL = "https://acs-mirror.azureedge.net/azure-cni/v1.1.3/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.3.zip"
 $global:IsDualStackEnabled = $false
 
-# Telemetry settings
-$global:EnableTelemetry = [System.Convert]::ToBoolean("false");
-$global:TelemetryKey = "";
-
 # CSI Proxy settings
 $global:EnableCsiProxy = [System.Convert]::ToBoolean("false");
 $global:CsiProxyUrl = "";
@@ -210,77 +206,19 @@ try
 
         Write-Log ".\CustomDataSetupScript.ps1 -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp -MasterFQDNPrefix $MasterFQDNPrefix -Location $Location -AADClientId $AADClientId -NetworkAPIVersion $NetworkAPIVersion -TargetEnvironment $TargetEnvironment"
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
-
-            $configAppInsightsClientTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            # Get app insights binaries and set up app insights client
-            Create-Directory -FullPath c:\k\appinsights -DirectoryUsage "storing appinsights"
-            DownloadFileOverHttp -Url "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg" -DestinationPath "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip"
-            Expand-Archive -Path "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip" -DestinationPath "c:\k\appinsights"
-            $appInsightsDll = "c:\k\appinsights\lib\net46\Microsoft.ApplicationInsights.dll"
-            [Reflection.Assembly]::LoadFile($appInsightsDll)
-            $conf = New-Object "Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration"
-            $conf.DisableTelemetry = -not $global:EnableTelemetry
-            $conf.InstrumentationKey = $global:TelemetryKey
-            $global:AppInsightsClient = New-Object "Microsoft.ApplicationInsights.TelemetryClient"($conf)
-
-            $global:AppInsightsClient.Context.Properties["correlation_id"] = New-Guid
-            $global:AppInsightsClient.Context.Properties["cri"] = $global:ContainerRuntime
-            # TODO: Update once containerd versioning story is decided
-            $global:AppInsightsClient.Context.Properties["cri_version"] = if ($global:ContainerRuntime -eq "docker") { $global:DockerVersion } else { "" }
-            $global:AppInsightsClient.Context.Properties["k8s_version"] = $global:KubeBinariesVersion
-            $global:AppInsightsClient.Context.Properties["lb_sku"] = $global:LoadBalancerSku
-            $global:AppInsightsClient.Context.Properties["location"] = $Location
-            $global:AppInsightsClient.Context.Properties["os_type"] = "windows"
-            $global:AppInsightsClient.Context.Properties["os_version"] = Get-WindowsVersion
-            $global:AppInsightsClient.Context.Properties["network_plugin"] = $global:NetworkPlugin
-            $global:AppInsightsClient.Context.Properties["network_plugin_version"] = Get-CniVersion
-            $global:AppInsightsClient.Context.Properties["network_mode"] = $global:NetworkMode
-            $global:AppInsightsClient.Context.Properties["subscription_id"] = $global:SubscriptionId
-
-            $vhdId = ""
-            if (Test-Path "c:\vhd-id.txt") {
-                $vhdId = Get-Content "c:\vhd-id.txt"
-            }
-            $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
-
-            $imdsProperties = Get-InstanceMetadataServiceTelemetry
-            foreach ($key in $imdsProperties.keys) {
-                $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-            }
-
-            $configAppInsightsClientTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Config-AppInsightsClient", $configAppInsightsClientTimer.Elapsed.TotalSeconds)
-        }
-
         # Install OpenSSH if SSH enabled
         $sshEnabled = [System.Convert]::ToBoolean("true")
 
         if ( $sshEnabled ) {
             Write-Log "Install OpenSSH"
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-OpenSSH -SSHKeys $SSHKeys
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-OpenSSH", $installOpenSSHTimer.Elapsed.TotalSeconds)
-            }
         }
 
         Write-Log "Apply telemetry data setting"
         Set-TelemetrySetting -WindowsTelemetryGUID $global:WindowsTelemetryGUID
 
         Write-Log "Resize os drive if possible"
-        if ($global:EnableTelemetry) {
-            $resizeTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         Resize-OSDrive
-        if ($global:EnableTelemetry) {
-            $resizeTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Resize-OSDrive", $resizeTimer.Elapsed.TotalSeconds)
-        }
 
         Write-Log "Initialize data disks"
         Initialize-DataDisks
@@ -314,9 +252,6 @@ try
 
         if ($useContainerD) {
             Write-Log "Installing ContainerD"
-            if ($global:EnableTelemetry) {
-                $containerdTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             $cniBinPath = $global:AzureCNIBinDir
             $cniConfigPath = $global:AzureCNIConfDir
             if ($global:NetworkPlugin -eq "kubenet") {
@@ -324,21 +259,10 @@ try
                 $cniConfigPath = $global:CNIConfigPath
             }
             Install-Containerd -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir
-            if ($global:EnableTelemetry) {
-                $containerdTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-ContainerD", $containerdTimer.Elapsed.TotalSeconds)
-            }
         } else {
             Write-Log "Install docker"
-            if ($global:EnableTelemetry) {
-                $dockerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-Docker -DockerVersion $global:DockerVersion
             Set-DockerLogFileOptions
-            if ($global:EnableTelemetry) {
-                $dockerTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-Docker", $dockerTimer.Elapsed.TotalSeconds)
-            }
         }
 
         # For AKSClustomCloud, TargetEnvironment must be set to AzureStackCloud
@@ -412,14 +336,7 @@ try
          }
 
         Write-Log "Create the Pause Container kubletwin/pause"
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         New-InfraContainer -KubeDir $global:KubeDir -ContainerRuntime $global:ContainerRuntime
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("New-InfraContainer", $infraContainerTimer.Elapsed.TotalSeconds)
-        }
 
         if (-not (Test-ContainerImageExists -Image "kubletwin/pause" -ContainerRuntime $global:ContainerRuntime)) {
             Write-Log "Could not find container with name kubletwin/pause"
@@ -518,12 +435,6 @@ try
             Remove-Item $CacheDir -Recurse -Force
         }
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("TotalDuration", $global:globalTimer.Elapsed.TotalSeconds)
-            $global:AppInsightsClient.Flush()
-        }
-
         if ($global:TLSBootstrapToken) {
             Write-Log "Removing temporary kube config"
             $kubeConfigFile = [io.path]::Combine($KubeDir, "config")
@@ -536,13 +447,6 @@ try
 }
 catch
 {
-    if ($global:EnableTelemetry) {
-        $exceptionTelemtry = New-Object "Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry"
-        $exceptionTelemtry.Exception = $_.Exception
-        $global:AppInsightsClient.TrackException($exceptionTelemtry)
-        $global:AppInsightsClient.Flush()
-    }
-
     # Set-ExitCode will exit with the specified ExitCode immediately and not be caught by this catch block
     # Ideally all exceptions will be handled and no exception will be thrown.
     Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_UNKNOWN -ErrorMessage $_

--- a/pkg/agent/testdata/AKSWindows2019+CustomVnet/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+CustomVnet/CustomData
@@ -149,10 +149,6 @@ $global:NetworkPlugin = "azure"
 $global:VNetCNIPluginsURL = "https://acs-mirror.azureedge.net/azure-cni/v1.1.3/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.3.zip"
 $global:IsDualStackEnabled = $false
 
-# Telemetry settings
-$global:EnableTelemetry = [System.Convert]::ToBoolean("false");
-$global:TelemetryKey = "";
-
 # CSI Proxy settings
 $global:EnableCsiProxy = [System.Convert]::ToBoolean("false");
 $global:CsiProxyUrl = "";
@@ -210,77 +206,19 @@ try
 
         Write-Log ".\CustomDataSetupScript.ps1 -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp -MasterFQDNPrefix $MasterFQDNPrefix -Location $Location -AADClientId $AADClientId -NetworkAPIVersion $NetworkAPIVersion -TargetEnvironment $TargetEnvironment"
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
-
-            $configAppInsightsClientTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            # Get app insights binaries and set up app insights client
-            Create-Directory -FullPath c:\k\appinsights -DirectoryUsage "storing appinsights"
-            DownloadFileOverHttp -Url "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg" -DestinationPath "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip"
-            Expand-Archive -Path "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip" -DestinationPath "c:\k\appinsights"
-            $appInsightsDll = "c:\k\appinsights\lib\net46\Microsoft.ApplicationInsights.dll"
-            [Reflection.Assembly]::LoadFile($appInsightsDll)
-            $conf = New-Object "Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration"
-            $conf.DisableTelemetry = -not $global:EnableTelemetry
-            $conf.InstrumentationKey = $global:TelemetryKey
-            $global:AppInsightsClient = New-Object "Microsoft.ApplicationInsights.TelemetryClient"($conf)
-
-            $global:AppInsightsClient.Context.Properties["correlation_id"] = New-Guid
-            $global:AppInsightsClient.Context.Properties["cri"] = $global:ContainerRuntime
-            # TODO: Update once containerd versioning story is decided
-            $global:AppInsightsClient.Context.Properties["cri_version"] = if ($global:ContainerRuntime -eq "docker") { $global:DockerVersion } else { "" }
-            $global:AppInsightsClient.Context.Properties["k8s_version"] = $global:KubeBinariesVersion
-            $global:AppInsightsClient.Context.Properties["lb_sku"] = $global:LoadBalancerSku
-            $global:AppInsightsClient.Context.Properties["location"] = $Location
-            $global:AppInsightsClient.Context.Properties["os_type"] = "windows"
-            $global:AppInsightsClient.Context.Properties["os_version"] = Get-WindowsVersion
-            $global:AppInsightsClient.Context.Properties["network_plugin"] = $global:NetworkPlugin
-            $global:AppInsightsClient.Context.Properties["network_plugin_version"] = Get-CniVersion
-            $global:AppInsightsClient.Context.Properties["network_mode"] = $global:NetworkMode
-            $global:AppInsightsClient.Context.Properties["subscription_id"] = $global:SubscriptionId
-
-            $vhdId = ""
-            if (Test-Path "c:\vhd-id.txt") {
-                $vhdId = Get-Content "c:\vhd-id.txt"
-            }
-            $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
-
-            $imdsProperties = Get-InstanceMetadataServiceTelemetry
-            foreach ($key in $imdsProperties.keys) {
-                $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-            }
-
-            $configAppInsightsClientTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Config-AppInsightsClient", $configAppInsightsClientTimer.Elapsed.TotalSeconds)
-        }
-
         # Install OpenSSH if SSH enabled
         $sshEnabled = [System.Convert]::ToBoolean("true")
 
         if ( $sshEnabled ) {
             Write-Log "Install OpenSSH"
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-OpenSSH -SSHKeys $SSHKeys
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-OpenSSH", $installOpenSSHTimer.Elapsed.TotalSeconds)
-            }
         }
 
         Write-Log "Apply telemetry data setting"
         Set-TelemetrySetting -WindowsTelemetryGUID $global:WindowsTelemetryGUID
 
         Write-Log "Resize os drive if possible"
-        if ($global:EnableTelemetry) {
-            $resizeTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         Resize-OSDrive
-        if ($global:EnableTelemetry) {
-            $resizeTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Resize-OSDrive", $resizeTimer.Elapsed.TotalSeconds)
-        }
 
         Write-Log "Initialize data disks"
         Initialize-DataDisks
@@ -314,9 +252,6 @@ try
 
         if ($useContainerD) {
             Write-Log "Installing ContainerD"
-            if ($global:EnableTelemetry) {
-                $containerdTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             $cniBinPath = $global:AzureCNIBinDir
             $cniConfigPath = $global:AzureCNIConfDir
             if ($global:NetworkPlugin -eq "kubenet") {
@@ -324,21 +259,10 @@ try
                 $cniConfigPath = $global:CNIConfigPath
             }
             Install-Containerd -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir
-            if ($global:EnableTelemetry) {
-                $containerdTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-ContainerD", $containerdTimer.Elapsed.TotalSeconds)
-            }
         } else {
             Write-Log "Install docker"
-            if ($global:EnableTelemetry) {
-                $dockerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-Docker -DockerVersion $global:DockerVersion
             Set-DockerLogFileOptions
-            if ($global:EnableTelemetry) {
-                $dockerTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-Docker", $dockerTimer.Elapsed.TotalSeconds)
-            }
         }
 
         # For AKSClustomCloud, TargetEnvironment must be set to AzureStackCloud
@@ -406,14 +330,7 @@ try
          }
 
         Write-Log "Create the Pause Container kubletwin/pause"
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         New-InfraContainer -KubeDir $global:KubeDir -ContainerRuntime $global:ContainerRuntime
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("New-InfraContainer", $infraContainerTimer.Elapsed.TotalSeconds)
-        }
 
         if (-not (Test-ContainerImageExists -Image "kubletwin/pause" -ContainerRuntime $global:ContainerRuntime)) {
             Write-Log "Could not find container with name kubletwin/pause"
@@ -512,12 +429,6 @@ try
             Remove-Item $CacheDir -Recurse -Force
         }
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("TotalDuration", $global:globalTimer.Elapsed.TotalSeconds)
-            $global:AppInsightsClient.Flush()
-        }
-
         if ($global:TLSBootstrapToken) {
             Write-Log "Removing temporary kube config"
             $kubeConfigFile = [io.path]::Combine($KubeDir, "config")
@@ -530,13 +441,6 @@ try
 }
 catch
 {
-    if ($global:EnableTelemetry) {
-        $exceptionTelemtry = New-Object "Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry"
-        $exceptionTelemtry.Exception = $_.Exception
-        $global:AppInsightsClient.TrackException($exceptionTelemtry)
-        $global:AppInsightsClient.Flush()
-    }
-
     # Set-ExitCode will exit with the specified ExitCode immediately and not be caught by this catch block
     # Ideally all exceptions will be handled and no exception will be thrown.
     Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_UNKNOWN -ErrorMessage $_

--- a/pkg/agent/testdata/AKSWindows2019+EnablePrivateClusterHostsConfigAgent/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+EnablePrivateClusterHostsConfigAgent/CustomData
@@ -149,10 +149,6 @@ $global:NetworkPlugin = "azure"
 $global:VNetCNIPluginsURL = "https://acs-mirror.azureedge.net/azure-cni/v1.1.3/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.3.zip"
 $global:IsDualStackEnabled = $false
 
-# Telemetry settings
-$global:EnableTelemetry = [System.Convert]::ToBoolean("false");
-$global:TelemetryKey = "";
-
 # CSI Proxy settings
 $global:EnableCsiProxy = [System.Convert]::ToBoolean("false");
 $global:CsiProxyUrl = "";
@@ -210,77 +206,19 @@ try
 
         Write-Log ".\CustomDataSetupScript.ps1 -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp -MasterFQDNPrefix $MasterFQDNPrefix -Location $Location -AADClientId $AADClientId -NetworkAPIVersion $NetworkAPIVersion -TargetEnvironment $TargetEnvironment"
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
-
-            $configAppInsightsClientTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            # Get app insights binaries and set up app insights client
-            Create-Directory -FullPath c:\k\appinsights -DirectoryUsage "storing appinsights"
-            DownloadFileOverHttp -Url "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg" -DestinationPath "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip"
-            Expand-Archive -Path "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip" -DestinationPath "c:\k\appinsights"
-            $appInsightsDll = "c:\k\appinsights\lib\net46\Microsoft.ApplicationInsights.dll"
-            [Reflection.Assembly]::LoadFile($appInsightsDll)
-            $conf = New-Object "Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration"
-            $conf.DisableTelemetry = -not $global:EnableTelemetry
-            $conf.InstrumentationKey = $global:TelemetryKey
-            $global:AppInsightsClient = New-Object "Microsoft.ApplicationInsights.TelemetryClient"($conf)
-
-            $global:AppInsightsClient.Context.Properties["correlation_id"] = New-Guid
-            $global:AppInsightsClient.Context.Properties["cri"] = $global:ContainerRuntime
-            # TODO: Update once containerd versioning story is decided
-            $global:AppInsightsClient.Context.Properties["cri_version"] = if ($global:ContainerRuntime -eq "docker") { $global:DockerVersion } else { "" }
-            $global:AppInsightsClient.Context.Properties["k8s_version"] = $global:KubeBinariesVersion
-            $global:AppInsightsClient.Context.Properties["lb_sku"] = $global:LoadBalancerSku
-            $global:AppInsightsClient.Context.Properties["location"] = $Location
-            $global:AppInsightsClient.Context.Properties["os_type"] = "windows"
-            $global:AppInsightsClient.Context.Properties["os_version"] = Get-WindowsVersion
-            $global:AppInsightsClient.Context.Properties["network_plugin"] = $global:NetworkPlugin
-            $global:AppInsightsClient.Context.Properties["network_plugin_version"] = Get-CniVersion
-            $global:AppInsightsClient.Context.Properties["network_mode"] = $global:NetworkMode
-            $global:AppInsightsClient.Context.Properties["subscription_id"] = $global:SubscriptionId
-
-            $vhdId = ""
-            if (Test-Path "c:\vhd-id.txt") {
-                $vhdId = Get-Content "c:\vhd-id.txt"
-            }
-            $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
-
-            $imdsProperties = Get-InstanceMetadataServiceTelemetry
-            foreach ($key in $imdsProperties.keys) {
-                $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-            }
-
-            $configAppInsightsClientTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Config-AppInsightsClient", $configAppInsightsClientTimer.Elapsed.TotalSeconds)
-        }
-
         # Install OpenSSH if SSH enabled
         $sshEnabled = [System.Convert]::ToBoolean("true")
 
         if ( $sshEnabled ) {
             Write-Log "Install OpenSSH"
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-OpenSSH -SSHKeys $SSHKeys
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-OpenSSH", $installOpenSSHTimer.Elapsed.TotalSeconds)
-            }
         }
 
         Write-Log "Apply telemetry data setting"
         Set-TelemetrySetting -WindowsTelemetryGUID $global:WindowsTelemetryGUID
 
         Write-Log "Resize os drive if possible"
-        if ($global:EnableTelemetry) {
-            $resizeTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         Resize-OSDrive
-        if ($global:EnableTelemetry) {
-            $resizeTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Resize-OSDrive", $resizeTimer.Elapsed.TotalSeconds)
-        }
 
         Write-Log "Initialize data disks"
         Initialize-DataDisks
@@ -314,9 +252,6 @@ try
 
         if ($useContainerD) {
             Write-Log "Installing ContainerD"
-            if ($global:EnableTelemetry) {
-                $containerdTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             $cniBinPath = $global:AzureCNIBinDir
             $cniConfigPath = $global:AzureCNIConfDir
             if ($global:NetworkPlugin -eq "kubenet") {
@@ -324,21 +259,10 @@ try
                 $cniConfigPath = $global:CNIConfigPath
             }
             Install-Containerd -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir
-            if ($global:EnableTelemetry) {
-                $containerdTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-ContainerD", $containerdTimer.Elapsed.TotalSeconds)
-            }
         } else {
             Write-Log "Install docker"
-            if ($global:EnableTelemetry) {
-                $dockerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-Docker -DockerVersion $global:DockerVersion
             Set-DockerLogFileOptions
-            if ($global:EnableTelemetry) {
-                $dockerTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-Docker", $dockerTimer.Elapsed.TotalSeconds)
-            }
         }
 
         # For AKSClustomCloud, TargetEnvironment must be set to AzureStackCloud
@@ -406,14 +330,7 @@ try
          }
 
         Write-Log "Create the Pause Container kubletwin/pause"
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         New-InfraContainer -KubeDir $global:KubeDir -ContainerRuntime $global:ContainerRuntime
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("New-InfraContainer", $infraContainerTimer.Elapsed.TotalSeconds)
-        }
 
         if (-not (Test-ContainerImageExists -Image "kubletwin/pause" -ContainerRuntime $global:ContainerRuntime)) {
             Write-Log "Could not find container with name kubletwin/pause"
@@ -512,12 +429,6 @@ try
             Remove-Item $CacheDir -Recurse -Force
         }
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("TotalDuration", $global:globalTimer.Elapsed.TotalSeconds)
-            $global:AppInsightsClient.Flush()
-        }
-
         if ($global:TLSBootstrapToken) {
             Write-Log "Removing temporary kube config"
             $kubeConfigFile = [io.path]::Combine($KubeDir, "config")
@@ -530,13 +441,6 @@ try
 }
 catch
 {
-    if ($global:EnableTelemetry) {
-        $exceptionTelemtry = New-Object "Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry"
-        $exceptionTelemtry.Exception = $_.Exception
-        $global:AppInsightsClient.TrackException($exceptionTelemtry)
-        $global:AppInsightsClient.Flush()
-    }
-
     # Set-ExitCode will exit with the specified ExitCode immediately and not be caught by this catch block
     # Ideally all exceptions will be handled and no exception will be thrown.
     Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_UNKNOWN -ErrorMessage $_

--- a/pkg/agent/testdata/AKSWindows2019+K8S116/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S116/CustomData
@@ -149,10 +149,6 @@ $global:NetworkPlugin = "azure"
 $global:VNetCNIPluginsURL = "https://acs-mirror.azureedge.net/azure-cni/v1.1.3/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.3.zip"
 $global:IsDualStackEnabled = $false
 
-# Telemetry settings
-$global:EnableTelemetry = [System.Convert]::ToBoolean("false");
-$global:TelemetryKey = "";
-
 # CSI Proxy settings
 $global:EnableCsiProxy = [System.Convert]::ToBoolean("false");
 $global:CsiProxyUrl = "";
@@ -210,77 +206,19 @@ try
 
         Write-Log ".\CustomDataSetupScript.ps1 -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp -MasterFQDNPrefix $MasterFQDNPrefix -Location $Location -AADClientId $AADClientId -NetworkAPIVersion $NetworkAPIVersion -TargetEnvironment $TargetEnvironment"
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
-
-            $configAppInsightsClientTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            # Get app insights binaries and set up app insights client
-            Create-Directory -FullPath c:\k\appinsights -DirectoryUsage "storing appinsights"
-            DownloadFileOverHttp -Url "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg" -DestinationPath "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip"
-            Expand-Archive -Path "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip" -DestinationPath "c:\k\appinsights"
-            $appInsightsDll = "c:\k\appinsights\lib\net46\Microsoft.ApplicationInsights.dll"
-            [Reflection.Assembly]::LoadFile($appInsightsDll)
-            $conf = New-Object "Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration"
-            $conf.DisableTelemetry = -not $global:EnableTelemetry
-            $conf.InstrumentationKey = $global:TelemetryKey
-            $global:AppInsightsClient = New-Object "Microsoft.ApplicationInsights.TelemetryClient"($conf)
-
-            $global:AppInsightsClient.Context.Properties["correlation_id"] = New-Guid
-            $global:AppInsightsClient.Context.Properties["cri"] = $global:ContainerRuntime
-            # TODO: Update once containerd versioning story is decided
-            $global:AppInsightsClient.Context.Properties["cri_version"] = if ($global:ContainerRuntime -eq "docker") { $global:DockerVersion } else { "" }
-            $global:AppInsightsClient.Context.Properties["k8s_version"] = $global:KubeBinariesVersion
-            $global:AppInsightsClient.Context.Properties["lb_sku"] = $global:LoadBalancerSku
-            $global:AppInsightsClient.Context.Properties["location"] = $Location
-            $global:AppInsightsClient.Context.Properties["os_type"] = "windows"
-            $global:AppInsightsClient.Context.Properties["os_version"] = Get-WindowsVersion
-            $global:AppInsightsClient.Context.Properties["network_plugin"] = $global:NetworkPlugin
-            $global:AppInsightsClient.Context.Properties["network_plugin_version"] = Get-CniVersion
-            $global:AppInsightsClient.Context.Properties["network_mode"] = $global:NetworkMode
-            $global:AppInsightsClient.Context.Properties["subscription_id"] = $global:SubscriptionId
-
-            $vhdId = ""
-            if (Test-Path "c:\vhd-id.txt") {
-                $vhdId = Get-Content "c:\vhd-id.txt"
-            }
-            $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
-
-            $imdsProperties = Get-InstanceMetadataServiceTelemetry
-            foreach ($key in $imdsProperties.keys) {
-                $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-            }
-
-            $configAppInsightsClientTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Config-AppInsightsClient", $configAppInsightsClientTimer.Elapsed.TotalSeconds)
-        }
-
         # Install OpenSSH if SSH enabled
         $sshEnabled = [System.Convert]::ToBoolean("true")
 
         if ( $sshEnabled ) {
             Write-Log "Install OpenSSH"
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-OpenSSH -SSHKeys $SSHKeys
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-OpenSSH", $installOpenSSHTimer.Elapsed.TotalSeconds)
-            }
         }
 
         Write-Log "Apply telemetry data setting"
         Set-TelemetrySetting -WindowsTelemetryGUID $global:WindowsTelemetryGUID
 
         Write-Log "Resize os drive if possible"
-        if ($global:EnableTelemetry) {
-            $resizeTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         Resize-OSDrive
-        if ($global:EnableTelemetry) {
-            $resizeTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Resize-OSDrive", $resizeTimer.Elapsed.TotalSeconds)
-        }
 
         Write-Log "Initialize data disks"
         Initialize-DataDisks
@@ -314,9 +252,6 @@ try
 
         if ($useContainerD) {
             Write-Log "Installing ContainerD"
-            if ($global:EnableTelemetry) {
-                $containerdTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             $cniBinPath = $global:AzureCNIBinDir
             $cniConfigPath = $global:AzureCNIConfDir
             if ($global:NetworkPlugin -eq "kubenet") {
@@ -324,21 +259,10 @@ try
                 $cniConfigPath = $global:CNIConfigPath
             }
             Install-Containerd -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir
-            if ($global:EnableTelemetry) {
-                $containerdTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-ContainerD", $containerdTimer.Elapsed.TotalSeconds)
-            }
         } else {
             Write-Log "Install docker"
-            if ($global:EnableTelemetry) {
-                $dockerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-Docker -DockerVersion $global:DockerVersion
             Set-DockerLogFileOptions
-            if ($global:EnableTelemetry) {
-                $dockerTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-Docker", $dockerTimer.Elapsed.TotalSeconds)
-            }
         }
 
         # For AKSClustomCloud, TargetEnvironment must be set to AzureStackCloud
@@ -406,14 +330,7 @@ try
          }
 
         Write-Log "Create the Pause Container kubletwin/pause"
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         New-InfraContainer -KubeDir $global:KubeDir -ContainerRuntime $global:ContainerRuntime
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("New-InfraContainer", $infraContainerTimer.Elapsed.TotalSeconds)
-        }
 
         if (-not (Test-ContainerImageExists -Image "kubletwin/pause" -ContainerRuntime $global:ContainerRuntime)) {
             Write-Log "Could not find container with name kubletwin/pause"
@@ -512,12 +429,6 @@ try
             Remove-Item $CacheDir -Recurse -Force
         }
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("TotalDuration", $global:globalTimer.Elapsed.TotalSeconds)
-            $global:AppInsightsClient.Flush()
-        }
-
         if ($global:TLSBootstrapToken) {
             Write-Log "Removing temporary kube config"
             $kubeConfigFile = [io.path]::Combine($KubeDir, "config")
@@ -530,13 +441,6 @@ try
 }
 catch
 {
-    if ($global:EnableTelemetry) {
-        $exceptionTelemtry = New-Object "Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry"
-        $exceptionTelemtry.Exception = $_.Exception
-        $global:AppInsightsClient.TrackException($exceptionTelemtry)
-        $global:AppInsightsClient.Flush()
-    }
-
     # Set-ExitCode will exit with the specified ExitCode immediately and not be caught by this catch block
     # Ideally all exceptions will be handled and no exception will be thrown.
     Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_UNKNOWN -ErrorMessage $_

--- a/pkg/agent/testdata/AKSWindows2019+K8S117/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S117/CustomData
@@ -149,10 +149,6 @@ $global:NetworkPlugin = "azure"
 $global:VNetCNIPluginsURL = "https://acs-mirror.azureedge.net/azure-cni/v1.1.3/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.3.zip"
 $global:IsDualStackEnabled = $false
 
-# Telemetry settings
-$global:EnableTelemetry = [System.Convert]::ToBoolean("false");
-$global:TelemetryKey = "";
-
 # CSI Proxy settings
 $global:EnableCsiProxy = [System.Convert]::ToBoolean("false");
 $global:CsiProxyUrl = "";
@@ -210,77 +206,19 @@ try
 
         Write-Log ".\CustomDataSetupScript.ps1 -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp -MasterFQDNPrefix $MasterFQDNPrefix -Location $Location -AADClientId $AADClientId -NetworkAPIVersion $NetworkAPIVersion -TargetEnvironment $TargetEnvironment"
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
-
-            $configAppInsightsClientTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            # Get app insights binaries and set up app insights client
-            Create-Directory -FullPath c:\k\appinsights -DirectoryUsage "storing appinsights"
-            DownloadFileOverHttp -Url "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg" -DestinationPath "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip"
-            Expand-Archive -Path "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip" -DestinationPath "c:\k\appinsights"
-            $appInsightsDll = "c:\k\appinsights\lib\net46\Microsoft.ApplicationInsights.dll"
-            [Reflection.Assembly]::LoadFile($appInsightsDll)
-            $conf = New-Object "Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration"
-            $conf.DisableTelemetry = -not $global:EnableTelemetry
-            $conf.InstrumentationKey = $global:TelemetryKey
-            $global:AppInsightsClient = New-Object "Microsoft.ApplicationInsights.TelemetryClient"($conf)
-
-            $global:AppInsightsClient.Context.Properties["correlation_id"] = New-Guid
-            $global:AppInsightsClient.Context.Properties["cri"] = $global:ContainerRuntime
-            # TODO: Update once containerd versioning story is decided
-            $global:AppInsightsClient.Context.Properties["cri_version"] = if ($global:ContainerRuntime -eq "docker") { $global:DockerVersion } else { "" }
-            $global:AppInsightsClient.Context.Properties["k8s_version"] = $global:KubeBinariesVersion
-            $global:AppInsightsClient.Context.Properties["lb_sku"] = $global:LoadBalancerSku
-            $global:AppInsightsClient.Context.Properties["location"] = $Location
-            $global:AppInsightsClient.Context.Properties["os_type"] = "windows"
-            $global:AppInsightsClient.Context.Properties["os_version"] = Get-WindowsVersion
-            $global:AppInsightsClient.Context.Properties["network_plugin"] = $global:NetworkPlugin
-            $global:AppInsightsClient.Context.Properties["network_plugin_version"] = Get-CniVersion
-            $global:AppInsightsClient.Context.Properties["network_mode"] = $global:NetworkMode
-            $global:AppInsightsClient.Context.Properties["subscription_id"] = $global:SubscriptionId
-
-            $vhdId = ""
-            if (Test-Path "c:\vhd-id.txt") {
-                $vhdId = Get-Content "c:\vhd-id.txt"
-            }
-            $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
-
-            $imdsProperties = Get-InstanceMetadataServiceTelemetry
-            foreach ($key in $imdsProperties.keys) {
-                $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-            }
-
-            $configAppInsightsClientTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Config-AppInsightsClient", $configAppInsightsClientTimer.Elapsed.TotalSeconds)
-        }
-
         # Install OpenSSH if SSH enabled
         $sshEnabled = [System.Convert]::ToBoolean("true")
 
         if ( $sshEnabled ) {
             Write-Log "Install OpenSSH"
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-OpenSSH -SSHKeys $SSHKeys
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-OpenSSH", $installOpenSSHTimer.Elapsed.TotalSeconds)
-            }
         }
 
         Write-Log "Apply telemetry data setting"
         Set-TelemetrySetting -WindowsTelemetryGUID $global:WindowsTelemetryGUID
 
         Write-Log "Resize os drive if possible"
-        if ($global:EnableTelemetry) {
-            $resizeTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         Resize-OSDrive
-        if ($global:EnableTelemetry) {
-            $resizeTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Resize-OSDrive", $resizeTimer.Elapsed.TotalSeconds)
-        }
 
         Write-Log "Initialize data disks"
         Initialize-DataDisks
@@ -314,9 +252,6 @@ try
 
         if ($useContainerD) {
             Write-Log "Installing ContainerD"
-            if ($global:EnableTelemetry) {
-                $containerdTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             $cniBinPath = $global:AzureCNIBinDir
             $cniConfigPath = $global:AzureCNIConfDir
             if ($global:NetworkPlugin -eq "kubenet") {
@@ -324,21 +259,10 @@ try
                 $cniConfigPath = $global:CNIConfigPath
             }
             Install-Containerd -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir
-            if ($global:EnableTelemetry) {
-                $containerdTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-ContainerD", $containerdTimer.Elapsed.TotalSeconds)
-            }
         } else {
             Write-Log "Install docker"
-            if ($global:EnableTelemetry) {
-                $dockerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-Docker -DockerVersion $global:DockerVersion
             Set-DockerLogFileOptions
-            if ($global:EnableTelemetry) {
-                $dockerTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-Docker", $dockerTimer.Elapsed.TotalSeconds)
-            }
         }
 
         # For AKSClustomCloud, TargetEnvironment must be set to AzureStackCloud
@@ -406,14 +330,7 @@ try
          }
 
         Write-Log "Create the Pause Container kubletwin/pause"
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         New-InfraContainer -KubeDir $global:KubeDir -ContainerRuntime $global:ContainerRuntime
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("New-InfraContainer", $infraContainerTimer.Elapsed.TotalSeconds)
-        }
 
         if (-not (Test-ContainerImageExists -Image "kubletwin/pause" -ContainerRuntime $global:ContainerRuntime)) {
             Write-Log "Could not find container with name kubletwin/pause"
@@ -512,12 +429,6 @@ try
             Remove-Item $CacheDir -Recurse -Force
         }
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("TotalDuration", $global:globalTimer.Elapsed.TotalSeconds)
-            $global:AppInsightsClient.Flush()
-        }
-
         if ($global:TLSBootstrapToken) {
             Write-Log "Removing temporary kube config"
             $kubeConfigFile = [io.path]::Combine($KubeDir, "config")
@@ -530,13 +441,6 @@ try
 }
 catch
 {
-    if ($global:EnableTelemetry) {
-        $exceptionTelemtry = New-Object "Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry"
-        $exceptionTelemtry.Exception = $_.Exception
-        $global:AppInsightsClient.TrackException($exceptionTelemtry)
-        $global:AppInsightsClient.Flush()
-    }
-
     # Set-ExitCode will exit with the specified ExitCode immediately and not be caught by this catch block
     # Ideally all exceptions will be handled and no exception will be thrown.
     Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_UNKNOWN -ErrorMessage $_

--- a/pkg/agent/testdata/AKSWindows2019+K8S118/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S118/CustomData
@@ -149,10 +149,6 @@ $global:NetworkPlugin = "azure"
 $global:VNetCNIPluginsURL = "https://acs-mirror.azureedge.net/azure-cni/v1.1.3/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.3.zip"
 $global:IsDualStackEnabled = $false
 
-# Telemetry settings
-$global:EnableTelemetry = [System.Convert]::ToBoolean("false");
-$global:TelemetryKey = "";
-
 # CSI Proxy settings
 $global:EnableCsiProxy = [System.Convert]::ToBoolean("false");
 $global:CsiProxyUrl = "";
@@ -210,77 +206,19 @@ try
 
         Write-Log ".\CustomDataSetupScript.ps1 -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp -MasterFQDNPrefix $MasterFQDNPrefix -Location $Location -AADClientId $AADClientId -NetworkAPIVersion $NetworkAPIVersion -TargetEnvironment $TargetEnvironment"
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
-
-            $configAppInsightsClientTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            # Get app insights binaries and set up app insights client
-            Create-Directory -FullPath c:\k\appinsights -DirectoryUsage "storing appinsights"
-            DownloadFileOverHttp -Url "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg" -DestinationPath "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip"
-            Expand-Archive -Path "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip" -DestinationPath "c:\k\appinsights"
-            $appInsightsDll = "c:\k\appinsights\lib\net46\Microsoft.ApplicationInsights.dll"
-            [Reflection.Assembly]::LoadFile($appInsightsDll)
-            $conf = New-Object "Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration"
-            $conf.DisableTelemetry = -not $global:EnableTelemetry
-            $conf.InstrumentationKey = $global:TelemetryKey
-            $global:AppInsightsClient = New-Object "Microsoft.ApplicationInsights.TelemetryClient"($conf)
-
-            $global:AppInsightsClient.Context.Properties["correlation_id"] = New-Guid
-            $global:AppInsightsClient.Context.Properties["cri"] = $global:ContainerRuntime
-            # TODO: Update once containerd versioning story is decided
-            $global:AppInsightsClient.Context.Properties["cri_version"] = if ($global:ContainerRuntime -eq "docker") { $global:DockerVersion } else { "" }
-            $global:AppInsightsClient.Context.Properties["k8s_version"] = $global:KubeBinariesVersion
-            $global:AppInsightsClient.Context.Properties["lb_sku"] = $global:LoadBalancerSku
-            $global:AppInsightsClient.Context.Properties["location"] = $Location
-            $global:AppInsightsClient.Context.Properties["os_type"] = "windows"
-            $global:AppInsightsClient.Context.Properties["os_version"] = Get-WindowsVersion
-            $global:AppInsightsClient.Context.Properties["network_plugin"] = $global:NetworkPlugin
-            $global:AppInsightsClient.Context.Properties["network_plugin_version"] = Get-CniVersion
-            $global:AppInsightsClient.Context.Properties["network_mode"] = $global:NetworkMode
-            $global:AppInsightsClient.Context.Properties["subscription_id"] = $global:SubscriptionId
-
-            $vhdId = ""
-            if (Test-Path "c:\vhd-id.txt") {
-                $vhdId = Get-Content "c:\vhd-id.txt"
-            }
-            $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
-
-            $imdsProperties = Get-InstanceMetadataServiceTelemetry
-            foreach ($key in $imdsProperties.keys) {
-                $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-            }
-
-            $configAppInsightsClientTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Config-AppInsightsClient", $configAppInsightsClientTimer.Elapsed.TotalSeconds)
-        }
-
         # Install OpenSSH if SSH enabled
         $sshEnabled = [System.Convert]::ToBoolean("true")
 
         if ( $sshEnabled ) {
             Write-Log "Install OpenSSH"
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-OpenSSH -SSHKeys $SSHKeys
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-OpenSSH", $installOpenSSHTimer.Elapsed.TotalSeconds)
-            }
         }
 
         Write-Log "Apply telemetry data setting"
         Set-TelemetrySetting -WindowsTelemetryGUID $global:WindowsTelemetryGUID
 
         Write-Log "Resize os drive if possible"
-        if ($global:EnableTelemetry) {
-            $resizeTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         Resize-OSDrive
-        if ($global:EnableTelemetry) {
-            $resizeTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Resize-OSDrive", $resizeTimer.Elapsed.TotalSeconds)
-        }
 
         Write-Log "Initialize data disks"
         Initialize-DataDisks
@@ -314,9 +252,6 @@ try
 
         if ($useContainerD) {
             Write-Log "Installing ContainerD"
-            if ($global:EnableTelemetry) {
-                $containerdTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             $cniBinPath = $global:AzureCNIBinDir
             $cniConfigPath = $global:AzureCNIConfDir
             if ($global:NetworkPlugin -eq "kubenet") {
@@ -324,21 +259,10 @@ try
                 $cniConfigPath = $global:CNIConfigPath
             }
             Install-Containerd -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir
-            if ($global:EnableTelemetry) {
-                $containerdTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-ContainerD", $containerdTimer.Elapsed.TotalSeconds)
-            }
         } else {
             Write-Log "Install docker"
-            if ($global:EnableTelemetry) {
-                $dockerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-Docker -DockerVersion $global:DockerVersion
             Set-DockerLogFileOptions
-            if ($global:EnableTelemetry) {
-                $dockerTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-Docker", $dockerTimer.Elapsed.TotalSeconds)
-            }
         }
 
         # For AKSClustomCloud, TargetEnvironment must be set to AzureStackCloud
@@ -406,14 +330,7 @@ try
          }
 
         Write-Log "Create the Pause Container kubletwin/pause"
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         New-InfraContainer -KubeDir $global:KubeDir -ContainerRuntime $global:ContainerRuntime
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("New-InfraContainer", $infraContainerTimer.Elapsed.TotalSeconds)
-        }
 
         if (-not (Test-ContainerImageExists -Image "kubletwin/pause" -ContainerRuntime $global:ContainerRuntime)) {
             Write-Log "Could not find container with name kubletwin/pause"
@@ -512,12 +429,6 @@ try
             Remove-Item $CacheDir -Recurse -Force
         }
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("TotalDuration", $global:globalTimer.Elapsed.TotalSeconds)
-            $global:AppInsightsClient.Flush()
-        }
-
         if ($global:TLSBootstrapToken) {
             Write-Log "Removing temporary kube config"
             $kubeConfigFile = [io.path]::Combine($KubeDir, "config")
@@ -530,13 +441,6 @@ try
 }
 catch
 {
-    if ($global:EnableTelemetry) {
-        $exceptionTelemtry = New-Object "Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry"
-        $exceptionTelemtry.Exception = $_.Exception
-        $global:AppInsightsClient.TrackException($exceptionTelemtry)
-        $global:AppInsightsClient.Flush()
-    }
-
     # Set-ExitCode will exit with the specified ExitCode immediately and not be caught by this catch block
     # Ideally all exceptions will be handled and no exception will be thrown.
     Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_UNKNOWN -ErrorMessage $_

--- a/pkg/agent/testdata/AKSWindows2019+K8S119+CSI/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S119+CSI/CustomData
@@ -149,10 +149,6 @@ $global:NetworkPlugin = "azure"
 $global:VNetCNIPluginsURL = "https://acs-mirror.azureedge.net/azure-cni/v1.1.3/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.3.zip"
 $global:IsDualStackEnabled = $false
 
-# Telemetry settings
-$global:EnableTelemetry = [System.Convert]::ToBoolean("false");
-$global:TelemetryKey = "";
-
 # CSI Proxy settings
 $global:EnableCsiProxy = [System.Convert]::ToBoolean("true");
 $global:CsiProxyUrl = "https://acs-mirror.azureedge.net/csi-proxy/v0.1.0/binaries/csi-proxy.tar.gz";
@@ -210,77 +206,19 @@ try
 
         Write-Log ".\CustomDataSetupScript.ps1 -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp -MasterFQDNPrefix $MasterFQDNPrefix -Location $Location -AADClientId $AADClientId -NetworkAPIVersion $NetworkAPIVersion -TargetEnvironment $TargetEnvironment"
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
-
-            $configAppInsightsClientTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            # Get app insights binaries and set up app insights client
-            Create-Directory -FullPath c:\k\appinsights -DirectoryUsage "storing appinsights"
-            DownloadFileOverHttp -Url "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg" -DestinationPath "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip"
-            Expand-Archive -Path "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip" -DestinationPath "c:\k\appinsights"
-            $appInsightsDll = "c:\k\appinsights\lib\net46\Microsoft.ApplicationInsights.dll"
-            [Reflection.Assembly]::LoadFile($appInsightsDll)
-            $conf = New-Object "Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration"
-            $conf.DisableTelemetry = -not $global:EnableTelemetry
-            $conf.InstrumentationKey = $global:TelemetryKey
-            $global:AppInsightsClient = New-Object "Microsoft.ApplicationInsights.TelemetryClient"($conf)
-
-            $global:AppInsightsClient.Context.Properties["correlation_id"] = New-Guid
-            $global:AppInsightsClient.Context.Properties["cri"] = $global:ContainerRuntime
-            # TODO: Update once containerd versioning story is decided
-            $global:AppInsightsClient.Context.Properties["cri_version"] = if ($global:ContainerRuntime -eq "docker") { $global:DockerVersion } else { "" }
-            $global:AppInsightsClient.Context.Properties["k8s_version"] = $global:KubeBinariesVersion
-            $global:AppInsightsClient.Context.Properties["lb_sku"] = $global:LoadBalancerSku
-            $global:AppInsightsClient.Context.Properties["location"] = $Location
-            $global:AppInsightsClient.Context.Properties["os_type"] = "windows"
-            $global:AppInsightsClient.Context.Properties["os_version"] = Get-WindowsVersion
-            $global:AppInsightsClient.Context.Properties["network_plugin"] = $global:NetworkPlugin
-            $global:AppInsightsClient.Context.Properties["network_plugin_version"] = Get-CniVersion
-            $global:AppInsightsClient.Context.Properties["network_mode"] = $global:NetworkMode
-            $global:AppInsightsClient.Context.Properties["subscription_id"] = $global:SubscriptionId
-
-            $vhdId = ""
-            if (Test-Path "c:\vhd-id.txt") {
-                $vhdId = Get-Content "c:\vhd-id.txt"
-            }
-            $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
-
-            $imdsProperties = Get-InstanceMetadataServiceTelemetry
-            foreach ($key in $imdsProperties.keys) {
-                $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-            }
-
-            $configAppInsightsClientTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Config-AppInsightsClient", $configAppInsightsClientTimer.Elapsed.TotalSeconds)
-        }
-
         # Install OpenSSH if SSH enabled
         $sshEnabled = [System.Convert]::ToBoolean("true")
 
         if ( $sshEnabled ) {
             Write-Log "Install OpenSSH"
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-OpenSSH -SSHKeys $SSHKeys
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-OpenSSH", $installOpenSSHTimer.Elapsed.TotalSeconds)
-            }
         }
 
         Write-Log "Apply telemetry data setting"
         Set-TelemetrySetting -WindowsTelemetryGUID $global:WindowsTelemetryGUID
 
         Write-Log "Resize os drive if possible"
-        if ($global:EnableTelemetry) {
-            $resizeTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         Resize-OSDrive
-        if ($global:EnableTelemetry) {
-            $resizeTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Resize-OSDrive", $resizeTimer.Elapsed.TotalSeconds)
-        }
 
         Write-Log "Initialize data disks"
         Initialize-DataDisks
@@ -314,9 +252,6 @@ try
 
         if ($useContainerD) {
             Write-Log "Installing ContainerD"
-            if ($global:EnableTelemetry) {
-                $containerdTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             $cniBinPath = $global:AzureCNIBinDir
             $cniConfigPath = $global:AzureCNIConfDir
             if ($global:NetworkPlugin -eq "kubenet") {
@@ -324,21 +259,10 @@ try
                 $cniConfigPath = $global:CNIConfigPath
             }
             Install-Containerd -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir
-            if ($global:EnableTelemetry) {
-                $containerdTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-ContainerD", $containerdTimer.Elapsed.TotalSeconds)
-            }
         } else {
             Write-Log "Install docker"
-            if ($global:EnableTelemetry) {
-                $dockerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-Docker -DockerVersion $global:DockerVersion
             Set-DockerLogFileOptions
-            if ($global:EnableTelemetry) {
-                $dockerTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-Docker", $dockerTimer.Elapsed.TotalSeconds)
-            }
         }
 
         # For AKSClustomCloud, TargetEnvironment must be set to AzureStackCloud
@@ -406,14 +330,7 @@ try
          }
 
         Write-Log "Create the Pause Container kubletwin/pause"
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         New-InfraContainer -KubeDir $global:KubeDir -ContainerRuntime $global:ContainerRuntime
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("New-InfraContainer", $infraContainerTimer.Elapsed.TotalSeconds)
-        }
 
         if (-not (Test-ContainerImageExists -Image "kubletwin/pause" -ContainerRuntime $global:ContainerRuntime)) {
             Write-Log "Could not find container with name kubletwin/pause"
@@ -512,12 +429,6 @@ try
             Remove-Item $CacheDir -Recurse -Force
         }
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("TotalDuration", $global:globalTimer.Elapsed.TotalSeconds)
-            $global:AppInsightsClient.Flush()
-        }
-
         if ($global:TLSBootstrapToken) {
             Write-Log "Removing temporary kube config"
             $kubeConfigFile = [io.path]::Combine($KubeDir, "config")
@@ -530,13 +441,6 @@ try
 }
 catch
 {
-    if ($global:EnableTelemetry) {
-        $exceptionTelemtry = New-Object "Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry"
-        $exceptionTelemtry.Exception = $_.Exception
-        $global:AppInsightsClient.TrackException($exceptionTelemtry)
-        $global:AppInsightsClient.Flush()
-    }
-
     # Set-ExitCode will exit with the specified ExitCode immediately and not be caught by this catch block
     # Ideally all exceptions will be handled and no exception will be thrown.
     Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_UNKNOWN -ErrorMessage $_

--- a/pkg/agent/testdata/AKSWindows2019+K8S119+FIPS/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S119+FIPS/CustomData
@@ -149,10 +149,6 @@ $global:NetworkPlugin = "azure"
 $global:VNetCNIPluginsURL = "https://acs-mirror.azureedge.net/azure-cni/v1.1.3/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.3.zip"
 $global:IsDualStackEnabled = $false
 
-# Telemetry settings
-$global:EnableTelemetry = [System.Convert]::ToBoolean("false");
-$global:TelemetryKey = "";
-
 # CSI Proxy settings
 $global:EnableCsiProxy = [System.Convert]::ToBoolean("false");
 $global:CsiProxyUrl = "";
@@ -210,77 +206,19 @@ try
 
         Write-Log ".\CustomDataSetupScript.ps1 -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp -MasterFQDNPrefix $MasterFQDNPrefix -Location $Location -AADClientId $AADClientId -NetworkAPIVersion $NetworkAPIVersion -TargetEnvironment $TargetEnvironment"
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
-
-            $configAppInsightsClientTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            # Get app insights binaries and set up app insights client
-            Create-Directory -FullPath c:\k\appinsights -DirectoryUsage "storing appinsights"
-            DownloadFileOverHttp -Url "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg" -DestinationPath "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip"
-            Expand-Archive -Path "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip" -DestinationPath "c:\k\appinsights"
-            $appInsightsDll = "c:\k\appinsights\lib\net46\Microsoft.ApplicationInsights.dll"
-            [Reflection.Assembly]::LoadFile($appInsightsDll)
-            $conf = New-Object "Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration"
-            $conf.DisableTelemetry = -not $global:EnableTelemetry
-            $conf.InstrumentationKey = $global:TelemetryKey
-            $global:AppInsightsClient = New-Object "Microsoft.ApplicationInsights.TelemetryClient"($conf)
-
-            $global:AppInsightsClient.Context.Properties["correlation_id"] = New-Guid
-            $global:AppInsightsClient.Context.Properties["cri"] = $global:ContainerRuntime
-            # TODO: Update once containerd versioning story is decided
-            $global:AppInsightsClient.Context.Properties["cri_version"] = if ($global:ContainerRuntime -eq "docker") { $global:DockerVersion } else { "" }
-            $global:AppInsightsClient.Context.Properties["k8s_version"] = $global:KubeBinariesVersion
-            $global:AppInsightsClient.Context.Properties["lb_sku"] = $global:LoadBalancerSku
-            $global:AppInsightsClient.Context.Properties["location"] = $Location
-            $global:AppInsightsClient.Context.Properties["os_type"] = "windows"
-            $global:AppInsightsClient.Context.Properties["os_version"] = Get-WindowsVersion
-            $global:AppInsightsClient.Context.Properties["network_plugin"] = $global:NetworkPlugin
-            $global:AppInsightsClient.Context.Properties["network_plugin_version"] = Get-CniVersion
-            $global:AppInsightsClient.Context.Properties["network_mode"] = $global:NetworkMode
-            $global:AppInsightsClient.Context.Properties["subscription_id"] = $global:SubscriptionId
-
-            $vhdId = ""
-            if (Test-Path "c:\vhd-id.txt") {
-                $vhdId = Get-Content "c:\vhd-id.txt"
-            }
-            $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
-
-            $imdsProperties = Get-InstanceMetadataServiceTelemetry
-            foreach ($key in $imdsProperties.keys) {
-                $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-            }
-
-            $configAppInsightsClientTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Config-AppInsightsClient", $configAppInsightsClientTimer.Elapsed.TotalSeconds)
-        }
-
         # Install OpenSSH if SSH enabled
         $sshEnabled = [System.Convert]::ToBoolean("true")
 
         if ( $sshEnabled ) {
             Write-Log "Install OpenSSH"
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-OpenSSH -SSHKeys $SSHKeys
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-OpenSSH", $installOpenSSHTimer.Elapsed.TotalSeconds)
-            }
         }
 
         Write-Log "Apply telemetry data setting"
         Set-TelemetrySetting -WindowsTelemetryGUID $global:WindowsTelemetryGUID
 
         Write-Log "Resize os drive if possible"
-        if ($global:EnableTelemetry) {
-            $resizeTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         Resize-OSDrive
-        if ($global:EnableTelemetry) {
-            $resizeTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Resize-OSDrive", $resizeTimer.Elapsed.TotalSeconds)
-        }
 
         Write-Log "Initialize data disks"
         Initialize-DataDisks
@@ -314,9 +252,6 @@ try
 
         if ($useContainerD) {
             Write-Log "Installing ContainerD"
-            if ($global:EnableTelemetry) {
-                $containerdTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             $cniBinPath = $global:AzureCNIBinDir
             $cniConfigPath = $global:AzureCNIConfDir
             if ($global:NetworkPlugin -eq "kubenet") {
@@ -324,21 +259,10 @@ try
                 $cniConfigPath = $global:CNIConfigPath
             }
             Install-Containerd -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir
-            if ($global:EnableTelemetry) {
-                $containerdTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-ContainerD", $containerdTimer.Elapsed.TotalSeconds)
-            }
         } else {
             Write-Log "Install docker"
-            if ($global:EnableTelemetry) {
-                $dockerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-Docker -DockerVersion $global:DockerVersion
             Set-DockerLogFileOptions
-            if ($global:EnableTelemetry) {
-                $dockerTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-Docker", $dockerTimer.Elapsed.TotalSeconds)
-            }
         }
 
         # For AKSClustomCloud, TargetEnvironment must be set to AzureStackCloud
@@ -406,14 +330,7 @@ try
          }
 
         Write-Log "Create the Pause Container kubletwin/pause"
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         New-InfraContainer -KubeDir $global:KubeDir -ContainerRuntime $global:ContainerRuntime
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("New-InfraContainer", $infraContainerTimer.Elapsed.TotalSeconds)
-        }
 
         if (-not (Test-ContainerImageExists -Image "kubletwin/pause" -ContainerRuntime $global:ContainerRuntime)) {
             Write-Log "Could not find container with name kubletwin/pause"
@@ -512,12 +429,6 @@ try
             Remove-Item $CacheDir -Recurse -Force
         }
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("TotalDuration", $global:globalTimer.Elapsed.TotalSeconds)
-            $global:AppInsightsClient.Flush()
-        }
-
         if ($global:TLSBootstrapToken) {
             Write-Log "Removing temporary kube config"
             $kubeConfigFile = [io.path]::Combine($KubeDir, "config")
@@ -530,13 +441,6 @@ try
 }
 catch
 {
-    if ($global:EnableTelemetry) {
-        $exceptionTelemtry = New-Object "Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry"
-        $exceptionTelemtry.Exception = $_.Exception
-        $global:AppInsightsClient.TrackException($exceptionTelemtry)
-        $global:AppInsightsClient.Flush()
-    }
-
     # Set-ExitCode will exit with the specified ExitCode immediately and not be caught by this catch block
     # Ideally all exceptions will be handled and no exception will be thrown.
     Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_UNKNOWN -ErrorMessage $_

--- a/pkg/agent/testdata/AKSWindows2019+K8S119/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S119/CustomData
@@ -149,10 +149,6 @@ $global:NetworkPlugin = "azure"
 $global:VNetCNIPluginsURL = "https://acs-mirror.azureedge.net/azure-cni/v1.1.3/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.3.zip"
 $global:IsDualStackEnabled = $false
 
-# Telemetry settings
-$global:EnableTelemetry = [System.Convert]::ToBoolean("false");
-$global:TelemetryKey = "";
-
 # CSI Proxy settings
 $global:EnableCsiProxy = [System.Convert]::ToBoolean("false");
 $global:CsiProxyUrl = "";
@@ -210,77 +206,19 @@ try
 
         Write-Log ".\CustomDataSetupScript.ps1 -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp -MasterFQDNPrefix $MasterFQDNPrefix -Location $Location -AADClientId $AADClientId -NetworkAPIVersion $NetworkAPIVersion -TargetEnvironment $TargetEnvironment"
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
-
-            $configAppInsightsClientTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            # Get app insights binaries and set up app insights client
-            Create-Directory -FullPath c:\k\appinsights -DirectoryUsage "storing appinsights"
-            DownloadFileOverHttp -Url "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg" -DestinationPath "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip"
-            Expand-Archive -Path "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip" -DestinationPath "c:\k\appinsights"
-            $appInsightsDll = "c:\k\appinsights\lib\net46\Microsoft.ApplicationInsights.dll"
-            [Reflection.Assembly]::LoadFile($appInsightsDll)
-            $conf = New-Object "Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration"
-            $conf.DisableTelemetry = -not $global:EnableTelemetry
-            $conf.InstrumentationKey = $global:TelemetryKey
-            $global:AppInsightsClient = New-Object "Microsoft.ApplicationInsights.TelemetryClient"($conf)
-
-            $global:AppInsightsClient.Context.Properties["correlation_id"] = New-Guid
-            $global:AppInsightsClient.Context.Properties["cri"] = $global:ContainerRuntime
-            # TODO: Update once containerd versioning story is decided
-            $global:AppInsightsClient.Context.Properties["cri_version"] = if ($global:ContainerRuntime -eq "docker") { $global:DockerVersion } else { "" }
-            $global:AppInsightsClient.Context.Properties["k8s_version"] = $global:KubeBinariesVersion
-            $global:AppInsightsClient.Context.Properties["lb_sku"] = $global:LoadBalancerSku
-            $global:AppInsightsClient.Context.Properties["location"] = $Location
-            $global:AppInsightsClient.Context.Properties["os_type"] = "windows"
-            $global:AppInsightsClient.Context.Properties["os_version"] = Get-WindowsVersion
-            $global:AppInsightsClient.Context.Properties["network_plugin"] = $global:NetworkPlugin
-            $global:AppInsightsClient.Context.Properties["network_plugin_version"] = Get-CniVersion
-            $global:AppInsightsClient.Context.Properties["network_mode"] = $global:NetworkMode
-            $global:AppInsightsClient.Context.Properties["subscription_id"] = $global:SubscriptionId
-
-            $vhdId = ""
-            if (Test-Path "c:\vhd-id.txt") {
-                $vhdId = Get-Content "c:\vhd-id.txt"
-            }
-            $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
-
-            $imdsProperties = Get-InstanceMetadataServiceTelemetry
-            foreach ($key in $imdsProperties.keys) {
-                $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-            }
-
-            $configAppInsightsClientTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Config-AppInsightsClient", $configAppInsightsClientTimer.Elapsed.TotalSeconds)
-        }
-
         # Install OpenSSH if SSH enabled
         $sshEnabled = [System.Convert]::ToBoolean("true")
 
         if ( $sshEnabled ) {
             Write-Log "Install OpenSSH"
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-OpenSSH -SSHKeys $SSHKeys
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-OpenSSH", $installOpenSSHTimer.Elapsed.TotalSeconds)
-            }
         }
 
         Write-Log "Apply telemetry data setting"
         Set-TelemetrySetting -WindowsTelemetryGUID $global:WindowsTelemetryGUID
 
         Write-Log "Resize os drive if possible"
-        if ($global:EnableTelemetry) {
-            $resizeTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         Resize-OSDrive
-        if ($global:EnableTelemetry) {
-            $resizeTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Resize-OSDrive", $resizeTimer.Elapsed.TotalSeconds)
-        }
 
         Write-Log "Initialize data disks"
         Initialize-DataDisks
@@ -314,9 +252,6 @@ try
 
         if ($useContainerD) {
             Write-Log "Installing ContainerD"
-            if ($global:EnableTelemetry) {
-                $containerdTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             $cniBinPath = $global:AzureCNIBinDir
             $cniConfigPath = $global:AzureCNIConfDir
             if ($global:NetworkPlugin -eq "kubenet") {
@@ -324,21 +259,10 @@ try
                 $cniConfigPath = $global:CNIConfigPath
             }
             Install-Containerd -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir
-            if ($global:EnableTelemetry) {
-                $containerdTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-ContainerD", $containerdTimer.Elapsed.TotalSeconds)
-            }
         } else {
             Write-Log "Install docker"
-            if ($global:EnableTelemetry) {
-                $dockerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-Docker -DockerVersion $global:DockerVersion
             Set-DockerLogFileOptions
-            if ($global:EnableTelemetry) {
-                $dockerTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-Docker", $dockerTimer.Elapsed.TotalSeconds)
-            }
         }
 
         # For AKSClustomCloud, TargetEnvironment must be set to AzureStackCloud
@@ -406,14 +330,7 @@ try
          }
 
         Write-Log "Create the Pause Container kubletwin/pause"
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         New-InfraContainer -KubeDir $global:KubeDir -ContainerRuntime $global:ContainerRuntime
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("New-InfraContainer", $infraContainerTimer.Elapsed.TotalSeconds)
-        }
 
         if (-not (Test-ContainerImageExists -Image "kubletwin/pause" -ContainerRuntime $global:ContainerRuntime)) {
             Write-Log "Could not find container with name kubletwin/pause"
@@ -512,12 +429,6 @@ try
             Remove-Item $CacheDir -Recurse -Force
         }
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("TotalDuration", $global:globalTimer.Elapsed.TotalSeconds)
-            $global:AppInsightsClient.Flush()
-        }
-
         if ($global:TLSBootstrapToken) {
             Write-Log "Removing temporary kube config"
             $kubeConfigFile = [io.path]::Combine($KubeDir, "config")
@@ -530,13 +441,6 @@ try
 }
 catch
 {
-    if ($global:EnableTelemetry) {
-        $exceptionTelemtry = New-Object "Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry"
-        $exceptionTelemtry.Exception = $_.Exception
-        $global:AppInsightsClient.TrackException($exceptionTelemtry)
-        $global:AppInsightsClient.Flush()
-    }
-
     # Set-ExitCode will exit with the specified ExitCode immediately and not be caught by this catch block
     # Ideally all exceptions will be handled and no exception will be thrown.
     Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_UNKNOWN -ErrorMessage $_

--- a/pkg/agent/testdata/AKSWindows2019+KubeletClientTLSBootstrapping/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+KubeletClientTLSBootstrapping/CustomData
@@ -149,10 +149,6 @@ $global:NetworkPlugin = "azure"
 $global:VNetCNIPluginsURL = "https://acs-mirror.azureedge.net/azure-cni/v1.1.3/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.3.zip"
 $global:IsDualStackEnabled = $false
 
-# Telemetry settings
-$global:EnableTelemetry = [System.Convert]::ToBoolean("false");
-$global:TelemetryKey = "";
-
 # CSI Proxy settings
 $global:EnableCsiProxy = [System.Convert]::ToBoolean("false");
 $global:CsiProxyUrl = "";
@@ -210,77 +206,19 @@ try
 
         Write-Log ".\CustomDataSetupScript.ps1 -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp -MasterFQDNPrefix $MasterFQDNPrefix -Location $Location -AADClientId $AADClientId -NetworkAPIVersion $NetworkAPIVersion -TargetEnvironment $TargetEnvironment"
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
-
-            $configAppInsightsClientTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            # Get app insights binaries and set up app insights client
-            Create-Directory -FullPath c:\k\appinsights -DirectoryUsage "storing appinsights"
-            DownloadFileOverHttp -Url "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg" -DestinationPath "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip"
-            Expand-Archive -Path "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip" -DestinationPath "c:\k\appinsights"
-            $appInsightsDll = "c:\k\appinsights\lib\net46\Microsoft.ApplicationInsights.dll"
-            [Reflection.Assembly]::LoadFile($appInsightsDll)
-            $conf = New-Object "Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration"
-            $conf.DisableTelemetry = -not $global:EnableTelemetry
-            $conf.InstrumentationKey = $global:TelemetryKey
-            $global:AppInsightsClient = New-Object "Microsoft.ApplicationInsights.TelemetryClient"($conf)
-
-            $global:AppInsightsClient.Context.Properties["correlation_id"] = New-Guid
-            $global:AppInsightsClient.Context.Properties["cri"] = $global:ContainerRuntime
-            # TODO: Update once containerd versioning story is decided
-            $global:AppInsightsClient.Context.Properties["cri_version"] = if ($global:ContainerRuntime -eq "docker") { $global:DockerVersion } else { "" }
-            $global:AppInsightsClient.Context.Properties["k8s_version"] = $global:KubeBinariesVersion
-            $global:AppInsightsClient.Context.Properties["lb_sku"] = $global:LoadBalancerSku
-            $global:AppInsightsClient.Context.Properties["location"] = $Location
-            $global:AppInsightsClient.Context.Properties["os_type"] = "windows"
-            $global:AppInsightsClient.Context.Properties["os_version"] = Get-WindowsVersion
-            $global:AppInsightsClient.Context.Properties["network_plugin"] = $global:NetworkPlugin
-            $global:AppInsightsClient.Context.Properties["network_plugin_version"] = Get-CniVersion
-            $global:AppInsightsClient.Context.Properties["network_mode"] = $global:NetworkMode
-            $global:AppInsightsClient.Context.Properties["subscription_id"] = $global:SubscriptionId
-
-            $vhdId = ""
-            if (Test-Path "c:\vhd-id.txt") {
-                $vhdId = Get-Content "c:\vhd-id.txt"
-            }
-            $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
-
-            $imdsProperties = Get-InstanceMetadataServiceTelemetry
-            foreach ($key in $imdsProperties.keys) {
-                $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-            }
-
-            $configAppInsightsClientTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Config-AppInsightsClient", $configAppInsightsClientTimer.Elapsed.TotalSeconds)
-        }
-
         # Install OpenSSH if SSH enabled
         $sshEnabled = [System.Convert]::ToBoolean("true")
 
         if ( $sshEnabled ) {
             Write-Log "Install OpenSSH"
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-OpenSSH -SSHKeys $SSHKeys
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-OpenSSH", $installOpenSSHTimer.Elapsed.TotalSeconds)
-            }
         }
 
         Write-Log "Apply telemetry data setting"
         Set-TelemetrySetting -WindowsTelemetryGUID $global:WindowsTelemetryGUID
 
         Write-Log "Resize os drive if possible"
-        if ($global:EnableTelemetry) {
-            $resizeTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         Resize-OSDrive
-        if ($global:EnableTelemetry) {
-            $resizeTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Resize-OSDrive", $resizeTimer.Elapsed.TotalSeconds)
-        }
 
         Write-Log "Initialize data disks"
         Initialize-DataDisks
@@ -314,9 +252,6 @@ try
 
         if ($useContainerD) {
             Write-Log "Installing ContainerD"
-            if ($global:EnableTelemetry) {
-                $containerdTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             $cniBinPath = $global:AzureCNIBinDir
             $cniConfigPath = $global:AzureCNIConfDir
             if ($global:NetworkPlugin -eq "kubenet") {
@@ -324,21 +259,10 @@ try
                 $cniConfigPath = $global:CNIConfigPath
             }
             Install-Containerd -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir
-            if ($global:EnableTelemetry) {
-                $containerdTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-ContainerD", $containerdTimer.Elapsed.TotalSeconds)
-            }
         } else {
             Write-Log "Install docker"
-            if ($global:EnableTelemetry) {
-                $dockerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-Docker -DockerVersion $global:DockerVersion
             Set-DockerLogFileOptions
-            if ($global:EnableTelemetry) {
-                $dockerTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-Docker", $dockerTimer.Elapsed.TotalSeconds)
-            }
         }
 
         # For AKSClustomCloud, TargetEnvironment must be set to AzureStackCloud
@@ -406,14 +330,7 @@ try
          }
 
         Write-Log "Create the Pause Container kubletwin/pause"
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         New-InfraContainer -KubeDir $global:KubeDir -ContainerRuntime $global:ContainerRuntime
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("New-InfraContainer", $infraContainerTimer.Elapsed.TotalSeconds)
-        }
 
         if (-not (Test-ContainerImageExists -Image "kubletwin/pause" -ContainerRuntime $global:ContainerRuntime)) {
             Write-Log "Could not find container with name kubletwin/pause"
@@ -512,12 +429,6 @@ try
             Remove-Item $CacheDir -Recurse -Force
         }
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("TotalDuration", $global:globalTimer.Elapsed.TotalSeconds)
-            $global:AppInsightsClient.Flush()
-        }
-
         if ($global:TLSBootstrapToken) {
             Write-Log "Removing temporary kube config"
             $kubeConfigFile = [io.path]::Combine($KubeDir, "config")
@@ -530,13 +441,6 @@ try
 }
 catch
 {
-    if ($global:EnableTelemetry) {
-        $exceptionTelemtry = New-Object "Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry"
-        $exceptionTelemtry.Exception = $_.Exception
-        $global:AppInsightsClient.TrackException($exceptionTelemtry)
-        $global:AppInsightsClient.Flush()
-    }
-
     # Set-ExitCode will exit with the specified ExitCode immediately and not be caught by this catch block
     # Ideally all exceptions will be handled and no exception will be thrown.
     Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_UNKNOWN -ErrorMessage $_

--- a/pkg/agent/testdata/AKSWindows2019+ManagedIdentity/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+ManagedIdentity/CustomData
@@ -149,10 +149,6 @@ $global:NetworkPlugin = "azure"
 $global:VNetCNIPluginsURL = "https://acs-mirror.azureedge.net/azure-cni/v1.1.3/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.3.zip"
 $global:IsDualStackEnabled = $false
 
-# Telemetry settings
-$global:EnableTelemetry = [System.Convert]::ToBoolean("false");
-$global:TelemetryKey = "";
-
 # CSI Proxy settings
 $global:EnableCsiProxy = [System.Convert]::ToBoolean("false");
 $global:CsiProxyUrl = "";
@@ -210,77 +206,19 @@ try
 
         Write-Log ".\CustomDataSetupScript.ps1 -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp -MasterFQDNPrefix $MasterFQDNPrefix -Location $Location -AADClientId $AADClientId -NetworkAPIVersion $NetworkAPIVersion -TargetEnvironment $TargetEnvironment"
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
-
-            $configAppInsightsClientTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            # Get app insights binaries and set up app insights client
-            Create-Directory -FullPath c:\k\appinsights -DirectoryUsage "storing appinsights"
-            DownloadFileOverHttp -Url "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg" -DestinationPath "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip"
-            Expand-Archive -Path "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip" -DestinationPath "c:\k\appinsights"
-            $appInsightsDll = "c:\k\appinsights\lib\net46\Microsoft.ApplicationInsights.dll"
-            [Reflection.Assembly]::LoadFile($appInsightsDll)
-            $conf = New-Object "Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration"
-            $conf.DisableTelemetry = -not $global:EnableTelemetry
-            $conf.InstrumentationKey = $global:TelemetryKey
-            $global:AppInsightsClient = New-Object "Microsoft.ApplicationInsights.TelemetryClient"($conf)
-
-            $global:AppInsightsClient.Context.Properties["correlation_id"] = New-Guid
-            $global:AppInsightsClient.Context.Properties["cri"] = $global:ContainerRuntime
-            # TODO: Update once containerd versioning story is decided
-            $global:AppInsightsClient.Context.Properties["cri_version"] = if ($global:ContainerRuntime -eq "docker") { $global:DockerVersion } else { "" }
-            $global:AppInsightsClient.Context.Properties["k8s_version"] = $global:KubeBinariesVersion
-            $global:AppInsightsClient.Context.Properties["lb_sku"] = $global:LoadBalancerSku
-            $global:AppInsightsClient.Context.Properties["location"] = $Location
-            $global:AppInsightsClient.Context.Properties["os_type"] = "windows"
-            $global:AppInsightsClient.Context.Properties["os_version"] = Get-WindowsVersion
-            $global:AppInsightsClient.Context.Properties["network_plugin"] = $global:NetworkPlugin
-            $global:AppInsightsClient.Context.Properties["network_plugin_version"] = Get-CniVersion
-            $global:AppInsightsClient.Context.Properties["network_mode"] = $global:NetworkMode
-            $global:AppInsightsClient.Context.Properties["subscription_id"] = $global:SubscriptionId
-
-            $vhdId = ""
-            if (Test-Path "c:\vhd-id.txt") {
-                $vhdId = Get-Content "c:\vhd-id.txt"
-            }
-            $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
-
-            $imdsProperties = Get-InstanceMetadataServiceTelemetry
-            foreach ($key in $imdsProperties.keys) {
-                $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-            }
-
-            $configAppInsightsClientTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Config-AppInsightsClient", $configAppInsightsClientTimer.Elapsed.TotalSeconds)
-        }
-
         # Install OpenSSH if SSH enabled
         $sshEnabled = [System.Convert]::ToBoolean("true")
 
         if ( $sshEnabled ) {
             Write-Log "Install OpenSSH"
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-OpenSSH -SSHKeys $SSHKeys
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-OpenSSH", $installOpenSSHTimer.Elapsed.TotalSeconds)
-            }
         }
 
         Write-Log "Apply telemetry data setting"
         Set-TelemetrySetting -WindowsTelemetryGUID $global:WindowsTelemetryGUID
 
         Write-Log "Resize os drive if possible"
-        if ($global:EnableTelemetry) {
-            $resizeTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         Resize-OSDrive
-        if ($global:EnableTelemetry) {
-            $resizeTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Resize-OSDrive", $resizeTimer.Elapsed.TotalSeconds)
-        }
 
         Write-Log "Initialize data disks"
         Initialize-DataDisks
@@ -314,9 +252,6 @@ try
 
         if ($useContainerD) {
             Write-Log "Installing ContainerD"
-            if ($global:EnableTelemetry) {
-                $containerdTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             $cniBinPath = $global:AzureCNIBinDir
             $cniConfigPath = $global:AzureCNIConfDir
             if ($global:NetworkPlugin -eq "kubenet") {
@@ -324,21 +259,10 @@ try
                 $cniConfigPath = $global:CNIConfigPath
             }
             Install-Containerd -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir
-            if ($global:EnableTelemetry) {
-                $containerdTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-ContainerD", $containerdTimer.Elapsed.TotalSeconds)
-            }
         } else {
             Write-Log "Install docker"
-            if ($global:EnableTelemetry) {
-                $dockerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-Docker -DockerVersion $global:DockerVersion
             Set-DockerLogFileOptions
-            if ($global:EnableTelemetry) {
-                $dockerTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-Docker", $dockerTimer.Elapsed.TotalSeconds)
-            }
         }
 
         # For AKSClustomCloud, TargetEnvironment must be set to AzureStackCloud
@@ -406,14 +330,7 @@ try
          }
 
         Write-Log "Create the Pause Container kubletwin/pause"
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         New-InfraContainer -KubeDir $global:KubeDir -ContainerRuntime $global:ContainerRuntime
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("New-InfraContainer", $infraContainerTimer.Elapsed.TotalSeconds)
-        }
 
         if (-not (Test-ContainerImageExists -Image "kubletwin/pause" -ContainerRuntime $global:ContainerRuntime)) {
             Write-Log "Could not find container with name kubletwin/pause"
@@ -512,12 +429,6 @@ try
             Remove-Item $CacheDir -Recurse -Force
         }
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("TotalDuration", $global:globalTimer.Elapsed.TotalSeconds)
-            $global:AppInsightsClient.Flush()
-        }
-
         if ($global:TLSBootstrapToken) {
             Write-Log "Removing temporary kube config"
             $kubeConfigFile = [io.path]::Combine($KubeDir, "config")
@@ -530,13 +441,6 @@ try
 }
 catch
 {
-    if ($global:EnableTelemetry) {
-        $exceptionTelemtry = New-Object "Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry"
-        $exceptionTelemtry.Exception = $_.Exception
-        $global:AppInsightsClient.TrackException($exceptionTelemtry)
-        $global:AppInsightsClient.Flush()
-    }
-
     # Set-ExitCode will exit with the specified ExitCode immediately and not be caught by this catch block
     # Ideally all exceptions will be handled and no exception will be thrown.
     Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_UNKNOWN -ErrorMessage $_

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -5713,10 +5713,6 @@ $global:NetworkPlugin = "{{GetParameter "networkPlugin"}}"
 $global:VNetCNIPluginsURL = "{{GetParameter "vnetCniWindowsPluginsURL"}}"
 $global:IsDualStackEnabled = {{if IsIPv6DualStackFeatureEnabled}}$true{{else}}$false{{end}}
 
-# Telemetry settings
-$global:EnableTelemetry = [System.Convert]::ToBoolean("{{GetVariable "enableTelemetry" }}");
-$global:TelemetryKey = "{{GetVariable "applicationInsightsKey" }}";
-
 # CSI Proxy settings
 $global:EnableCsiProxy = [System.Convert]::ToBoolean("{{GetVariable "windowsEnableCSIProxy" }}");
 $global:CsiProxyUrl = "{{GetVariable "windowsCSIProxyURL" }}";
@@ -5774,77 +5770,19 @@ try
 
         Write-Log ".\CustomDataSetupScript.ps1 -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp -MasterFQDNPrefix $MasterFQDNPrefix -Location $Location -AADClientId $AADClientId -NetworkAPIVersion $NetworkAPIVersion -TargetEnvironment $TargetEnvironment"
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer = [System.Diagnostics.Stopwatch]::StartNew()
-
-            $configAppInsightsClientTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            # Get app insights binaries and set up app insights client
-            Create-Directory -FullPath c:\k\appinsights -DirectoryUsage "storing appinsights"
-            DownloadFileOverHttp -Url "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg" -DestinationPath "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip"
-            Expand-Archive -Path "c:\k\appinsights\microsoft.applicationinsights.2.11.0.zip" -DestinationPath "c:\k\appinsights"
-            $appInsightsDll = "c:\k\appinsights\lib\net46\Microsoft.ApplicationInsights.dll"
-            [Reflection.Assembly]::LoadFile($appInsightsDll)
-            $conf = New-Object "Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration"
-            $conf.DisableTelemetry = -not $global:EnableTelemetry
-            $conf.InstrumentationKey = $global:TelemetryKey
-            $global:AppInsightsClient = New-Object "Microsoft.ApplicationInsights.TelemetryClient"($conf)
-
-            $global:AppInsightsClient.Context.Properties["correlation_id"] = New-Guid
-            $global:AppInsightsClient.Context.Properties["cri"] = $global:ContainerRuntime
-            # TODO: Update once containerd versioning story is decided
-            $global:AppInsightsClient.Context.Properties["cri_version"] = if ($global:ContainerRuntime -eq "docker") { $global:DockerVersion } else { "" }
-            $global:AppInsightsClient.Context.Properties["k8s_version"] = $global:KubeBinariesVersion
-            $global:AppInsightsClient.Context.Properties["lb_sku"] = $global:LoadBalancerSku
-            $global:AppInsightsClient.Context.Properties["location"] = $Location
-            $global:AppInsightsClient.Context.Properties["os_type"] = "windows"
-            $global:AppInsightsClient.Context.Properties["os_version"] = Get-WindowsVersion
-            $global:AppInsightsClient.Context.Properties["network_plugin"] = $global:NetworkPlugin
-            $global:AppInsightsClient.Context.Properties["network_plugin_version"] = Get-CniVersion
-            $global:AppInsightsClient.Context.Properties["network_mode"] = $global:NetworkMode
-            $global:AppInsightsClient.Context.Properties["subscription_id"] = $global:SubscriptionId
-
-            $vhdId = ""
-            if (Test-Path "c:\vhd-id.txt") {
-                $vhdId = Get-Content "c:\vhd-id.txt"
-            }
-            $global:AppInsightsClient.Context.Properties["vhd_id"] = $vhdId
-
-            $imdsProperties = Get-InstanceMetadataServiceTelemetry
-            foreach ($key in $imdsProperties.keys) {
-                $global:AppInsightsClient.Context.Properties[$key] = $imdsProperties[$key]
-            }
-
-            $configAppInsightsClientTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Config-AppInsightsClient", $configAppInsightsClientTimer.Elapsed.TotalSeconds)
-        }
-
         # Install OpenSSH if SSH enabled
         $sshEnabled = [System.Convert]::ToBoolean("{{ WindowsSSHEnabled }}")
 
         if ( $sshEnabled ) {
             Write-Log "Install OpenSSH"
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-OpenSSH -SSHKeys $SSHKeys
-            if ($global:EnableTelemetry) {
-                $installOpenSSHTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-OpenSSH", $installOpenSSHTimer.Elapsed.TotalSeconds)
-            }
         }
 
         Write-Log "Apply telemetry data setting"
         Set-TelemetrySetting -WindowsTelemetryGUID $global:WindowsTelemetryGUID
 
         Write-Log "Resize os drive if possible"
-        if ($global:EnableTelemetry) {
-            $resizeTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         Resize-OSDrive
-        if ($global:EnableTelemetry) {
-            $resizeTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("Resize-OSDrive", $resizeTimer.Elapsed.TotalSeconds)
-        }
 
         Write-Log "Initialize data disks"
         Initialize-DataDisks
@@ -5878,9 +5816,6 @@ try
 
         if ($useContainerD) {
             Write-Log "Installing ContainerD"
-            if ($global:EnableTelemetry) {
-                $containerdTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             $cniBinPath = $global:AzureCNIBinDir
             $cniConfigPath = $global:AzureCNIConfDir
             if ($global:NetworkPlugin -eq "kubenet") {
@@ -5888,21 +5823,10 @@ try
                 $cniConfigPath = $global:CNIConfigPath
             }
             Install-Containerd -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir
-            if ($global:EnableTelemetry) {
-                $containerdTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-ContainerD", $containerdTimer.Elapsed.TotalSeconds)
-            }
         } else {
             Write-Log "Install docker"
-            if ($global:EnableTelemetry) {
-                $dockerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            }
             Install-Docker -DockerVersion $global:DockerVersion
             Set-DockerLogFileOptions
-            if ($global:EnableTelemetry) {
-                $dockerTimer.Stop()
-                $global:AppInsightsClient.TrackMetric("Install-Docker", $dockerTimer.Elapsed.TotalSeconds)
-            }
         }
 
         # For AKSClustomCloud, TargetEnvironment must be set to AzureStackCloud
@@ -5976,14 +5900,7 @@ try
          }
 
         Write-Log "Create the Pause Container kubletwin/pause"
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer = [System.Diagnostics.Stopwatch]::StartNew()
-        }
         New-InfraContainer -KubeDir $global:KubeDir -ContainerRuntime $global:ContainerRuntime
-        if ($global:EnableTelemetry) {
-            $infraContainerTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("New-InfraContainer", $infraContainerTimer.Elapsed.TotalSeconds)
-        }
 
         if (-not (Test-ContainerImageExists -Image "kubletwin/pause" -ContainerRuntime $global:ContainerRuntime)) {
             Write-Log "Could not find container with name kubletwin/pause"
@@ -6082,12 +5999,6 @@ try
             Remove-Item $CacheDir -Recurse -Force
         }
 
-        if ($global:EnableTelemetry) {
-            $global:globalTimer.Stop()
-            $global:AppInsightsClient.TrackMetric("TotalDuration", $global:globalTimer.Elapsed.TotalSeconds)
-            $global:AppInsightsClient.Flush()
-        }
-
         if ($global:TLSBootstrapToken) {
             Write-Log "Removing temporary kube config"
             $kubeConfigFile = [io.path]::Combine($KubeDir, "config")
@@ -6100,13 +6011,6 @@ try
 }
 catch
 {
-    if ($global:EnableTelemetry) {
-        $exceptionTelemtry = New-Object "Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry"
-        $exceptionTelemtry.Exception = $_.Exception
-        $global:AppInsightsClient.TrackException($exceptionTelemtry)
-        $global:AppInsightsClient.Flush()
-    }
-
     # Set-ExitCode will exit with the specified ExitCode immediately and not be caught by this catch block
     # Ideally all exceptions will be handled and no exception will be thrown.
     Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_UNKNOWN -ErrorMessage $_


### PR DESCRIPTION
Remove telemetry code in Windows CSE code
1. AKS never uses it
2. CustomData is too long and it will reach the limit when adding new features (We will resolve this by using a package to download the ps files later)