### PR TITLE
doc: Add release notes for AKS Windows images with 2022.10OOB

### DIFF
--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -238,8 +238,9 @@ const (
 	// DO NOT MODIFY: used for freezing linux images with docker
 	FrozenLinuxSIGImageVersionForDocker string = "2022.08.29"
 
-	Windows2019SIGImageVersion string = "17763.3532.221012"
-	Windows2022SIGImageVersion string = "20348.1129.221012"
+	Windows2019SIGImageVersion string = "17763.3534.221019"
+	Windows2022SIGImageVersion string = "20348.1131.221019"
+	Windows2022Gen2SIGImageVersion string = "20348.1131.221019"
 
 	Arm64LinuxSIGImageVersion   string = "2022.10.18"
 	Ubuntu2204TLSIGImageVersion string = "2022.10.13"
@@ -434,7 +435,7 @@ var (
 		ResourceGroup: AKSWindowsResourceGroup,
 		Gallery:       AKSWindowsGalleryName,
 		Definition:    "windows-2022-containerd-gen2",
-		Version:       "20348.1006.220930", // TODO (wanqingfu, ShiqianTao) Workaround. Will improve it.
+		Version:       Windows2022Gen2SIGImageVersion, // TODO (wanqingfu, ShiqianTao) Improving by adding a new Gen 2 version.
 	}
 )
 

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -435,7 +435,7 @@ var (
 		ResourceGroup: AKSWindowsResourceGroup,
 		Gallery:       AKSWindowsGalleryName,
 		Definition:    "windows-2022-containerd-gen2",
-		Version:       Windows2022Gen2SIGImageVersion, // TODO (wanqingfu, ShiqianTao) Improving over #7a81766 by using the added Gen 2 version instead of hard-coded value.
+		Version:       Windows2022Gen2SIGImageVersion, // TODO (wanqingfu, ShiqianTao) Improving on #7a81766 by using the added Gen 2 version instead of hard-coded value.
 	}
 )
 

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -240,7 +240,6 @@ const (
 
 	Windows2019SIGImageVersion string = "17763.3534.221019"
 	Windows2022SIGImageVersion string = "20348.1131.221019"
-	Windows2022Gen2SIGImageVersion string = "20348.1131.221019" // TODO (wanqingfu, ShiqianTao) Adding one to replace the hard-coded version in #7a81766.
 
 	Arm64LinuxSIGImageVersion   string = "2022.10.18"
 	Ubuntu2204TLSIGImageVersion string = "2022.10.13"
@@ -435,7 +434,7 @@ var (
 		ResourceGroup: AKSWindowsResourceGroup,
 		Gallery:       AKSWindowsGalleryName,
 		Definition:    "windows-2022-containerd-gen2",
-		Version:       Windows2022Gen2SIGImageVersion, // TODO (wanqingfu, ShiqianTao) Improving on #7a81766 by using the added Gen 2 version instead of hard-coded value.
+		Version:       Windows2022SIGImageVersion,
 	}
 )
 

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -240,7 +240,7 @@ const (
 
 	Windows2019SIGImageVersion string = "17763.3534.221019"
 	Windows2022SIGImageVersion string = "20348.1131.221019"
-	Windows2022Gen2SIGImageVersion string = "20348.1131.221019"
+	Windows2022Gen2SIGImageVersion string = "20348.1131.221019" // TODO (wanqingfu, ShiqianTao) Adding one to replace the hard-coded version in #7a81766.
 
 	Arm64LinuxSIGImageVersion   string = "2022.10.18"
 	Ubuntu2204TLSIGImageVersion string = "2022.10.13"
@@ -435,7 +435,7 @@ var (
 		ResourceGroup: AKSWindowsResourceGroup,
 		Gallery:       AKSWindowsGalleryName,
 		Definition:    "windows-2022-containerd-gen2",
-		Version:       Windows2022Gen2SIGImageVersion, // TODO (wanqingfu, ShiqianTao) Improving by adding a new Gen 2 version.
+		Version:       Windows2022Gen2SIGImageVersion, // TODO (wanqingfu, ShiqianTao) Improving over #7a81766 by using the added Gen 2 version instead of hard-coded value.
 	}
 )
 

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -79,7 +79,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(windows2022ContainerdGen2.ResourceGroup).To(Equal("AKS-Windows"))
 		Expect(windows2022ContainerdGen2.Gallery).To(Equal("AKSWindows"))
 		Expect(windows2022ContainerdGen2.Definition).To(Equal("windows-2022-containerd-gen2"))
-		Expect(windows2022ContainerdGen2.Version).To(Equal("20348.1131.221019")) // TODO (wanqingfu, ShiqianTao) Improving it.
+		Expect(windows2022ContainerdGen2.Version).To(Equal("20348.1131.221019")) // TODO (wanqingfu, ShiqianTao) Improving over #7a81766. Check against latest Gen 2 sig release.
 
 		aksUbuntuArm641804Gen2 := sigConfig.SigUbuntuImageConfig[AKSUbuntuArm64Containerd1804Gen2]
 		Expect(aksUbuntuArm641804Gen2.ResourceGroup).To(Equal("resourcegroup"))

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -61,7 +61,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(windows2019.ResourceGroup).To(Equal("AKS-Windows"))
 		Expect(windows2019.Gallery).To(Equal("AKSWindows"))
 		Expect(windows2019.Definition).To(Equal("windows-2019"))
-		Expect(windows2019.Version).To(Equal("17763.3532.221012"))
+		Expect(windows2019.Version).To(Equal("17763.3532.221019"))
 
 		windows2019Containerd := sigConfig.SigWindowsImageConfig[AKSWindows2019Containerd]
 		Expect(windows2019Containerd.ResourceGroup).To(Equal("AKS-Windows"))

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -61,7 +61,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(windows2019.ResourceGroup).To(Equal("AKS-Windows"))
 		Expect(windows2019.Gallery).To(Equal("AKSWindows"))
 		Expect(windows2019.Definition).To(Equal("windows-2019"))
-		Expect(windows2019.Version).To(Equal("17763.3532.221019"))
+		Expect(windows2019.Version).To(Equal("17763.3534.221019"))
 
 		windows2019Containerd := sigConfig.SigWindowsImageConfig[AKSWindows2019Containerd]
 		Expect(windows2019Containerd.ResourceGroup).To(Equal("AKS-Windows"))

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -67,19 +67,19 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(windows2019Containerd.ResourceGroup).To(Equal("AKS-Windows"))
 		Expect(windows2019Containerd.Gallery).To(Equal("AKSWindows"))
 		Expect(windows2019Containerd.Definition).To(Equal("windows-2019-containerd"))
-		Expect(windows2019Containerd.Version).To(Equal("17763.3532.221012"))
+		Expect(windows2019Containerd.Version).To(Equal("17763.3534.221019"))
 
 		windows2022Containerd := sigConfig.SigWindowsImageConfig[AKSWindows2022Containerd]
 		Expect(windows2022Containerd.ResourceGroup).To(Equal("AKS-Windows"))
 		Expect(windows2022Containerd.Gallery).To(Equal("AKSWindows"))
 		Expect(windows2022Containerd.Definition).To(Equal("windows-2022-containerd"))
-		Expect(windows2022Containerd.Version).To(Equal("20348.1129.221012"))
+		Expect(windows2022Containerd.Version).To(Equal("20348.1131.221019"))
 
 		windows2022ContainerdGen2 := sigConfig.SigWindowsImageConfig[AKSWindows2022ContainerdGen2]
 		Expect(windows2022ContainerdGen2.ResourceGroup).To(Equal("AKS-Windows"))
 		Expect(windows2022ContainerdGen2.Gallery).To(Equal("AKSWindows"))
 		Expect(windows2022ContainerdGen2.Definition).To(Equal("windows-2022-containerd-gen2"))
-		Expect(windows2022ContainerdGen2.Version).To(Equal("20348.1006.220930")) // TODO (wanqingfu, ShiqianTao) Workaround. Will improve it.
+		Expect(windows2022ContainerdGen2.Version).To(Equal("20348.1131.221019")) // TODO (wanqingfu, ShiqianTao) Improving it.
 
 		aksUbuntuArm641804Gen2 := sigConfig.SigUbuntuImageConfig[AKSUbuntuArm64Containerd1804Gen2]
 		Expect(aksUbuntuArm641804Gen2.ResourceGroup).To(Equal("resourcegroup"))

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -79,7 +79,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(windows2022ContainerdGen2.ResourceGroup).To(Equal("AKS-Windows"))
 		Expect(windows2022ContainerdGen2.Gallery).To(Equal("AKSWindows"))
 		Expect(windows2022ContainerdGen2.Definition).To(Equal("windows-2022-containerd-gen2"))
-		Expect(windows2022ContainerdGen2.Version).To(Equal("20348.1131.221019")) // TODO (wanqingfu, ShiqianTao) Improving over #7a81766. Check against latest Gen 2 sig release.
+		Expect(windows2022ContainerdGen2.Version).To(Equal("20348.1131.221019")) // TODO (wanqingfu, ShiqianTao) Improving on #7a81766. Check against latest Gen 2 sig release.
 
 		aksUbuntuArm641804Gen2 := sigConfig.SigUbuntuImageConfig[AKSUbuntuArm64Containerd1804Gen2]
 		Expect(aksUbuntuArm641804Gen2.ResourceGroup).To(Equal("resourcegroup"))

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -79,7 +79,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(windows2022ContainerdGen2.ResourceGroup).To(Equal("AKS-Windows"))
 		Expect(windows2022ContainerdGen2.Gallery).To(Equal("AKSWindows"))
 		Expect(windows2022ContainerdGen2.Definition).To(Equal("windows-2022-containerd-gen2"))
-		Expect(windows2022ContainerdGen2.Version).To(Equal("20348.1131.221019")) // TODO (wanqingfu, ShiqianTao) Improving on #7a81766. Check against latest Gen 2 sig release.
+		Expect(windows2022ContainerdGen2.Version).To(Equal("20348.1131.221019"))
 
 		aksUbuntuArm641804Gen2 := sigConfig.SigUbuntuImageConfig[AKSUbuntuArm64Containerd1804Gen2]
 		Expect(aksUbuntuArm641804Gen2.ResourceGroup).To(Equal("resourcegroup"))

