### PR TITLE
chore: cache v3.23.3 images for Calico

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -146,9 +146,8 @@
         "v3.8.9.3"
       ],
       "multiArchVersions": [
-        "v3.21.4",
         "v3.21.6",
-        "v3.23.1"
+        "v3.23.3"
       ]
     },
     {
@@ -157,9 +156,8 @@
         "v3.8.9.5"
       ],
       "multiArchVersions": [
-        "v3.21.4",
         "v3.21.6",
-        "v3.23.1"
+        "v3.23.3"
       ]
     },
     {
@@ -168,9 +166,8 @@
         "v3.8.9"
       ],
       "multiArchVersions": [
-        "v3.21.4",
         "v3.21.6",
-        "v3.23.1"
+        "v3.23.3"
       ]
     },
     {
@@ -179,18 +176,16 @@
         "v3.8.9.1"
       ],
       "multiArchVersions": [
-        "v3.21.4",
         "v3.21.6",
-        "v3.23.1"
+        "v3.23.3"
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/oss/calico/kube-controllers:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v3.21.4",
         "v3.21.6",
-        "v3.23.1"
+        "v3.23.3"
       ]
     },
     {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

tigera-operator v1.27.12 was cached [here](https://github.com/Azure/AgentBaker/pull/2348), this is the 2nd part which adds the Calico image which it expects to install.

Since we are going with different version (based on k8s version), this will cover the two cases fully:
v1.27.12 will install Calico v3.23.3
v1.23.8 will install Calico v3.21.6

**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
