### PR TITLE
chore: Upgrade Windows base image to 2021-11B

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -270,11 +270,6 @@ function Update-WindowsFeatures {
 }
 
 function Update-Registry {
-    # if multple LB policies are included for same endpoint then HNS hangs.
-    # this fix forces an error
-    Write-Log "Enable a HNS fix in 2021-2C"
-    Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSControlFlag -Value 3 -Type DWORD
-
     # Enables DNS resolution of SMB shares for containerD
     # https://github.com/kubernetes-sigs/windows-gmsa/issues/30#issuecomment-802240945
     if ($containerRuntime -eq 'containerd') {

--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -121,14 +121,6 @@ function Test-ImagesPulled {
 }
 
 function Test-RegistryAdded {
-    Write-Output "Get the registry for the HNS fix in 2021-2C"
-    $result=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSControlFlag)
-    if ($result.HNSControlFlag -eq 3) {
-        Write-Output "The registry for the HNS fix is added"
-    } else {
-        Write-Error "The registry for the HNS fix is not added"
-        exit 1
-    }
     if ($containerRuntime -eq 'containerd') {
         $result=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name EnableCompartmentNamespace)
         if ($result.EnableCompartmentNamespace -eq 1) {

--- a/vhdbuilder/packer/windows-image.env
+++ b/vhdbuilder/packer/windows-image.env
@@ -4,4 +4,4 @@
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core-smalldisk:latest
 WINDOWS_2019_BASE_IMAGE_SKU=2019-Datacenter-Core-smalldisk
-WINDOWS_2019_BASE_IMAGE_VERSION=17763.2237.2110070715
+WINDOWS_2019_BASE_IMAGE_VERSION=17763.2300.2111032328


### PR DESCRIPTION
1. Upgrade Windows base image to 2021-11B
2. Remove HNS flag since it has existed since 2021-10C