### PR TITLE
chore: add Calico images for v3.23.1

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -153,7 +153,8 @@
         "v3.8.9.3"
       ],
       "multiArchVersions": [
-        "v3.21.4"
+        "v3.21.4",
+        "v3.23.1"
       ]
     },
     {
@@ -162,7 +163,8 @@
         "v3.8.9.5"
       ],
       "multiArchVersions": [
-        "v3.21.4"
+        "v3.21.4",
+        "v3.23.1"
       ]
     },
     {
@@ -171,7 +173,8 @@
         "v3.8.9"
       ],
       "multiArchVersions": [
-        "v3.21.4"
+        "v3.21.4",
+        "v3.23.1"
       ]
     },
     {
@@ -180,14 +183,16 @@
         "v3.8.9.1"
       ],
       "multiArchVersions": [
-        "v3.21.4"
+        "v3.21.4",
+        "v3.23.1"
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/oss/calico/kube-controllers:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v3.21.4"
+        "v3.21.4",
+        "v3.23.1"
       ]
     },
     {
@@ -215,7 +220,8 @@
       "amd64OnlyVersions": [],
       "multiArchVersions": [
         "v1.20.0",
-        "v1.24.2"
+        "v1.24.2",
+        "v1.27.4"
       ]
     },
     {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Add v3.23.1 images for Calico cni, node, typha,
pod2daemon-flexvol, and  kube-controllers.

Add v1.27.4 for tigera/operator, which is compatible
with v3.23.1 of Calico.

These images will be used for managed Calico clusters in AKS.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)

**Special notes for your reviewer**:


**Release note**:
```
Add v3.23.1 images for Calico cni, node, typha,
pod2daemon-flexvol, and  kube-controllers. Add v1.27.4 for tigera/operator.
```
