### PR TITLE
fix: add new gen 2 sig version and sig config template in AgentBaker

### DIFF
--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -207,7 +207,7 @@ steps:
       echo MODE=$(MODE) && \
       if [[ "${GEN2_SIG_FOR_PRODUCTION}" == "True" ]]; then gen2_captured_sig_version="$(cat vhdbuilder/packer/settings.json | grep "gen2_captured_sig_version" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')"; \
       [ -n "${gen2_captured_sig_version}" ] && VHD_NAME="${gen2_captured_sig_version}.vhd"; \
-      SKU_NAME="windows-$WINDOWS_SKU-gen2"; \
+      SKU_NAME="windows-$WINDOWS_SKU"; \
       else \
       OS_DISK_SAS="$(cat packer-output | grep -a "OSDiskUriReadOnlySas:" | cut -d " " -f 2)"; \
       VHD_NAME="$(echo $OS_DISK_SAS | cut -d "/" -f 8 | cut -d "?" -f 1)"; \

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -207,7 +207,7 @@ steps:
       echo MODE=$(MODE) && \
       if [[ "${GEN2_SIG_FOR_PRODUCTION}" == "True" ]]; then gen2_captured_sig_version="$(cat vhdbuilder/packer/settings.json | grep "gen2_captured_sig_version" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')"; \
       [ -n "${gen2_captured_sig_version}" ] && VHD_NAME="${gen2_captured_sig_version}.vhd"; \
-      SKU_NAME="windows-$WINDOWS_SKU"; \
+      SKU_NAME="windows-$WINDOWS_SKU-gen2"; \
       else \
       OS_DISK_SAS="$(cat packer-output | grep -a "OSDiskUriReadOnlySas:" | cut -d " " -f 2)"; \
       VHD_NAME="$(echo $OS_DISK_SAS | cut -d "/" -f 8 | cut -d "?" -f 1)"; \

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -236,6 +236,7 @@ const (
 
 	Windows2019SIGImageVersion string = "17763.3406.220913"
 	Windows2022SIGImageVersion string = "20348.1006.220913"
+	Windows2022Gen2SIGImageVersion string = "20348.1006.220930"
 
 	Arm64LinuxSIGImageVersion    string = "2022.09.27"
 	Ubuntu2204SIGImageVersion    string = "2022.09.27"
@@ -424,7 +425,7 @@ var (
 		ResourceGroup: AKSWindowsResourceGroup,
 		Gallery:       AKSWindowsGalleryName,
 		Definition:    "windows-2022-containerd-gen2",
-		Version:       Windows2022SIGImageVersion,
+		Version:       Windows2022Gen2SIGImageVersion,
 	}
 )
 

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -236,7 +236,6 @@ const (
 
 	Windows2019SIGImageVersion string = "17763.3406.220913"
 	Windows2022SIGImageVersion string = "20348.1006.220913"
-	Windows2022Gen2SIGImageVersion string = "20348.1006.220930"
 
 	Arm64LinuxSIGImageVersion    string = "2022.09.27"
 	Ubuntu2204SIGImageVersion    string = "2022.09.27"
@@ -425,7 +424,7 @@ var (
 		ResourceGroup: AKSWindowsResourceGroup,
 		Gallery:       AKSWindowsGalleryName,
 		Definition:    "windows-2022-containerd-gen2",
-		Version:       Windows2022Gen2SIGImageVersion,
+		Version:       "20348.1006.220930",
 	}
 )
 

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -79,7 +79,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(windows2022ContainerdGen2.ResourceGroup).To(Equal("AKS-Windows"))
 		Expect(windows2022ContainerdGen2.Gallery).To(Equal("AKSWindows"))
 		Expect(windows2022ContainerdGen2.Definition).To(Equal("windows-2022-containerd-gen2"))
-		Expect(windows2022ContainerdGen2.Version).To(Equal("20348.1006.220913"))
+		Expect(windows2022ContainerdGen2.Version).To(Equal("20348.1006.220930"))
 
 		aksUbuntuArm641804Gen2 := sigConfig.SigUbuntuImageConfig[AKSUbuntuArm64Containerd1804Gen2]
 		Expect(aksUbuntuArm641804Gen2.ResourceGroup).To(Equal("resourcegroup"))


### PR DESCRIPTION
**What type of PR is this?**
To support the new Windows Gen 2 sig image in AgentBaker.

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
1. Add a new Gen 2 sig version.
2. Add a new Gen 2 sig config template for RP to use.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
The sig image version comes from the build artifact `vhd-publishing-info.json` of the latest Gen 2 VHD production pipeline run.

**Release note**:
```
none
```
