### PR TITLE
fix: Exclude UDP source port 65330 in Windows nodes

### DIFF
--- a/staging/cse/windows/configfunc.ps1
+++ b/staging/cse/windows/configfunc.ps1
@@ -123,6 +123,13 @@ function Adjust-DynamicPortRange()
     # The fix which reduces dynamic port usage for non-DSR load balancers is shiped with KB4550969 in April 2020
     # Update the range to [33000, 65535] to avoid that it conflicts with NodePort range (30000 - 32767)
     Invoke-Executable -Executable "netsh.exe" -ArgList @("int", "ipv4", "set", "dynamicportrange", "tcp", "33000", "32536")
+
+    # https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-faq#what-protocols-can-i-use-within-vnets
+    # Default UDP Dynamic Port Range in Windows server: Start Port: 49152, Number of Ports : 16384. Range: [49152, 65535]
+    # Exclude UDP source port 65330: Start Port: 49152, Number of Ports : 16178. Range: [49152, 65329]
+    # This only excludes the port in AKS Windows nodes but will not impact Windows containers.
+    # Reference: https://github.com/Azure/AKS/issues/2988
+    Invoke-Executable -Executable "netsh.exe" -ArgList @("int", "ipv4", "set", "dynamicportrange", "udp", "49152", "16178")
 }
 
 # TODO: should this be in this PR?


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
When a DNS UDP request uses 65330 as the source port, the response will be dropped because UDP source port 65330 is reserved for the host.
Reference: [Azure Virtual Network FAQ | Microsoft Docs](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-faq#what-protocols-can-i-use-within-vnets)

This only excludes the port in AKS Windows nodes but will not impact Windows containers.
Reference: https://github.com/Azure/AKS/issues/2988

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
