### PR TITLE
chore: add Cilium images for v1.12.0

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -193,7 +193,15 @@
       "downloadURL": "mcr.microsoft.com/oss/cilium/operator:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "1.10.5"
+        "1.10.5",
+        "v1.12.0"
+      ]
+    },
+    {
+      "downloadURL": "mcr.microsoft.com/oss/cilium/operator-generic:*",
+      "amd64OnlyVersions": [],
+      "multiArchVersions": [
+        "v1.12.0"
       ]
     },
     {
@@ -201,7 +209,8 @@
       "amd64OnlyVersions": [],
       "multiArchVersions": [
         "1.10.5.10",
-        "1.10.5.11"
+        "1.10.5.11",
+        "v1.12.0"
       ]
     },
     {


### PR DESCRIPTION
Add v1.12.0 images for cilium, cilium-operator, and cilium-operator-generic.

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Add latest Cilium images.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)

**Special notes for your reviewer**:

cilium/operator-generic is a new image that we started publishing recently.

**Release note**:
```
Add v1.12.0 images for cilium, cilium-operator, and cilium-operator-generic.
```