### PR TITLE
fix: Move imported_image_name="" into Windows block

### DIFF
--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -245,9 +245,9 @@ WINDOWS_IMAGE_OFFER="WindowsServer"
 WINDOWS_IMAGE_SKU=""
 WINDOWS_IMAGE_VERSION=""
 WINDOWS_IMAGE_URL=""
-IMPORTED_IMAGE_NAME=""
 # shellcheck disable=SC2236
 if [ ! -z "${WINDOWS_SKU}" ]; then
+	IMPORTED_IMAGE_NAME=""
 	source $CDIR/windows-image.env
 	case "${WINDOWS_SKU}" in
 	"2019"|"2019-containerd")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind regression


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes Mariner vhd builds. The changes from https://github.com/Azure/AgentBaker/pull/1791 caused the IMPORTED_IMAGE_NAME variable value from the Mariner 'if' block to be overwritten. 

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
