### PR TITLE
fix: fix vhd-debug check bug in run-test

### DIFF
--- a/.pipelines/.vsts-vhd-builder-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-windows.yaml
@@ -24,7 +24,7 @@ parameters:
 - name: vhddebug
   displayName: VHD Debug
   type: boolean
-  default: false
+  default: False
 
 variables:
   CONTAINER_IMAGE:  'mcr.microsoft.com/oss/azcu/go-dev:v1.34.0'

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -64,7 +64,7 @@ steps:
       -e WINDOWS_SKU=$(WINDOWS_SKU) \
       -e OS_TYPE="Windows" \
       -e MODE=$(MODE) \
-      -e VHD_DEBUG=${VHD_DEBUG} \
+      -e VHD_DEBUG=$(VHD_DEBUG) \
       -e SIG_GALLERY_NAME=${SIG_GALLERY_NAME} \
       -e SIG_IMAGE_NAME=${SIG_IMAGE_NAME} \
       -e SIG_IMAGE_VERSION=${SIG_IMAGE_VERSION} \

--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -22,7 +22,7 @@ az group create --name $RESOURCE_GROUP_NAME --location ${AZURE_LOCATION} --tags 
 
 # defer function to cleanup resource group when VHD debug is not enabled
 function cleanup() {
-  if [[ "$VHD_DEBUG" == "True" ]]; then
+  if [[ $VHD_DEBUG == True ]]; then
     echo "VHD debug mode is enabled, please manually delete test vm resource group $RESOURCE_GROUP_NAME after debugging"
   else
     echo "Deleting resource group ${RESOURCE_GROUP_NAME}"

--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -22,9 +22,10 @@ az group create --name $RESOURCE_GROUP_NAME --location ${AZURE_LOCATION} --tags 
 
 # defer function to cleanup resource group when VHD debug is not enabled
 function cleanup() {
-  if [ "$VHD_DEBUG" == "true" ]; then
+  if [[ "$VHD_DEBUG" == "true" || "$VHD_DEBUG" == "True" ]]; then
     echo "VHD debug mode is enabled, please manually delete test vm resource group $RESOURCE_GROUP_NAME after debugging"
   else
+    echo "Deleting resource group ${RESOURCE_GROUP_NAME}"
     az group delete --name $RESOURCE_GROUP_NAME --yes --no-wait
   fi
 }

--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -22,7 +22,7 @@ az group create --name $RESOURCE_GROUP_NAME --location ${AZURE_LOCATION} --tags 
 
 # defer function to cleanup resource group when VHD debug is not enabled
 function cleanup() {
-  if [[ "$VHD_DEBUG" == "true" || "$VHD_DEBUG" == "True" ]]; then
+  if [[ "$VHD_DEBUG" == "True" ]]; then
     echo "VHD debug mode is enabled, please manually delete test vm resource group $RESOURCE_GROUP_NAME after debugging"
   else
     echo "Deleting resource group ${RESOURCE_GROUP_NAME}"


### PR DESCRIPTION
**What type of PR is this?**
/kind test
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
If both VHD_DEBUG is checked and the variable VHD_DEBUG is set to "true" running a pipeline, line 25 of cleanup() in runtest.sh will fail. The reason is "True" == "true" fails.


**Which issue(s) this PR fixes**:
This PR fixes the VHD_DEBUG check issue in run-test.
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
