### PR TITLE
Bump SIG image version to 2021.10.13

### DIFF
--- a/pkg/agent/bakerapi_test.go
+++ b/pkg/agent/bakerapi_test.go
@@ -160,12 +160,12 @@ var _ = Describe("AgentBaker API implementation tests", func() {
 			Expect(nodeBootStrapping.OSImageConfig.ImageOffer).To(Equal("aks"))
 			Expect(nodeBootStrapping.OSImageConfig.ImageSku).To(Equal("aks-ubuntu-1604-2021-q3"))
 			Expect(nodeBootStrapping.OSImageConfig.ImagePublisher).To(Equal("microsoft-aks"))
-			Expect(nodeBootStrapping.OSImageConfig.ImageVersion).To(Equal("2021.10.11"))
+			Expect(nodeBootStrapping.OSImageConfig.ImageVersion).To(Equal("2021.10.13"))
 
 			Expect(nodeBootStrapping.SigImageConfig.ResourceGroup).To(Equal("resourcegroup"))
 			Expect(nodeBootStrapping.SigImageConfig.Gallery).To(Equal("aksubuntu"))
 			Expect(nodeBootStrapping.SigImageConfig.Definition).To(Equal("1604"))
-			Expect(nodeBootStrapping.SigImageConfig.Version).To(Equal("2021.10.11"))
+			Expect(nodeBootStrapping.SigImageConfig.Version).To(Equal("2021.10.13"))
 		})
 
 		It("should return an error if cloud is not found", func() {
@@ -198,7 +198,7 @@ var _ = Describe("AgentBaker API implementation tests", func() {
 			Expect(sigImageConfig.ResourceGroup).To(Equal("resourcegroup"))
 			Expect(sigImageConfig.Gallery).To(Equal("aksubuntu"))
 			Expect(sigImageConfig.Definition).To(Equal("1604"))
-			Expect(sigImageConfig.Version).To(Equal("2021.10.11"))
+			Expect(sigImageConfig.Version).To(Equal("2021.10.13"))
 		})
 
 		It("should return error if image config not found for distro", func() {

--- a/pkg/agent/datamodel/osimageconfig.go
+++ b/pkg/agent/datamodel/osimageconfig.go
@@ -22,7 +22,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-ubuntu-1804-gen2-2021-q3",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2021.10.11",
+		ImageVersion:   "2021.10.13",
 	}
 
 	RHELOSImageConfig = AzureOSImageConfig{
@@ -36,14 +36,14 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aks-ubuntu-1604-2021-q3",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2021.10.11",
+		ImageVersion:   "2021.10.13",
 	}
 
 	AKSUbuntu1804OSImageConfig = AzureOSImageConfig{
 		ImageOffer:     "aks",
 		ImageSku:       "aks-ubuntu-1804-2021-q3",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "2021.10.11",
+		ImageVersion:   "2021.10.13",
 	}
 
 	AKSWindowsServer2019OSImageConfig = AzureOSImageConfig{

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -200,7 +200,7 @@ const (
 )
 
 const (
-	LinuxSIGImageVersion   string = "2021.10.11"
+	LinuxSIGImageVersion   string = "2021.10.13"
 	WindowsSIGImageVersion string = "17763.2213.210922"
 )
 

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -45,7 +45,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(aksUbuntuGPU1804Gen2.ResourceGroup).To(Equal("resourcegroup"))
 		Expect(aksUbuntuGPU1804Gen2.Gallery).To(Equal("aksubuntu"))
 		Expect(aksUbuntuGPU1804Gen2.Definition).To(Equal("1804gen2gpu"))
-		Expect(aksUbuntuGPU1804Gen2.Version).To(Equal("2021.10.11"))
+		Expect(aksUbuntuGPU1804Gen2.Version).To(Equal("2021.10.13"))
 
 		Expect(len(sigConfig.SigCBLMarinerImageConfig)).To(Equal(1))
 
@@ -53,7 +53,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(mariner.ResourceGroup).To(Equal("resourcegroup"))
 		Expect(mariner.Gallery).To(Equal("akscblmariner"))
 		Expect(mariner.Definition).To(Equal("V1"))
-		Expect(mariner.Version).To(Equal("2021.10.11"))
+		Expect(mariner.Version).To(Equal("2021.10.13"))
 
 		Expect(len(sigConfig.SigWindowsImageConfig)).To(Equal(2))
 


### PR DESCRIPTION
For updated weekly build with CoreDNS change.