### PR TITLE
Remove CBLMariner Auditd enable

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -85,7 +85,6 @@ if [[ $OS == $MARINER_OS_NAME ]]; then
     disableSystemdIptables
     forceEnableIpForward
     networkdWorkaround
-    enableSystemdAuditd
     enableDNFAutomatic
     fixCBLMarinerPermissions
 fi

--- a/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
+++ b/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
@@ -37,12 +37,6 @@ listInstalledPackages() {
     rpm -qa
 }
 
-# By default the audit service is disabled on Mariner.
-# Ensure that it is enabled explicitly to satisfy ASC scanning rules.
-enableSystemdAuditd() {
-    systemctlEnableAndStart auditd || exit $ERR_SYSTEMCTL_START_FAIL
-}
-
 # By default the dnf-automatic is service is notify only in Mariner.
 # Enable the automatic install timer and the check-restart timer.
 enableDNFAutomatic() {


### PR DESCRIPTION
Enabling auditd on the host by default has caused conflicts with some container based scanning.
Revert the change to enable it on the CBLMariner container host.