### PR TITLE
dont replace PIR version in osimageconfig.go for VHD Automation

### DIFF
--- a/vhdbuilder/scripts/automate_version_bump.sh
+++ b/vhdbuilder/scripts/automate_version_bump.sh
@@ -43,7 +43,6 @@ find_current_image_version() {
 
 # This function replaces the old image version with the new input image version for all relevant files
 update_image_version() {
-    sed -i "s/${current_image_version}/${new_image_version}/g" pkg/agent/datamodel/osimageconfig.go
     sed -i "s/${current_image_version}/${new_image_version}/g" pkg/agent/bakerapi_test.go
     sed -i "s/${current_image_version}/${new_image_version}/g" pkg/agent/datamodel/sig_config.go
     sed -i "s/${current_image_version}/${new_image_version}/g" pkg/agent/datamodel/sig_config_test.go


### PR DESCRIPTION
As per discussion to stop publishing PIR images till needed, disable updating image version for PIR images in AB in the following file at 
1) https://github.com/Azure/AgentBaker/blob/dfaa2c90cc754c4da0d23a23c36ae73628e69f40/pkg/agent/datamodel/osimageconfig.go#L42
2) https://github.com/Azure/AgentBaker/blob/dfaa2c90cc754c4da0d23a23c36ae73628e69f40/pkg/agent/datamodel/osimageconfig.go#L21