### PR TITLE
chore: add Cilium images for 1.12.1

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -186,21 +186,21 @@
       "downloadURL": "mcr.microsoft.com/oss/cilium/operator:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.12.0"
+        "1.12.1"
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/oss/cilium/operator-generic:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.12.0"
+        "1.12.1"
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/oss/cilium/cilium:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.12.0"
+        "1.12.1.1"
       ]
     },
     {


### PR DESCRIPTION
Add 1.12.1 images for cilium, cilium-operator, and cilium-operator-generic.

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Add latest Cilium images.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)

**Special notes for your reviewer**:


**Release note**:
```
Add 1.12.1 images for cilium, cilium-operator, and cilium-operator-generic.
```