### PR TITLE
Improve e2e script

### DIFF
--- a/e2e/e2e-script.sh
+++ b/e2e/e2e-script.sh
@@ -9,13 +9,12 @@ echo "Starting e2e tests"
 : "${CLUSTER_NAME:=agentbaker-e2e-test-cluster}"
 
 # Create a resource group for the cluster
-if [ $(az group exists -n $RESOURCE_GROUP_NAME --subscription $SUBSCRIPTION_ID -ojson) == "false" ]; then
-    echo "Creating resource group"
-    az group create -l $LOCATION -n $RESOURCE_GROUP_NAME --subscription $SUBSCRIPTION_ID -ojson
-fi
+echo "Creating resource group"
+az group create -l $LOCATION -n $RESOURCE_GROUP_NAME --subscription $SUBSCRIPTION_ID -ojson
 
 # Create the AKS cluster and get the kubeconfig
-if [ -z $(az aks list -g $RESOURCE_GROUP_NAME -ojson | jq '.[].name') ]; then
+out=$(az aks list -g $RESOURCE_GROUP_NAME -ojson | jq '.[].name')
+if [ -z "$out" ]; then
     echo "Cluster doesnt exist, creating"
     az aks create -g $RESOURCE_GROUP_NAME -n $CLUSTER_NAME --node-count 1 --generate-ssh-keys -ojson
 fi

--- a/e2e/e2e-script.sh
+++ b/e2e/e2e-script.sh
@@ -164,9 +164,9 @@ KUBECONFIG=$(pwd)/kubeconfig; export KUBECONFIG
 
 # Check if the node joined the cluster
 if kubectl get nodes | grep -q $vmInstanceName; then
-	echo "Test succeeded, node joined the cluster"
+    echo "Test succeeded, node joined the cluster"
 else
-	echo "Node did not join cluster"
+    echo "Node did not join cluster"
 fi
 
 # Run a nginx pod on the node to check if pod runs

--- a/e2e/e2e-script.sh
+++ b/e2e/e2e-script.sh
@@ -3,10 +3,10 @@ set -euxo pipefail
 source e2e-helper.sh
 echo "Starting e2e tests"
 
-SUBSCRIPTION_ID="8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8" #Azure Container Service - Test Subscription
-RESOURCE_GROUP_NAME="agentbaker-e2e-tests"
-LOCATION="eastus"
-CLUSTER_NAME="agentbaker-e2e-test-cluster"
+: "${SUBSCRIPTION_ID:=8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8}" #Azure Container Service - Test Subscription
+: "${RESOURCE_GROUP_NAME:=agentbaker-e2e-tests}"
+: "${LOCATION:=eastus}"
+: "${CLUSTER_NAME:=agentbaker-e2e-test-cluster}"
 
 # Create a resource group for the cluster
 if [ $(az group exists -n $RESOURCE_GROUP_NAME --subscription $SUBSCRIPTION_ID -ojson) == "false" ]; then

--- a/e2e/e2e-script.sh
+++ b/e2e/e2e-script.sh
@@ -122,7 +122,7 @@ go test -run TestE2EBasic
 # TODO 3: Discuss about the --image version, probably go with aks-ubuntu-1804-gen2-2021-q2:latest
 #       However, how to incorporate chaning quarters?
 
-VMSS_NAME="$(mktemp --dry-run abtest-XXXXXXX | tr '[A-Z]' '[a-z]')"
+VMSS_NAME="$(mktemp --dry-run abtest-XXXXXXX | tr '[:upper:]' '[:lower:]')"
 
 az vmss create -n ${VMSS_NAME} \
     -g $MC_RESOURCE_GROUP_NAME \

--- a/e2e/e2e-script.sh
+++ b/e2e/e2e-script.sh
@@ -122,7 +122,6 @@ go test -run TestE2EBasic
 # TODO 3: Discuss about the --image version, probably go with aks-ubuntu-1804-gen2-2021-q2:latest
 #       However, how to incorporate chaning quarters?
 
-# TODO 4: Random name for the VMSS for when we have multiple scenarios to run
 VMSS_NAME="$(mktemp --dry-run abtest-XXXXXXX | tr '[A-Z]' '[a-z]')"
 
 az vmss create -n ${VMSS_NAME} \

--- a/e2e/e2e-script.sh
+++ b/e2e/e2e-script.sh
@@ -167,6 +167,7 @@ if kubectl get nodes | grep -q $vmInstanceName; then
     echo "Test succeeded, node joined the cluster"
 else
     echo "Node did not join cluster"
+    exit 1
 fi
 
 # Run a nginx pod on the node to check if pod runs
@@ -180,4 +181,5 @@ if kubectl get pods -o wide | grep -q 'Running'; then
     echo "Pod ran successfully"
 else
     echo "Pod pending/not running"
+    exit 1
 fi

--- a/e2e/e2e-script.sh
+++ b/e2e/e2e-script.sh
@@ -123,8 +123,7 @@ go test -run TestE2EBasic
 #       However, how to incorporate chaning quarters?
 
 # TODO 4: Random name for the VMSS for when we have multiple scenarios to run
-RAND_NAME="$(tr -dc '[:lower:]' < /dev/urandom | fold -w 8 | head -n 1)"
-VMSS_NAME="abtest-$RAND_NAME"
+VMSS_NAME="$(mktemp --dry-run abtest-XXXXXXX | tr '[A-Z]' '[a-z]')"
 
 az vmss create -n ${VMSS_NAME} \
     -g $MC_RESOURCE_GROUP_NAME \


### PR DESCRIPTION
This PR improves the e2e script.

Summary of changes:

- Avoid altering the user's global kubeconfig file.
- Explicitly use JSON output in all `az` commands to mitigate environment variations.
- Allow overriding script params using env vars.
- Wrap fragile API calls in retry logic.
- Fix masked exit codes in calls to the Azure API.
- Misc cleanups.