### PR TITLE
chore: Upgrade virtual-kubelet to 1.4.4

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -362,7 +362,8 @@
       "downloadURL": "mcr.microsoft.com/oss/virtual-kubelet/virtual-kubelet:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "1.4.1"
+        "1.4.1",
+        "1.4.4"
       ]
     },
     {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

Upgrade the `virtual-kubelet` (aka `aci-connector`) to new version `1.4.4`.
The PR [pipeline](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=60227176&view=logs&j=b70fcb88-51b8-5a35-5913-c4ebbf2cc2da&t=c16572e4-db87-54a6-6aeb-677d6e540e6e) in aks-rp is failing due to vhd for a couple of distros.

**Which issue(s) this PR fixes**:

Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
Upgrade `virtual-kubelet` from 1.4.1 to 1.4.4
```
