### PR TITLE
add virtual-kubelet 1.4.1 into VHD

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -300,7 +300,6 @@
     {
       "downloadURL": "mcr.microsoft.com/oss/virtual-kubelet/virtual-kubelet:*",
       "versions": [
-        "1.3.6",
         "1.4.0",
         "1.4.1"
       ]

--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -301,7 +301,8 @@
       "downloadURL": "mcr.microsoft.com/oss/virtual-kubelet/virtual-kubelet:*",
       "versions": [
         "1.3.6",
-        "1.4.0"
+        "1.4.0",
+        "1.4.1"
       ]
     },
     {


### PR DESCRIPTION
virtual-kubelet 1.4.1 has [fix](https://github.com/virtual-kubelet/azure-aci/pull/171) to ensure docker config auth deserialized to username/password