### PR TITLE
Update Calico to v3.21.0

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -141,6 +141,7 @@
       "downloadURL": "mcr.microsoft.com/oss/calico/node:*",
       "versions": [
         "v3.20.0",
+        "v3.21.0",
         "v3.8.9.5"
       ]
     },
@@ -148,6 +149,7 @@
       "downloadURL": "mcr.microsoft.com/oss/calico/typha:*",
       "versions": [
         "v3.20.0",
+        "v3.21.0",
         "v3.8.9"
       ]
     },
@@ -160,7 +162,8 @@
     {
       "downloadURL": "mcr.microsoft.com/oss/calico/kube-controllers:*",
       "versions": [
-        "v3.20.0"
+        "v3.20.0",
+        "v3.21.0"
       ]
     },
     {
@@ -179,8 +182,8 @@
     {
       "downloadURL": "mcr.microsoft.com/oss/tigera/operator:*",
       "versions": [
-        "v1.17.1",
-        "v1.20.0"
+        "v1.20.0",
+        "v1.23.1"
       ]
     },
     {


### PR DESCRIPTION
Calico v3.21.0 images and tigera-operator v1.23.1

Release: https://github.com/tigera/operator/releases/tag/v1.23.1