### PR TITLE
chore: cache azure-cns v1.4.35

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -63,9 +63,9 @@
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-cns:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.4.22",
         "v1.4.27",
-        "v1.4.29"
+        "v1.4.29",
+        "v1.4.35"
       ]
     },
     {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

cache azure-cns v1.4.35

**Which issue(s) this PR fixes**:
N/A

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)

**Special notes for your reviewer**:


**Release note**:
```
Cache azure-cns v1.4.35, remove cached v1.4.22
```
