### PR TITLE
[Chore] remove network monitor and vnet telemetry

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -88,24 +88,10 @@
       ]
     },
     {
-      "downloadURL": "mcr.microsoft.com/containernetworking/networkmonitor:*",
-      "amd64OnlyVersions": [
-        "v1.1.8_hotfix"
-      ],
-      "multiArchVersions": []
-    },
-    {
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-npm:*",
       "amd64OnlyVersions": [
         "v1.4.9",
         "v1.4.18"
-      ],
-      "multiArchVersions": []
-    },
-    {
-      "downloadURL": "mcr.microsoft.com/containernetworking/azure-vnet-telemetry:*",
-      "amd64OnlyVersions": [
-        "v1.0.30"
       ],
       "multiArchVersions": []
     },


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Not used any more in aks. 

[8:55 AM] Paul Miller (AWESOME)
    Time to rip out network monitor since its its no used in 1.21? Ace Eldeib noticied this in agentbaker recently...



{​​​​​​​​{​​​​​​​​- if semverCompare "<1.21.0" .Values.global.commonGlobals.Versions.Kubernetes }​​​​​​​​}​​​​​​​​
    {​​​​​​​​{​​​​​​​​- include (print $.Template.BasePath "/addons/system-addons/_azure-cni-networkmonitor.yaml") . | nindent 2 }​​​​​​​​}​​​​​​​​



**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
