### PR TITLE
Fix quoting on systemd Environment= drop-ins

### DIFF
--- a/parts/linux/cloud-init/artifacts/10-componentconfig.conf
+++ b/parts/linux/cloud-init/artifacts/10-componentconfig.conf
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONFIG_FILE_FLAGS="--config /etc/default/kubeletconfig.json"
+Environment="KUBELET_CONFIG_FILE_FLAGS=--config /etc/default/kubeletconfig.json"

--- a/parts/linux/cloud-init/artifacts/10-containerd.conf
+++ b/parts/linux/cloud-init/artifacts/10-containerd.conf
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/parts/linux/cloud-init/artifacts/10-tlsbootstrap.conf
+++ b/parts/linux/cloud-init/artifacts/10-tlsbootstrap.conf
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_TLS_BOOTSTRAP_FLAGS="--kubeconfig /var/lib/kubelet/kubeconfig --bootstrap-kubeconfig /var/lib/kubelet/bootstrap-kubeconfig"
+Environment="KUBELET_TLS_BOOTSTRAP_FLAGS=--kubeconfig /var/lib/kubelet/kubeconfig --bootstrap-kubeconfig /var/lib/kubelet/bootstrap-kubeconfig"

--- a/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+CustomLinuxOSConfig/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+CustomLinuxOSConfig/CustomData
@@ -131,7 +131,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/4oOTi0qy0xOjeVyzSvLLMrPy03NK7H1DnVy9XENiXf293PzdI938/RxjXfzcXQPtlXS1U3Oz0vLTFfQTy1J1k9JTUsszSnRzy5NSs1JLYFI6WUV5+cpcQECAAD//33DAeVbAAAA
+    H4sIAAAAAAAA/4oOTi0qy0xOjeVyzSvLLMrPy03NK7FV8g51cvVxDYl39vdz83SPd/P0cY1383F0D7bV1U3Oz0vLTFfQTy1J1k9JTUsszSnRzy5NSs1JLYFI6WUV5+cpcQECAAD//wFXt55bAAAA
 
 
 - path: /var/lib/kubelet/kubeconfig

--- a/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+CustomLinuxOSConfig/line134.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+CustomLinuxOSConfig/line134.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONFIG_FILE_FLAGS="--config /etc/default/kubeletconfig.json"
+Environment="KUBELET_CONFIG_FILE_FLAGS=--config /etc/default/kubeletconfig.json"

--- a/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+DynamicKubeletConfig/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+DynamicKubeletConfig/CustomData
@@ -131,7 +131,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/4oOTi0qy0xOjeVyzSvLLMrPy03NK7H1DnVy9XENiXf293PzdI938/RxjXfzcXQPtlXS1U3Oz0vLTFfQTy1J1k9JTUsszSnRzy5NSs1JLYFI6WUV5+cpcQECAAD//33DAeVbAAAA
+    H4sIAAAAAAAA/4oOTi0qy0xOjeVyzSvLLMrPy03NK7FV8g51cvVxDYl39vdz83SPd/P0cY1383F0D7bV1U3Oz0vLTFfQTy1J1k9JTUsszSnRzy5NSs1JLYFI6WUV5+cpcQECAAD//wFXt55bAAAA
 
 
 - path: /var/lib/kubelet/kubeconfig

--- a/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+DynamicKubeletConfig/line134.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+DynamicKubeletConfig/line134.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONFIG_FILE_FLAGS="--config /etc/default/kubeletconfig.json"
+Environment="KUBELET_CONFIG_FILE_FLAGS=--config /etc/default/kubeletconfig.json"