--- a/vhdbuilder/release-notes/AKSWindows/2019-containerd/17763.3534.221019.txt
+++ b/vhdbuilder/release-notes/AKSWindows/2019-containerd/17763.3534.221019.txt
@@ -1,0 +1,190 @@
+﻿Build Number: 20221019.1_master_62318107
+Build Id:     62318107
+Build Repo:   https://github.com/Azure/AgentBaker
+Build Branch: master
+Commit:       043611943ae0f424da8fd88ab46ad8927bae0f98
+
+VHD ID:      2fe1a69f-5b89-4bd3-acb1-386b7581532d
+
+System Info
+	OS Name        : Windows Server 2019 Datacenter
+	OS Version     : 17763.3534
+	OS InstallType : Server Core
+
+Allowed security protocols: Tls, Tls11, Tls12
+
+Installed Features
+
+Display Name                                            Name                       Install State
+------------                                            ----                       -------------
+[X] File and Storage Services                           FileAndStorage-Services        Installed
+    [X] Storage Services                                Storage-Services               Installed
+[X] Hyper-V                                             Hyper-V                        Installed
+[X] .NET Framework 4.7 Features                         NET-Framework-45-Fea...        Installed
+    [X] .NET Framework 4.7                              NET-Framework-45-Core          Installed
+    [X] WCF Services                                    NET-WCF-Services45             Installed
+        [X] TCP Port Sharing                            NET-WCF-TCP-PortShar...        Installed
+[X] BitLocker Drive Encryption                          BitLocker                      Installed
+[X] Containers                                          Containers                     Installed
+[X] Enhanced Storage                                    EnhancedStorage                Installed
+[X] Remote Server Administration Tools                  RSAT                           Installed
+    [X] Role Administration Tools                       RSAT-Role-Tools                Installed
+        [X] Hyper-V Management Tools                    RSAT-Hyper-V-Tools             Installed
+            [X] Hyper-V Module for Windows PowerShell   Hyper-V-PowerShell             Installed
+[X] System Data Archiver                                System-DataArchiver            Installed
+[X] Windows Defender Antivirus                          Windows-Defender               Installed
+[X] Windows PowerShell                                  PowerShellRoot                 Installed
+    [X] Windows PowerShell 5.1                          PowerShell                     Installed
+[X] WoW64 Support                                       WoW64-Support                  Installed
+
+
+
+Installed Packages
+	Language.Basic~~~en-US~0.0.1.0
+	Language.Handwriting~~~en-US~0.0.1.0
+	Language.OCR~~~en-US~0.0.1.0
+	Language.Speech~~~en-US~0.0.1.0
+	Language.TextToSpeech~~~en-US~0.0.1.0
+	MathRecognizer~~~~0.0.1.0
+	OpenSSH.Client~~~~0.0.1.0
+	OpenSSH.Server~~~~0.0.1.0
+
+Installed QFEs
+	KB5013641 : Update          : https://support.microsoft.com/kb/5013641
+	KB5020438 : Update          : https://support.microsoft.com/kb/5020438
+	KB5017400 : Update          : https://support.microsoft.com/kb/5017400
+
+Installed Updates
+	2022-05 Cumulative Update for .NET Framework 3.5, 4.7.2 and 4.8 for Windows Server 2019 for x64 (KB5013868)
+	Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.377.456.0)
+
+Windows Update Registry Settings
+	https://docs.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+		NoAutoUpdate : 1
+	HKLM:\SYSTEM\CurrentControlSet\Services\hns\State
+		EnableCompartmentNamespace : 1
+
+ContainerD Info
+Version: ctr github.com/containerd/containerd v1.6.8+azure
+
+Images:
+REF                                                                                                                                    TYPE                                                      DIGEST                                                                  SIZE      PLATFORMS                                          LABELS                          
+mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod10042022-3c05dd1b                                                    application/vnd.docker.distribution.manifest.list.v2+json sha256:1fb1183f28055f3716e75dd50037034a89f4bea83a53c3462fae4cddecd730d6 3.3 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/azuremonitor/containerinsights/ciprod@sha256:1fb1183f28055f3716e75dd50037034a89f4bea83a53c3462fae4cddecd730d6        application/vnd.docker.distribution.manifest.list.v2+json sha256:1fb1183f28055f3716e75dd50037034a89f4bea83a53c3462fae4cddecd730d6 3.3 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure:v1.2.0                                                                        application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 110.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure@sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27       application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 110.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.22.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:5f8471481ed9fe85661fd5010c56090a9cfb63fe698410c3e366b5c767054b12 121.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.23.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:492de0426ff8299b043ba6845ff517cf477b985c927b522e6b01a65e9537aa1e 122.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi@sha256:492de0426ff8299b043ba6845ff517cf477b985c927b522e6b01a65e9537aa1e             application/vnd.docker.distribution.manifest.list.v2+json sha256:492de0426ff8299b043ba6845ff517cf477b985c927b522e6b01a65e9537aa1e 122.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi@sha256:5f8471481ed9fe85661fd5010c56090a9cfb63fe698410c3e366b5c767054b12             application/vnd.docker.distribution.manifest.list.v2+json sha256:5f8471481ed9fe85661fd5010c56090a9cfb63fe698410c3e366b5c767054b12 121.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.21.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:b21ba2841a705f0f9fef5afa9f3f50c5cb11ddb504028626cc507966c52edf30 110.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.22.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:d8802d555a169c34ce1ebbfb8d0228777250ab8fdd4af084e0ea98476eb60f90 111.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi@sha256:b21ba2841a705f0f9fef5afa9f3f50c5cb11ddb504028626cc507966c52edf30             application/vnd.docker.distribution.manifest.list.v2+json sha256:b21ba2841a705f0f9fef5afa9f3f50c5cb11ddb504028626cc507966c52edf30 110.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi@sha256:d8802d555a169c34ce1ebbfb8d0228777250ab8fdd4af084e0ea98476eb60f90             application/vnd.docker.distribution.manifest.list.v2+json sha256:d8802d555a169c34ce1ebbfb8d0228777250ab8fdd4af084e0ea98476eb60f90 111.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.4.0                                                                  application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 106.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.5.0                                                                  application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 106.3 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar@sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 106.3 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar@sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 106.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.5.0                                                                              application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 105.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.6.0                                                                              application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 105.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe@sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6             application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 105.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe@sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8             application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 105.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v1.2.2                                                                       application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 122.3 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver@sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc      application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 122.3 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.21                                                                      application/vnd.docker.distribution.manifest.list.v2+json sha256:ccbbf5b1cd731796d223751510355b34bfe761a7946f1d43fb180599108d9629 110.5 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.18                                                                      application/vnd.docker.distribution.manifest.list.v2+json sha256:2dfff4dc10f6d25b0a34c01bf4d166540cbf1ff2bccd52635350039138eb23c4 111.1 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.1.14                                                                      application/vnd.docker.distribution.manifest.list.v2+json sha256:72fbc9d17947d1a54c09a16671e6810fd7c0d8f09c0502fdbdd212c2192451a7 111.6 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.23.11                                                                     application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 111.9 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.24.3                                                                      application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 111.8 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab      application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 111.9 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:2dfff4dc10f6d25b0a34c01bf4d166540cbf1ff2bccd52635350039138eb23c4      application/vnd.docker.distribution.manifest.list.v2+json sha256:2dfff4dc10f6d25b0a34c01bf4d166540cbf1ff2bccd52635350039138eb23c4 111.1 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:72fbc9d17947d1a54c09a16671e6810fd7c0d8f09c0502fdbdd212c2192451a7      application/vnd.docker.distribution.manifest.list.v2+json sha256:72fbc9d17947d1a54c09a16671e6810fd7c0d8f09c0502fdbdd212c2192451a7 111.6 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8      application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 111.8 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:ccbbf5b1cd731796d223751510355b34bfe761a7946f1d43fb180599108d9629      application/vnd.docker.distribution.manifest.list.v2+json sha256:ccbbf5b1cd731796d223751510355b34bfe761a7946f1d43fb180599108d9629 110.5 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/pause:3.6-hotfix.20220114                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 255.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/pause@sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0                         application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 255.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/nanoserver:1809                                                                                              application/vnd.docker.distribution.manifest.list.v2+json sha256:95dc925380113306e1aee00aa406d82949061d8ad97f5e96b54ec61df40fb0bb 98.6 MiB  windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/nanoserver@sha256:95dc925380113306e1aee00aa406d82949061d8ad97f5e96b54ec61df40fb0bb                           application/vnd.docker.distribution.manifest.list.v2+json sha256:95dc925380113306e1aee00aa406d82949061d8ad97f5e96b54ec61df40fb0bb 98.6 MiB  windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/servercore:ltsc2019                                                                                          application/vnd.docker.distribution.manifest.list.v2+json sha256:d365ab93a48e9b6fcf2d7db6474fbe78c5e725a2768b3ec1388600a078bd3177 2.5 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/servercore@sha256:d365ab93a48e9b6fcf2d7db6474fbe78c5e725a2768b3ec1388600a078bd3177                           application/vnd.docker.distribution.manifest.list.v2+json sha256:d365ab93a48e9b6fcf2d7db6474fbe78c5e725a2768b3ec1388600a078bd3177 2.5 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:021891d98f72ec97d5ccacab9adb084d59710aff6d1a97bf571e0936d050c5ab                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 111.8 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:113c123f64be3c8ee333d9c3647bfb9bf50a6a6fc737279218fab90175df30ae                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 106.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:1638cf2640b70d3db2072c4bbe659dbbe1db7009a410b3bd09fa3d36d8e02b04                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:d365ab93a48e9b6fcf2d7db6474fbe78c5e725a2768b3ec1388600a078bd3177 2.5 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:1ad6e0e7018fc4fb38ff025964336c75bc74552d90d3191df8ee419f8d7c9f19                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:2dfff4dc10f6d25b0a34c01bf4d166540cbf1ff2bccd52635350039138eb23c4 111.1 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:22b6b24067f9ff3e81927216310b494f3dac89f50b5f2cffba578339fd382652                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 111.9 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:374cdbe6550755eb457b46c51444fab2b1e42653027910f408411f761d0295bc                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:5f8471481ed9fe85661fd5010c56090a9cfb63fe698410c3e366b5c767054b12 121.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:4a58524cd16c498868dc2cf96e1bd8e89e1bf74a9b8459f288928f33c278241e                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:95dc925380113306e1aee00aa406d82949061d8ad97f5e96b54ec61df40fb0bb 98.6 MiB  windows/amd64                                      io.cri-containerd.image=managed 
+sha256:5abc0bfef52aa623927a9e2a2a38f69128cb379208fedcdb80e77a3e0b3b25f9                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 105.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:66c0d76f7600b7c69830dc17a3cbbea550aca935ff39cdbaeede6c2df6fcbdfc                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 122.3 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:ac0f053e4ea44fd1a8947bbde6e037309da6c2bbc249f1b25c771d1015e8a2fb                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 255.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:b27a07d1a69a0ea9721faccea8b2aaef4c5303acba448d92f3692320710a35e9                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:1fb1183f28055f3716e75dd50037034a89f4bea83a53c3462fae4cddecd730d6 3.3 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:b8ecb74b5e0099f69f84309996a4be64689b2f0f1c2ebab0b71c2e09deda2ea3                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:b21ba2841a705f0f9fef5afa9f3f50c5cb11ddb504028626cc507966c52edf30 110.9 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:bb13ca9a48d7e87d0633436542a72ff54563c17da52dc76928f2b8fe87469ca0                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:ccbbf5b1cd731796d223751510355b34bfe761a7946f1d43fb180599108d9629 110.5 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:c2773a95eb5f9ca541734d4834487add43907404542cd4be545bb4ca2884d805                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 106.3 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:d0cd472e2aa7bd8bb0903d0bfb9f870eefd6ac807d56c227ab8dfed3aa3a9345                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:72fbc9d17947d1a54c09a16671e6810fd7c0d8f09c0502fdbdd212c2192451a7 111.6 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:d1ef3ce400a35521cc986684d39541e4b3f32b51142e0dba515584b6784d8740                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:d8802d555a169c34ce1ebbfb8d0228777250ab8fdd4af084e0ea98476eb60f90 111.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:e511d780cf667480d2617aa59b9ca574a511d2f417c6606c565ef05e4163e662                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 110.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:f60b08e9c50ea7ff82875e5e47676eee4771bed44248eaf5e22134570f694216                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:492de0426ff8299b043ba6845ff517cf477b985c927b522e6b01a65e9537aa1e 122.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:fef3c5781cdae9619d838b2273b9da5db96d20bca068ab6ec7775c7fab875fd4                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 105.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+
+Cached Files:
+
+File                                                                                      Sha256                                                           SizeBytes
+----                                                                                      ------                                                           ---------
+c:\akse-cache\aks-windows-cse-scripts-v0.0.12.zip                                         9B8CBD3789CECE390BBD488F6887AD300794BA39B7C2C7BCF68ADF247543E4F6    105895
+c:\akse-cache\aks-windows-cse-scripts-v0.0.13.zip                                         218B5188FA3673A555AB3E5471805F968F8EE477A08D01E2DAE570CFFF572CA4    116529
+c:\akse-cache\aks-windows-cse-scripts-v0.0.14.zip                                         6B88E4E5BE6B9D22C898CE274B24FA89F1AF57488FC75580BA92E5246E532568    119110
+c:\akse-cache\aks-windows-cse-scripts-v0.0.15.zip                                         342CA2388BB9E1B51A4AD6B4CFE40698C6A509389EAA0B0199C8B913B5EAA326    119241
+c:\akse-cache\aks-windows-cse-scripts-v0.0.16.zip                                         B12DB1E44A18655512D2E6AD9A1326634A882CEDD8D12AD8AD45E5979408A596    119068
+c:\akse-cache\collect-windows-logs.ps1                                                    C095FE4E41C73489C143CA3AF67C584A4CAD339EBF3409F151D57DB62956FAC4      8436
+c:\akse-cache\collectlogs.ps1                                                             00A22F407C7D9DE46995751476C8C81AC82B68AA3AFDC14230297E15CC0E1903     13037
+c:\akse-cache\dumpVfpPolicies.ps1                                                         02BFF0235421F1C8477E809B8EB354B313C348CE2732C4842B710239CD6FE665      1642
+c:\akse-cache\helper.psm1                                                                 BC45AA98FA40D51C4E8640865C329BDC4B522EA53CC17A5F0B512B4D44058C8C     17945
+c:\akse-cache\hns.psm1                                                                    A8A53ED4FAC2E27C7E4268DB069D4CF3129A56D466EF3BF9465FB52DCD76A29C     14733
+c:\akse-cache\hns.v2.psm1                                                                 D72975CE1282ADCFA32078AA66A85CBCC10BA0426325BE0E206A98E426E148C7     89314
+c:\akse-cache\microsoft.applicationinsights.2.11.0.nupkg                                  4B0448F9640FCD84979D6CE736348EE9304A7A069F77E38FF411F3211E699C68    776442
+c:\akse-cache\networkhealth.ps1                                                           E829FE0A562F537795F9A9B9CEE8DED203DBC5B8E590A140BFF3D5DD3E010CC6     46377
+c:\akse-cache\portReservationTest.ps1                                                     0940BA8A0A564E5937F60871F7F87C866C8617882D121FF33BBB0798B0C82AC0      4370
+c:\akse-cache\starthnstrace.cmd                                                           5AD52503471E17584A7BCE9D57EC0064AE7536B9B19032940CD50813BBF315EA       802
+c:\akse-cache\starthnstrace.ps1                                                           D2A9E71159F8AC9F8B99E021B0D63C9E592F422127F39467579B441DE6AB08A9     10591
+c:\akse-cache\startpacketcapture.cmd                                                      1F68B49570C88BB3CF06DE1798D26DFD0EACF5AAB69BF9A277A1C8180166CE29       808
+c:\akse-cache\startpacketcapture.ps1                                                      A4F24398023CA481127F356840D39FAB86973EBC20C596BB24F1B85687F62904     11762
+c:\akse-cache\stoppacketcapture.cmd                                                       BD966D7738A3C0FC73E651BAF196C0FB60D889F1180B2D114F8EA3F8A8453C3D        17
+c:\akse-cache\VFP.psm1                                                                    3F2F44BD4B3219E8BB29EB9F8958EC96F2C8DDCEF556E995790B6476231A92DB      9616
+c:\akse-cache\win-bridge.exe                                                              CA12506E55DF3E3428B29994AE1FC8131DDFBB6838A550DFA22287CDC6548634   9599488
+c:\akse-cache\windows-gmsa-ccgakvplugin-v1.1.5.zip                                        844BFA33F77BDEBA529D353C79A6B361640B0909E6092C572C51AA7A881494EF    484167
+c:\akse-cache\calico\calico-windows-v3.21.6.zip                                           2316A5D3132CE836C571B057E77E304B0AE48479CC06FBDE4A4814425A52D69C  70552548
+c:\akse-cache\containerd\containerd-v0.0.47-windows-amd64.tar.gz                          DF18C3C7985EEDD76E7D169E5CBD99349CDF55C3004567E3097727E095378292  74676384
+c:\akse-cache\csi-proxy\csi-proxy-v0.2.2.tar.gz                                           60BF51D4FB425386C235ABC3BCBD50D70C23CACB94C32A77509DA91CF0F066AD   6481034
+c:\akse-cache\csi-proxy\csi-proxy-v1.0.2.tar.gz                                           60205FB7C3D477182B4AA91C66F10C001EDCBF9FE26410B17522961EC23798DC   6649244
+c:\akse-cache\win-k8s\v1.21.1-hotfix.20211115-1int.zip                                    45AF4FB48AF2604394A0B6893707B174FEE606523A16B60640FFA49A597FFDD6  59489442
+c:\akse-cache\win-k8s\v1.21.13-1int.zip                                                   3D188AF788F3CF7CC37721AD9886640108CBB9B40BDFC26CE9DB7371DDDC7139  59328318
+c:\akse-cache\win-k8s\v1.21.14-1int.zip                                                   6BFF5504EA577958DE99AD73D2C128D27F9F496654FE2B9597F0D000998A6E19  59328306
+c:\akse-cache\win-k8s\v1.21.2-hotfix.20211115-1int.zip                                    25F0DE8DC69EE655D08145DBDEF4D08BC17E53E7073F76B0E4CBFAB0CBEBC331  59161811
+c:\akse-cache\win-k8s\v1.21.7-hotfix.20220204-1int.zip                                    5639975241EA68337A6F855CF02812341024FC270990334630BEC7D78826C0AF  59295514
+c:\akse-cache\win-k8s\v1.21.9-hotfix.20220204-1int.zip                                    DF862114D24018A1F65106252E6C8C1BD70432703D7F41D86412C38B8AE2CC68  59301522
+c:\akse-cache\win-k8s\v1.22.1-hotfix.20211115-1int.zip                                    6B6694817C54DA05EC804F21EE7C57828DCF16241400C94653DC4E432619E869  59924075
+c:\akse-cache\win-k8s\v1.22.10-1int.zip                                                   86B9E348BFF606274C91219DC463F35011083C13641463D484F547A53DB6707E  59983584
+c:\akse-cache\win-k8s\v1.22.11-hotfix.20220728-1int.zip                                   6565445A89D5087B22AF819362D451A00731178D86D7E52EEB2B4679EF5651D9  59902098
+c:\akse-cache\win-k8s\v1.22.15-1int.zip                                                   A86D2A9C335B16DFF7E9A982ED8F8DC413CEFFCB39E58C581E3485DDF1F650CE  59911599
+c:\akse-cache\win-k8s\v1.22.4-hotfix.20220201-1int.zip                                    063EC1C9E47FE5CADB0FDCF254DB03D942EEC0CAC3E03736ADC711B2DB0E4A80  59960191
+c:\akse-cache\win-k8s\v1.22.6-hotfix.20220728-1int.zip                                    3ECF60C807680AB3611D1C69AF3C4B4FA0A9A2FB68BC40AFF5DF591F36B4253B  59887661
+c:\akse-cache\win-k8s\v1.23.12-hotfix.20220922-1int.zip                                   8DEB47A9AA78154B39CFA4292C084C4CD3A500E8FE30C741F0A4D71AD189C628  60153618
+c:\akse-cache\win-k8s\v1.23.3-hotfix.20220130-1int.zip                                    4F5DEAE4F39B19450ABFF9AA64FC051D6F38AC2360EE5B4AF50311646F39406D  60192942
+c:\akse-cache\win-k8s\v1.23.4-1int.zip                                                    746AC0F8144FAFABDFF0A7440D6B1D80051A04FB4769331500DC376E6754044F  60203085
+c:\akse-cache\win-k8s\v1.23.5-hotfix.20220728-1int.zip                                    C1E1544EA046A857ACECD03792689D06BC0742E8D56485312630887FB8E3DC8E  60119319
+c:\akse-cache\win-k8s\v1.23.7-1int.zip                                                    086BEFB44BA8244091503A10A421631725A2D3C6DB5E945DAB8B3DD7B23F6A0C  60206592
+c:\akse-cache\win-k8s\v1.23.8-hotfix.20220728-1int.zip                                    29392AAC26762742F28A588204A7B17E8186313EAC269D329D24551AEE80447E  60139096
+c:\akse-cache\win-k8s\v1.24.3-hotfix.20221006-1int.zip                                    B47DA7063EC169803D39A9415B1097AA425F89C216A33436369EE08097B4E8C8  60078963
+c:\akse-cache\win-k8s\v1.24.6-hotfix.20221006-1int.zip                                    4326B9865703EACCCA611675FF85DEAB462A3501105DDBE8694BEDAC7E621F71  60113083
+c:\akse-cache\win-k8s\v1.25.2-hotfix.20221006-1int.zip                                    7FE00EDE5374851CE4EDF197B4036D6AB28919E1679F78DBF72AB64152ABF807  61125744
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-overlay-windows-amd64-v1.4.35.zip 181944D8117393EB5F5F3C256692C55C7D8794309A865FD5351B3DD26AD8A7E3  68876662
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-swift-windows-amd64-v1.4.35.zip   F1DC1DDA095A07FBBA48C5E12E6595D1D0AFEF62C566234175FD1F3982D19E3C  68876694
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.4.22.zip         BD1E3F02A9A95478D67CECEB2C35F9F67094055D031AC1C17781F96A1EB60993  63391064
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.4.35.zip         F84EADBFD0DE847F3D1B1BA2DFFA05A2CF052BD7E5CA1662F6D2BE22BF3085DE  68876637
+
+
+
+

