### PR TITLE
Fix CBLMariner permissions on rsyslog.d and product_uuid

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -87,6 +87,7 @@ if [[ $OS == $MARINER_OS_NAME ]]; then
     networkdWorkaround
     enableSystemdAuditd
     enableDNFAutomatic
+    fixCBLMarinerPermissions
 fi
 
 downloadKrustlet

--- a/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
+++ b/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
@@ -57,3 +57,29 @@ enableDNFAutomatic() {
     # This helps avoid a Mariner specific reboot check command in kured.
     systemctlEnableAndStart check-restart.timer || exit $ERR_SYSTEMCTL_START_FAIL
 }
+
+# There are several issues in default file permissions when trying to run AMA and ASA extensions.
+# These will be resolved in an upcoming base image. Work around them here for now.
+fixCBLMarinerPermissions() {
+# Set the dmi/id/product_uuid permissions to 444 so that mdsd can read the VM unique ID
+# https://github.com/Azure/WALinuxAgent/blob/develop/config/99-azure-product-uuid.rules
+# Future base images will include this config in the WALinuxAgent package.
+    CONFIG_FILEPATH="/etc/udev/rules.d/99-azure-product-uuid.rules"
+    touch ${CONFIG_FILEPATH}
+    cat << EOF > ${CONFIG_FILEPATH}
+SUBSYSTEM!="dmi", GOTO="product_uuid-exit"
+ATTR{sys_vendor}!="Microsoft Corporation", GOTO="product_uuid-exit"
+ATTR{product_name}!="Virtual Machine", GOTO="product_uuid-exit"
+TEST!="/sys/devices/virtual/dmi/id/product_uuid", GOTO="product_uuid-exit"
+
+RUN+="/bin/chmod 0444 /sys/devices/virtual/dmi/id/product_uuid"
+
+LABEL="product_uuid-exit"
+
+EOF
+
+# /etc/rsyslog.d is 750 but should be 755 so non root users can read the configs
+# This occurs because the umask in Mariner is 0027 and packer_source.sh created the folder
+# Future base images will already have rsyslog installed with 755 /etc/rsyslog.d
+    chmod 755 /etc/rsyslog.d
+}


### PR DESCRIPTION
While enabling AMA and ASA we ran into several permissions issues.
These will be fixed in the base image in the future, but for the time being correct them in the AKS image.