### PR TITLE
fix: Remove the code to exclude UDP source port 65330 in Windows nodes

### DIFF
--- a/staging/cse/windows/README
+++ b/staging/cse/windows/README
@@ -2,10 +2,10 @@
 All files except *_test.ps1 and README will be published in AKS Windows CSE Scripts Package.
 
 ## v0.0.10
-- feat: Update the command to exclude UDP source port in Windows node #1924
+- feat: Update the command to exclude UDP source port in Windows node #1924 **NOTE: DO NOT USE**
 
 ## v0.0.9
-- fix: Exclude UDP source port 65330 in Windows nodes #1784
+- fix: Exclude UDP source port 65330 in Windows nodes #1784 **NOTE: DO NOT USE**
 
 ## v0.0.8
 - Use provisioning scripts in CSEScriptsPackage. #1623

--- a/staging/cse/windows/configfunc.ps1
+++ b/staging/cse/windows/configfunc.ps1
@@ -123,14 +123,6 @@ function Adjust-DynamicPortRange()
     # The fix which reduces dynamic port usage is still needed for DSR mode
     # Update the range to [33000, 65535] to avoid that it conflicts with NodePort range (30000 - 32767)
     Invoke-Executable -Executable "netsh.exe" -ArgList @("int", "ipv4", "set", "dynamicportrange", "tcp", "33000", "32536")
-
-    # https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-faq#what-protocols-can-i-use-within-vnets
-    # Default UDP Dynamic Port Range in Windows server: Start Port: 49152, Number of Ports : 16384. Range: [49152, 65535]
-    # Exclude UDP source port 65330: Start Port: 49152, Number of Ports : 16178. Range: [49152, 65329]
-    # This only excludes the port in AKS Windows nodes but will not impact Windows containers.
-    # Reference: https://github.com/Azure/AKS/issues/2988
-    # List command: netsh int ipv4 show excludedportrange udp
-    Invoke-Executable -Executable "netsh.exe" -ArgList @("int", "ipv4", "add", "excludedportrange", "udp", "65330", "1", "persistent")
 }
 
 # TODO: should this be in this PR?


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
fix: Remove the code to exclude UDP source port 65330 in Windows nodes
The command may fail because the UDP source port 65330 is being used. Retry may still not work so let us remove it for now.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
