### PR TITLE
fix: Disable Windows WS2022 GEN2 in check-in pipeline

### DIFF
--- a/.pipelines/.vsts-vhd-builder-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-windows.yaml
@@ -20,7 +20,7 @@ parameters:
 - name: build2022containerdgen2
   displayName: Build 2022 containerd Gen 2
   type: boolean
-  default: True  
+  default: False  
 - name: dryrun
   displayName: Dry run
   type: boolean


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Disabled Windows WS2022 GEN2 VHD build in release pipeline before @wanqingfu fixes the issue https://github.com/Azure/AgentBaker/issues/2147.
Disable Windows WS2022 GEN2 in check-in pipeline

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
