### PR TITLE
chore: add tigera-operator v1.23.8

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -215,6 +215,7 @@
       "amd64OnlyVersions": [],
       "multiArchVersions": [
         "v1.20.0",
+        "v1.23.8",
         "v1.24.2",
         "v1.27.4"
       ]


### PR DESCRIPTION


/kind feature

**What this PR does / why we need it**:

tigera-operator 1.23.8 installs Calico 3.21.6

related to https://github.com/Azure/AgentBaker/pull/2026

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)

**Special notes for your reviewer**:

**Release note**:
```
none
```