--- a/vhdbuilder/release-notes/AKSWindows/2019/17763.3534.221019.txt
+++ b/vhdbuilder/release-notes/AKSWindows/2019/17763.3534.221019.txt
@@ -1,0 +1,153 @@
+﻿Build Number: 20221019.1_master_62318107
+Build Id:     62318107
+Build Repo:   https://github.com/Azure/AgentBaker
+Build Branch: master
+Commit:       043611943ae0f424da8fd88ab46ad8927bae0f98
+
+VHD ID:      e6a9ce77-a3a0-4df4-b90a-c0d9a46b70fe
+
+System Info
+	OS Name        : Windows Server 2019 Datacenter
+	OS Version     : 17763.3534
+	OS InstallType : Server Core
+
+Allowed security protocols: Tls, Tls11, Tls12
+
+Installed Features
+
+Display Name                                            Name                       Install State
+------------                                            ----                       -------------
+[X] File and Storage Services                           FileAndStorage-Services        Installed
+    [X] Storage Services                                Storage-Services               Installed
+[X] Hyper-V                                             Hyper-V                        Installed
+[X] .NET Framework 4.7 Features                         NET-Framework-45-Fea...        Installed
+    [X] .NET Framework 4.7                              NET-Framework-45-Core          Installed
+    [X] WCF Services                                    NET-WCF-Services45             Installed
+        [X] TCP Port Sharing                            NET-WCF-TCP-PortShar...        Installed
+[X] BitLocker Drive Encryption                          BitLocker                      Installed
+[X] Containers                                          Containers                     Installed
+[X] Enhanced Storage                                    EnhancedStorage                Installed
+[X] Remote Server Administration Tools                  RSAT                           Installed
+    [X] Role Administration Tools                       RSAT-Role-Tools                Installed
+        [X] Hyper-V Management Tools                    RSAT-Hyper-V-Tools             Installed
+            [X] Hyper-V Module for Windows PowerShell   Hyper-V-PowerShell             Installed
+[X] System Data Archiver                                System-DataArchiver            Installed
+[X] Windows Defender Antivirus                          Windows-Defender               Installed
+[X] Windows PowerShell                                  PowerShellRoot                 Installed
+    [X] Windows PowerShell 5.1                          PowerShell                     Installed
+[X] WoW64 Support                                       WoW64-Support                  Installed
+
+
+
+Installed Packages
+	Language.Basic~~~en-US~0.0.1.0
+	Language.Handwriting~~~en-US~0.0.1.0
+	Language.OCR~~~en-US~0.0.1.0
+	Language.Speech~~~en-US~0.0.1.0
+	Language.TextToSpeech~~~en-US~0.0.1.0
+	MathRecognizer~~~~0.0.1.0
+	OpenSSH.Client~~~~0.0.1.0
+	OpenSSH.Server~~~~0.0.1.0
+
+Installed QFEs
+	KB5013641 : Update          : https://support.microsoft.com/kb/5013641
+	KB5020438 : Update          : https://support.microsoft.com/kb/5020438
+	KB5017400 : Update          : https://support.microsoft.com/kb/5017400
+
+Installed Updates
+	2022-05 Cumulative Update for .NET Framework 3.5, 4.7.2 and 4.8 for Windows Server 2019 for x64 (KB5013868)
+	Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.377.456.0)
+
+Windows Update Registry Settings
+	https://docs.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+		NoAutoUpdate : 1
+	HKLM:\SYSTEM\CurrentControlSet\Services\hns\State
+
+Docker Info
+Version: Docker version 20.10.9, build 591094d
+
+Images:
+
+Repository                                                     Tag                         ID          
+----------                                                     ---                         --          
+mcr.microsoft.com/windows/servercore                           ltsc2019                    1638cf2640b7
+mcr.microsoft.com/windows/nanoserver                           1809                        4a58524cd16c
+mcr.microsoft.com/azuremonitor/containerinsights/ciprod        win-ciprod10042022-3c05dd1b b27a07d1a69a
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi             v1.23.0                     f60b08e9c50e
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi             v1.22.0                     d1ef3ce400a3
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi             v1.21.0                     b8ecb74b5e00
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi             v1.22.0                     374cdbe65507
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver      v1.2.2                      66c0d76f7600
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure       v1.2.0                      e511d780cf66
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager      v1.1.14                     d0cd472e2aa7
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager      v1.23.11                    22b6b24067f9
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager      v1.0.18                     1ad6e0e7018f
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager      v0.7.21                     bb13ca9a48d7
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar v2.5.0                      c2773a95eb5f
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe             v2.6.0                      5abc0bfef52a
+mcr.microsoft.com/oss/kubernetes/pause                         3.6-hotfix.20220114         ac0f053e4ea4
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar v2.4.0                      113c123f64be
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe             v2.5.0                      fef3c5781cda
+
+
+
+Cached Files:
+
+File                                                                                      Sha256                                                           SizeBytes
+----                                                                                      ------                                                           ---------
+c:\akse-cache\aks-windows-cse-scripts-v0.0.12.zip                                         9B8CBD3789CECE390BBD488F6887AD300794BA39B7C2C7BCF68ADF247543E4F6    105895
+c:\akse-cache\aks-windows-cse-scripts-v0.0.13.zip                                         218B5188FA3673A555AB3E5471805F968F8EE477A08D01E2DAE570CFFF572CA4    116529
+c:\akse-cache\aks-windows-cse-scripts-v0.0.14.zip                                         6B88E4E5BE6B9D22C898CE274B24FA89F1AF57488FC75580BA92E5246E532568    119110
+c:\akse-cache\aks-windows-cse-scripts-v0.0.15.zip                                         342CA2388BB9E1B51A4AD6B4CFE40698C6A509389EAA0B0199C8B913B5EAA326    119241
+c:\akse-cache\aks-windows-cse-scripts-v0.0.16.zip                                         B12DB1E44A18655512D2E6AD9A1326634A882CEDD8D12AD8AD45E5979408A596    119068
+c:\akse-cache\collect-windows-logs.ps1                                                    C095FE4E41C73489C143CA3AF67C584A4CAD339EBF3409F151D57DB62956FAC4      8436
+c:\akse-cache\collectlogs.ps1                                                             00A22F407C7D9DE46995751476C8C81AC82B68AA3AFDC14230297E15CC0E1903     13037
+c:\akse-cache\dumpVfpPolicies.ps1                                                         02BFF0235421F1C8477E809B8EB354B313C348CE2732C4842B710239CD6FE665      1642
+c:\akse-cache\helper.psm1                                                                 BC45AA98FA40D51C4E8640865C329BDC4B522EA53CC17A5F0B512B4D44058C8C     17945
+c:\akse-cache\hns.psm1                                                                    A8A53ED4FAC2E27C7E4268DB069D4CF3129A56D466EF3BF9465FB52DCD76A29C     14733
+c:\akse-cache\hns.v2.psm1                                                                 D72975CE1282ADCFA32078AA66A85CBCC10BA0426325BE0E206A98E426E148C7     89314
+c:\akse-cache\microsoft.applicationinsights.2.11.0.nupkg                                  4B0448F9640FCD84979D6CE736348EE9304A7A069F77E38FF411F3211E699C68    776442
+c:\akse-cache\networkhealth.ps1                                                           E829FE0A562F537795F9A9B9CEE8DED203DBC5B8E590A140BFF3D5DD3E010CC6     46377
+c:\akse-cache\portReservationTest.ps1                                                     0940BA8A0A564E5937F60871F7F87C866C8617882D121FF33BBB0798B0C82AC0      4370
+c:\akse-cache\starthnstrace.cmd                                                           5AD52503471E17584A7BCE9D57EC0064AE7536B9B19032940CD50813BBF315EA       802
+c:\akse-cache\starthnstrace.ps1                                                           D2A9E71159F8AC9F8B99E021B0D63C9E592F422127F39467579B441DE6AB08A9     10591
+c:\akse-cache\startpacketcapture.cmd                                                      1F68B49570C88BB3CF06DE1798D26DFD0EACF5AAB69BF9A277A1C8180166CE29       808
+c:\akse-cache\startpacketcapture.ps1                                                      A4F24398023CA481127F356840D39FAB86973EBC20C596BB24F1B85687F62904     11762
+c:\akse-cache\stoppacketcapture.cmd                                                       BD966D7738A3C0FC73E651BAF196C0FB60D889F1180B2D114F8EA3F8A8453C3D        17
+c:\akse-cache\VFP.psm1                                                                    3F2F44BD4B3219E8BB29EB9F8958EC96F2C8DDCEF556E995790B6476231A92DB      9616
+c:\akse-cache\win-bridge.exe                                                              CA12506E55DF3E3428B29994AE1FC8131DDFBB6838A550DFA22287CDC6548634   9599488
+c:\akse-cache\windows-gmsa-ccgakvplugin-v1.1.5.zip                                        844BFA33F77BDEBA529D353C79A6B361640B0909E6092C572C51AA7A881494EF    484167
+c:\akse-cache\calico\calico-windows-v3.21.6.zip                                           2316A5D3132CE836C571B057E77E304B0AE48479CC06FBDE4A4814425A52D69C  70552548
+c:\akse-cache\csi-proxy\csi-proxy-v0.2.2.tar.gz                                           60BF51D4FB425386C235ABC3BCBD50D70C23CACB94C32A77509DA91CF0F066AD   6481034
+c:\akse-cache\csi-proxy\csi-proxy-v1.0.2.tar.gz                                           60205FB7C3D477182B4AA91C66F10C001EDCBF9FE26410B17522961EC23798DC   6649244
+c:\akse-cache\win-k8s\v1.21.1-hotfix.20211115-1int.zip                                    45AF4FB48AF2604394A0B6893707B174FEE606523A16B60640FFA49A597FFDD6  59489442
+c:\akse-cache\win-k8s\v1.21.13-1int.zip                                                   3D188AF788F3CF7CC37721AD9886640108CBB9B40BDFC26CE9DB7371DDDC7139  59328318
+c:\akse-cache\win-k8s\v1.21.14-1int.zip                                                   6BFF5504EA577958DE99AD73D2C128D27F9F496654FE2B9597F0D000998A6E19  59328306
+c:\akse-cache\win-k8s\v1.21.2-hotfix.20211115-1int.zip                                    25F0DE8DC69EE655D08145DBDEF4D08BC17E53E7073F76B0E4CBFAB0CBEBC331  59161811
+c:\akse-cache\win-k8s\v1.21.7-hotfix.20220204-1int.zip                                    5639975241EA68337A6F855CF02812341024FC270990334630BEC7D78826C0AF  59295514
+c:\akse-cache\win-k8s\v1.21.9-hotfix.20220204-1int.zip                                    DF862114D24018A1F65106252E6C8C1BD70432703D7F41D86412C38B8AE2CC68  59301522
+c:\akse-cache\win-k8s\v1.22.1-hotfix.20211115-1int.zip                                    6B6694817C54DA05EC804F21EE7C57828DCF16241400C94653DC4E432619E869  59924075
+c:\akse-cache\win-k8s\v1.22.10-1int.zip                                                   86B9E348BFF606274C91219DC463F35011083C13641463D484F547A53DB6707E  59983584
+c:\akse-cache\win-k8s\v1.22.11-hotfix.20220728-1int.zip                                   6565445A89D5087B22AF819362D451A00731178D86D7E52EEB2B4679EF5651D9  59902098
+c:\akse-cache\win-k8s\v1.22.15-1int.zip                                                   A86D2A9C335B16DFF7E9A982ED8F8DC413CEFFCB39E58C581E3485DDF1F650CE  59911599
+c:\akse-cache\win-k8s\v1.22.4-hotfix.20220201-1int.zip                                    063EC1C9E47FE5CADB0FDCF254DB03D942EEC0CAC3E03736ADC711B2DB0E4A80  59960191
+c:\akse-cache\win-k8s\v1.22.6-hotfix.20220728-1int.zip                                    3ECF60C807680AB3611D1C69AF3C4B4FA0A9A2FB68BC40AFF5DF591F36B4253B  59887661
+c:\akse-cache\win-k8s\v1.23.12-hotfix.20220922-1int.zip                                   8DEB47A9AA78154B39CFA4292C084C4CD3A500E8FE30C741F0A4D71AD189C628  60153618
+c:\akse-cache\win-k8s\v1.23.3-hotfix.20220130-1int.zip                                    4F5DEAE4F39B19450ABFF9AA64FC051D6F38AC2360EE5B4AF50311646F39406D  60192942
+c:\akse-cache\win-k8s\v1.23.4-1int.zip                                                    746AC0F8144FAFABDFF0A7440D6B1D80051A04FB4769331500DC376E6754044F  60203085
+c:\akse-cache\win-k8s\v1.23.5-hotfix.20220728-1int.zip                                    C1E1544EA046A857ACECD03792689D06BC0742E8D56485312630887FB8E3DC8E  60119319
+c:\akse-cache\win-k8s\v1.23.7-1int.zip                                                    086BEFB44BA8244091503A10A421631725A2D3C6DB5E945DAB8B3DD7B23F6A0C  60206592
+c:\akse-cache\win-k8s\v1.23.8-hotfix.20220728-1int.zip                                    29392AAC26762742F28A588204A7B17E8186313EAC269D329D24551AEE80447E  60139096
+c:\akse-cache\win-k8s\v1.24.3-hotfix.20221006-1int.zip                                    B47DA7063EC169803D39A9415B1097AA425F89C216A33436369EE08097B4E8C8  60078963
+c:\akse-cache\win-k8s\v1.24.6-hotfix.20221006-1int.zip                                    4326B9865703EACCCA611675FF85DEAB462A3501105DDBE8694BEDAC7E621F71  60113083
+c:\akse-cache\win-k8s\v1.25.2-hotfix.20221006-1int.zip                                    7FE00EDE5374851CE4EDF197B4036D6AB28919E1679F78DBF72AB64152ABF807  61125744
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-overlay-windows-amd64-v1.4.35.zip 181944D8117393EB5F5F3C256692C55C7D8794309A865FD5351B3DD26AD8A7E3  68876662
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-swift-windows-amd64-v1.4.35.zip   F1DC1DDA095A07FBBA48C5E12E6595D1D0AFEF62C566234175FD1F3982D19E3C  68876694
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.4.22.zip         BD1E3F02A9A95478D67CECEB2C35F9F67094055D031AC1C17781F96A1EB60993  63391064
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.4.35.zip         F84EADBFD0DE847F3D1B1BA2DFFA05A2CF052BD7E5CA1662F6D2BE22BF3085DE  68876637
+
+
+
+

