### PR TITLE
feat: Support mutilple Windows containerd versions in cse package

### DIFF
--- a/staging/cse/windows/README
+++ b/staging/cse/windows/README
@@ -1,5 +1,14 @@
+# Unit Tests
+1. Please install [pester](https://github.com/pester/Pester) with the command `Install-Module -Name pester -SkipPublisherCheck -Force`.
+  - Doc: https://pester.dev/docs/quick-start
+  - Courses: https://docs.microsoft.com/en-us/shows/testing-powershell-with-pester/
+1. You need to run unit tests on Windows. NOTE: WSL does not work.
+1. Run unit tests
+  - `cd staging\cse\windows\`
+  - `.\cse.tests.ps1`
+
 # AKS Windows CSE Scripts Package
-All files except *_test.ps1 and README will be published in AKS Windows CSE Scripts Package.
+All files except *.test.ps1 and README will be published in AKS Windows CSE Scripts Package.
 
 ## v0.0.10
 - feat: Update the command to exclude UDP source port in Windows node #1924 **NOTE: DO NOT USE**

--- a/staging/cse/windows/azurecnifunc.tests.ps1
+++ b/staging/cse/windows/azurecnifunc.tests.ps1
@@ -1,4 +1,7 @@
-. $PSScriptRoot\windowsazurecnifunc.ps1
+BeforeAll {
+    . $PSScriptRoot\..\..\..\parts\windows\windowscsehelper.ps1
+    . $PSCommandPath.Replace('.tests.ps1','.ps1')
+  }
 
 Describe 'GetBroadestRangesForEachAddress' {
 

--- a/staging/cse/windows/containerdfunc.ps1
+++ b/staging/cse/windows/containerdfunc.ps1
@@ -2,6 +2,12 @@
 $global:ContainerdInstallLocation = "$Env:ProgramFiles\containerd"
 $global:Containerdbinary = (Join-Path $global:ContainerdInstallLocation containerd.exe)
 
+# NOTE: KubernetesVersion does not contain "v"
+$global:MinimalKubernetesVersionWithLatestContainerd = "1.30.0" # Will change it to the correct version when we support new Windows containerd version
+$global:StableContainerdPackage = "v0.0.46/binaries/containerd-v0.0.46-windows-amd64.tar.gz"
+# The containerd package name may be changed in future
+$global:LatestContainerdPackage = "v1.0.46/binaries/containerd-v1.0.46-windows-amd64.tar.gz" # It does not exist and is only for test for now
+
 function RegisterContainerDService {
   Param(
     [Parameter(Mandatory = $true)][string]
@@ -117,6 +123,41 @@ function Enable-Logging {
   else {
     Write-Log "Containerd hyperv logging script not avalaible"
   }
+}
+
+function Install-Containerd-Based-On-Kubernetes-Version {
+  Param(
+    [Parameter(Mandatory = $true)][string]
+    $ContainerdUrl,
+    [Parameter(Mandatory = $true)][string]
+    $CNIBinDir,
+    [Parameter(Mandatory = $true)][string]
+    $CNIConfDir,
+    [Parameter(Mandatory = $true)][string]
+    $KubeDir,
+    [Parameter(Mandatory = $true)][string]
+    $KubernetesVersion
+  )
+
+  # In the past, $global:ContainerdUrl is a full URL to download Windows containerd package.
+  # Example: "https://acs-mirror.azureedge.net/containerd/windows/v0.0.46/binaries/containerd-v0.0.46-windows-amd64.tar.gz"
+  # To support multiple containerd versions, we only set the endpoint in $global:ContainerdUrl.
+  # Example: "https://acs-mirror.azureedge.net/containerd/windows/"
+  # We only set containerd package based on kubernetes version when $global:ContainerdUrl ends with "/" so we support:
+  #   1. Current behavior to set the full URL
+  #   2. Setting containerd package in toggle for test purpose or hotfix
+  if ($ContainerdUrl.EndsWith("/")) {
+    Write-Log "ContainerdURL is $ContainerdUrl"
+    $containerdPackage=$global:StableContainerdPackage
+    if (([version]$KubernetesVersion).CompareTo([version]$global:MinimalKubernetesVersionWithLatestContainerd) -ge 0) {
+      $containerdPackage=$global:LatestContainerdPackage
+      Write-Log "Kubernetes version $KubernetesVersion is greater than or equal to $global:MinimalKubernetesVersionWithLatestContainerd so the latest containerd version $containerdPackage is used"
+    } else {
+      Write-Log "Kubernetes version $KubernetesVersion is less than $global:MinimalKubernetesVersionWithLatestContainerd so the stable containerd version $containerdPackage is used"
+    }
+    $ContainerdUrl = $ContainerdUrl + $containerdPackage
+  }
+  Install-Containerd -ContainerdUrl $ContainerdUrl -CNIBinDir $CNIBinDir -CNIConfDir $CNIConfDir -KubeDir $KubeDir
 }
 
 function Install-Containerd {

--- a/staging/cse/windows/containerdfunc.tests.ps1
+++ b/staging/cse/windows/containerdfunc.tests.ps1
@@ -1,0 +1,46 @@
+BeforeAll {
+  . $PSScriptRoot\..\..\..\parts\windows\windowscsehelper.ps1
+  . $PSCommandPath.Replace('.tests.ps1','.ps1')
+}
+
+Describe 'Install-Containerd-Based-On-Kubernetes-Version' {
+  BeforeAll{
+      Mock Install-Containerd -MockWith {
+        Param(
+          [Parameter(Mandatory = $true)][string]
+          $ContainerdUrl,
+          [Parameter(Mandatory = $true)][string]
+          $CNIBinDir,
+          [Parameter(Mandatory = $true)][string]
+          $CNIConfDir,
+          [Parameter(Mandatory = $true)][string]
+          $KubeDir
+        )
+        Write-Host $ContainerdUrl
+    } -Verifiable
+  }
+
+  It 'k8s version is less than MinimalKubernetesVersionWithLatestContainerd' {
+    $expectedURL = "https://acs-mirror.azureedge.net/containerd/windows/v0.0.46/binaries/containerd-v0.0.46-windows-amd64.tar.gz"
+    & Install-Containerd-Based-On-Kubernetes-Version -ContainerdUrl "https://acs-mirror.azureedge.net/containerd/windows/" -KubernetesVersion "1.24.0" -CNIBinDir "cniBinPath" -CNIConfDir "cniConfigPath" -KubeDir "kubeDir"
+    Assert-MockCalled -CommandName "Install-Containerd" -Exactly -Times 1 -ParameterFilter { $ContainerdUrl -eq $expectedURL }
+  }
+
+  It 'k8s version is equal to MinimalKubernetesVersionWithLatestContainerd' {
+    $expectedURL = "https://acs-mirror.azureedge.net/containerd/windows/v1.0.46/binaries/containerd-v1.0.46-windows-amd64.tar.gz"
+    & Install-Containerd-Based-On-Kubernetes-Version -ContainerdUrl "https://acs-mirror.azureedge.net/containerd/windows/" -KubernetesVersion "1.30.0" -CNIBinDir "cniBinPath" -CNIConfDir "cniConfigPath" -KubeDir "kubeDir"
+    Assert-MockCalled -CommandName "Install-Containerd" -Exactly -Times 1 -ParameterFilter { $ContainerdUrl -eq $expectedURL }
+  }
+
+  It 'k8s version is greater than MinimalKubernetesVersionWithLatestContainerd' {
+    $expectedURL = "https://mirror.azk8s.cn/containerd/windows/v1.0.46/binaries/containerd-v1.0.46-windows-amd64.tar.gz"
+    & Install-Containerd-Based-On-Kubernetes-Version -ContainerdUrl "https://mirror.azk8s.cn/containerd/windows/" -KubernetesVersion "1.30.1" -CNIBinDir "cniBinPath" -CNIConfDir "cniConfigPath" -KubeDir "kubeDir"
+    Assert-MockCalled -CommandName "Install-Containerd" -Exactly -Times 1 -ParameterFilter { $ContainerdUrl -eq $expectedURL }
+  }
+
+  It 'full URL is set' {
+    $expectedURL = "https://privatecotnainer.com/windows-containerd-v1.2.3.tar.gz"
+    & Install-Containerd-Based-On-Kubernetes-Version -ContainerdUrl "https://privatecotnainer.com/windows-containerd-v1.2.3.tar.gz" -KubernetesVersion "1.26.1" -CNIBinDir "cniBinPath" -CNIConfDir "cniConfigPath" -KubeDir "kubeDir"
+    Assert-MockCalled -CommandName "Install-Containerd" -Exactly -Times 1 -ParameterFilter { $ContainerdUrl -eq $expectedURL }
+  }
+}

--- a/staging/cse/windows/cse.tests.ps1
+++ b/staging/cse/windows/cse.tests.ps1
@@ -1,0 +1,2 @@
+Invoke-Pester -Output Detailed $PSScriptRoot\azurecnifunc.tests.ps1
+Invoke-Pester -Output Detailed $PSScriptRoot\containerdfunc.tests.ps1


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Support mutilple Windows containerd versions in cse package

 In the past, $global:ContainerdUrl is a full URL to download Windows containerd package.
Example: "https://acs-mirror.azureedge.net/containerd/windows/v0.0.46/binaries/containerd-v0.0.46-windows-amd64.tar.gz"
To support multiple containerd versions, we only set the endpoint in $global:ContainerdUrl.
Example: "https://acs-mirror.azureedge.net/containerd/windows/"
We only set containerd package based on kubernetes version when $global:ContainerdUrl ends with "/" so we support:
  1. Current behavior to set the full URL
  2. Setting containerd package in toggle for test purpose or hotfix

When using new CSE package with this change, we will change
`Install-Containerd -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir`
to
`Install-Containerd-Based-On-Kubernetes-Version -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir -KubernetesVersion $global:KubeBinariesVersion`.

I have tested this change with setting `$global:MinimalKubernetesVersionWithLatestContainerd` to `1.24.0`, `$global:LatestContainerdPackage` to `v0.0.45/binaries/containerd-v0.0.45-windows-amd64.tar.gz` and `$global:ContainerdUrl` to `"https://acs-mirror.azureedge.net/containerd/windows/"`.
```
NAME                            STATUS   ROLES   AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION     CONTAINER-RUNTIME
aks-nodes-35774791-vmss000000   Ready    agent   19m     v1.24.0   10.224.0.4    <none>        Ubuntu 18.04.6 LTS               5.4.0-1085-azure   containerd://1.6.4+azure-4
aksnpwin000000                  Ready    agent   16m     v1.24.0   10.224.0.33   <none>        Windows Server 2019 Datacenter   10.0.17763.3046    containerd://1.6.1+azure
aksnpwin3000000                 Ready    agent   6m14s   v1.23.5   10.224.0.64   <none>        Windows Server 2019 Datacenter   10.0.17763.3046    containerd://1.6.6+azure
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
