### PR TITLE
fix: check-generated tests: use `go install` instead of `go get`

### DIFF
--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -8,19 +8,19 @@ install: $(LOCALBIN)/go-bindata $(LOCALBIN)/gox $(LOCALBIN)/ginkgo $(LOCALBIN)/g
 	@echo > /dev/null
 
 $(LOCALBIN)/go-bindata:
-	GOBIN=$(LOCALBIN) $(GO) get github.com/go-bindata/go-bindata/...@v3.1.2
+	GOBIN=$(LOCALBIN) $(GO) install github.com/go-bindata/go-bindata/...@v3.1.2
 
 $(LOCALBIN)/gox:
-	GOBIN=$(LOCALBIN) $(GO) get github.com/mitchellh/gox/...@v1.0.1
+	GOBIN=$(LOCALBIN) $(GO) install github.com/mitchellh/gox/...@v1.0.1
 
 $(LOCALBIN)/ginkgo:
-	GOBIN=$(LOCALBIN) $(GO) get github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+	GOBIN=$(LOCALBIN) $(GO) install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
 
 $(LOCALBIN)/golangci-lint:
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(LOCALBIN) v1.21.0
 
 $(LOCALBIN)/cue:
-	GOBIN=$(LOCALBIN) $(GO) get cuelang.org/go/cmd/cue@v0.4.2
+	GOBIN=$(LOCALBIN) $(GO) install cuelang.org/go/cmd/cue@v0.4.2
 
 .PHONY: reload
 reload: clean install


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
It updates `go get` to `go install`, as `go get` has been deprecated for installing executables since `go 1.17`:
https://go.dev/doc/go-get-install-deprecation. 

This fixes failures in `check-generate` test that is run for every Agentbaker PR. Go 1.18 is the go runtime environment for this Agentbaker check. 

Example failure: https://github.com/Azure/AgentBaker/runs/5820763299?check_suite_focus=true

```
make[1]: Leaving directory '/home/runner/work/AgentBaker/AgentBaker/hack/tools'
-mod=vendor
bash: go-bindata: command not found'
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