--- a/vhdbuilder/release-notes/AKSWindows/2022-containerd-gen2/20348.1131.221019.txt
+++ b/vhdbuilder/release-notes/AKSWindows/2022-containerd-gen2/20348.1131.221019.txt
@@ -1,0 +1,190 @@
+﻿Build Number: 20221019.1_master_62318107
+Build Id:     62318107
+Build Repo:   https://github.com/Azure/AgentBaker
+Build Branch: master
+Commit:       043611943ae0f424da8fd88ab46ad8927bae0f98
+
+VHD ID:      610a4ca1-b270-4c08-bb1c-4295c0cffadb
+
+System Info
+	OS Name        : Windows Server 2022 Datacenter
+	OS Version     : 20348.1131
+	OS InstallType : Server Core
+
+Allowed security protocols: SystemDefault
+
+Installed Features
+
+Display Name                                            Name                       Install State
+------------                                            ----                       -------------
+[X] File and Storage Services                           FileAndStorage-Services        Installed
+    [X] Storage Services                                Storage-Services               Installed
+[X] Hyper-V                                             Hyper-V                        Installed
+[X] .NET Framework 4.8 Features                         NET-Framework-45-Fea...        Installed
+    [X] .NET Framework 4.8                              NET-Framework-45-Core          Installed
+    [X] WCF Services                                    NET-WCF-Services45             Installed
+        [X] TCP Port Sharing                            NET-WCF-TCP-PortShar...        Installed
+[X] BitLocker Drive Encryption                          BitLocker                      Installed
+[X] Containers                                          Containers                     Installed
+[X] Enhanced Storage                                    EnhancedStorage                Installed
+[X] Microsoft Defender Antivirus                        Windows-Defender               Installed
+[X] Remote Server Administration Tools                  RSAT                           Installed
+    [X] Role Administration Tools                       RSAT-Role-Tools                Installed
+        [X] Hyper-V Management Tools                    RSAT-Hyper-V-Tools             Installed
+            [X] Hyper-V Module for Windows PowerShell   Hyper-V-PowerShell             Installed
+[X] System Data Archiver                                System-DataArchiver            Installed
+[X] Windows PowerShell                                  PowerShellRoot                 Installed
+    [X] Windows PowerShell 5.1                          PowerShell                     Installed
+[X] WoW64 Support                                       WoW64-Support                  Installed
+
+
+
+Installed Packages
+	DirectX.Configuration.Database~~~~0.0.1.0
+	Downlevel.NLS.Sorting.Versions.Server~~~~0.0.1.0
+	Language.Basic~~~en-US~0.0.1.0
+	Language.Speech~~~en-US~0.0.1.0
+	Language.TextToSpeech~~~en-US~0.0.1.0
+	Microsoft.Windows.MSPaint~~~~0.0.1.0
+	Microsoft.Windows.Notepad~~~~0.0.1.0
+	Microsoft.Windows.WordPad~~~~0.0.1.0
+	OpenSSH.Client~~~~0.0.1.0
+	OpenSSH.Server~~~~0.0.1.0
+
+Installed QFEs
+	KB5017028 : Update          : https://support.microsoft.com/kb/5017028
+	KB5020436 : Update          : https://support.microsoft.com/kb/5020436
+	KB5017399 : Update          : https://support.microsoft.com/kb/5017399
+
+Installed Updates
+	Update for Windows Defender Antivirus antimalware platform - KB4052623 (Version 4.18.2001.10)
+	2022-09 Cumulative Update for .NET Framework 3.5, 4.8 and 4.8.1 for Microsoft server operating system version 21H2 for x64 (KB5017501)
+	Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.377.456.0)
+
+Windows Update Registry Settings
+	https://docs.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+		NoAutoUpdate : 1
+	HKLM:\SYSTEM\CurrentControlSet\Services\hns\State
+		EnableCompartmentNamespace : 1
+
+ContainerD Info
+Version: ctr github.com/containerd/containerd v1.6.8+azure
+
+Images:
+REF                                                                                                                                    TYPE                                                      DIGEST                                                                  SIZE      PLATFORMS                                          LABELS                          
+mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod10042022-3c05dd1b                                                    application/vnd.docker.distribution.manifest.list.v2+json sha256:1fb1183f28055f3716e75dd50037034a89f4bea83a53c3462fae4cddecd730d6 3.0 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/azuremonitor/containerinsights/ciprod@sha256:1fb1183f28055f3716e75dd50037034a89f4bea83a53c3462fae4cddecd730d6        application/vnd.docker.distribution.manifest.list.v2+json sha256:1fb1183f28055f3716e75dd50037034a89f4bea83a53c3462fae4cddecd730d6 3.0 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/containernetworking/azure-cns:v1.4.29                                                                                application/vnd.oci.image.index.v1+json                   sha256:b14c4befa018fd7965d9c551f334e7b2d550051f68a765d63cd9d63148c18fd1 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/containernetworking/azure-cns@sha256:b14c4befa018fd7965d9c551f334e7b2d550051f68a765d63cd9d63148c18fd1                application/vnd.oci.image.index.v1+json                   sha256:b14c4befa018fd7965d9c551f334e7b2d550051f68a765d63cd9d63148c18fd1 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/containernetworking/azure-npm:v1.4.29                                                                                application/vnd.oci.image.index.v1+json                   sha256:a7970e115f810b2cdd3a2283fb54aeef8908b2fcd86d00d61b3c7ed4edd4fd21 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/containernetworking/azure-npm@sha256:a7970e115f810b2cdd3a2283fb54aeef8908b2fcd86d00d61b3c7ed4edd4fd21                application/vnd.oci.image.index.v1+json                   sha256:a7970e115f810b2cdd3a2283fb54aeef8908b2fcd86d00d61b3c7ed4edd4fd21 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure:v1.2.0                                                                        application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 124.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure@sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27       application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 124.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.22.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:5f8471481ed9fe85661fd5010c56090a9cfb63fe698410c3e366b5c767054b12 136.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.23.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:492de0426ff8299b043ba6845ff517cf477b985c927b522e6b01a65e9537aa1e 136.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi@sha256:492de0426ff8299b043ba6845ff517cf477b985c927b522e6b01a65e9537aa1e             application/vnd.docker.distribution.manifest.list.v2+json sha256:492de0426ff8299b043ba6845ff517cf477b985c927b522e6b01a65e9537aa1e 136.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi@sha256:5f8471481ed9fe85661fd5010c56090a9cfb63fe698410c3e366b5c767054b12             application/vnd.docker.distribution.manifest.list.v2+json sha256:5f8471481ed9fe85661fd5010c56090a9cfb63fe698410c3e366b5c767054b12 136.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.21.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:b21ba2841a705f0f9fef5afa9f3f50c5cb11ddb504028626cc507966c52edf30 125.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.22.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:d8802d555a169c34ce1ebbfb8d0228777250ab8fdd4af084e0ea98476eb60f90 125.2 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi@sha256:b21ba2841a705f0f9fef5afa9f3f50c5cb11ddb504028626cc507966c52edf30             application/vnd.docker.distribution.manifest.list.v2+json sha256:b21ba2841a705f0f9fef5afa9f3f50c5cb11ddb504028626cc507966c52edf30 125.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi@sha256:d8802d555a169c34ce1ebbfb8d0228777250ab8fdd4af084e0ea98476eb60f90             application/vnd.docker.distribution.manifest.list.v2+json sha256:d8802d555a169c34ce1ebbfb8d0228777250ab8fdd4af084e0ea98476eb60f90 125.2 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.4.0                                                                  application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 119.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.5.0                                                                  application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 120.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar@sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 120.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar@sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 119.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.5.0                                                                              application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 118.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.6.0                                                                              application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 119.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe@sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6             application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 118.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe@sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8             application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 119.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v1.2.2                                                                       application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 136.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver@sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc      application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 136.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.23.11                                                                     application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 125.7 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.24.3                                                                      application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 126.0 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab      application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 125.7 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8      application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 126.0 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/pause:3.6-hotfix.20220114                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 291.6 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/pause@sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0                         application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 291.6 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/nanoserver:ltsc2022                                                                                          application/vnd.docker.distribution.manifest.list.v2+json sha256:fefb912e2942912f1cd55bfe6bbb697a601a7787caf5c1875aaf105c86a28027 112.7 MiB windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/nanoserver@sha256:fefb912e2942912f1cd55bfe6bbb697a601a7787caf5c1875aaf105c86a28027                           application/vnd.docker.distribution.manifest.list.v2+json sha256:fefb912e2942912f1cd55bfe6bbb697a601a7787caf5c1875aaf105c86a28027 112.7 MiB windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/servercore:ltsc2022                                                                                          application/vnd.docker.distribution.manifest.list.v2+json sha256:6983a9d56e4d8d1fac3819e4bed8ff537400ea21150b9d65bfbdc0ef3c27c99c 2.3 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/servercore@sha256:6983a9d56e4d8d1fac3819e4bed8ff537400ea21150b9d65bfbdc0ef3c27c99c                           application/vnd.docker.distribution.manifest.list.v2+json sha256:6983a9d56e4d8d1fac3819e4bed8ff537400ea21150b9d65bfbdc0ef3c27c99c 2.3 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:06bb218927a8a95b424acfad0e0e6ae0fb5694c0b510f9930ed5881075eaec2f                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:6983a9d56e4d8d1fac3819e4bed8ff537400ea21150b9d65bfbdc0ef3c27c99c 2.3 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:17d5a7e95bb6150ece279ddfd1f484a4a8bf54a1eb7f201fe3c49236da84fda9                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 118.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:2453367b5356144b645167517ea1024501b859b92fe2b6d97185b744ceeaa0e6                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:d8802d555a169c34ce1ebbfb8d0228777250ab8fdd4af084e0ea98476eb60f90 125.2 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:255ec55f9730903a13be47d51cd83a8c36549d7e853ad92298269814bd516241                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 119.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:47a1e1d14429c460fbe10547631014f444858d38a64ec86a827e94b735ef6198                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:492de0426ff8299b043ba6845ff517cf477b985c927b522e6b01a65e9537aa1e 136.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:4d45d35f934a62503a1df703d4f7862d61854cc42d7e1b0dba9249f009cdaf01                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 291.6 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:57d1cd7f5e0796e35af60688b0cae5aed8c4b587f2136ac194d54a23c88a073d                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 119.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:76139fdf1eb94661570fb051f9af5da56d94c04a5dc93b61ecdb69a790bbefab                                                                application/vnd.oci.image.index.v1+json                   sha256:b14c4befa018fd7965d9c551f334e7b2d550051f68a765d63cd9d63148c18fd1 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:8d9453088438abfd7f1b8b82f1124612054d99d545bff726bd0637da051a7c36                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 124.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:b1a822dabd8ec1ff252d23143dad5a4010f8c61466f9e582d01b38d2c6e63416                                                                application/vnd.oci.image.index.v1+json                   sha256:a7970e115f810b2cdd3a2283fb54aeef8908b2fcd86d00d61b3c7ed4edd4fd21 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:b8c32952da321842aeb551b514f46a3876780f37a25f58b65bca92c56ef69b85                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 126.0 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:bfb9689e0bf135fdaf041badce5f1913059f065ac1552318304d1fa3a628bc0b                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:1fb1183f28055f3716e75dd50037034a89f4bea83a53c3462fae4cddecd730d6 3.0 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:c733789646e295f3f35d7bde9657b09d92069fc4791f6886b81ce6034cdda4f3                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 125.7 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:e424d3c0688cc28f85b5719146c458ba1ea24fa503ec7e0c2e33f265977da619                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 136.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:e8459e4e82bea14900ee7997bed956b9c6045374881a44a6d9b15ba31b3dfed0                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:5f8471481ed9fe85661fd5010c56090a9cfb63fe698410c3e366b5c767054b12 136.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:f59744965c7df75be557efdc65c477c2307c2f9d7cc987683feda1b295825816                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:b21ba2841a705f0f9fef5afa9f3f50c5cb11ddb504028626cc507966c52edf30 125.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:f7312d5d67fe06fcadda4280531f5c253cf563895bc381e18520bfa345fd3ae9                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 120.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:fc628a662d22511a75bc42a625029f7ba6f669d0423870a07113d65867b92a3f                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:fefb912e2942912f1cd55bfe6bbb697a601a7787caf5c1875aaf105c86a28027 112.7 MiB windows/amd64                                      io.cri-containerd.image=managed 
+
+Cached Files:
+
+File                                                                                      Sha256                                                           SizeBytes
+----                                                                                      ------                                                           ---------
+c:\akse-cache\aks-windows-cse-scripts-v0.0.12.zip                                         9B8CBD3789CECE390BBD488F6887AD300794BA39B7C2C7BCF68ADF247543E4F6    105895
+c:\akse-cache\aks-windows-cse-scripts-v0.0.13.zip                                         218B5188FA3673A555AB3E5471805F968F8EE477A08D01E2DAE570CFFF572CA4    116529
+c:\akse-cache\aks-windows-cse-scripts-v0.0.14.zip                                         6B88E4E5BE6B9D22C898CE274B24FA89F1AF57488FC75580BA92E5246E532568    119110
+c:\akse-cache\aks-windows-cse-scripts-v0.0.15.zip                                         342CA2388BB9E1B51A4AD6B4CFE40698C6A509389EAA0B0199C8B913B5EAA326    119241
+c:\akse-cache\aks-windows-cse-scripts-v0.0.16.zip                                         B12DB1E44A18655512D2E6AD9A1326634A882CEDD8D12AD8AD45E5979408A596    119068
+c:\akse-cache\collect-windows-logs.ps1                                                    C095FE4E41C73489C143CA3AF67C584A4CAD339EBF3409F151D57DB62956FAC4      8436
+c:\akse-cache\collectlogs.ps1                                                             00A22F407C7D9DE46995751476C8C81AC82B68AA3AFDC14230297E15CC0E1903     13037
+c:\akse-cache\dumpVfpPolicies.ps1                                                         02BFF0235421F1C8477E809B8EB354B313C348CE2732C4842B710239CD6FE665      1642
+c:\akse-cache\helper.psm1                                                                 BC45AA98FA40D51C4E8640865C329BDC4B522EA53CC17A5F0B512B4D44058C8C     17945
+c:\akse-cache\hns.psm1                                                                    A8A53ED4FAC2E27C7E4268DB069D4CF3129A56D466EF3BF9465FB52DCD76A29C     14733
+c:\akse-cache\hns.v2.psm1                                                                 D72975CE1282ADCFA32078AA66A85CBCC10BA0426325BE0E206A98E426E148C7     89314
+c:\akse-cache\microsoft.applicationinsights.2.11.0.nupkg                                  4B0448F9640FCD84979D6CE736348EE9304A7A069F77E38FF411F3211E699C68    776442
+c:\akse-cache\networkhealth.ps1                                                           E829FE0A562F537795F9A9B9CEE8DED203DBC5B8E590A140BFF3D5DD3E010CC6     46377
+c:\akse-cache\portReservationTest.ps1                                                     0940BA8A0A564E5937F60871F7F87C866C8617882D121FF33BBB0798B0C82AC0      4370
+c:\akse-cache\starthnstrace.cmd                                                           5AD52503471E17584A7BCE9D57EC0064AE7536B9B19032940CD50813BBF315EA       802
+c:\akse-cache\starthnstrace.ps1                                                           D2A9E71159F8AC9F8B99E021B0D63C9E592F422127F39467579B441DE6AB08A9     10591
+c:\akse-cache\startpacketcapture.cmd                                                      1F68B49570C88BB3CF06DE1798D26DFD0EACF5AAB69BF9A277A1C8180166CE29       808
+c:\akse-cache\startpacketcapture.ps1                                                      A4F24398023CA481127F356840D39FAB86973EBC20C596BB24F1B85687F62904     11762
+c:\akse-cache\stoppacketcapture.cmd                                                       BD966D7738A3C0FC73E651BAF196C0FB60D889F1180B2D114F8EA3F8A8453C3D        17
+c:\akse-cache\VFP.psm1                                                                    3F2F44BD4B3219E8BB29EB9F8958EC96F2C8DDCEF556E995790B6476231A92DB      9616
+c:\akse-cache\win-bridge.exe                                                              CA12506E55DF3E3428B29994AE1FC8131DDFBB6838A550DFA22287CDC6548634   9599488
+c:\akse-cache\windows-gmsa-ccgakvplugin-v1.1.5.zip                                        844BFA33F77BDEBA529D353C79A6B361640B0909E6092C572C51AA7A881494EF    484167
+c:\akse-cache\calico\calico-windows-v3.21.6.zip                                           2316A5D3132CE836C571B057E77E304B0AE48479CC06FBDE4A4814425A52D69C  70552548
+c:\akse-cache\containerd\containerd-v0.0.47-windows-amd64.tar.gz                          DF18C3C7985EEDD76E7D169E5CBD99349CDF55C3004567E3097727E095378292  74676384
+c:\akse-cache\csi-proxy\csi-proxy-v0.2.2.tar.gz                                           60BF51D4FB425386C235ABC3BCBD50D70C23CACB94C32A77509DA91CF0F066AD   6481034
+c:\akse-cache\csi-proxy\csi-proxy-v1.0.2.tar.gz                                           60205FB7C3D477182B4AA91C66F10C001EDCBF9FE26410B17522961EC23798DC   6649244
+c:\akse-cache\win-k8s\v1.21.1-hotfix.20211115-1int.zip                                    45AF4FB48AF2604394A0B6893707B174FEE606523A16B60640FFA49A597FFDD6  59489442
+c:\akse-cache\win-k8s\v1.21.13-1int.zip                                                   3D188AF788F3CF7CC37721AD9886640108CBB9B40BDFC26CE9DB7371DDDC7139  59328318
+c:\akse-cache\win-k8s\v1.21.14-1int.zip                                                   6BFF5504EA577958DE99AD73D2C128D27F9F496654FE2B9597F0D000998A6E19  59328306
+c:\akse-cache\win-k8s\v1.21.2-hotfix.20211115-1int.zip                                    25F0DE8DC69EE655D08145DBDEF4D08BC17E53E7073F76B0E4CBFAB0CBEBC331  59161811
+c:\akse-cache\win-k8s\v1.21.7-hotfix.20220204-1int.zip                                    5639975241EA68337A6F855CF02812341024FC270990334630BEC7D78826C0AF  59295514
+c:\akse-cache\win-k8s\v1.21.9-hotfix.20220204-1int.zip                                    DF862114D24018A1F65106252E6C8C1BD70432703D7F41D86412C38B8AE2CC68  59301522
+c:\akse-cache\win-k8s\v1.22.1-hotfix.20211115-1int.zip                                    6B6694817C54DA05EC804F21EE7C57828DCF16241400C94653DC4E432619E869  59924075
+c:\akse-cache\win-k8s\v1.22.10-1int.zip                                                   86B9E348BFF606274C91219DC463F35011083C13641463D484F547A53DB6707E  59983584
+c:\akse-cache\win-k8s\v1.22.11-hotfix.20220728-1int.zip                                   6565445A89D5087B22AF819362D451A00731178D86D7E52EEB2B4679EF5651D9  59902098
+c:\akse-cache\win-k8s\v1.22.15-1int.zip                                                   A86D2A9C335B16DFF7E9A982ED8F8DC413CEFFCB39E58C581E3485DDF1F650CE  59911599
+c:\akse-cache\win-k8s\v1.22.4-hotfix.20220201-1int.zip                                    063EC1C9E47FE5CADB0FDCF254DB03D942EEC0CAC3E03736ADC711B2DB0E4A80  59960191
+c:\akse-cache\win-k8s\v1.22.6-hotfix.20220728-1int.zip                                    3ECF60C807680AB3611D1C69AF3C4B4FA0A9A2FB68BC40AFF5DF591F36B4253B  59887661
+c:\akse-cache\win-k8s\v1.23.12-hotfix.20220922-1int.zip                                   8DEB47A9AA78154B39CFA4292C084C4CD3A500E8FE30C741F0A4D71AD189C628  60153618
+c:\akse-cache\win-k8s\v1.23.3-hotfix.20220130-1int.zip                                    4F5DEAE4F39B19450ABFF9AA64FC051D6F38AC2360EE5B4AF50311646F39406D  60192942
+c:\akse-cache\win-k8s\v1.23.4-1int.zip                                                    746AC0F8144FAFABDFF0A7440D6B1D80051A04FB4769331500DC376E6754044F  60203085
+c:\akse-cache\win-k8s\v1.23.5-hotfix.20220728-1int.zip                                    C1E1544EA046A857ACECD03792689D06BC0742E8D56485312630887FB8E3DC8E  60119319
+c:\akse-cache\win-k8s\v1.23.7-1int.zip                                                    086BEFB44BA8244091503A10A421631725A2D3C6DB5E945DAB8B3DD7B23F6A0C  60206592
+c:\akse-cache\win-k8s\v1.23.8-hotfix.20220728-1int.zip                                    29392AAC26762742F28A588204A7B17E8186313EAC269D329D24551AEE80447E  60139096
+c:\akse-cache\win-k8s\v1.24.3-hotfix.20221006-1int.zip                                    B47DA7063EC169803D39A9415B1097AA425F89C216A33436369EE08097B4E8C8  60078963
+c:\akse-cache\win-k8s\v1.24.6-hotfix.20221006-1int.zip                                    4326B9865703EACCCA611675FF85DEAB462A3501105DDBE8694BEDAC7E621F71  60113083
+c:\akse-cache\win-k8s\v1.25.2-hotfix.20221006-1int.zip                                    7FE00EDE5374851CE4EDF197B4036D6AB28919E1679F78DBF72AB64152ABF807  61125744
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-overlay-windows-amd64-v1.4.35.zip 181944D8117393EB5F5F3C256692C55C7D8794309A865FD5351B3DD26AD8A7E3  68876662
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-swift-windows-amd64-v1.4.35.zip   F1DC1DDA095A07FBBA48C5E12E6595D1D0AFEF62C566234175FD1F3982D19E3C  68876694
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.4.22.zip         BD1E3F02A9A95478D67CECEB2C35F9F67094055D031AC1C17781F96A1EB60993  63391064
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.4.35.zip         F84EADBFD0DE847F3D1B1BA2DFFA05A2CF052BD7E5CA1662F6D2BE22BF3085DE  68876637
+
+
+
+

