### PR TITLE
chore: removing networkmonitor and azure-vnet-telemetry docker images

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -67,23 +67,9 @@
       ]
     },
     {
-      "downloadURL": "mcr.microsoft.com/containernetworking/networkmonitor:*",
-      "versions": [
-        "v1.1.8_hotfix",
-        "v1.1.8post2",
-        "v1.1.8"
-      ]
-    },
-    {
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-npm:*",
       "versions": [
         "v1.4.9"
-      ]
-    },
-    {
-      "downloadURL": "mcr.microsoft.com/containernetworking/azure-vnet-telemetry:*",
-      "versions": [
-        "v1.0.30"
       ]
     },
     {


### PR DESCRIPTION
networkmonitor and azure-vnet-telemtry docker images are no longer used with versions of azure-cni 1.2.0+

Removing them from agent baker