--- a/pkg/agent/testdata/AKSUbuntu1604+KubeletConfigFile/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+KubeletConfigFile/CustomData
@@ -131,7 +131,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/4oOTi0qy0xOjeVyzSvLLMrPy03NK7H1DnVy9XENiXf293PzdI938/RxjXfzcXQPtlXS1U3Oz0vLTFfQTy1J1k9JTUsszSnRzy5NSs1JLYFI6WUV5+cpcQECAAD//33DAeVbAAAA
+    H4sIAAAAAAAA/4oOTi0qy0xOjeVyzSvLLMrPy03NK7FV8g51cvVxDYl39vdz83SPd/P0cY1383F0D7bV1U3Oz0vLTFfQTy1J1k9JTUsszSnRzy5NSs1JLYFI6WUV5+cpcQECAAD//wFXt55bAAAA
 
 
 - path: /var/lib/kubelet/kubeconfig

--- a/pkg/agent/testdata/AKSUbuntu1604+KubeletConfigFile/line134.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+KubeletConfigFile/line134.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONFIG_FILE_FLAGS="--config /etc/default/kubeletconfig.json"
+Environment="KUBELET_CONFIG_FILE_FLAGS=--config /etc/default/kubeletconfig.json"

--- a/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd++GPU+runcshimv2/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd++GPU+runcshimv2/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd++GPU+runcshimv2/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd++GPU+runcshimv2/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Certsd/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Certsd/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Certsd/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Certsd/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+ContainerdVersion/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+ContainerdVersion/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+ContainerdVersion/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+ContainerdVersion/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPMasqAgent/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPMasqAgent/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPMasqAgent/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPMasqAgent/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+Calico/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+Calico/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+Calico/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+Calico/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+FIPSEnabled/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+FIPSEnabled/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+FIPSEnabled/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+FIPSEnabled/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG/CustomData
@@ -112,7 +112,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG/line115.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG/line115.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+PrivateACR/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+PrivateACR/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+PrivateACR/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+PrivateACR/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Teleport/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Teleport/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Teleport/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Teleport/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=false/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=false/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=false/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=false/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=true/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=true/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=true/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=true/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+KubeletClientTLSBootstrapping/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+KubeletClientTLSBootstrapping/CustomData
@@ -149,7 +149,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/4oOTi0qy0xOjeVyzSvLLMrPy03NK7H1DnVy9XENiQ/xCY538vcPCQ4JcgyId/NxdA+2VdLVzS5NSk3Oz0vLTFfQL0ss0s/JTNIHieWklugjyenqJuXnlxSXFCUW4NWCTZUSFyAAAP//T/4r1JoAAAA=
+    H4sIAAAAAAAA/4oOTi0qy0xOjeVyzSvLLMrPy03NK7FV8g51cvVxDYkP8QmOd/L3DwkOCXIMiHfzcXQPttXVzS5NSk3Oz0vLTFfQL0ss0s/JTNIHieWklugjyenqJuXnlxSXFCUW4NWCTZUSFyAAAP//gGy8QpoAAAA=
 
 
 - path: /etc/default/kubelet

--- a/pkg/agent/testdata/AKSUbuntu1804+KubeletClientTLSBootstrapping/line152.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+KubeletClientTLSBootstrapping/line152.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_TLS_BOOTSTRAP_FLAGS="--kubeconfig /var/lib/kubelet/kubeconfig --bootstrap-kubeconfig /var/lib/kubelet/bootstrap-kubeconfig"
+Environment="KUBELET_TLS_BOOTSTRAP_FLAGS=--kubeconfig /var/lib/kubelet/kubeconfig --bootstrap-kubeconfig /var/lib/kubelet/bootstrap-kubeconfig"

--- a/pkg/agent/testdata/AKSUbuntu1804+NoneCNI/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+NoneCNI/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+NoneCNI/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+NoneCNI/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804+krustlet/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+krustlet/CustomData
@@ -89,7 +89,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"
@@ -237,7 +237,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/4oOTi0qy0xOjeVyzSvLLMrPy03NK7H1DnVy9XENiQ/xCY538vcPCQ4JcgyId/NxdA+2VdLVzS5NSk3Oz0vLTFfQL0ss0s/JTNIHieWklugjyenqJuXnlxSXFCUW4NWCTZUSFyAAAP//T/4r1JoAAAA=
+    H4sIAAAAAAAA/4oOTi0qy0xOjeVyzSvLLMrPy03NK7FV8g51cvVxDYkP8QmOd/L3DwkOCXIMiHfzcXQPttXVzS5NSk3Oz0vLTFfQL0ss0s/JTNIHieWklugjyenqJuXnlxSXFCUW4NWCTZUSFyAAAP//gGy8QpoAAAA=
 
 
 - path: /etc/default/kubelet

