### PR TITLE
fix: Set loopbackdsr in Azure CNI conflist for WinDSR

### DIFF
--- a/staging/cse/windows/azurecnifunc.ps1
+++ b/staging/cse/windows/azurecnifunc.ps1
@@ -93,6 +93,14 @@ function Set-AzureCNIConfig
         $configJson.plugins[0].AdditionalArgs[1].Value.DestinationPrefix = $KubeServiceCIDR
     }
 
+    if ($global:KubeproxyFeatureGates.Contains("WinDSR=true")) {
+        Write-Log "Setting enableLoopbackDSR in Azure CNI conflist for WinDSR"
+        $jsonContent = [PSCustomObject]@{
+            'enableLoopbackDSR' = $True
+        }
+        $configJson.plugins[0]|Add-Member -Name "windowsSettings" -Value $jsonContent -MemberType NoteProperty
+    }
+
     $aclRule1 = [PSCustomObject]@{
         Type = 'ACL'
         Protocols = '6'


### PR DESCRIPTION
When WinDSR is enabled, we need to set enableLoopbackDSR in Azure CNI conflist. enableLoopbackDSR is only supported from v1.4.16.