### PR TITLE
Add updated calico pod2daemon and cni images

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -165,7 +165,9 @@
       "amd64OnlyVersions": [
         "v3.8.9.3"
       ],
-      "multiArchVersions": []
+      "multiArchVersions": [
+        "v3.21.4"
+      ]
     },
     {
       "downloadURL": "mcr.microsoft.com/oss/calico/node:*",
@@ -173,7 +175,6 @@
         "v3.8.9.5"
       ],
       "multiArchVersions": [
-        "v3.20.0",
         "v3.21.4"
       ]
     },
@@ -183,7 +184,6 @@
         "v3.8.9"
       ],
       "multiArchVersions": [
-        "v3.20.0",
         "v3.21.4"
       ]
     },
@@ -192,13 +192,14 @@
       "amd64OnlyVersions": [
         "v3.8.9.1"
       ],
-      "multiArchVersions": []
+      "multiArchVersions": [
+        "v3.21.4"
+      ]
     },
     {
       "downloadURL": "mcr.microsoft.com/oss/calico/kube-controllers:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v3.20.0",
         "v3.21.4"
       ]
     },


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

We still pull these images as part of a normal managed Calico cluster on AKS. 

Also removing Calico v3.20.0 since that is no longer in use.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
