### PR TITLE
chore: cache cni v1.4.12 for linux

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -360,9 +360,9 @@
       "downloadURL": "https://acs-mirror.azureedge.net/azure-cni/v*/binaries",
       "versions": [
         "1.2.7",
-        "1.4.0",
         "1.4.7",
-        "1.4.9"
+        "1.4.9",
+        "1.4.12"
       ]
     },
     {
@@ -371,9 +371,9 @@
       "downloadURL": "https://acs-mirror.azureedge.net/azure-cni/v*/binaries",
       "versions": [
         "1.2.7",
-        "1.4.0",
         "1.4.7",
-        "1.4.9"
+        "1.4.9",
+        "1.4.12"
       ]
     },
     {

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -192,9 +192,9 @@ for imageToBePulled in ${ContainerImages[*]}; do
 done
 
 VNET_CNI_VERSIONS="
+1.4.12
 1.4.9
 1.4.7
-1.4.0
 1.2.7
 "
 for VNET_CNI_VERSION in $VNET_CNI_VERSIONS; do
@@ -205,9 +205,9 @@ done
 
 # merge with above after two more version releases
 SWIFT_CNI_VERSIONS="
+1.4.12
 1.4.9
 1.4.7
-1.4.0
 1.2.7
 "
 


### PR DESCRIPTION
cache the v1.4.12 CNI for Linux (it is already cached for Windows)