### PR TITLE
fix: Pin Mariner 2.0 SIG image to 2022.08.29 temporarily

### DIFF
--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -230,6 +230,9 @@ const (
 	// DO NOT MODIFY: used for freezing linux images with docker
 	FrozenLinuxSIGImageVersionForDocker string = "2022.09.13"
 
+	// Freezing the version of Mariner 2.0 until fix for cloud-init is published.
+	MarinerV2Gen2SIGImageVersion string = "2022.08.29"
+
 	LinuxSIGImageVersion string = "2022.09.13"
 
 	Windows2019SIGImageVersion string = "17763.3406.220913"
@@ -380,7 +383,7 @@ var (
 		ResourceGroup: AKSCBLMarinerResourceGroup,
 		Gallery:       AKSCBLMarinerGalleryName,
 		Definition:    "V2gen2",
-		Version:       LinuxSIGImageVersion,
+		Version:       MarinerV2Gen2SIGImageVersion,
 	}
 
 	SIGCBLMarinerV2Arm64ImageConfigTemplate = SigImageConfigTemplate{


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind regression
-->

**What this PR does / why we need it**:
This PR pins the Mariner 2.0 SIG image version to 2022.08.29.

An issue in Mariner 2.0 cloud-init-22.2-7 is causing AKS nodes to fail to persist their hostname across reboots. After a node reboots the hostname is localhost.localdomain, and kubelet fails to become Ready again.

We're close to publishing a fix, but in the meanwhile we need AKS to keep using the 2022.08.29 image which contains the cloud-init package from before the introduction of this issue.

There's no issue with existing clusters upgrading to this impacted version of cloud-init, since the proper hostname is permanently persisted by the time that can happen.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
