### PR TITLE
no longer building docker vhds

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -12,19 +12,19 @@ parameters:
 - name: build1804
   displayName: Build 1804
   type: boolean
-  default: true
+  default: false
 - name: build1804gen2
   displayName: Build 1804 Gen2
   type: boolean
-  default: true
+  default: false
 - name: build1804gpu
   displayName: Build 1804 GPU
   type: boolean
-  default: true
+  default: false
 - name: build1804gen2gpu
   displayName: Build 1804 Gen2 GPU
   type: boolean
-  default: true
+  default: false
 - name: build1804containerd
   displayName: Build 1804 containerd
   type: boolean


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:
No longer building docker vhds to support migration to containerd-only.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
