### PR TITLE
doc: Add release notes for AKS Windows images with 2022.08B

### DIFF
--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -228,8 +228,8 @@ const (
 const (
 	LinuxSIGImageVersion string = "2022.08.02"
 
-	Windows2019SIGImageVersion string = "17763.3232.220722"
-	Windows2022SIGImageVersion string = "20348.859.220722"
+	Windows2019SIGImageVersion string = "17763.3287.220810"
+	Windows2022SIGImageVersion string = "20348.887.220810"
 
 	Arm64LinuxSIGImageVersion    string = "2022.08.09"
 	Ubuntu2204SIGImageVersion    string = "2022.07.25"

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -61,19 +61,19 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(windows2019.ResourceGroup).To(Equal("AKS-Windows"))
 		Expect(windows2019.Gallery).To(Equal("AKSWindows"))
 		Expect(windows2019.Definition).To(Equal("windows-2019"))
-		Expect(windows2019.Version).To(Equal("17763.3232.220722"))
+		Expect(windows2019.Version).To(Equal("17763.3287.220810"))
 
 		windows2019Containerd := sigConfig.SigWindowsImageConfig[AKSWindows2019Containerd]
 		Expect(windows2019Containerd.ResourceGroup).To(Equal("AKS-Windows"))
 		Expect(windows2019Containerd.Gallery).To(Equal("AKSWindows"))
 		Expect(windows2019Containerd.Definition).To(Equal("windows-2019-containerd"))
-		Expect(windows2019Containerd.Version).To(Equal("17763.3232.220722"))
+		Expect(windows2019Containerd.Version).To(Equal("17763.3287.220810"))
 
 		windows2022Containerd := sigConfig.SigWindowsImageConfig[AKSWindows2022Containerd]
 		Expect(windows2022Containerd.ResourceGroup).To(Equal("AKS-Windows"))
 		Expect(windows2022Containerd.Gallery).To(Equal("AKSWindows"))
 		Expect(windows2022Containerd.Definition).To(Equal("windows-2022-containerd"))
-		Expect(windows2022Containerd.Version).To(Equal("20348.859.220722"))
+		Expect(windows2022Containerd.Version).To(Equal("20348.887.220810"))
 
 		aksUbuntuArm641804Gen2 := sigConfig.SigUbuntuImageConfig[AKSUbuntuArm64Containerd1804Gen2]
 		Expect(aksUbuntuArm641804Gen2.ResourceGroup).To(Equal("resourcegroup"))

--- a/vhdbuilder/release-notes/AKSWindows/2019-containerd/17763.3287.220810.txt
+++ b/vhdbuilder/release-notes/AKSWindows/2019-containerd/17763.3287.220810.txt
@@ -1,0 +1,186 @@
+﻿Build Number: 20220810.1_master_58845286
+Build Id:     58845286
+Build Repo:   https://github.com/Azure/AgentBaker
+Build Branch: master
+Commit:       7b4c1e31c318f26d323479e193180f5b8c80f891
+
+VHD ID:      eb22b389-362e-482e-ae5c-2065e72bd539
+
+System Info
+	OS Name        : Windows Server 2019 Datacenter
+	OS Version     : 17763.3287
+	OS InstallType : Server Core
+
+Allowed security protocols: Tls, Tls11, Tls12
+
+Installed Features
+
+Display Name                                            Name                       Install State
+------------                                            ----                       -------------
+[X] File and Storage Services                           FileAndStorage-Services        Installed
+    [X] Storage Services                                Storage-Services               Installed
+[X] Hyper-V                                             Hyper-V                        Installed
+[X] .NET Framework 4.7 Features                         NET-Framework-45-Fea...        Installed
+    [X] .NET Framework 4.7                              NET-Framework-45-Core          Installed
+    [X] WCF Services                                    NET-WCF-Services45             Installed
+        [X] TCP Port Sharing                            NET-WCF-TCP-PortShar...        Installed
+[X] BitLocker Drive Encryption                          BitLocker                      Installed
+[X] Containers                                          Containers                     Installed
+[X] Enhanced Storage                                    EnhancedStorage                Installed
+[X] Remote Server Administration Tools                  RSAT                           Installed
+    [X] Role Administration Tools                       RSAT-Role-Tools                Installed
+        [X] Hyper-V Management Tools                    RSAT-Hyper-V-Tools             Installed
+            [X] Hyper-V Module for Windows PowerShell   Hyper-V-PowerShell             Installed
+[X] System Data Archiver                                System-DataArchiver            Installed
+[X] Windows Defender Antivirus                          Windows-Defender               Installed
+[X] Windows PowerShell                                  PowerShellRoot                 Installed
+    [X] Windows PowerShell 5.1                          PowerShell                     Installed
+[X] WoW64 Support                                       WoW64-Support                  Installed
+
+
+
+Installed Packages
+	Language.Basic~~~en-US~0.0.1.0
+	Language.Handwriting~~~en-US~0.0.1.0
+	Language.OCR~~~en-US~0.0.1.0
+	Language.Speech~~~en-US~0.0.1.0
+	Language.TextToSpeech~~~en-US~0.0.1.0
+	MathRecognizer~~~~0.0.1.0
+	OpenSSH.Client~~~~0.0.1.0
+	OpenSSH.Server~~~~0.0.1.0
+
+Installed QFEs
+	KB5013641 : Update          : https://support.microsoft.com/kb/5013641
+	KB5016623 : Security Update : https://support.microsoft.com/kb/5016623
+	KB5015896 : Update          : https://support.microsoft.com/kb/5015896
+
+Installed Updates
+	2022-05 Cumulative Update for .NET Framework 3.5, 4.7.2 and 4.8 for Windows Server 2019 for x64 (KB5013868)
+	Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.373.71.0)
+
+Windows Update Registry Settings
+	https://docs.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+		NoAutoUpdate : 1
+	HKLM:\SYSTEM\CurrentControlSet\Services\hns\State
+		EnableCompartmentNamespace : 1
+
+ContainerD Info
+Version: ctr github.com/containerd/containerd v1.6.6+azure
+
+Images:
+REF                                                                                                                                    TYPE                                                      DIGEST                                                                  SIZE      PLATFORMS                                          LABELS                          
+mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod06142022                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:0088411ef25582c961116c2b84235ad1bf3489b4f759d13bd320c81a14b6a0f0 3.3 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/azuremonitor/containerinsights/ciprod@sha256:0088411ef25582c961116c2b84235ad1bf3489b4f759d13bd320c81a14b6a0f0        application/vnd.docker.distribution.manifest.list.v2+json sha256:0088411ef25582c961116c2b84235ad1bf3489b4f759d13bd320c81a14b6a0f0 3.3 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure:v1.2.0                                                                        application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 110.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure@sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27       application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 110.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.20.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:66fa9ff20ac0e7a0141c22e7a6fab2a3366fadf4c9eb080af35c9cb4241f9d6e 121.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.21.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:591550802308c55e4c5fa01c4720fd0dfbad673fc70cea0b09ae345eff6180d0 121.8 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi@sha256:591550802308c55e4c5fa01c4720fd0dfbad673fc70cea0b09ae345eff6180d0             application/vnd.docker.distribution.manifest.list.v2+json sha256:591550802308c55e4c5fa01c4720fd0dfbad673fc70cea0b09ae345eff6180d0 121.8 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi@sha256:66fa9ff20ac0e7a0141c22e7a6fab2a3366fadf4c9eb080af35c9cb4241f9d6e             application/vnd.docker.distribution.manifest.list.v2+json sha256:66fa9ff20ac0e7a0141c22e7a6fab2a3366fadf4c9eb080af35c9cb4241f9d6e 121.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.19.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:52eb5867c901156f0c853c0ff2fc7e6e02858b8cd9479797760ec37bc76ef524 110.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.20.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:a7e8252e01acad4bb1e987ed5e873bfec1602226c36a58ebeb6e7d99133eb549 110.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi@sha256:52eb5867c901156f0c853c0ff2fc7e6e02858b8cd9479797760ec37bc76ef524             application/vnd.docker.distribution.manifest.list.v2+json sha256:52eb5867c901156f0c853c0ff2fc7e6e02858b8cd9479797760ec37bc76ef524 110.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi@sha256:a7e8252e01acad4bb1e987ed5e873bfec1602226c36a58ebeb6e7d99133eb549             application/vnd.docker.distribution.manifest.list.v2+json sha256:a7e8252e01acad4bb1e987ed5e873bfec1602226c36a58ebeb6e7d99133eb549 110.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.4.0                                                                  application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 106.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.5.0                                                                  application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 106.3 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar@sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 106.3 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar@sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 106.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.5.0                                                                              application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 105.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.6.0                                                                              application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 105.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe@sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6             application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 105.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe@sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8             application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 105.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v1.2.2                                                                       application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 122.3 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver@sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc      application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 122.3 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.21                                                                      application/vnd.docker.distribution.manifest.list.v2+json sha256:ccbbf5b1cd731796d223751510355b34bfe761a7946f1d43fb180599108d9629 110.5 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.18                                                                      application/vnd.docker.distribution.manifest.list.v2+json sha256:2dfff4dc10f6d25b0a34c01bf4d166540cbf1ff2bccd52635350039138eb23c4 111.1 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.1.14                                                                      application/vnd.docker.distribution.manifest.list.v2+json sha256:72fbc9d17947d1a54c09a16671e6810fd7c0d8f09c0502fdbdd212c2192451a7 111.6 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.23.11                                                                     application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 111.9 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.24.3                                                                      application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 111.8 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab      application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 111.9 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:2dfff4dc10f6d25b0a34c01bf4d166540cbf1ff2bccd52635350039138eb23c4      application/vnd.docker.distribution.manifest.list.v2+json sha256:2dfff4dc10f6d25b0a34c01bf4d166540cbf1ff2bccd52635350039138eb23c4 111.1 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:72fbc9d17947d1a54c09a16671e6810fd7c0d8f09c0502fdbdd212c2192451a7      application/vnd.docker.distribution.manifest.list.v2+json sha256:72fbc9d17947d1a54c09a16671e6810fd7c0d8f09c0502fdbdd212c2192451a7 111.6 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8      application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 111.8 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:ccbbf5b1cd731796d223751510355b34bfe761a7946f1d43fb180599108d9629      application/vnd.docker.distribution.manifest.list.v2+json sha256:ccbbf5b1cd731796d223751510355b34bfe761a7946f1d43fb180599108d9629 110.5 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/pause:3.6-hotfix.20220114                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 255.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/pause@sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0                         application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 255.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/nanoserver:1809                                                                                              application/vnd.docker.distribution.manifest.list.v2+json sha256:c827903a303cb7a76214adb4376e462a241b3cd763cb88655cd901c5a0e867a0 98.4 MiB  windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/nanoserver@sha256:c827903a303cb7a76214adb4376e462a241b3cd763cb88655cd901c5a0e867a0                           application/vnd.docker.distribution.manifest.list.v2+json sha256:c827903a303cb7a76214adb4376e462a241b3cd763cb88655cd901c5a0e867a0 98.4 MiB  windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/servercore:ltsc2019                                                                                          application/vnd.docker.distribution.manifest.list.v2+json sha256:8ca3aaeb91e7715a98a0769dc62ed69212aac3e0bbee12ffd13b5e36d992d127 2.5 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/servercore@sha256:8ca3aaeb91e7715a98a0769dc62ed69212aac3e0bbee12ffd13b5e36d992d127                           application/vnd.docker.distribution.manifest.list.v2+json sha256:8ca3aaeb91e7715a98a0769dc62ed69212aac3e0bbee12ffd13b5e36d992d127 2.5 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:021891d98f72ec97d5ccacab9adb084d59710aff6d1a97bf571e0936d050c5ab                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 111.8 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:113c123f64be3c8ee333d9c3647bfb9bf50a6a6fc737279218fab90175df30ae                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 106.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:1ad6e0e7018fc4fb38ff025964336c75bc74552d90d3191df8ee419f8d7c9f19                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:2dfff4dc10f6d25b0a34c01bf4d166540cbf1ff2bccd52635350039138eb23c4 111.1 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:22b6b24067f9ff3e81927216310b494f3dac89f50b5f2cffba578339fd382652                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 111.9 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:5abc0bfef52aa623927a9e2a2a38f69128cb379208fedcdb80e77a3e0b3b25f9                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 105.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:5fa59fbac91615c10d98b496b46ac5e681c0ed5060df21123f5d988689624bf9                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:c827903a303cb7a76214adb4376e462a241b3cd763cb88655cd901c5a0e867a0 98.4 MiB  windows/amd64                                      io.cri-containerd.image=managed 
+sha256:66c0d76f7600b7c69830dc17a3cbbea550aca935ff39cdbaeede6c2df6fcbdfc                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 122.3 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:7cde9cce69a9910369e5cc99d8a8121e069a92830fbc41961c3c8d12c06cb7b3                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:52eb5867c901156f0c853c0ff2fc7e6e02858b8cd9479797760ec37bc76ef524 110.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:99f1d36c6adc7439deebf7f3d2fb8235fd7b4186506d31565b4e29c22bc996e4                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:0088411ef25582c961116c2b84235ad1bf3489b4f759d13bd320c81a14b6a0f0 3.3 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:ac0f053e4ea44fd1a8947bbde6e037309da6c2bbc249f1b25c771d1015e8a2fb                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 255.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:bb13ca9a48d7e87d0633436542a72ff54563c17da52dc76928f2b8fe87469ca0                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:ccbbf5b1cd731796d223751510355b34bfe761a7946f1d43fb180599108d9629 110.5 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:c2773a95eb5f9ca541734d4834487add43907404542cd4be545bb4ca2884d805                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 106.3 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:cfed1068ffdb10a9d675392bc5fdb3256fb8cbc9c06c6f9982d35a62f2419a64                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:a7e8252e01acad4bb1e987ed5e873bfec1602226c36a58ebeb6e7d99133eb549 110.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:d0cd472e2aa7bd8bb0903d0bfb9f870eefd6ac807d56c227ab8dfed3aa3a9345                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:72fbc9d17947d1a54c09a16671e6810fd7c0d8f09c0502fdbdd212c2192451a7 111.6 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:e1ac5eb644b281f79fc1d5601c7fe0e45a9c9fbe605b9c973a0a6d447807df13                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:66fa9ff20ac0e7a0141c22e7a6fab2a3366fadf4c9eb080af35c9cb4241f9d6e 121.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:e511d780cf667480d2617aa59b9ca574a511d2f417c6606c565ef05e4163e662                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 110.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:e795f3f8aa80ed14fd102e995a567cbfbec1a698aa7e10428ecfdaa34fd0382c                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:8ca3aaeb91e7715a98a0769dc62ed69212aac3e0bbee12ffd13b5e36d992d127 2.5 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:f495854cc1b1235d4b4df29990841b287cba2d6d2113eb4e02e06d448007ea66                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:591550802308c55e4c5fa01c4720fd0dfbad673fc70cea0b09ae345eff6180d0 121.8 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:fef3c5781cdae9619d838b2273b9da5db96d20bca068ab6ec7775c7fab875fd4                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 105.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+
+Cached Files:
+
+File                                                                                    Sha256                                                           SizeBytes
+----                                                                                    ------                                                           ---------
+c:\akse-cache\aks-windows-cse-scripts-v0.0.11.zip                                       CEB1C9BC3EF5F1076FC78BCED8588403F7B2C118375C8DC16BAAABDB4761EBCF    105425
+c:\akse-cache\aks-windows-cse-scripts-v0.0.12.zip                                       9B8CBD3789CECE390BBD488F6887AD300794BA39B7C2C7BCF68ADF247543E4F6    105895
+c:\akse-cache\collect-windows-logs.ps1                                                  4008248A3E7D3C51AF105934B1FA9D3382CEC796FF91A48E13063866312A8F0F      8055
+c:\akse-cache\collectlogs.ps1                                                           09E8A8A2892153C27804E0FF4345EA2E6A2C81380DD412B9705BC06D24F4B21E     11519
+c:\akse-cache\dumpVfpPolicies.ps1                                                       02BFF0235421F1C8477E809B8EB354B313C348CE2732C4842B710239CD6FE665      1642
+c:\akse-cache\helper.psm1                                                               BC45AA98FA40D51C4E8640865C329BDC4B522EA53CC17A5F0B512B4D44058C8C     17945
+c:\akse-cache\hns.psm1                                                                  A8A53ED4FAC2E27C7E4268DB069D4CF3129A56D466EF3BF9465FB52DCD76A29C     14733
+c:\akse-cache\microsoft.applicationinsights.2.11.0.nupkg                                4B0448F9640FCD84979D6CE736348EE9304A7A069F77E38FF411F3211E699C68    776442
+c:\akse-cache\portReservationTest.ps1                                                   0940BA8A0A564E5937F60871F7F87C866C8617882D121FF33BBB0798B0C82AC0      4370
+c:\akse-cache\starthnstrace.cmd                                                         5AD52503471E17584A7BCE9D57EC0064AE7536B9B19032940CD50813BBF315EA       802
+c:\akse-cache\starthnstrace.ps1                                                         D2A9E71159F8AC9F8B99E021B0D63C9E592F422127F39467579B441DE6AB08A9     10591
+c:\akse-cache\startpacketcapture.cmd                                                    1F68B49570C88BB3CF06DE1798D26DFD0EACF5AAB69BF9A277A1C8180166CE29       808
+c:\akse-cache\startpacketcapture.ps1                                                    A4F24398023CA481127F356840D39FAB86973EBC20C596BB24F1B85687F62904     11762
+c:\akse-cache\stoppacketcapture.cmd                                                     BD966D7738A3C0FC73E651BAF196C0FB60D889F1180B2D114F8EA3F8A8453C3D        17
+c:\akse-cache\VFP.psm1                                                                  3F2F44BD4B3219E8BB29EB9F8958EC96F2C8DDCEF556E995790B6476231A92DB      9616
+c:\akse-cache\win-bridge.exe                                                            CA12506E55DF3E3428B29994AE1FC8131DDFBB6838A550DFA22287CDC6548634   9599488
+c:\akse-cache\windows-gmsa-ccgakvplugin-v1.1.5.zip                                      844BFA33F77BDEBA529D353C79A6B361640B0909E6092C572C51AA7A881494EF    484167
+c:\akse-cache\calico\calico-windows-v3.21.4.zip                                         06C99A250B9138B2836254B6F1BEF0A1C713347BDDBFFEEA95C2E6693D686293  70489815
+c:\akse-cache\calico\calico-windows-v3.21.6.zip                                         2316A5D3132CE836C571B057E77E304B0AE48479CC06FBDE4A4814425A52D69C  70552548
+c:\akse-cache\containerd\containerd-v0.0.46-windows-amd64.tar.gz                        28111572889D63C14A5E08B6153718A13E142C95A0DAA431C05CDCFB1BC13FB4  74661916
+c:\akse-cache\csi-proxy\csi-proxy-v0.2.2.tar.gz                                         60BF51D4FB425386C235ABC3BCBD50D70C23CACB94C32A77509DA91CF0F066AD   6481034
+c:\akse-cache\csi-proxy\csi-proxy-v1.0.2.tar.gz                                         60205FB7C3D477182B4AA91C66F10C001EDCBF9FE26410B17522961EC23798DC   6649244
+c:\akse-cache\win-k8s\v1.21.1-hotfix.20211115-1int.zip                                  45AF4FB48AF2604394A0B6893707B174FEE606523A16B60640FFA49A597FFDD6  59489442
+c:\akse-cache\win-k8s\v1.21.13-1int.zip                                                 3D188AF788F3CF7CC37721AD9886640108CBB9B40BDFC26CE9DB7371DDDC7139  59328318
+c:\akse-cache\win-k8s\v1.21.14-1int.zip                                                 6BFF5504EA577958DE99AD73D2C128D27F9F496654FE2B9597F0D000998A6E19  59328306
+c:\akse-cache\win-k8s\v1.21.2-hotfix.20211115-1int.zip                                  25F0DE8DC69EE655D08145DBDEF4D08BC17E53E7073F76B0E4CBFAB0CBEBC331  59161811
+c:\akse-cache\win-k8s\v1.21.7-hotfix.20220204-1int.zip                                  5639975241EA68337A6F855CF02812341024FC270990334630BEC7D78826C0AF  59295514
+c:\akse-cache\win-k8s\v1.21.9-hotfix.20220204-1int.zip                                  DF862114D24018A1F65106252E6C8C1BD70432703D7F41D86412C38B8AE2CC68  59301522
+c:\akse-cache\win-k8s\v1.22.1-hotfix.20211115-1int.zip                                  6B6694817C54DA05EC804F21EE7C57828DCF16241400C94653DC4E432619E869  59924075
+c:\akse-cache\win-k8s\v1.22.10-1int.zip                                                 86B9E348BFF606274C91219DC463F35011083C13641463D484F547A53DB6707E  59983584
+c:\akse-cache\win-k8s\v1.22.11-1int.zip                                                 F1FF831E171728F0AB3F37618D07B32F019E6A5DF6C706BE93EBEE888C8A0791  59982886
+c:\akse-cache\win-k8s\v1.22.11-hotfix.20220728-1int.zip                                 6565445A89D5087B22AF819362D451A00731178D86D7E52EEB2B4679EF5651D9  59902098
+c:\akse-cache\win-k8s\v1.22.4-hotfix.20220201-1int.zip                                  063EC1C9E47FE5CADB0FDCF254DB03D942EEC0CAC3E03736ADC711B2DB0E4A80  59960191
+c:\akse-cache\win-k8s\v1.22.6-hotfix.20220130-1int.zip                                  D76C969C138D9EC6403FA5DC84D9166EABCE112BFCB84E55296AD6858C7DBFDD  59960764
+c:\akse-cache\win-k8s\v1.22.6-hotfix.20220728-1int.zip                                  3ECF60C807680AB3611D1C69AF3C4B4FA0A9A2FB68BC40AFF5DF591F36B4253B  59887661
+c:\akse-cache\win-k8s\v1.23.3-hotfix.20220130-1int.zip                                  4F5DEAE4F39B19450ABFF9AA64FC051D6F38AC2360EE5B4AF50311646F39406D  60192942
+c:\akse-cache\win-k8s\v1.23.4-1int.zip                                                  746AC0F8144FAFABDFF0A7440D6B1D80051A04FB4769331500DC376E6754044F  60203085
+c:\akse-cache\win-k8s\v1.23.5-hotfix.20220331-1int.zip                                  C0983BF9EB8DDC8DEF5AD74547AAFC65CBACE36B56573EF02E60132EB0ED5B67  60207070
+c:\akse-cache\win-k8s\v1.23.5-hotfix.20220728-1int.zip                                  C1E1544EA046A857ACECD03792689D06BC0742E8D56485312630887FB8E3DC8E  60119319
+c:\akse-cache\win-k8s\v1.23.7-1int.zip                                                  086BEFB44BA8244091503A10A421631725A2D3C6DB5E945DAB8B3DD7B23F6A0C  60206592
+c:\akse-cache\win-k8s\v1.23.8-1int.zip                                                  7B4CED218490BDCA7F932ACAC5BDAD99F16B5C601D7AD1A3FC4FD3113ED7DB6C  60210761
+c:\akse-cache\win-k8s\v1.23.8-hotfix.20220728-1int.zip                                  29392AAC26762742F28A588204A7B17E8186313EAC269D329D24551AEE80447E  60139096
+c:\akse-cache\win-k8s\v1.24.0-1int.zip                                                  B0115E45144360999ADA73623774C8B9DCA5DAF2504C95677B86DA589562EA9F  60148070
+c:\akse-cache\win-k8s\v1.24.3-1int.zip                                                  2C8EE6B3FB80D25489917F128347AC211A314B5AF4DC2084779FB703B73EEECC  60081075
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-swift-windows-amd64-v1.4.29.zip 26F2F663C6CD59F8A0BF7F1C3BC2885E026C66C8386F9E55527098A0326DD182  67233971
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.4.22.zip       BD1E3F02A9A95478D67CECEB2C35F9F67094055D031AC1C17781F96A1EB60993  63391064
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.4.29.zip       5C0227482F2D23687A5B176DD5D7BEAB2D63B3BDF472A077A15CB388D5DE80B8  67233914
+
+
+
+

--- a/vhdbuilder/release-notes/AKSWindows/2019/17763.3287.220810.txt
+++ b/vhdbuilder/release-notes/AKSWindows/2019/17763.3287.220810.txt
@@ -1,0 +1,149 @@
+﻿Build Number: 20220810.1_master_58845286
+Build Id:     58845286
+Build Repo:   https://github.com/Azure/AgentBaker
+Build Branch: master
+Commit:       7b4c1e31c318f26d323479e193180f5b8c80f891
+
+VHD ID:      128dbe9c-09f0-4382-bf9a-a9407d20c092
+
+System Info
+	OS Name        : Windows Server 2019 Datacenter
+	OS Version     : 17763.3287
+	OS InstallType : Server Core
+
+Allowed security protocols: Tls, Tls11, Tls12
+
+Installed Features
+
+Display Name                                            Name                       Install State
+------------                                            ----                       -------------
+[X] File and Storage Services                           FileAndStorage-Services        Installed
+    [X] Storage Services                                Storage-Services               Installed
+[X] Hyper-V                                             Hyper-V                        Installed
+[X] .NET Framework 4.7 Features                         NET-Framework-45-Fea...        Installed
+    [X] .NET Framework 4.7                              NET-Framework-45-Core          Installed
+    [X] WCF Services                                    NET-WCF-Services45             Installed
+        [X] TCP Port Sharing                            NET-WCF-TCP-PortShar...        Installed
+[X] BitLocker Drive Encryption                          BitLocker                      Installed
+[X] Containers                                          Containers                     Installed
+[X] Enhanced Storage                                    EnhancedStorage                Installed
+[X] Remote Server Administration Tools                  RSAT                           Installed
+    [X] Role Administration Tools                       RSAT-Role-Tools                Installed
+        [X] Hyper-V Management Tools                    RSAT-Hyper-V-Tools             Installed
+            [X] Hyper-V Module for Windows PowerShell   Hyper-V-PowerShell             Installed
+[X] System Data Archiver                                System-DataArchiver            Installed
+[X] Windows Defender Antivirus                          Windows-Defender               Installed
+[X] Windows PowerShell                                  PowerShellRoot                 Installed
+    [X] Windows PowerShell 5.1                          PowerShell                     Installed
+[X] WoW64 Support                                       WoW64-Support                  Installed
+
+
+
+Installed Packages
+	Language.Basic~~~en-US~0.0.1.0
+	Language.Handwriting~~~en-US~0.0.1.0
+	Language.OCR~~~en-US~0.0.1.0
+	Language.Speech~~~en-US~0.0.1.0
+	Language.TextToSpeech~~~en-US~0.0.1.0
+	MathRecognizer~~~~0.0.1.0
+	OpenSSH.Client~~~~0.0.1.0
+	OpenSSH.Server~~~~0.0.1.0
+
+Installed QFEs
+	KB5013641 : Update          : https://support.microsoft.com/kb/5013641
+	KB5016623 : Security Update : https://support.microsoft.com/kb/5016623
+	KB5015896 : Update          : https://support.microsoft.com/kb/5015896
+
+Installed Updates
+	2022-05 Cumulative Update for .NET Framework 3.5, 4.7.2 and 4.8 for Windows Server 2019 for x64 (KB5013868)
+	Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.373.71.0)
+
+Windows Update Registry Settings
+	https://docs.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+		NoAutoUpdate : 1
+	HKLM:\SYSTEM\CurrentControlSet\Services\hns\State
+
+Docker Info
+Version: Docker version 20.10.9, build 591094d
+
+Images:
+
+Repository                                                     Tag                 ID          
+----------                                                     ---                 --          
+mcr.microsoft.com/windows/servercore                           ltsc2019            e795f3f8aa80
+mcr.microsoft.com/windows/nanoserver                           1809                5fa59fbac916
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi             v1.21.0             f495854cc1b1
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi             v1.20.0             e1ac5eb644b2
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi             v1.20.0             cfed1068ffdb
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver      v1.2.2              66c0d76f7600
+mcr.microsoft.com/azuremonitor/containerinsights/ciprod        win-ciprod06142022  99f1d36c6adc
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure       v1.2.0              e511d780cf66
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi             v1.19.0             7cde9cce69a9
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager      v1.1.14             d0cd472e2aa7
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager      v1.23.11            22b6b24067f9
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager      v1.0.18             1ad6e0e7018f
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager      v0.7.21             bb13ca9a48d7
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar v2.5.0              c2773a95eb5f
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe             v2.6.0              5abc0bfef52a
+mcr.microsoft.com/oss/kubernetes/pause                         3.6-hotfix.20220114 ac0f053e4ea4
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar v2.4.0              113c123f64be
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe             v2.5.0              fef3c5781cda
+
+
+
+Cached Files:
+
+File                                                                                    Sha256                                                           SizeBytes
+----                                                                                    ------                                                           ---------
+c:\akse-cache\aks-windows-cse-scripts-v0.0.11.zip                                       CEB1C9BC3EF5F1076FC78BCED8588403F7B2C118375C8DC16BAAABDB4761EBCF    105425
+c:\akse-cache\aks-windows-cse-scripts-v0.0.12.zip                                       9B8CBD3789CECE390BBD488F6887AD300794BA39B7C2C7BCF68ADF247543E4F6    105895
+c:\akse-cache\collect-windows-logs.ps1                                                  4008248A3E7D3C51AF105934B1FA9D3382CEC796FF91A48E13063866312A8F0F      8055
+c:\akse-cache\collectlogs.ps1                                                           09E8A8A2892153C27804E0FF4345EA2E6A2C81380DD412B9705BC06D24F4B21E     11519
+c:\akse-cache\dumpVfpPolicies.ps1                                                       02BFF0235421F1C8477E809B8EB354B313C348CE2732C4842B710239CD6FE665      1642
+c:\akse-cache\helper.psm1                                                               BC45AA98FA40D51C4E8640865C329BDC4B522EA53CC17A5F0B512B4D44058C8C     17945
+c:\akse-cache\hns.psm1                                                                  A8A53ED4FAC2E27C7E4268DB069D4CF3129A56D466EF3BF9465FB52DCD76A29C     14733
+c:\akse-cache\microsoft.applicationinsights.2.11.0.nupkg                                4B0448F9640FCD84979D6CE736348EE9304A7A069F77E38FF411F3211E699C68    776442
+c:\akse-cache\portReservationTest.ps1                                                   0940BA8A0A564E5937F60871F7F87C866C8617882D121FF33BBB0798B0C82AC0      4370
+c:\akse-cache\starthnstrace.cmd                                                         5AD52503471E17584A7BCE9D57EC0064AE7536B9B19032940CD50813BBF315EA       802
+c:\akse-cache\starthnstrace.ps1                                                         D2A9E71159F8AC9F8B99E021B0D63C9E592F422127F39467579B441DE6AB08A9     10591
+c:\akse-cache\startpacketcapture.cmd                                                    1F68B49570C88BB3CF06DE1798D26DFD0EACF5AAB69BF9A277A1C8180166CE29       808
+c:\akse-cache\startpacketcapture.ps1                                                    A4F24398023CA481127F356840D39FAB86973EBC20C596BB24F1B85687F62904     11762
+c:\akse-cache\stoppacketcapture.cmd                                                     BD966D7738A3C0FC73E651BAF196C0FB60D889F1180B2D114F8EA3F8A8453C3D        17
+c:\akse-cache\VFP.psm1                                                                  3F2F44BD4B3219E8BB29EB9F8958EC96F2C8DDCEF556E995790B6476231A92DB      9616
+c:\akse-cache\win-bridge.exe                                                            CA12506E55DF3E3428B29994AE1FC8131DDFBB6838A550DFA22287CDC6548634   9599488
+c:\akse-cache\windows-gmsa-ccgakvplugin-v1.1.5.zip                                      844BFA33F77BDEBA529D353C79A6B361640B0909E6092C572C51AA7A881494EF    484167
+c:\akse-cache\calico\calico-windows-v3.21.4.zip                                         06C99A250B9138B2836254B6F1BEF0A1C713347BDDBFFEEA95C2E6693D686293  70489815
+c:\akse-cache\calico\calico-windows-v3.21.6.zip                                         2316A5D3132CE836C571B057E77E304B0AE48479CC06FBDE4A4814425A52D69C  70552548
+c:\akse-cache\csi-proxy\csi-proxy-v0.2.2.tar.gz                                         60BF51D4FB425386C235ABC3BCBD50D70C23CACB94C32A77509DA91CF0F066AD   6481034
+c:\akse-cache\csi-proxy\csi-proxy-v1.0.2.tar.gz                                         60205FB7C3D477182B4AA91C66F10C001EDCBF9FE26410B17522961EC23798DC   6649244
+c:\akse-cache\win-k8s\v1.21.1-hotfix.20211115-1int.zip                                  45AF4FB48AF2604394A0B6893707B174FEE606523A16B60640FFA49A597FFDD6  59489442
+c:\akse-cache\win-k8s\v1.21.13-1int.zip                                                 3D188AF788F3CF7CC37721AD9886640108CBB9B40BDFC26CE9DB7371DDDC7139  59328318
+c:\akse-cache\win-k8s\v1.21.14-1int.zip                                                 6BFF5504EA577958DE99AD73D2C128D27F9F496654FE2B9597F0D000998A6E19  59328306
+c:\akse-cache\win-k8s\v1.21.2-hotfix.20211115-1int.zip                                  25F0DE8DC69EE655D08145DBDEF4D08BC17E53E7073F76B0E4CBFAB0CBEBC331  59161811
+c:\akse-cache\win-k8s\v1.21.7-hotfix.20220204-1int.zip                                  5639975241EA68337A6F855CF02812341024FC270990334630BEC7D78826C0AF  59295514
+c:\akse-cache\win-k8s\v1.21.9-hotfix.20220204-1int.zip                                  DF862114D24018A1F65106252E6C8C1BD70432703D7F41D86412C38B8AE2CC68  59301522
+c:\akse-cache\win-k8s\v1.22.1-hotfix.20211115-1int.zip                                  6B6694817C54DA05EC804F21EE7C57828DCF16241400C94653DC4E432619E869  59924075
+c:\akse-cache\win-k8s\v1.22.10-1int.zip                                                 86B9E348BFF606274C91219DC463F35011083C13641463D484F547A53DB6707E  59983584
+c:\akse-cache\win-k8s\v1.22.11-1int.zip                                                 F1FF831E171728F0AB3F37618D07B32F019E6A5DF6C706BE93EBEE888C8A0791  59982886
+c:\akse-cache\win-k8s\v1.22.11-hotfix.20220728-1int.zip                                 6565445A89D5087B22AF819362D451A00731178D86D7E52EEB2B4679EF5651D9  59902098
+c:\akse-cache\win-k8s\v1.22.4-hotfix.20220201-1int.zip                                  063EC1C9E47FE5CADB0FDCF254DB03D942EEC0CAC3E03736ADC711B2DB0E4A80  59960191
+c:\akse-cache\win-k8s\v1.22.6-hotfix.20220130-1int.zip                                  D76C969C138D9EC6403FA5DC84D9166EABCE112BFCB84E55296AD6858C7DBFDD  59960764
+c:\akse-cache\win-k8s\v1.22.6-hotfix.20220728-1int.zip                                  3ECF60C807680AB3611D1C69AF3C4B4FA0A9A2FB68BC40AFF5DF591F36B4253B  59887661
+c:\akse-cache\win-k8s\v1.23.3-hotfix.20220130-1int.zip                                  4F5DEAE4F39B19450ABFF9AA64FC051D6F38AC2360EE5B4AF50311646F39406D  60192942
+c:\akse-cache\win-k8s\v1.23.4-1int.zip                                                  746AC0F8144FAFABDFF0A7440D6B1D80051A04FB4769331500DC376E6754044F  60203085
+c:\akse-cache\win-k8s\v1.23.5-hotfix.20220331-1int.zip                                  C0983BF9EB8DDC8DEF5AD74547AAFC65CBACE36B56573EF02E60132EB0ED5B67  60207070
+c:\akse-cache\win-k8s\v1.23.5-hotfix.20220728-1int.zip                                  C1E1544EA046A857ACECD03792689D06BC0742E8D56485312630887FB8E3DC8E  60119319
+c:\akse-cache\win-k8s\v1.23.7-1int.zip                                                  086BEFB44BA8244091503A10A421631725A2D3C6DB5E945DAB8B3DD7B23F6A0C  60206592
+c:\akse-cache\win-k8s\v1.23.8-1int.zip                                                  7B4CED218490BDCA7F932ACAC5BDAD99F16B5C601D7AD1A3FC4FD3113ED7DB6C  60210761
+c:\akse-cache\win-k8s\v1.23.8-hotfix.20220728-1int.zip                                  29392AAC26762742F28A588204A7B17E8186313EAC269D329D24551AEE80447E  60139096
+c:\akse-cache\win-k8s\v1.24.0-1int.zip                                                  B0115E45144360999ADA73623774C8B9DCA5DAF2504C95677B86DA589562EA9F  60148070
+c:\akse-cache\win-k8s\v1.24.3-1int.zip                                                  2C8EE6B3FB80D25489917F128347AC211A314B5AF4DC2084779FB703B73EEECC  60081075
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-swift-windows-amd64-v1.4.29.zip 26F2F663C6CD59F8A0BF7F1C3BC2885E026C66C8386F9E55527098A0326DD182  67233971
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.4.22.zip       BD1E3F02A9A95478D67CECEB2C35F9F67094055D031AC1C17781F96A1EB60993  63391064
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.4.29.zip       5C0227482F2D23687A5B176DD5D7BEAB2D63B3BDF472A077A15CB388D5DE80B8  67233914
+
+
+
+

