### PR TITLE
chore: Update Windows SIG image version to 2022-1B with patch

### DIFF
--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -205,7 +205,7 @@ const (
 
 const (
 	LinuxSIGImageVersion   string = "2022.01.19"
-	WindowsSIGImageVersion string = "17763.2366.220117"
+	WindowsSIGImageVersion string = "17763.2458.220120"
 	// will not do weekly vhd release as amd64 when ARM64 Compute/AKS is still under development
 	Arm64LinuxSIGImageVersion string = "2022.01.15"
 )

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -61,7 +61,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(windows2019Containerd.ResourceGroup).To(Equal("resourcegroup"))
 		Expect(windows2019Containerd.Gallery).To(Equal("akswindows"))
 		Expect(windows2019Containerd.Definition).To(Equal("windows-2019-containerd"))
-		Expect(windows2019Containerd.Version).To(Equal("17763.2366.220117"))
+		Expect(windows2019Containerd.Version).To(Equal("17763.2458.220120"))
 
 		aksUbuntuArm64804Gen2 := sigConfig.SigUbuntuImageConfig[AKSUbuntuArm64Containerd1804Gen2]
 		Expect(aksUbuntuArm64804Gen2.ResourceGroup).To(Equal("resourcegroup"))


### PR DESCRIPTION
chore: Update Windows SIG image version to 2022-1B with patch 17763.2458.220120