### PR TITLE
fix: Build Windows 2022 Containerd Gen 2 VHD

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -20,7 +20,7 @@ parameters:
 - name: build2022containerdgen2
   displayName: Build 2022 containerd Gen 2
   type: boolean
-  default: False
+  default: True
 - name: dryrun
   displayName: Dry run
   type: boolean

--- a/.pipelines/.vsts-vhd-builder-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-windows.yaml
@@ -20,7 +20,7 @@ parameters:
 - name: build2022containerdgen2
   displayName: Build 2022 containerd Gen 2
   type: boolean
-  default: False  
+  default: True
 - name: dryrun
   displayName: Dry run
   type: boolean

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -15,6 +15,7 @@ steps:
 #               we will hard-code the task variables SIG_GALLERY_NAME, SIG_IMAGE_NAME, and SIG_IMAGE_VERSION.
 #               Task variable GEN2_SIG_FOR_PRODUCTION is set to True and passed to the following steps.
 #               Built sig will be deleted because it has been converted to VHD, and thus not needed.
+#               Use the suffix $RANDOM to avoid duplication while running concurrent builds.
   - bash: |
       if [[ $(HYPERV_GENERATION) == "V2" ]]; then \
         m="sigMode"; \
@@ -22,8 +23,8 @@ steps:
           sigImageName="${SIG_IMAGE_NAME_PREFIX}-${WINDOWS_SKU}-gen2"; \
           echo "##vso[task.setvariable variable=GEN2_SIG_FOR_PRODUCTION]False"; \
         else
-          sigImageName="windows-${WINDOWS_SKU}"; \
-          sigGalleryName="WS2022Gen2Gallery$(date +"%y%m%d")"; \          
+          sigImageName="windows-${WINDOWS_SKU}-gen2-$RANDOM"; \
+          sigGalleryName="WS2022Gen2Gallery$(date +"%y%m%d%H%M%S")$RANDOM"; \          
           echo "##vso[task.setvariable variable=SIG_GALLERY_NAME]$sigGalleryName"; \
           echo "##vso[task.setvariable variable=SIG_IMAGE_VERSION]1.0.0"; \
           echo "##vso[task.setvariable variable=GEN2_SIG_FOR_PRODUCTION]True"; \
@@ -135,25 +136,26 @@ steps:
 
 # Moved conversion to VHD before cleanup.
 # Gen 2 packer outputs a sig in destination. This step: dest sig=>disk=>VHD in classic SA for publishing.
+# Credentials and resource group name come from the BUILD_**** pipeline variables because source sig is in the build subscription.
   - bash: |
         echo MODE=$(MODE) && \
-        create_time="$(cat vhdbuilder/packer/settings.json | grep "create_time" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
         SIG_IMAGE_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_image_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
         gen2_captured_sig_version="$(cat vhdbuilder/packer/settings.json | grep "gen2_captured_sig_version" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
         docker run --rm \
         -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
         -w /go/src/github.com/Azure/AgentBaker \
-        -e CLIENT_ID=${CLIENT_ID} \
-        -e CLIENT_SECRET="$(CLIENT_SECRET)" \
-        -e TENANT_ID=${TENANT_ID} \
-        -e SUBSCRIPTION_ID="${SUBSCRIPTION_ID}" \
-        -e RESOURCE_GROUP_NAME="${AZURE_RESOURCE_GROUP_NAME}" \
-        -e CREATE_TIME="${create_time}" \
-        -e LOCATION="${AZURE_LOCATION}" \
+        -e CLIENT_ID=${BUILD_CLIENT_ID} \
+        -e CLIENT_SECRET="$(BUILD_CLIENT_SECRET)" \
+        -e TENANT_ID=${BUILD_TENANT_ID} \
+        -e SUBSCRIPTION_ID="${BUILD_SUBSCRIPTION_ID}" \
+        -e RESOURCE_GROUP_NAME="${BUILD_AZURE_RESOURCE_GROUP_NAME}" \
+        -e LOCATION="${BUILD_AZURE_LOCATION}" \
         -e OS_TYPE="Windows" \
-        -e CLASSIC_BLOB=${STORAGE_ACCT_BLOB_URL} \
         -e CLASSIC_SAS_TOKEN="$(STORAGE_ACCT_SAS_TOKEN)" \
+        -e CLASSIC_BLOB="$(STORAGE_ACCT_BLOB_URL)" \
         -e SIG_IMAGE_NAME=${SIG_IMAGE_NAME} \
+        -e SIG_GALLERY_NAME=${SIG_GALLERY_NAME} \
+        -e SIG_IMAGE_VERSION=${SIG_IMAGE_VERSION} \
         -e GEN2_CAPTURED_SIG_VERSION=${gen2_captured_sig_version} \
         ${CONTAINER_IMAGE} make -f packer.mk convert-sig-to-classic-storage-account-blob
     displayName: Convert Shared Image Gallery To VHD Blob In Classic Storage Account

--- a/packer.mk
+++ b/packer.mk
@@ -73,7 +73,7 @@ else
 ifeq (${GEN2_SIG_FOR_PRODUCTION},True)
 	@echo "${MODE}: Building with Hyper-v generation 2 VM and save to Classic Storage Account"
 else
-	@echo "${MODE}: Building with Hyper-v generation 2 VM and save to Shared Image Gallery"
+	@echo "${MODE}: Building and save to Shared Image Gallery"
 endif
 endif
 	@packer build -var-file=vhdbuilder/packer/settings.json vhdbuilder/packer/windows-vhd-builder-sig.json

--- a/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
+++ b/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
@@ -18,7 +18,20 @@ do
     fi
 done
 
-sig_resource_id="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/${SIG_IMAGE_NAME}/versions/${GEN2_CAPTURED_SIG_VERSION}"
+# Default to this hard-coded value for Linux does not pass this environment variable into here
+if [[ -z "$SIG_GALLERY_NAME" ]]; then
+  SIG_GALLERY_NAME="PackerSigGalleryEastUS"
+fi
+
+echo "SIG_IMAGE_VERSION before checking and assigning is $SIG_IMAGE_VERSION"
+# Windows Gen 2: use the passed environment variable $SIG_IMAGE_VERSION
+# Linux Gen 2: assign $GEN2_CAPTURED_SIG_VERSION to $SIG_IMAGE_VERSION
+if [[ -z "$SIG_IMAGE_VERSION" ]]; then
+  SIG_IMAGE_VERSION=${GEN2_CAPTURED_SIG_VERSION}
+fi
+
+# Use $SIG_IMAGE_VERSION for the sig resource, and $GEN2_CAPTURED_SIG_VERSION (a random number) for the disk resource
+sig_resource_id="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/galleries/${SIG_GALLERY_NAME}/images/${SIG_IMAGE_NAME}/versions/${SIG_IMAGE_VERSION}"
 disk_resource_id="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/disks/${GEN2_CAPTURED_SIG_VERSION}"
 
 az resource create --id $disk_resource_id  --is-full-object --location $LOCATION --properties "{\"location\": \"$LOCATION\", \


### PR DESCRIPTION
**What type of PR is this?**
Fix the issues of Gen 2 VHD building.

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
1. Gen 1 and Gen 2 VHD sig destinations are not differentiated.

2. Gen 2 VHD build succeeds but test failed.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