--- a/pkg/agent/testdata/AKSUbuntu1804+krustlet/line240.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+krustlet/line240.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_TLS_BOOTSTRAP_FLAGS="--kubeconfig /var/lib/kubelet/kubeconfig --bootstrap-kubeconfig /var/lib/kubelet/bootstrap-kubeconfig"
+Environment="KUBELET_TLS_BOOTSTRAP_FLAGS=--kubeconfig /var/lib/kubelet/kubeconfig --bootstrap-kubeconfig /var/lib/kubelet/bootstrap-kubeconfig"

--- a/pkg/agent/testdata/AKSUbuntu1804+krustlet/line92.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+krustlet/line92.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+CustomKubeImageandBinaries/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+CustomKubeImageandBinaries/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+CustomKubeImageandBinaries/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+CustomKubeImageandBinaries/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+NoCustomKubeImageandBinaries/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+NoCustomKubeImageandBinaries/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+NoCustomKubeImageandBinaries/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+NoCustomKubeImageandBinaries/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/AKSUbuntu1804Containerd+RuncVersion/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804Containerd+RuncVersion/CustomData
@@ -88,7 +88,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804Containerd+RuncVersion/line91.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804Containerd+RuncVersion/line91.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/agent/testdata/RawUbuntuContainerd/CustomData
+++ b/pkg/agent/testdata/RawUbuntuContainerd/CustomData
@@ -131,7 +131,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc3vjotQhbZb7uu23NbhsOrWVblpfAHQC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2cSLE2uAAAA
+    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/RawUbuntuContainerd/line134.sh
+++ b/pkg/agent/testdata/RawUbuntuContainerd/line134.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -134,7 +134,7 @@ func linuxCloudInitArtifacts10BindmountConf() (*asset, error) {
 }
 
 var _linuxCloudInitArtifacts10ComponentconfigConf = []byte(`[Service]
-Environment=KUBELET_CONFIG_FILE_FLAGS="--config /etc/default/kubeletconfig.json"
+Environment="KUBELET_CONFIG_FILE_FLAGS=--config /etc/default/kubeletconfig.json"
 `)
 
 func linuxCloudInitArtifacts10ComponentconfigConfBytes() ([]byte, error) {
@@ -153,7 +153,7 @@ func linuxCloudInitArtifacts10ComponentconfigConf() (*asset, error) {
 }
 
 var _linuxCloudInitArtifacts10ContainerdConf = []byte(`[Service]
-Environment=KUBELET_CONTAINERD_FLAGS="--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
 `)
 
 func linuxCloudInitArtifacts10ContainerdConfBytes() ([]byte, error) {
@@ -191,7 +191,7 @@ func linuxCloudInitArtifacts10HttpproxyConf() (*asset, error) {
 }
 
 var _linuxCloudInitArtifacts10TlsbootstrapConf = []byte(`[Service]
-Environment=KUBELET_TLS_BOOTSTRAP_FLAGS="--kubeconfig /var/lib/kubelet/kubeconfig --bootstrap-kubeconfig /var/lib/kubelet/bootstrap-kubeconfig"
+Environment="KUBELET_TLS_BOOTSTRAP_FLAGS=--kubeconfig /var/lib/kubelet/kubeconfig --bootstrap-kubeconfig /var/lib/kubelet/bootstrap-kubeconfig"
 `)
 
 func linuxCloudInitArtifacts10TlsbootstrapConfBytes() ([]byte, error) {


### PR DESCRIPTION
Fixes quoting on systemd environment file drop-ins. This actually works fine on newer versions, but breaks node registration on older systemd versions (e.g. you can't build a 1.15.12 test cluster without this change).