### PR TITLE
Update AKS Windows VHD to 17763.2686.220317

### DIFF
--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -205,7 +205,7 @@ const (
 
 const (
 	LinuxSIGImageVersion   string = "2022.03.15"
-	WindowsSIGImageVersion string = "17763.2686.220309"
+	WindowsSIGImageVersion string = "17763.2686.220317"
 
 	// will not do weekly vhd release as amd64 when ARM64 Compute/AKS is still under development
 	Arm64LinuxSIGImageVersion string = "2022.03.12"

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -61,7 +61,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(windows2019Containerd.ResourceGroup).To(Equal("resourcegroup"))
 		Expect(windows2019Containerd.Gallery).To(Equal("akswindows"))
 		Expect(windows2019Containerd.Definition).To(Equal("windows-2019-containerd"))
-		Expect(windows2019Containerd.Version).To(Equal("17763.2686.220309"))
+		Expect(windows2019Containerd.Version).To(Equal("17763.2686.220317"))
 
 		aksUbuntuArm64804Gen2 := sigConfig.SigUbuntuImageConfig[AKSUbuntuArm64Containerd1804Gen2]
 		Expect(aksUbuntuArm64804Gen2.ResourceGroup).To(Equal("resourcegroup"))


### PR DESCRIPTION
Update AKS Windows VHD to 17763.2686.220317

- [Use Windows containerd 1.6](https://github.com/Azure/AgentBaker/pull/1631) 
- [chore: Cache new AKS Windows CSE scripts package v0.0.8](https://github.com/Azure/AgentBaker/pull/1624) 
- [chore: Cache Windows containerd 1.6](https://github.com/Azure/AgentBaker/pull/1605)