### PR TITLE
fix: Mask iptables systemd service

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -109,7 +109,7 @@ fi
 
 if [[ $OS == $MARINER_OS_NAME ]]; then
     disableSystemdResolvedCache
-    disableSystemdIptables
+    disableSystemdIptables || exit 1
     forceEnableIpForward
     setMarinerNetworkdConfig
     fixCBLMarinerPermissions

--- a/vhdbuilder/scripts/linux/tool_installs.sh
+++ b/vhdbuilder/scripts/linux/tool_installs.sh
@@ -65,4 +65,7 @@ EOF
 
 disableSystemdIptables() {
     systemctlDisableAndStop iptables || exit $ERR_DISBALE_IPTABLES
+
+    # Mask the iptables service to prevent it from ever re-enabling and breaking pod networking.
+    systemctl mask iptables || exit $ERR_DISBALE_IPTABLES
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Currently Mariner disables and stops the iptables.service because it conflicts with K8s' use of iptables for pod routing.
This is insufficient to permanently disable the service, when systemd takes a package update it reevaluates the vendor presets and reenables the iptables service after a reboot.
In order to permanently disable iptables.service we can mask it with "systemctl mask iptables", causing vendor preset evaluation to leave it disabled, and manual attempts to start it are blocked until the service is unmasked.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
