### PR TITLE
Change e2e pool to DevInfra

### DIFF
--- a/.pipelines/e2e.yaml
+++ b/.pipelines/e2e.yaml
@@ -4,7 +4,7 @@ variables:
 - group: ab-e2e
 
 pool:
-  vmImage: ubuntu-18.04
+  name: 1ES-AKS-Elastic-DevInfra-Normal-Pool
 
 jobs:
 - job: E2E


### PR DESCRIPTION
The original Ubuntu 1804 pool had a large queue on an average delaying testing. Changing to DevInfra pool.