### PR TITLE
chore: remove k8s 1.20 from VHD

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -459,8 +459,6 @@ done
 # Please do not use the .1 suffix, because that's only for the base image patches
 # regular version >= v1.17.0 or hotfixes >= 20211009 has arm64 binaries. For versions with arm64, please add it blow
 MULTI_ARCH_KUBE_BINARY_VERSIONS="
-1.20.13-hotfix.20220210
-1.20.15-hotfix.20220201
 1.21.7-hotfix.20220204
 1.21.9-hotfix.20220204
 1.22.4-hotfix.20220201

--- a/vhdbuilder/packer/kube-proxy-images.json
+++ b/vhdbuilder/packer/kube-proxy-images.json
@@ -5,10 +5,6 @@
         "downloadURL": "mcr.microsoft.com/oss/kubernetes/kube-proxy:v*",
         "amd64OnlyVersions": [],
         "multiArchVersions": [
-          "1.20.13-hotfix.20220210.1",
-          "1.20.13-hotfix.20220210.3",
-          "1.20.15-hotfix.20220201.1",
-          "1.20.15-hotfix.20220201.3",
           "1.21.7-hotfix.20220310.1",
           "1.21.7-hotfix.20220330.2",
           "1.21.9-hotfix.20220310.1",
@@ -33,10 +29,6 @@
         "downloadURL": "mcr.microsoft.com/oss/kubernetes/kube-proxy:v*",
         "amd64OnlyVersions": [],
         "multiArchVersions": [
-          "1.20.13-hotfix.20220210.1",
-          "1.20.13-hotfix.20220210.3",
-          "1.20.15-hotfix.20220201.1",
-          "1.20.15-hotfix.20220201.3",
           "1.21.7-hotfix.20220310.1",
           "1.21.7-hotfix.20220330.2",
           "1.21.9-hotfix.20220310.1",

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -219,8 +219,6 @@ testKubeBinariesPresent() {
   containerRuntime=$1
   binaryDir=/usr/local/bin
   k8sVersions="
-  1.20.13-hotfix.20220210
-  1.20.15-hotfix.20220201
   1.21.7-hotfix.20220204
   1.21.9-hotfix.20220204
   1.22.4-hotfix.20220201


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Remove k8s 1.20 k8s binaries and images to reduce space used on VHD. k8s 1.20 on AKS has been deprecated so it does not need to be cached on the VHD now. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
