### PR TITLE
fix: Unpin Mariner 2.0 SIG image version

### DIFF
--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -234,9 +234,6 @@ const (
 	// DO NOT MODIFY: used for freezing linux images with docker
 	FrozenLinuxSIGImageVersionForDocker string = "2022.08.29"
 
-	// Freezing the version of Mariner 2.0 until fix for cloud-init is published.
-	MarinerV2Gen2SIGImageVersion string = "2022.08.29"
-
 	Windows2019SIGImageVersion string = "17763.3406.220913"
 	Windows2022SIGImageVersion string = "20348.1006.220913"
 
@@ -385,14 +382,14 @@ var (
 		ResourceGroup: AKSCBLMarinerResourceGroup,
 		Gallery:       AKSCBLMarinerGalleryName,
 		Definition:    "V2gen2",
-		Version:       MarinerV2Gen2SIGImageVersion,
+		Version:       LinuxSIGImageVersion,
 	}
 
 	SIGCBLMarinerV2KataImageConfigTemplate = SigImageConfigTemplate{
 		ResourceGroup: AKSCBLMarinerResourceGroup,
 		Gallery:       AKSCBLMarinerGalleryName,
 		Definition:    "V2gen2", // TODO(ace): change to V2gen2kata or something when mariner is ready
-		Version:       MarinerV2Gen2SIGImageVersion,
+		Version:       LinuxSIGImageVersion,
 	}
 
 	SIGCBLMarinerV2Arm64ImageConfigTemplate = SigImageConfigTemplate{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Unpin the Mariner 2.0 SIG image version because the fixed cloud-init-22.2-8 is included in the [2022.09.22 image builds](https://github.com/Azure/AgentBaker/blob/4375247303b55d0065fecdb23d0143dcfbd0cb5b/vhdbuilder/release-notes/AKSCBLMarinerV2/gen2/2022.09.22.txt#L394).

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Reverts the version pinning introduced in https://github.com/Azure/AgentBaker/pull/2197 because the cloud-init package has been fixed and shipped.

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
