### PR TITLE
Automation Pipeline Bug Fixes

### DIFF
--- a/vhdbuilder/scripts/automate_ev2pipeline_trigger.sh
+++ b/vhdbuilder/scripts/automate_ev2pipeline_trigger.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -euxo pipefail
 
 source vhdbuilder/scripts/automate_helpers.sh
 

--- a/vhdbuilder/scripts/automate_helpers.sh
+++ b/vhdbuilder/scripts/automate_helpers.sh
@@ -36,7 +36,13 @@ create_pull_request() {
 
     git remote set-url origin https://anujmaheshwari1:$2@github.com/Azure/AgentBaker.git  # Set remote URL with PAT
     git add .
-    git commit -m "Bumping image version to $1"
+    
+    if [[ $4 == "ReleaseNotes" ]]; then
+        git commit -m "Release notes for release $1"
+    else
+        git commit -m "Bumping image version to $1"
+    fi
+
     git push -u origin $3
 
     set +x  # To avoid logging PAT during curl

--- a/vhdbuilder/scripts/automate_release_notes.sh
+++ b/vhdbuilder/scripts/automate_release_notes.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -euxo pipefail
 
 source vhdbuilder/scripts/automate_helpers.sh
 

--- a/vhdbuilder/scripts/automate_version_bump.sh
+++ b/vhdbuilder/scripts/automate_version_bump.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -euxo pipefail
 
 source vhdbuilder/scripts/automate_helpers.sh
 


### PR DESCRIPTION
This PR addresses the following:
1) Incorrect commit message for Release Notes PR - Added logic to correctly differentiate commit message for VersionBump vs ReleaseNotes
2) Added pipefail since the pipeline was falsely succeeding even on some git operations failure.