### PR TITLE
Downgrade cloud-init in CBLMariner to a known good version

### DIFF
--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -14,6 +14,10 @@ installDeps() {
         exit $ERR_APT_INSTALL_TIMEOUT
       fi
     done
+
+    # Pin cloud-init to a known good configuration. Add azure-kvp handler for additional telemetry.
+    dnf install -y cloud-init-21.3-3.cm1.noarch cloud-init-azure-kvp-21.3-3.cm1.noarch
+
 }
 
 downloadGPUDrivers() {

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -3062,6 +3062,10 @@ installDeps() {
         exit $ERR_APT_INSTALL_TIMEOUT
       fi
     done
+
+    # Pin cloud-init to a known good configuration. Add azure-kvp handler for additional telemetry.
+    dnf install -y cloud-init-21.3-3.cm1.noarch cloud-init-azure-kvp-21.3-3.cm1.noarch
+
 }
 
 downloadGPUDrivers() {


### PR DESCRIPTION
On the latest node image (2022.03.02), we've been seeing provisioning failures very early in boot. One of the key packages that changed between the known good node image and the latest is a patch we applied to cloud init. 

This change also adds in the cloud-init-azure-kvp subpackage, which should help make logs from early boot earlier to retrieve.

Running the change through E2E test pipelines to see if the issue repros with these changes.