### PR TITLE
Add function parseWindowsCSEMessage to support Windows checkVMSSCSEMessage

### DIFF
--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -593,19 +593,40 @@ func addFeatureGateString(featureGates string, key string, value bool) string {
 
 // ParseCSEMessage parses the raw CSE output
 func ParseCSEMessage(message string) (*datamodel.CSEStatus, *datamodel.CSEStatusParsingError) {
-	var cseStatus datamodel.CSEStatus
 	start := strings.Index(message, "[stdout]") + len("[stdout]")
 	end := strings.Index(message, "[stderr]")
 	if end > start {
-		rawInstanceViewInfo := message[start:end]
-		err := json.Unmarshal([]byte(rawInstanceViewInfo), &cseStatus)
-		if err != nil {
-			return nil, datamodel.NewError(datamodel.CSEMessageUnmarshalError, message)
-		}
-		if cseStatus.ExitCode == "" {
-			return nil, datamodel.NewError(datamodel.CSEMessageExitCodeEmptyError, message)
-		}
-		return &cseStatus, nil
+		return parseLinuxCSEMessage(message, start, end)
+	} else if strings.Contains(message, "Command execution finished") {
+		return parseWindowsCSEMessage(message)
 	}
 	return nil, datamodel.NewError(datamodel.InvalidCSEMessage, message)
+}
+
+func parseLinuxCSEMessage(message string, start int, end int) (*datamodel.CSEStatus, *datamodel.CSEStatusParsingError) {
+	// Linux CSE message example: Enable succeeded: \n[stdout]\n{ \"ExitCode\": \"0\", \"Output\": \"Tue Dec 28" } }\n\n[stderr]\nBootup is not yet finished. Please try again later.
+	var cseStatus datamodel.CSEStatus
+	rawInstanceViewInfo := message[start:end]
+	err := json.Unmarshal([]byte(rawInstanceViewInfo), &cseStatus)
+	if err != nil {
+		return nil, datamodel.NewError(datamodel.CSEMessageUnmarshalError, message)
+	}
+	if cseStatus.ExitCode == "" {
+		return nil, datamodel.NewError(datamodel.CSEMessageExitCodeEmptyError, message)
+	}
+	return &cseStatus, nil
+}
+
+func parseWindowsCSEMessage(message string) (*datamodel.CSEStatus, *datamodel.CSEStatusParsingError) {
+	// Windows CSE message example: Command execution finished, but failed because it returned a non-zero exit code of: '1'.
+	var cseStatus datamodel.CSEStatus
+	re := regexp.MustCompile(`a non-zero exit code of: '(\d+)'`)
+	match := re.FindStringSubmatch(message)
+	if match != nil {
+		cseStatus.ExitCode = match[1]
+	} else {
+		cseStatus.ExitCode = "0"
+	}
+	cseStatus.Output = message
+	return &cseStatus, nil
 }

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -233,4 +233,27 @@ var _ = Describe("Assert ParseCSE", func() {
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(ContainSubstring("InstanceErrorCode=CSEMessageUnmarshalError"))
 	})
+
+	It("when Windows cse output is correct with exitcode is empty", func() {
+		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Command execution finished"
+		res, err := ParseCSEMessage(testMessage)
+		Expect(err).To(BeNil())
+		Expect(res.ExitCode).To(Equal("0"))
+		Expect(res.Output).To(Equal("vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Command execution finished"))
+	})
+
+	It("when Windows cse output is correct with exitcode is not empty", func() {
+		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Command execution finished, but failed because it returned a non-zero exit code of: '5'"
+		res, err := ParseCSEMessage(testMessage)
+		Expect(err).To(BeNil())
+		Expect(res.ExitCode).To(Equal("5"))
+		Expect(res.Output).To(Equal("vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Command execution finished, but failed because it returned a non-zero exit code of: '5'"))
+	})
+
+	It("when Windows cse output is incorrect", func() {
+		testMessage := "vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Command execution succeeded"
+		_, err := ParseCSEMessage(testMessage)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring("InstanceErrorCode=InvalidCSEMessage"))
+	})
 })

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -239,7 +239,7 @@ var _ = Describe("Assert ParseCSE", func() {
 		res, err := ParseCSEMessage(testMessage)
 		Expect(err).To(BeNil())
 		Expect(res.ExitCode).To(Equal("0"))
-		Expect(res.Output).To(Equal("vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Command execution finished"))
+		Expect(res.Output).To(Equal(testMessage))
 	})
 
 	It("when Windows cse output is correct with exitcode is not empty", func() {
@@ -247,7 +247,7 @@ var _ = Describe("Assert ParseCSE", func() {
 		res, err := ParseCSEMessage(testMessage)
 		Expect(err).To(BeNil())
 		Expect(res.ExitCode).To(Equal("5"))
-		Expect(res.Output).To(Equal("vmss aks-agentpool-test-vmss instance 0 vmssCSE message : Command execution finished, but failed because it returned a non-zero exit code of: '5'"))
+		Expect(res.Output).To(Equal(testMessage))
 	})
 
 	It("when Windows cse output is incorrect", func() {
@@ -255,5 +255,6 @@ var _ = Describe("Assert ParseCSE", func() {
 		_, err := ParseCSEMessage(testMessage)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(ContainSubstring("InstanceErrorCode=InvalidCSEMessage"))
+		Expect(err.Error()).To(ContainSubstring(testMessage))
 	})
 })


### PR DESCRIPTION
Add function parseWindowsCSEMessage to support Windows checkVMSSCSEMessage

[Task 12808128: Add Windows support in vmcheckVMSSCSEMessage](https://msazure.visualstudio.com/CloudNativeCompute/_workitems/edit/12808128/)