### PR TITLE
chore: cache v0.1.4 image for ip-masq-agent-v2

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -264,7 +264,8 @@
       "downloadURL": "mcr.microsoft.com/aks/ip-masq-agent-v2:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v0.1.3"
+        "v0.1.3",
+        "v0.1.4"
       ]
     },
     {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

**What this PR does / why we need it**:

Uses the newest `ip-masq-agent-v2` image, which includes the usage of a distroless-iptables image and a reduction in image size from 75.4MB to 34.2MB, a 45.4% decrease.

**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

Keeping `v0.1.3` cached until AKS uses `v0.1.4` everywhere.
