### PR TITLE
Update go dev to 1.34.7 to get packer to 1.8.1

### DIFF
--- a/.pipelines/.vsts-Marketpalce-win.yaml
+++ b/.pipelines/.vsts-Marketpalce-win.yaml
@@ -5,7 +5,7 @@ pool:
   vmImage: ubuntu-18.04
 
 variables:
-  CONTAINER_IMAGE: 'mcr.microsoft.com/oss/azcu/go-dev:v1.34.0'
+  CONTAINER_IMAGE: 'mcr.microsoft.com/oss/azcu/go-dev:v1.34.7'
 
 stages:
   - stage: create_sku_and_publish_2019_image

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -23,7 +23,7 @@ parameters:
   default: False
 
 variables:
-  CONTAINER_IMAGE:  'mcr.microsoft.com/oss/azcu/go-dev:v1.34.0'
+  CONTAINER_IMAGE:  'mcr.microsoft.com/oss/azcu/go-dev:v1.34.7'
 
 stages:
   - stage: build_vhd_2019

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -91,7 +91,7 @@ parameters:
   default: False
 
 variables:
-  CONTAINER_IMAGE:  'mcr.microsoft.com/oss/azcu/go-dev:v1.34.0'
+  CONTAINER_IMAGE:  'mcr.microsoft.com/oss/azcu/go-dev:v1.34.7'
 
 stages:
   - stage: build_vhd

--- a/.pipelines/.vsts-vhd-builder-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-windows.yaml
@@ -27,7 +27,7 @@ parameters:
   default: False
 
 variables:
-  CONTAINER_IMAGE:  'mcr.microsoft.com/oss/azcu/go-dev:v1.34.0'
+  CONTAINER_IMAGE:  'mcr.microsoft.com/oss/azcu/go-dev:v1.34.7'
 
 stages:
   - stage: build_vhd_2019

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -28,7 +28,7 @@ pool:
 #    - (offline)POST a new SKU to azure marketplace
 
 variables:
-  CONTAINER_IMAGE:  'mcr.microsoft.com/oss/azcu/go-dev:v1.34.0'
+  CONTAINER_IMAGE:  'mcr.microsoft.com/oss/azcu/go-dev:v1.34.7'
 
 stages:
   - stage: build_vhd

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ifeq ($(GITTAG),)
 GITTAG := $(VERSION_SHORT)
 endif
 
-DEV_ENV_IMAGE := mcr.microsoft.com/oss/azcu/go-dev:v1.34.0
+DEV_ENV_IMAGE := mcr.microsoft.com/oss/azcu/go-dev:v1.34.7
 DEV_ENV_WORK_DIR := /baker
 DEV_ENV_OPTS := --rm -v $(GOPATH)/pkg/mod:/go/pkg/mod -v $(CURDIR):$(DEV_ENV_WORK_DIR) -w $(DEV_ENV_WORK_DIR) $(DEV_ENV_VARS)
 DEV_ENV_CMD := docker run $(DEV_ENV_OPTS) $(DEV_ENV_IMAGE)


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
Packer fixes SSH issue for Ubuntu 22.04 in version 1.8.1 as noted here https://github.com/hashicorp/packer/issues/11656#issuecomment-1138011054
This is essential to build Ubuntu 22.04 VHD since currently, SSH to them is broken via packer. go-dev 1.34.7 has updated packer version as 1.8.1

**Release note**:
```
none
```