--- a/vhdbuilder/release-notes/AKSWindows/2022-containerd/20348.1131.221019.txt
+++ b/vhdbuilder/release-notes/AKSWindows/2022-containerd/20348.1131.221019.txt
@@ -1,0 +1,190 @@
+﻿Build Number: 20221019.1_master_62318107
+Build Id:     62318107
+Build Repo:   https://github.com/Azure/AgentBaker
+Build Branch: master
+Commit:       043611943ae0f424da8fd88ab46ad8927bae0f98
+
+VHD ID:      37959625-682e-4ed3-8cca-6ea1f92b4e00
+
+System Info
+	OS Name        : Windows Server 2022 Datacenter
+	OS Version     : 20348.1131
+	OS InstallType : Server Core
+
+Allowed security protocols: SystemDefault
+
+Installed Features
+
+Display Name                                            Name                       Install State
+------------                                            ----                       -------------
+[X] File and Storage Services                           FileAndStorage-Services        Installed
+    [X] Storage Services                                Storage-Services               Installed
+[X] Hyper-V                                             Hyper-V                        Installed
+[X] .NET Framework 4.8 Features                         NET-Framework-45-Fea...        Installed
+    [X] .NET Framework 4.8                              NET-Framework-45-Core          Installed
+    [X] WCF Services                                    NET-WCF-Services45             Installed
+        [X] TCP Port Sharing                            NET-WCF-TCP-PortShar...        Installed
+[X] BitLocker Drive Encryption                          BitLocker                      Installed
+[X] Containers                                          Containers                     Installed
+[X] Enhanced Storage                                    EnhancedStorage                Installed
+[X] Microsoft Defender Antivirus                        Windows-Defender               Installed
+[X] Remote Server Administration Tools                  RSAT                           Installed
+    [X] Role Administration Tools                       RSAT-Role-Tools                Installed
+        [X] Hyper-V Management Tools                    RSAT-Hyper-V-Tools             Installed
+            [X] Hyper-V Module for Windows PowerShell   Hyper-V-PowerShell             Installed
+[X] System Data Archiver                                System-DataArchiver            Installed
+[X] Windows PowerShell                                  PowerShellRoot                 Installed
+    [X] Windows PowerShell 5.1                          PowerShell                     Installed
+[X] WoW64 Support                                       WoW64-Support                  Installed
+
+
+
+Installed Packages
+	DirectX.Configuration.Database~~~~0.0.1.0
+	Downlevel.NLS.Sorting.Versions.Server~~~~0.0.1.0
+	Language.Basic~~~en-US~0.0.1.0
+	Language.Speech~~~en-US~0.0.1.0
+	Language.TextToSpeech~~~en-US~0.0.1.0
+	Microsoft.Windows.MSPaint~~~~0.0.1.0
+	Microsoft.Windows.Notepad~~~~0.0.1.0
+	Microsoft.Windows.WordPad~~~~0.0.1.0
+	OpenSSH.Client~~~~0.0.1.0
+	OpenSSH.Server~~~~0.0.1.0
+
+Installed QFEs
+	KB5017028 : Update          : https://support.microsoft.com/kb/5017028
+	KB5020436 : Update          : https://support.microsoft.com/kb/5020436
+	KB5017399 : Update          : https://support.microsoft.com/kb/5017399
+
+Installed Updates
+	Update for Windows Defender Antivirus antimalware platform - KB4052623 (Version 4.18.2001.10)
+	2022-09 Cumulative Update for .NET Framework 3.5, 4.8 and 4.8.1 for Microsoft server operating system version 21H2 for x64 (KB5017501)
+	Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.377.456.0)
+
+Windows Update Registry Settings
+	https://docs.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate
+	HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+		NoAutoUpdate : 1
+	HKLM:\SYSTEM\CurrentControlSet\Services\hns\State
+		EnableCompartmentNamespace : 1
+
+ContainerD Info
+Version: ctr github.com/containerd/containerd v1.6.8+azure
+
+Images:
+REF                                                                                                                                    TYPE                                                      DIGEST                                                                  SIZE      PLATFORMS                                          LABELS                          
+mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-ciprod10042022-3c05dd1b                                                    application/vnd.docker.distribution.manifest.list.v2+json sha256:1fb1183f28055f3716e75dd50037034a89f4bea83a53c3462fae4cddecd730d6 3.0 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/azuremonitor/containerinsights/ciprod@sha256:1fb1183f28055f3716e75dd50037034a89f4bea83a53c3462fae4cddecd730d6        application/vnd.docker.distribution.manifest.list.v2+json sha256:1fb1183f28055f3716e75dd50037034a89f4bea83a53c3462fae4cddecd730d6 3.0 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/containernetworking/azure-cns:v1.4.29                                                                                application/vnd.oci.image.index.v1+json                   sha256:b14c4befa018fd7965d9c551f334e7b2d550051f68a765d63cd9d63148c18fd1 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/containernetworking/azure-cns@sha256:b14c4befa018fd7965d9c551f334e7b2d550051f68a765d63cd9d63148c18fd1                application/vnd.oci.image.index.v1+json                   sha256:b14c4befa018fd7965d9c551f334e7b2d550051f68a765d63cd9d63148c18fd1 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/containernetworking/azure-npm:v1.4.29                                                                                application/vnd.oci.image.index.v1+json                   sha256:a7970e115f810b2cdd3a2283fb54aeef8908b2fcd86d00d61b3c7ed4edd4fd21 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/containernetworking/azure-npm@sha256:a7970e115f810b2cdd3a2283fb54aeef8908b2fcd86d00d61b3c7ed4edd4fd21                application/vnd.oci.image.index.v1+json                   sha256:a7970e115f810b2cdd3a2283fb54aeef8908b2fcd86d00d61b3c7ed4edd4fd21 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure:v1.2.0                                                                        application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 124.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure@sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27       application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 124.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.22.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:5f8471481ed9fe85661fd5010c56090a9cfb63fe698410c3e366b5c767054b12 136.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.23.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:492de0426ff8299b043ba6845ff517cf477b985c927b522e6b01a65e9537aa1e 136.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi@sha256:492de0426ff8299b043ba6845ff517cf477b985c927b522e6b01a65e9537aa1e             application/vnd.docker.distribution.manifest.list.v2+json sha256:492de0426ff8299b043ba6845ff517cf477b985c927b522e6b01a65e9537aa1e 136.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi@sha256:5f8471481ed9fe85661fd5010c56090a9cfb63fe698410c3e366b5c767054b12             application/vnd.docker.distribution.manifest.list.v2+json sha256:5f8471481ed9fe85661fd5010c56090a9cfb63fe698410c3e366b5c767054b12 136.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.21.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:b21ba2841a705f0f9fef5afa9f3f50c5cb11ddb504028626cc507966c52edf30 125.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.22.0                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:d8802d555a169c34ce1ebbfb8d0228777250ab8fdd4af084e0ea98476eb60f90 125.2 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi@sha256:b21ba2841a705f0f9fef5afa9f3f50c5cb11ddb504028626cc507966c52edf30             application/vnd.docker.distribution.manifest.list.v2+json sha256:b21ba2841a705f0f9fef5afa9f3f50c5cb11ddb504028626cc507966c52edf30 125.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi@sha256:d8802d555a169c34ce1ebbfb8d0228777250ab8fdd4af084e0ea98476eb60f90             application/vnd.docker.distribution.manifest.list.v2+json sha256:d8802d555a169c34ce1ebbfb8d0228777250ab8fdd4af084e0ea98476eb60f90 125.2 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.4.0                                                                  application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 119.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.5.0                                                                  application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 120.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar@sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 120.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar@sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 119.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.5.0                                                                              application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 118.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.6.0                                                                              application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 119.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe@sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6             application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 118.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/livenessprobe@sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8             application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 119.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v1.2.2                                                                       application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 136.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver@sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc      application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 136.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.23.11                                                                     application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 125.7 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.24.3                                                                      application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 126.0 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab      application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 125.7 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager@sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8      application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 126.0 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/pause:3.6-hotfix.20220114                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 291.6 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/oss/kubernetes/pause@sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0                         application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 291.6 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/nanoserver:ltsc2022                                                                                          application/vnd.docker.distribution.manifest.list.v2+json sha256:fefb912e2942912f1cd55bfe6bbb697a601a7787caf5c1875aaf105c86a28027 112.7 MiB windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/nanoserver@sha256:fefb912e2942912f1cd55bfe6bbb697a601a7787caf5c1875aaf105c86a28027                           application/vnd.docker.distribution.manifest.list.v2+json sha256:fefb912e2942912f1cd55bfe6bbb697a601a7787caf5c1875aaf105c86a28027 112.7 MiB windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/servercore:ltsc2022                                                                                          application/vnd.docker.distribution.manifest.list.v2+json sha256:6983a9d56e4d8d1fac3819e4bed8ff537400ea21150b9d65bfbdc0ef3c27c99c 2.3 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+mcr.microsoft.com/windows/servercore@sha256:6983a9d56e4d8d1fac3819e4bed8ff537400ea21150b9d65bfbdc0ef3c27c99c                           application/vnd.docker.distribution.manifest.list.v2+json sha256:6983a9d56e4d8d1fac3819e4bed8ff537400ea21150b9d65bfbdc0ef3c27c99c 2.3 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:06bb218927a8a95b424acfad0e0e6ae0fb5694c0b510f9930ed5881075eaec2f                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:6983a9d56e4d8d1fac3819e4bed8ff537400ea21150b9d65bfbdc0ef3c27c99c 2.3 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:17d5a7e95bb6150ece279ddfd1f484a4a8bf54a1eb7f201fe3c49236da84fda9                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:c96a6255c42766f6b8bb1a7cda02b0060ab1b20b2e2dafcc64ec09e7646745a6 118.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:2453367b5356144b645167517ea1024501b859b92fe2b6d97185b744ceeaa0e6                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:d8802d555a169c34ce1ebbfb8d0228777250ab8fdd4af084e0ea98476eb60f90 125.2 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:255ec55f9730903a13be47d51cd83a8c36549d7e853ad92298269814bd516241                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:dbec3a8166686b09b242176ab5b99e993da4126438bbce68147c3fd654f35662 119.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:47a1e1d14429c460fbe10547631014f444858d38a64ec86a827e94b735ef6198                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:492de0426ff8299b043ba6845ff517cf477b985c927b522e6b01a65e9537aa1e 136.7 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:4d45d35f934a62503a1df703d4f7862d61854cc42d7e1b0dba9249f009cdaf01                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:36f3fff3f2a59d0092ad4d1ac04115d289a8c90cd67bec88adadcce28775eea0 291.6 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:57d1cd7f5e0796e35af60688b0cae5aed8c4b587f2136ac194d54a23c88a073d                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:e01f5dae19d7e1be536606fe5deb893417429486b628b816d80ffa0e441eeae8 119.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:76139fdf1eb94661570fb051f9af5da56d94c04a5dc93b61ecdb69a790bbefab                                                                application/vnd.oci.image.index.v1+json                   sha256:b14c4befa018fd7965d9c551f334e7b2d550051f68a765d63cd9d63148c18fd1 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:8d9453088438abfd7f1b8b82f1124612054d99d545bff726bd0637da051a7c36                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:fd20ae0f7346fa807a67d338a00097e0e0a85d598107f41268981d223e189f27 124.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:b1a822dabd8ec1ff252d23143dad5a4010f8c61466f9e582d01b38d2c6e63416                                                                application/vnd.oci.image.index.v1+json                   sha256:a7970e115f810b2cdd3a2283fb54aeef8908b2fcd86d00d61b3c7ed4edd4fd21 2.1 GiB   linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:b8c32952da321842aeb551b514f46a3876780f37a25f58b65bca92c56ef69b85                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:96a00c127de83f2b5187e4eb09343b8557d1b1df836598962b306ac30f3968a8 126.0 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:bfb9689e0bf135fdaf041badce5f1913059f065ac1552318304d1fa3a628bc0b                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:1fb1183f28055f3716e75dd50037034a89f4bea83a53c3462fae4cddecd730d6 3.0 GiB   windows/amd64                                      io.cri-containerd.image=managed 
+sha256:c733789646e295f3f35d7bde9657b09d92069fc4791f6886b81ce6034cdda4f3                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:075ea1f8270312350f1396ab6677251e803e61a523822d5abfa5e6acd180cfab 125.7 MiB linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 io.cri-containerd.image=managed 
+sha256:e424d3c0688cc28f85b5719146c458ba1ea24fa503ec7e0c2e33f265977da619                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:a4e987e191c3c865a00449c043d40ff037208225c925ef37733393ddc21baebc 136.5 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:e8459e4e82bea14900ee7997bed956b9c6045374881a44a6d9b15ba31b3dfed0                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:5f8471481ed9fe85661fd5010c56090a9cfb63fe698410c3e366b5c767054b12 136.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:f59744965c7df75be557efdc65c477c2307c2f9d7cc987683feda1b295825816                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:b21ba2841a705f0f9fef5afa9f3f50c5cb11ddb504028626cc507966c52edf30 125.1 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:f7312d5d67fe06fcadda4280531f5c253cf563895bc381e18520bfa345fd3ae9                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:348b2d4eebc8da38687755a69b6c21035be232325a6bcde54e5ec4e04689fd93 120.0 MiB linux/amd64,linux/arm64,windows/amd64              io.cri-containerd.image=managed 
+sha256:fc628a662d22511a75bc42a625029f7ba6f669d0423870a07113d65867b92a3f                                                                application/vnd.docker.distribution.manifest.list.v2+json sha256:fefb912e2942912f1cd55bfe6bbb697a601a7787caf5c1875aaf105c86a28027 112.7 MiB windows/amd64                                      io.cri-containerd.image=managed 
+
+Cached Files:
+
+File                                                                                      Sha256                                                           SizeBytes
+----                                                                                      ------                                                           ---------
+c:\akse-cache\aks-windows-cse-scripts-v0.0.12.zip                                         9B8CBD3789CECE390BBD488F6887AD300794BA39B7C2C7BCF68ADF247543E4F6    105895
+c:\akse-cache\aks-windows-cse-scripts-v0.0.13.zip                                         218B5188FA3673A555AB3E5471805F968F8EE477A08D01E2DAE570CFFF572CA4    116529
+c:\akse-cache\aks-windows-cse-scripts-v0.0.14.zip                                         6B88E4E5BE6B9D22C898CE274B24FA89F1AF57488FC75580BA92E5246E532568    119110
+c:\akse-cache\aks-windows-cse-scripts-v0.0.15.zip                                         342CA2388BB9E1B51A4AD6B4CFE40698C6A509389EAA0B0199C8B913B5EAA326    119241
+c:\akse-cache\aks-windows-cse-scripts-v0.0.16.zip                                         B12DB1E44A18655512D2E6AD9A1326634A882CEDD8D12AD8AD45E5979408A596    119068
+c:\akse-cache\collect-windows-logs.ps1                                                    C095FE4E41C73489C143CA3AF67C584A4CAD339EBF3409F151D57DB62956FAC4      8436
+c:\akse-cache\collectlogs.ps1                                                             00A22F407C7D9DE46995751476C8C81AC82B68AA3AFDC14230297E15CC0E1903     13037
+c:\akse-cache\dumpVfpPolicies.ps1                                                         02BFF0235421F1C8477E809B8EB354B313C348CE2732C4842B710239CD6FE665      1642
+c:\akse-cache\helper.psm1                                                                 BC45AA98FA40D51C4E8640865C329BDC4B522EA53CC17A5F0B512B4D44058C8C     17945
+c:\akse-cache\hns.psm1                                                                    A8A53ED4FAC2E27C7E4268DB069D4CF3129A56D466EF3BF9465FB52DCD76A29C     14733
+c:\akse-cache\hns.v2.psm1                                                                 D72975CE1282ADCFA32078AA66A85CBCC10BA0426325BE0E206A98E426E148C7     89314
+c:\akse-cache\microsoft.applicationinsights.2.11.0.nupkg                                  4B0448F9640FCD84979D6CE736348EE9304A7A069F77E38FF411F3211E699C68    776442
+c:\akse-cache\networkhealth.ps1                                                           E829FE0A562F537795F9A9B9CEE8DED203DBC5B8E590A140BFF3D5DD3E010CC6     46377
+c:\akse-cache\portReservationTest.ps1                                                     0940BA8A0A564E5937F60871F7F87C866C8617882D121FF33BBB0798B0C82AC0      4370
+c:\akse-cache\starthnstrace.cmd                                                           5AD52503471E17584A7BCE9D57EC0064AE7536B9B19032940CD50813BBF315EA       802
+c:\akse-cache\starthnstrace.ps1                                                           D2A9E71159F8AC9F8B99E021B0D63C9E592F422127F39467579B441DE6AB08A9     10591
+c:\akse-cache\startpacketcapture.cmd                                                      1F68B49570C88BB3CF06DE1798D26DFD0EACF5AAB69BF9A277A1C8180166CE29       808
+c:\akse-cache\startpacketcapture.ps1                                                      A4F24398023CA481127F356840D39FAB86973EBC20C596BB24F1B85687F62904     11762
+c:\akse-cache\stoppacketcapture.cmd                                                       BD966D7738A3C0FC73E651BAF196C0FB60D889F1180B2D114F8EA3F8A8453C3D        17
+c:\akse-cache\VFP.psm1                                                                    3F2F44BD4B3219E8BB29EB9F8958EC96F2C8DDCEF556E995790B6476231A92DB      9616
+c:\akse-cache\win-bridge.exe                                                              CA12506E55DF3E3428B29994AE1FC8131DDFBB6838A550DFA22287CDC6548634   9599488
+c:\akse-cache\windows-gmsa-ccgakvplugin-v1.1.5.zip                                        844BFA33F77BDEBA529D353C79A6B361640B0909E6092C572C51AA7A881494EF    484167
+c:\akse-cache\calico\calico-windows-v3.21.6.zip                                           2316A5D3132CE836C571B057E77E304B0AE48479CC06FBDE4A4814425A52D69C  70552548
+c:\akse-cache\containerd\containerd-v0.0.47-windows-amd64.tar.gz                          DF18C3C7985EEDD76E7D169E5CBD99349CDF55C3004567E3097727E095378292  74676384
+c:\akse-cache\csi-proxy\csi-proxy-v0.2.2.tar.gz                                           60BF51D4FB425386C235ABC3BCBD50D70C23CACB94C32A77509DA91CF0F066AD   6481034
+c:\akse-cache\csi-proxy\csi-proxy-v1.0.2.tar.gz                                           60205FB7C3D477182B4AA91C66F10C001EDCBF9FE26410B17522961EC23798DC   6649244
+c:\akse-cache\win-k8s\v1.21.1-hotfix.20211115-1int.zip                                    45AF4FB48AF2604394A0B6893707B174FEE606523A16B60640FFA49A597FFDD6  59489442
+c:\akse-cache\win-k8s\v1.21.13-1int.zip                                                   3D188AF788F3CF7CC37721AD9886640108CBB9B40BDFC26CE9DB7371DDDC7139  59328318
+c:\akse-cache\win-k8s\v1.21.14-1int.zip                                                   6BFF5504EA577958DE99AD73D2C128D27F9F496654FE2B9597F0D000998A6E19  59328306
+c:\akse-cache\win-k8s\v1.21.2-hotfix.20211115-1int.zip                                    25F0DE8DC69EE655D08145DBDEF4D08BC17E53E7073F76B0E4CBFAB0CBEBC331  59161811
+c:\akse-cache\win-k8s\v1.21.7-hotfix.20220204-1int.zip                                    5639975241EA68337A6F855CF02812341024FC270990334630BEC7D78826C0AF  59295514
+c:\akse-cache\win-k8s\v1.21.9-hotfix.20220204-1int.zip                                    DF862114D24018A1F65106252E6C8C1BD70432703D7F41D86412C38B8AE2CC68  59301522
+c:\akse-cache\win-k8s\v1.22.1-hotfix.20211115-1int.zip                                    6B6694817C54DA05EC804F21EE7C57828DCF16241400C94653DC4E432619E869  59924075
+c:\akse-cache\win-k8s\v1.22.10-1int.zip                                                   86B9E348BFF606274C91219DC463F35011083C13641463D484F547A53DB6707E  59983584
+c:\akse-cache\win-k8s\v1.22.11-hotfix.20220728-1int.zip                                   6565445A89D5087B22AF819362D451A00731178D86D7E52EEB2B4679EF5651D9  59902098
+c:\akse-cache\win-k8s\v1.22.15-1int.zip                                                   A86D2A9C335B16DFF7E9A982ED8F8DC413CEFFCB39E58C581E3485DDF1F650CE  59911599
+c:\akse-cache\win-k8s\v1.22.4-hotfix.20220201-1int.zip                                    063EC1C9E47FE5CADB0FDCF254DB03D942EEC0CAC3E03736ADC711B2DB0E4A80  59960191
+c:\akse-cache\win-k8s\v1.22.6-hotfix.20220728-1int.zip                                    3ECF60C807680AB3611D1C69AF3C4B4FA0A9A2FB68BC40AFF5DF591F36B4253B  59887661
+c:\akse-cache\win-k8s\v1.23.12-hotfix.20220922-1int.zip                                   8DEB47A9AA78154B39CFA4292C084C4CD3A500E8FE30C741F0A4D71AD189C628  60153618
+c:\akse-cache\win-k8s\v1.23.3-hotfix.20220130-1int.zip                                    4F5DEAE4F39B19450ABFF9AA64FC051D6F38AC2360EE5B4AF50311646F39406D  60192942
+c:\akse-cache\win-k8s\v1.23.4-1int.zip                                                    746AC0F8144FAFABDFF0A7440D6B1D80051A04FB4769331500DC376E6754044F  60203085
+c:\akse-cache\win-k8s\v1.23.5-hotfix.20220728-1int.zip                                    C1E1544EA046A857ACECD03792689D06BC0742E8D56485312630887FB8E3DC8E  60119319
+c:\akse-cache\win-k8s\v1.23.7-1int.zip                                                    086BEFB44BA8244091503A10A421631725A2D3C6DB5E945DAB8B3DD7B23F6A0C  60206592
+c:\akse-cache\win-k8s\v1.23.8-hotfix.20220728-1int.zip                                    29392AAC26762742F28A588204A7B17E8186313EAC269D329D24551AEE80447E  60139096
+c:\akse-cache\win-k8s\v1.24.3-hotfix.20221006-1int.zip                                    B47DA7063EC169803D39A9415B1097AA425F89C216A33436369EE08097B4E8C8  60078963
+c:\akse-cache\win-k8s\v1.24.6-hotfix.20221006-1int.zip                                    4326B9865703EACCCA611675FF85DEAB462A3501105DDBE8694BEDAC7E621F71  60113083
+c:\akse-cache\win-k8s\v1.25.2-hotfix.20221006-1int.zip                                    7FE00EDE5374851CE4EDF197B4036D6AB28919E1679F78DBF72AB64152ABF807  61125744
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-overlay-windows-amd64-v1.4.35.zip 181944D8117393EB5F5F3C256692C55C7D8794309A865FD5351B3DD26AD8A7E3  68876662
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-swift-windows-amd64-v1.4.35.zip   F1DC1DDA095A07FBBA48C5E12E6595D1D0AFEF62C566234175FD1F3982D19E3C  68876694
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.4.22.zip         BD1E3F02A9A95478D67CECEB2C35F9F67094055D031AC1C17781F96A1EB60993  63391064
+c:\akse-cache\win-vnet-cni\azure-vnet-cni-singletenancy-windows-amd64-v1.4.35.zip         F84EADBFD0DE847F3D1B1BA2DFFA05A2CF052BD7E5CA1662F6D2BE22BF3085DE  68876637
+
+
+
+


### PR DESCRIPTION
**What type of PR is this?**
/kind doc

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Added release notes for AKS Windows images with 2022.10OOB
We still updated sig_config.go although we do not use it.
Replaced the hard-coded value in #2338 with the existing sig image version. 

- WS2019: [October 17, 2022—KB5020438 (OS Build 17763.3534) Out-of-band](https://support.microsoft.com/en-us/topic/october-17-2022-kb5020438-os-build-17763-3534-out-of-band-cd499c1a-6d60-49a1-9a40-fad42c1d393a)
- WS2022: [October 17, 2022—KB5020436 (OS Build 20348.1131) Out-of-band](https://support.microsoft.com/en-us/topic/october-17-2022-kb5020436-os-build-20348-1131-out-of-band-18baa25a-5fc0-4118-9b89-ddbe9819e578)



**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
a. Removed the comment in the previous commit #2338
b. Used existing `Windows2022SIGImageVersion`
c. Replaced hard-coded version value (workaround sig of last month).

Added a new release note folder for WS2022 Gen 2?

**Release note**:
```
none
```
