### PR TITLE
chore: Cache new AKS Windows CSE scripts package v0.0.8

### DIFF
--- a/staging/cse/windows/README
+++ b/staging/cse/windows/README
@@ -1,6 +1,9 @@
 # AKS Windows CSE Scripts Package
 All files except *_test.ps1 and README will be published in AKS Windows CSE Scripts Package.
 
+## v0.0.8
+- Use provisioning scripts in CSEScriptsPackage. #1623
+
 ## v0.0.7
 - Exclude dockerd in Microsoft Defender #1600
 

--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -131,8 +131,8 @@ $global:map = @{
         "https://globalcdn.nuget.org/packages/microsoft.applicationinsights.2.11.0.nupkg",
         "https://acs-mirror.azureedge.net/aks-engine/windows/provisioning/signedscripts-v0.0.16.zip",
         "https://acs-mirror.azureedge.net/ccgakvplugin/v1.1.4/binaries/windows-gmsa-ccgakvplugin-v1.1.4.zip",
-        "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v0.0.6.zip",
-        "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v0.0.7.zip"
+        "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v0.0.7.zip",
+        "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v0.0.8.zip"
     );
     # Different from other packages which are downloaded/cached and used later only during CSE, windows containerd is installed
     # during building the Windows VHD to cache container images.
@@ -183,7 +183,6 @@ $global:map = @{
         "https://acs-mirror.azureedge.net/kubernetes/v1.23.4/windowszip/v1.23.4-1int.zip"
     );
     "c:\akse-cache\win-vnet-cni\" = @(
-        "https://acs-mirror.azureedge.net/azure-cni/v1.4.16/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.4.16.zip",
         "https://acs-mirror.azureedge.net/azure-cni/v1.4.19/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.4.19.zip"
     );
     "c:\akse-cache\calico\" = @(

--- a/vhdbuilder/packer/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows-vhd-builder-sig.json
@@ -80,10 +80,6 @@
             "type": "windows-restart"
         },
         {
-            "restart_timeout": "10m",
-            "type": "windows-restart"
-        },
-        {
             "elevated_user": "packer",
             "elevated_password": "{{.WinRMPassword}}",
             "environment_vars": [

--- a/vhdbuilder/packer/windows-vhd-builder.json
+++ b/vhdbuilder/packer/windows-vhd-builder.json
@@ -69,10 +69,6 @@
             "type": "windows-restart"
         },
         {
-            "restart_timeout": "10m",
-            "type": "windows-restart"
-        },
-        {
             "elevated_user": "packer",
             "elevated_password": "{{.WinRMPassword}}",
             "environment_vars": [


### PR DESCRIPTION
1. Cache new AKS Windows CSE scripts package v0.0.8
2. Remove unused Azure CNI v1.4.16 and CSE scripts package v0.0.6