### PR TITLE
chore: Update AKS Windows SIG image version to 17763.2183.210915

### DIFF
--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -201,7 +201,7 @@ const (
 
 const (
 	LinuxSIGImageVersion   string = "2021.09.11"
-	WindowsSIGImageVersion string = "17763.2114.210811"
+	WindowsSIGImageVersion string = "17763.2183.210915"
 )
 
 // SIG config Template

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -61,6 +61,6 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(windows2019Containerd.ResourceGroup).To(Equal("resourcegroup"))
 		Expect(windows2019Containerd.Gallery).To(Equal("akswindows"))
 		Expect(windows2019Containerd.Definition).To(Equal("windows-2019-containerd"))
-		Expect(windows2019Containerd.Version).To(Equal("17763.2114.210811"))
+		Expect(windows2019Containerd.Version).To(Equal("17763.2183.210915"))
 	})
 })


### PR DESCRIPTION
Update AKS Windows SIG image version to 17763.2183.210915