### PR TITLE
Fix: Update Image tag with hotfix version (ciprod06272022-hotfix) for container insights

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -138,7 +138,8 @@
       "amd64OnlyVersions": [],
       "multiArchVersions": [
         "ciprod05192022",
-        "ciprod06272022"
+        "ciprod06272022",
+        "ciprod06272022-hotfix"
       ]
     },
     {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug : hotfix image update

**What this PR does / why we need it**:

Container Insights has a bug with the ciprod06272021 agent version where the node allocatable metric for cpu and memory limits are not being sent correctly. It is fixed in the following image : ciprod06272021-hotfix. This PR aims to include this hotfix image in the baked VHD.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
