### PR TITLE
Revert "chore: Update Windows SIG image version to 2022-1B (#1418)"

### DIFF
--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -205,7 +205,7 @@ const (
 
 const (
 	LinuxSIGImageVersion   string = "2022.01.08"
-	WindowsSIGImageVersion string = "17763.2452.220112"
+	WindowsSIGImageVersion string = "17763.2366.211215"
 	// will not do weekly vhd release as amd64 when ARM64 Compute/AKS is still under development
 	Arm64LinuxSIGImageVersion string = "2021.12.28"
 )

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -61,7 +61,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(windows2019Containerd.ResourceGroup).To(Equal("resourcegroup"))
 		Expect(windows2019Containerd.Gallery).To(Equal("akswindows"))
 		Expect(windows2019Containerd.Definition).To(Equal("windows-2019-containerd"))
-		Expect(windows2019Containerd.Version).To(Equal("17763.2452.220112"))
+		Expect(windows2019Containerd.Version).To(Equal("17763.2366.211215"))
 
 		aksUbuntuArm64804Gen2 := sigConfig.SigUbuntuImageConfig[AKSUbuntuArm64Containerd1804Gen2]
 		Expect(aksUbuntuArm64804Gen2.ResourceGroup).To(Equal("resourcegroup"))


### PR DESCRIPTION
This reverts commit bd16ffcf645590df7aa94045ac927d107928bd4c.
gMSAv2 is blocked by 2022-1B. We need to revert this change to avoid others to bring this change to AKS RP before we figure out the solution.