### PR TITLE
Fix random marinergen2 failure in build pipeline run including arm64 build

### DIFF
--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -185,6 +185,7 @@ if [[ "$OS_SKU" == "CBLMariner" ]]; then
 			--resource-group $AZURE_RESOURCE_GROUP_NAME \
 			--name $IMPORTED_IMAGE_NAME \
 			--source $IMPORTED_IMAGE_URL \
+			--location $AZURE_LOCATION \
 			--hyper-v-generation V2 \
 			--os-type Linux
 


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Linux VHDs are built in eastus region by default. However there is no arm64 support in eastus, so ARM64 vhd is built in westus2 explicitly. When a build pipeline run (contains amd64 ubuntu and mariner, as well as arm64 ubuntu) starts from clean state, the RG aksvhdtestbuildrg could be created in westus2 region. This could cause random failure to MarinerGen2 build while importing source VHD to an interim SIG (although this flake failure won't happen in weekly vhd build pipeline because in weekly vhd build, RG aksbhfbuilerrg was created in eastus and was there for long time). This PR is to fix this flake.

https://msazure.visualstudio.com/CloudNativeCompute/_build?definitionId=172842&_a=summary

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
