### PR TITLE
Explicitly purge and hold non-fips kernel in FIPS VHD (#2276)

### DIFF
--- a/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
+++ b/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
@@ -140,6 +140,17 @@ installFIPS() {
     echo "Installing FIPS..."
     wait_for_apt_locks
 
+    # installing fips kernel doesn't remove non-fips kernel now, purge current linux-image-azure
+    echo "purging linux-image-azure..."
+    linuxImages=$(apt list --installed | grep linux-image- | grep azure | cut -d '/' -f 1)
+    for image in $linuxImages; do
+        echo "Removing non-fips kernel ${image}..."
+        if [[ ${image} != "linux-image-$(uname -r)" ]]; then
+            apt_get_purge 5 10 120 ${image} || exit 1
+        fi
+        retrycmd_if_failure 120 5 25 apt-mark hold ${image} || exit 1
+    done
+
     echo "adding ua repository..."
     retrycmd_if_failure 5 10 120 add-apt-repository -y ppa:ua-client/stable || exit $ERR_ADD_UA_APT_REPO
     apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT


### PR DESCRIPTION
* Explicitly purge and hold non-fips kernel in FIPS VHD

* Explicitly purge and hold non-fips kernel in FIPS VHD

* Purge and hold all non-fips kernels installed in FIPS VHD

Co-authored-by: Charlie Li <charlili@microsoft.com>

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
