### PR TITLE
Windows VHD test case waits for containerd running before using containerd

### DIFF
--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -43,12 +43,9 @@ function Start-Job-To-Expected-State {
         Start-Job -Name $JobName -ScriptBlock $ScriptBlock
 
         do {
+            Start-Sleep $DelaySecond
             $job = (Get-Job -Name $JobName)
             if ($job -and ($job.State -Match $ExpectedState)) { return }
-
-            Write-Output 'Get-Job'
-            Write-Output (Get-Job)
-            Start-Sleep $DelaySecond
             $cnt++
         } while ($cnt -lt $MaxRetryCount)
 

--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -123,9 +123,49 @@ function Test-PatchInstalled {
     Write-Output "All pathced $patchIDs are installed"
 }
 
+function Start-Job-To-Expected-State {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Position=0, Mandatory=$true)]
+        [string]$JobName,
+
+        [Parameter(Position=1, Mandatory=$true)]
+        [scriptblock]$ScriptBlock,
+
+        [Parameter(Position=2, Mandatory=$false)]
+        [string]$ExpectedState = 'Running',
+
+        [Parameter(Position=3, Mandatory=$false)]
+        [int]$MaxRetryCount = 10,
+
+        [Parameter(Position=4, Mandatory=$false)]
+        [int]$DelaySecond = 10
+    )
+
+    Begin {
+        $cnt = 0
+    }
+
+    Process {
+        do {
+            Start-Job -Name $JobName -ScriptBlock $ScriptBlock
+            Start-Sleep $DelaySecond
+
+            $job = (Get-Job -Name $JobName)
+            if ($job -and ($job.State -Match $ExpectedState)) { return }
+
+            Write-Output 'Get-Job'
+            Write-Output (Get-Job)
+            $cnt++
+        } while ($cnt -lt $MaxRetryCount)
+
+        throw "Cannot start $JobName"
+    }
+}
+
 function Test-ImagesPulled {
     if ($containerRuntime -eq 'containerd') {
-        Start-Job -Name containerd -ScriptBlock { containerd.exe }
+        Start-Job-To-Expected-State -JobName containerd -ScriptBlock { containerd.exe }
         # NOTE:
         # 1. listing images with -q set is expected to return only image names/references, but in practise
         #    we got additional digest info. The following command works as a workaround to return only image names instad.


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
**Which issue(s) this PR fixes**:
The test is unstable: It immediately uses the job(containerd.exe) after starting the job(containerd.exe).

Fixes #
Wait for a time before using the job(containerd.exe).

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
