### PR TITLE
fix: Add kubeproxy and CNI binaries to defender exclusion list

### DIFF
--- a/staging/cse/windows/kubernetesfunc.ps1
+++ b/staging/cse/windows/kubernetesfunc.ps1
@@ -146,6 +146,16 @@ function Write-KubeClusterConfig {
 
 function Update-DefenderPreferences {
     Add-MpPreference -ExclusionProcess "c:\k\kubelet.exe"
+    Add-MpPreference -ExclusionProcess "c:\k\kube-proxy.exe"
+
+    # Azure CNI
+    Add-MpPreference -ExclusionProcess "C:\k\azurecni\bin\azure-cns.exe"
+    Add-MpPreference -ExclusionProcess "C:\k\azurecni\bin\azure-vnet-ipam.exe"
+    Add-MpPreference -ExclusionProcess "C:\k\azurecni\bin\azure-vnet-ipamv6.exe"
+    Add-MpPreference -ExclusionProcess "C:\k\azurecni\bin\azure-vnet-telemetry.exe"
+    Add-MpPreference -ExclusionProcess "C:\k\azurecni\bin\azure-vnet.exe"
+    Add-MpPreference -ExclusionProcess "C:\k\azurecni\bin\AzureNetworkContainer.exe"
+    Add-MpPreference -ExclusionProcess "C:\k\azurecni\bin\CnsWrapperService.exe"
 
     if ($global:EnableCsiProxy) {
         Add-MpPreference -ExclusionProcess "c:\k\csi-proxy.exe"


### PR DESCRIPTION
Add kubeproxy and CNI binaries to defender exclusion list
This needs to build a new CSE package