### PR TITLE
Revert version pinning for Mariner SIG image

### DIFF
--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -212,7 +212,6 @@ const (
 
 	// will not do weekly vhd release as amd64 when ARM64 Compute/AKS is still under development
 	Arm64LinuxSIGImageVersion string = "2022.03.19"
-	MarinerSIGImageVersion    string = "2022.02.19"
 )
 
 // SIG config Template
@@ -318,7 +317,7 @@ var (
 		ResourceGroup: AKSCBLMarinerResourceGroup,
 		Gallery:       AKSCBLMarinerGalleryName,
 		Definition:    "V1",
-		Version:       MarinerSIGImageVersion,
+		Version:       LinuxSIGImageVersion,
 	}
 
 	SIGWindows2019ImageConfigTemplate = SigImageConfigTemplate{

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -53,7 +53,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(mariner.ResourceGroup).To(Equal("resourcegroup"))
 		Expect(mariner.Gallery).To(Equal("akscblmariner"))
 		Expect(mariner.Definition).To(Equal("V1"))
-		Expect(mariner.Version).To(Equal("2022.02.19"))
+		Expect(mariner.Version).To(Equal("2022.03.15"))
 
 		Expect(len(sigConfig.SigWindowsImageConfig)).To(Equal(3))
 


### PR DESCRIPTION
The issue requiring that the Mariner image to be pinned to 2022.02.19 has been resolved in PR https://github.com/Azure/AgentBaker/pull/1636. Subsequent builds of the Mariner image out of the master branch are back to being healthy.

This commit reverts the change from PR https://github.com/Azure/AgentBaker/pull/1617, setting Mariner to use the same date tag as the other Linux images once again for upcoming releases.