--- a/vhdbuilder/release-notes/AKSWindows/2022-containerd/20348.887.220810.txt
+++ b/vhdbuilder/release-notes/AKSWindows/2022-containerd/20348.887.220810.txt
@@ -1,0 +1,186 @@
+﻿Build Number: 20220810.1_master_58845286
+Build Id:     58845286
+Build Repo:   https://github.com/Azure/AgentBaker
+Build Branch: master
+Commit:       7b4c1e31c318f26d323479e193180f5b8c80f891
+
+VHD ID:      6bed1efc-4912-4017-b27c-0c2775f66fd1
+
+System Info
+	OS Name        : Windows Server 2022 Datacenter
+	OS Version     : 20348.887
+	OS InstallType : Server Core
+
+Allowed security protocols: SystemDefault
+
+Installed Features
+
+Display Name                                            Name                       Install State
+------------                                            ----                       -------------
+[X] File and Storage Services                           FileAndStorage-Services        Installed
+    [X] Storage Services                                Storage-Services               Installed
+[X] Hyper-V                                             Hyper-V                        Installed
+[X] .NET Framework 4.8 Features                         NET-Framework-45-Fea...        Installed
+    [X] .NET Framework 4.8                              NET-Framework-45-Core          Installed
+    [X] WCF Services                                    NET-WCF-Services45             Installed
+        [X] TCP Port Sharing                            NET-WCF-TCP-PortShar...        Installed
+[X] BitLocker Drive Encryption                          BitLocker                      Installed
+[X] Containers                                          Containers                     Installed
+[X] Enhanced Storage                                    EnhancedStorage                Installed
+[X] Microsoft Defender Antivirus                        Windows-Defender               Installed
+[X] Remote Server Administration Tools                  RSAT                           Installed
+    [X] Role Administration Tools                       RSAT-Role-Tools                Installed
+        [X] Hyper-V Management Tools                    RSAT-Hyper-V-Tools             Installed
+            [X] Hyper-V Module for Windows PowerShell   Hyper-V-PowerShell             Installed
+[X] System Data Archiver                                System-DataArchiver            Installed
+[X] Windows PowerShell                                  PowerShellRoot                 Installed
+    [X] Windows PowerShell 5.1                          PowerShell                     Installed
+[X] WoW64 Support                                       WoW64-Support                  Installed
+
+
+
+Installed Packages
+	DirectX.Configuration.Database~~~~0.0.1.0
+	Downlevel.NLS.Sorting.Versions.Server~~~~0.0.1.0
+	Language.Basic~~~en-US~0.0.1.0
+	Language.Speech~~~en-US~0.0.1.0
+	Language.TextToSpeech~~~en-US~0.0.1.0
+	Microsoft.Windows.MSPaint~~~~0.0.1.0
+	Microsoft.Windows.Notepad~~~~0.0.1.0
+	Microsoft.Windows.WordPad~~~~0.0.1.0
+	OpenSSH.Client~~~~0.0.1.0
+	OpenSSH.Server~~~~0.0.1.0
+
+Installed QFEs
+	KB5013630 : Update          : https://support.microsoft.com/kb/5013630
+	KB5016627 : Security Update : https://support.microsoft.com/kb/5016627
+	KB5015897 : Update          : https://support.microsoft.com/kb/5015897
+
+Installed Updates
+	Update for Windows Defender Antivirus antimalware platform - KB4052623 (Version 4.18.2001.10)
+	2022-05 Cumulative Update for .NET Framework 3.5 and 4.8 for Microsoft server operating system version 21H2 for x64 (KB5013630)
+	Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.373.71.0)
+
+Windows Update Registry Settings
+	https://docs.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+		NoAutoUpdate : 1
+	HKLM:\SYSTEM\CurrentControlSet\Services\hns\State
+		EnableCompartmentNamespace : 1
+
+ContainerD Info
+Version: ctr github.com/containerd/containerd v1.6.6+azure
+
+Images:
+REF                                                                                                                                    TYPE                                                      DIGEST                                                                  SIZE      PLATFORMS                                          LABELS                          
+mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod06142022                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:0088411ef25582c961116c2b84235ad1bf3489b4f759d13bd320c81a14b6a0f0 2.9 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/azuremonitor/containerinsights/ciprod@sha256:0088411ef25582c961116c2b84235ad1bf3489b4f759d13bd320c81a14b6a0f0        application/vnd.docker.distribution.manifest.list.v2+json sha256:0088411ef25582c961116c2b84235ad1bf3489b4f759d13bd320c81a14b6a0f0 2.9 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/containernetworking/azure-cns:v1.4.29                                                                                application/vnd.oci.image.index.v1+json                   sha256:b14c4befa018fd7965d9c551f334e7b2d550051f68a765d63cd9d63148c18fd1 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/containernetworking/azure-cns@sha256:b14c4befa018fd7965d9c551f334e7b2d550051f68a765d63cd9d63148c18fd1                application/vnd.oci.image.index.v1+json                   sha256:b14c4befa018fd7965d9c551f334e7b2d550051f68a765d63cd9d63148c18fd1 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/containernetworking/azure-npm:v1.4.29                                                                                application/vnd.oci.image.index.v1+json                   sha256:a7970e115f810b2cdd3a2283fb54aeef8908b2fcd86d00d61b3c7ed4edd4fd21 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/containernetworking/azure-npm@sha256:a7970e115f810b2cdd3a2283fb54aeef8908b2fcd86d00d61b3c7ed4edd4fd21                application/vnd.oci.image.index.v1+json                   sha256:a7970e115f810b2cdd3a2283fb54aeef8908b2fcd86d00d61b3c7ed4edd4fd21 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure:v1.2.0                                                                        application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 124.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure@sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27       application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 124.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.20.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:66fa9ff20ac0e7a0141c22e7a6fab2a3366fadf4c9eb080af35c9cb4241f9d6e 136.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.21.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:591550802308c55e4c5fa01c4720fd0dfbad673fc70cea0b09ae345eff6180d0 136.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi@sha256:591550802308c55e4c5fa01c4720fd0dfbad673fc70cea0b09ae345eff6180d0             application/vnd.docker.distribution.manifest.list.v2+json sha256:591550802308c55e4c5fa01c4720fd0dfbad673fc70cea0b09ae345eff6180d0 136.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi@sha256:66fa9ff20ac0e7a0141c22e7a6fab2a3366fadf4c9eb080af35c9cb4241f9d6e             application/vnd.docker.distribution.manifest.list.v2+json sha256:66fa9ff20ac0e7a0141c22e7a6fab2a3366fadf4c9eb080af35c9cb4241f9d6e 136.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.19.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:52eb5867c901156f0c853c0ff2fc7e6e02858b8cd9479797760ec37bc76ef524 124.6 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.20.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:a7e8252e01acad4bb1e987ed5e873bfec1602226c36a58ebeb6e7d99133eb549 124.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi@sha256:52eb5867c901156f0c853c0ff2fc7e6e02858b8cd9479797760ec37bc76ef524             application/vnd.docker.distribution.manifest.list.v2+json sha256:52eb5867c901156f0c853c0ff2fc7e6e02858b8cd9479797760ec37bc76ef524 124.6 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi@sha256:a7e8252e01acad4bb1e987ed5e873bfec1602226c36a58ebeb6e7d99133eb549             application/vnd.docker.distribution.manifest.list.v2+json sha256:a7e8252e01acad4bb1e987ed5e873bfec1602226c36a58ebeb6e7d99133eb549 124.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.4.0                                                                  application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 119.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.5.0                                                                  application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 120.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar@sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 120.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar@sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 119.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.5.0                                                                              application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 118.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.6.0                                                                              application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 119.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe@sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6             application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 118.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe@sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8             application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 119.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v1.2.2                                                                       application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 136.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver@sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc      application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 136.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.23.11                                                                     application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 125.7 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.24.3                                                                      application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 126.0 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab      application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 125.7 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8      application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 126.0 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/pause:3.6-hotfix.20220114                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 291.6 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/pause@sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0                         application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 291.6 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/nanoserver:ltsc2022                                                                                          application/vnd.docker.distribution.manifest.list.v2+json sha256:5f57ddc9a47d079398506a7613c8a3cb8b5bf3f97040f590871b61a15bd5a36a 112.6 MiB windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/nanoserver@sha256:5f57ddc9a47d079398506a7613c8a3cb8b5bf3f97040f590871b61a15bd5a36a                           application/vnd.docker.distribution.manifest.list.v2+json sha256:5f57ddc9a47d079398506a7613c8a3cb8b5bf3f97040f590871b61a15bd5a36a 112.6 MiB windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/servercore:ltsc2022                                                                                          application/vnd.docker.distribution.manifest.list.v2+json sha256:35c3cb29ef2c9f05e36070d04c79d7fc861c035fa5df2df64ae607a276db42c6 2.2 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/servercore@sha256:35c3cb29ef2c9f05e36070d04c79d7fc861c035fa5df2df64ae607a276db42c6                           application/vnd.docker.distribution.manifest.list.v2+json sha256:35c3cb29ef2c9f05e36070d04c79d7fc861c035fa5df2df64ae607a276db42c6 2.2 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:17d5a7e95bb6150ece279ddfd1f484a4a8bf54a1eb7f201fe3c49236da84fda9                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 118.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:255ec55f9730903a13be47d51cd83a8c36549d7e853ad92298269814bd516241                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 119.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:2b2cfbd063d4c795be2cebdbdfde469a2968b095e88afc0a21667814f6e02abd                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:0088411ef25582c961116c2b84235ad1bf3489b4f759d13bd320c81a14b6a0f0 2.9 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:4d45d35f934a62503a1df703d4f7862d61854cc42d7e1b0dba9249f009cdaf01                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 291.6 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:5798b78d003a0eb4c52ddc590a333254e974bdc400f262bd7b4442bb2c6e49a2                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:35c3cb29ef2c9f05e36070d04c79d7fc861c035fa5df2df64ae607a276db42c6 2.2 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:57d1cd7f5e0796e35af60688b0cae5aed8c4b587f2136ac194d54a23c88a073d                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 119.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:76139fdf1eb94661570fb051f9af5da56d94c04a5dc93b61ecdb69a790bbefab                                                                application/vnd.oci.image.index.v1+json                   sha256:b14c4befa018fd7965d9c551f334e7b2d550051f68a765d63cd9d63148c18fd1 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:81d1ab400e47bf737ad07aaebb0615dda7283c5dbc2ece76fb5e0df8a7923617                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:a7e8252e01acad4bb1e987ed5e873bfec1602226c36a58ebeb6e7d99133eb549 124.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:8b94dd0c5a230e25861e1de91a5429d39e8063ef41796abc935571c0caae0ba2                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:591550802308c55e4c5fa01c4720fd0dfbad673fc70cea0b09ae345eff6180d0 136.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:8d9453088438abfd7f1b8b82f1124612054d99d545bff726bd0637da051a7c36                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 124.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:9ce3ae2c2ce814d08287e57f87795f2c68d5a21aa00469a0266ec223db02fc2e                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:5f57ddc9a47d079398506a7613c8a3cb8b5bf3f97040f590871b61a15bd5a36a 112.6 MiB windows/amd64                                      io.cri-containerd.image=managed 
+sha256:b1a822dabd8ec1ff252d23143dad5a4010f8c61466f9e582d01b38d2c6e63416                                                                application/vnd.oci.image.index.v1+json                   sha256:a7970e115f810b2cdd3a2283fb54aeef8908b2fcd86d00d61b3c7ed4edd4fd21 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:b8c32952da321842aeb551b514f46a3876780f37a25f58b65bca92c56ef69b85                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 126.0 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:c733789646e295f3f35d7bde9657b09d92069fc4791f6886b81ce6034cdda4f3                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 125.7 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:e424d3c0688cc28f85b5719146c458ba1ea24fa503ec7e0c2e33f265977da619                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 136.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:e8b238eef63d0e9afd787f40c9511f61ddf0226d8c49689e6b74a2ebda2c8b28                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:66fa9ff20ac0e7a0141c22e7a6fab2a3366fadf4c9eb080af35c9cb4241f9d6e 136.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:f7312d5d67fe06fcadda4280531f5c253cf563895bc381e18520bfa345fd3ae9                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 120.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:fa2aeb9a18b06cce7c5628af1e7ea9203771c50a099cc0b2659df2ef366b6fa3                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:52eb5867c901156f0c853c0ff2fc7e6e02858b8cd9479797760ec37bc76ef524 124.6 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+
+Cached Files:
+
+File                                                                                    Sha256                                                           SizeBytes
+----                                                                                    ------                                                           ---------
+c:\akse-cache\aks-windows-cse-scripts-v0.0.11.zip                                       CEB1C9BC3EF5F1076FC78BCED8588403F7B2C118375C8DC16BAAABDB4761EBCF    105425
+c:\akse-cache\aks-windows-cse-scripts-v0.0.12.zip                                       9B8CBD3789CECE390BBD488F6887AD300794BA39B7C2C7BCF68ADF247543E4F6    105895
+c:\akse-cache\collect-windows-logs.ps1                                                  4008248A3E7D3C51AF105934B1FA9D3382CEC796FF91A48E13063866312A8F0F      8055
+c:\akse-cache\collectlogs.ps1                                                           09E8A8A2892153C27804E0FF4345EA2E6A2C81380DD412B9705BC06D24F4B21E     11519
+c:\akse-cache\dumpVfpPolicies.ps1                                                       02BFF0235421F1C8477E809B8EB354B313C348CE2732C4842B710239CD6FE665      1642
+c:\akse-cache\helper.psm1                                                               BC45AA98FA40D51C4E8640865C329BDC4B522EA53CC17A5F0B512B4D44058C8C     17945
+c:\akse-cache\hns.psm1                                                                  A8A53ED4FAC2E27C7E4268DB069D4CF3129A56D466EF3BF9465FB52DCD76A29C     14733
+c:\akse-cache\microsoft.applicationinsights.2.11.0.nupkg                                4B0448F9640FCD84979D6CE736348EE9304A7A069F77E38FF411F3211E699C68    776442
+c:\akse-cache\portReservationTest.ps1                                                   0940BA8A0A564E5937F60871F7F87C866C8617882D121FF33BBB0798B0C82AC0      4370
+c:\akse-cache\starthnstrace.cmd                                                         5AD52503471E17584A7BCE9D57EC0064AE7536B9B19032940CD50813BBF315EA       802
+c:\akse-cache\starthnstrace.ps1                                                         D2A9E71159F8AC9F8B99E021B0D63C9E592F422127F39467579B441DE6AB08A9     10591
+c:\akse-cache\startpacketcapture.cmd                                                    1F68B49570C88BB3CF06DE1798D26DFD0EACF5AAB69BF9A277A1C8180166CE29       808
+c:\akse-cache\startpacketcapture.ps1                                                    A4F24398023CA481127F356840D39FAB86973EBC20C596BB24F1B85687F62904     11762
+c:\akse-cache\stoppacketcapture.cmd                                                     BD966D7738A3C0FC73E651BAF196C0FB60D889F1180B2D114F8EA3F8A8453C3D        17
+c:\akse-cache\VFP.psm1                                                                  3F2F44BD4B3219E8BB29EB9F8958EC96F2C8DDCEF556E995790B6476231A92DB      9616
+c:\akse-cache\win-bridge.exe                                                            CA12506E55DF3E3428B29994AE1FC8131DDFBB6838A550DFA22287CDC6548634   9599488
+c:\akse-cache\windows-gmsa-ccgakvplugin-v1.1.5.zip                                      844BFA33F77BDEBA529D353C79A6B361640B0909E6092C572C51AA7A881494EF    484167
+c:\akse-cache\calico\calico-windows-v3.21.4.zip                                         06C99A250B9138B2836254B6F1BEF0A1C713347BDDBFFEEA95C2E6693D686293  70489815
+c:\akse-cache\calico\calico-windows-v3.21.6.zip                                         2316A5D3132CE836C571B057E77E304B0AE48479CC06FBDE4A4814425A52D69C  70552548
+c:\akse-cache\containerd\containerd-v0.0.46-windows-amd64.tar.gz                        28111572889D63C14A5E08B6153718A13E142C95A0DAA431C05CDCFB1BC13FB4  74661916
+c:\akse-cache\csi-proxy\csi-proxy-v0.2.2.tar.gz                                         60BF51D4FB425386C235ABC3BCBD50D70C23CACB94C32A77509DA91CF0F066AD   6481034
+c:\akse-cache\csi-proxy\csi-proxy-v1.0.2.tar.gz                                         60205FB7C3D477182B4AA91C66F10C001EDCBF9FE26410B17522961EC23798DC   6649244
+c:\akse-cache\win-k8s\v1.21.1-hotfix.20211115-1int.zip                                  45AF4FB48AF2604394A0B6893707B174FEE606523A16B60640FFA49A597FFDD6  59489442
+c:\akse-cache\win-k8s\v1.21.13-1int.zip                                                 3D188AF788F3CF7CC37721AD9886640108CBB9B40BDFC26CE9DB7371DDDC7139  59328318
+c:\akse-cache\win-k8s\v1.21.14-1int.zip                                                 6BFF5504EA577958DE99AD73D2C128D27F9F496654FE2B9597F0D000998A6E19  59328306
+c:\akse-cache\win-k8s\v1.21.2-hotfix.20211115-1int.zip                                  25F0DE8DC69EE655D08145DBDEF4D08BC17E53E7073F76B0E4CBFAB0CBEBC331  59161811
+c:\akse-cache\win-k8s\v1.21.7-hotfix.20220204-1int.zip                                  5639975241EA68337A6F855CF02812341024FC270990334630BEC7D78826C0AF  59295514
+c:\akse-cache\win-k8s\v1.21.9-hotfix.20220204-1int.zip                                  DF862114D24018A1F65106252E6C8C1BD70432703D7F41D86412C38B8AE2CC68  59301522
+c:\akse-cache\win-k8s\v1.22.1-hotfix.20211115-1int.zip                                  6B6694817C54DA05EC804F21EE7C57828DCF16241400C94653DC4E432619E869  59924075
+c:\akse-cache\win-k8s\v1.22.10-1int.zip                                                 86B9E348BFF606274C91219DC463F35011083C13641463D484F547A53DB6707E  59983584
+c:\akse-cache\win-k8s\v1.22.11-1int.zip                                                 F1FF831E171728F0AB3F37618D07B32F019E6A5DF6C706BE93EBEE888C8A0791  59982886
+c:\akse-cache\win-k8s\v1.22.11-hotfix.20220728-1int.zip                                 6565445A89D5087B22AF819362D451A00731178D86D7E52EEB2B4679EF5651D9  59902098
+c:\akse-cache\win-k8s\v1.22.4-hotfix.20220201-1int.zip                                  063EC1C9E47FE5CADB0FDCF254DB03D942EEC0CAC3E03736ADC711B2DB0E4A80  59960191
+c:\akse-cache\win-k8s\v1.22.6-hotfix.20220130-1int.zip                                  D76C969C138D9EC6403FA5DC84D9166EABCE112BFCB84E55296AD6858C7DBFDD  59960764
+c:\akse-cache\win-k8s\v1.22.6-hotfix.20220728-1int.zip                                  3ECF60C807680AB3611D1C69AF3C4B4FA0A9A2FB68BC40AFF5DF591F36B4253B  59887661
+c:\akse-cache\win-k8s\v1.23.3-hotfix.20220130-1int.zip                                  4F5DEAE4F39B19450ABFF9AA64FC051D6F38AC2360EE5B4AF50311646F39406D  60192942
+c:\akse-cache\win-k8s\v1.23.4-1int.zip                                                  746AC0F8144FAFABDFF0A7440D6B1D80051A04FB4769331500DC376E6754044F  60203085
+c:\akse-cache\win-k8s\v1.23.5-hotfix.20220331-1int.zip                                  C0983BF9EB8DDC8DEF5AD74547AAFC65CBACE36B56573EF02E60132EB0ED5B67  60207070
+c:\akse-cache\win-k8s\v1.23.5-hotfix.20220728-1int.zip                                  C1E1544EA046A857ACECD03792689D06BC0742E8D56485312630887FB8E3DC8E  60119319
+c:\akse-cache\win-k8s\v1.23.7-1int.zip                                                  086BEFB44BA8244091503A10A421631725A2D3C6DB5E945DAB8B3DD7B23F6A0C  60206592
+c:\akse-cache\win-k8s\v1.23.8-1int.zip                                                  7B4CED218490BDCA7F932ACAC5BDAD99F16B5C601D7AD1A3FC4FD3113ED7DB6C  60210761
+c:\akse-cache\win-k8s\v1.23.8-hotfix.20220728-1int.zip                                  29392AAC26762742F28A588204A7B17E8186313EAC269D329D24551AEE80447E  60139096
+c:\akse-cache\win-k8s\v1.24.0-1int.zip                                                  B0115E45144360999ADA73623774C8B9DCA5DAF2504C95677B86DA589562EA9F  60148070
+c:\akse-cache\win-k8s\v1.24.3-1int.zip                                                  2C8EE6B3FB80D25489917F128347AC211A314B5AF4DC2084779FB703B73EEECC  60081075
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-swift-windows-amd64-v1.4.29.zip 26F2F663C6CD59F8A0BF7F1C3BC2885E026C66C8386F9E55527098A0326DD182  67233971
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.4.22.zip       BD1E3F02A9A95478D67CECEB2C35F9F67094055D031AC1C17781F96A1EB60993  63391064
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.4.29.zip       5C0227482F2D23687A5B176DD5D7BEAB2D63B3BDF472A077A15CB388D5DE80B8  67233914
+
+
+
+


### PR DESCRIPTION
**What type of PR is this?**
/kind doc
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Add release notes for AKS Windows images with 2022.08B
We still update sig_config.go although we do not use it.
Reference: https://github.com/Azure/AgentBaker/pull/2067
- WS2019: [August 9, 2022—KB5016623 (OS Build 17763.3287)](https://support.microsoft.com/en-us/topic/august-9-2022-kb5016623-os-build-17763-3287-c7a0bb3a-4083-4cd0-b9ad-119d9267628b)
- WS2022: [August 9, 2022—KB5016627 (OS Build 20348.887)](https://support.microsoft.com/en-us/topic/august-9-2022-kb5016627-os-build-20348-887-ef67367f-fab3-4d0c-8e80-72ac5a66d7d9)

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
Do not add release note since we do not use agentbaker to set the latest AKS Windows images.

**Release note**:
```
none
```
