### PR TITLE
upgrade azure disk driver to v1.14, azure file driver to v1.13

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -297,12 +297,11 @@
       "downloadURL": "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:*",
       "amd64OnlyVersions": [
         "v1.2.0.6",
-        "v1.8.0.1",
         "v1.8.0.2"
       ],
       "multiArchVersions": [
-        "v1.12.0",
-        "v1.13.0"
+        "v1.13.0",
+        "v1.14.0"
       ]
     },
     {
@@ -311,8 +310,8 @@
         "v1.2.0"
       ],
       "multiArchVersions": [
-        "v1.11.0",
-        "v1.12.0"
+        "v1.12.0",
+        "v1.13.0"
       ]
     },
     {


### PR DESCRIPTION
upgrade azure disk driver to v1.14, azure file driver to v1.13,
current version:
 - azure disk driver: v1.13
 - azure file driver: v1.12