### PR TITLE
fix: expose runtime slice metrics from kubelet /stats/summary

### DIFF
--- a/parts/linux/cloud-init/artifacts/10-containerd.conf
+++ b/parts/linux/cloud-init/artifacts/10-containerd.conf
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd++GPU+runcshimv2/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd++GPU+runcshimv2/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd++GPU+runcshimv2/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd++GPU+runcshimv2/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Certsd/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Certsd/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Certsd/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Certsd/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+ContainerdVersion/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+ContainerdVersion/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+ContainerdVersion/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+ContainerdVersion/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPMasqAgent/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPMasqAgent/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPMasqAgent/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPMasqAgent/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+Calico/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+Calico/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+Calico/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+Calico/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+FIPSEnabled/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+FIPSEnabled/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+FIPSEnabled/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+FIPSEnabled/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG/CustomData
@@ -118,7 +118,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG/line121.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG/line121.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+PrivateACR/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+PrivateACR/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+PrivateACR/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+PrivateACR/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Teleport/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Teleport/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Teleport/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Teleport/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=false/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=false/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=false/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=false/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=true/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=true/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=true/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=true/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+NoneCNI/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+NoneCNI/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+NoneCNI/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+NoneCNI/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804+krustlet/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+krustlet/CustomData
@@ -95,7 +95,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+krustlet/line98.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+krustlet/line98.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+CustomKubeImageandBinaries/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+CustomKubeImageandBinaries/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+CustomKubeImageandBinaries/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+CustomKubeImageandBinaries/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+NoCustomKubeImageandBinaries/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+NoCustomKubeImageandBinaries/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+NoCustomKubeImageandBinaries/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+NoCustomKubeImageandBinaries/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/AKSUbuntu1804Containerd+RuncVersion/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804Containerd+RuncVersion/CustomData
@@ -94,7 +94,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804Containerd+RuncVersion/line97.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804Containerd+RuncVersion/line97.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/agent/testdata/RawUbuntuContainerd/CustomData
+++ b/pkg/agent/testdata/RawUbuntuContainerd/CustomData
@@ -137,7 +137,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAA/2yLsarCQBBF+3xFSD9veYWNsEXUVcQQwcRKJEgyxSA7o5PZ4OeLhWJhd+/hnFODOlGP5yzwRCockc0Xu+MiVKHtlvu6Lbd1OKy6dVVuGg/QC9uFGBU0sVFErxjFMIc3AMV7wtHgdSSZ/5/F/EcIyMNNiM0npsfcOaeJ3UcbvubfKP21yJ4BAAD//2OFtCKuAAAA
+    H4sIAAAAAAAA/2yPwcrCMBCE732K0nsa/sN/EXKoGkUsFWw9iRRJFwmaTd1sir69iCgVvM0M3zDMvgYarIFDonGw5NEBssrWu6kuddPONlVTrCq9nbeLsljWSgjjkY8WgQRFZOtAETjPkIp3IAiuEQKLp/GR1d+/S38UBWDXe4usItrbREpJEeUH60YyD96cRwvmRD72QclwDwwuDxdr4It/3cqSRwAAAP//1Kx0RuEAAAA=
 
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/pkg/agent/testdata/RawUbuntuContainerd/line140.sh
+++ b/pkg/agent/testdata/RawUbuntuContainerd/line140.sh
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -153,7 +153,7 @@ func linuxCloudInitArtifacts10ComponentconfigConf() (*asset, error) {
 }
 
 var _linuxCloudInitArtifacts10ContainerdConf = []byte(`[Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_CONTAINERD_FLAGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"
 `)
 
 func linuxCloudInitArtifacts10ContainerdConfBytes() ([]byte, error) {


### PR DESCRIPTION
this fixes a regression from dockershim to cri w/containerd.

tested by doing 
```bash
# before this change
kubectl get --raw /api/v1/nodes/aks-nodepool1-26271385-vmss000000/proxy/stats/summary > before.json
jq .node.systemContainers before.json > bs.json

# apply the change in this PR to /etc/systemd/system/kubelet.service.d/10-containerd.conf
# systemctl daemon-reload && systemctl restart kubelet
kubectl get --raw /api/v1/nodes/aks-nodepool1-26271385-vmss000000/proxy/stats/summary > after.json
jq .node.systemContainers before.json > as.json

# https://dandavison.github.io/delta/
delta -s bs.json as.json
```

produces this output, where you can see there is a new item in the array called "runtime" which tracks the container runtime metrics.

![image](https://user-images.githubusercontent.com/6800857/152407237-e15c8bc0-764a-4b9d-abcd-30d7e2f19c8d.png)
