### PR TITLE
chore: bump virtual-kubelet to 1.4.0

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -282,8 +282,8 @@
     {
       "downloadURL": "mcr.microsoft.com/oss/virtual-kubelet/virtual-kubelet:*",
       "versions": [
-        "1.3.5",
-        "1.3.6"
+        "1.3.6",
+        "1.4.0"
       ]
     },
     {


### PR DESCRIPTION
chore: bump virtual-kubelet to 1.4.0