### PR TITLE
fips image improvement to survive non-fips kernel package reinstallation

### DIFF
--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -234,6 +234,7 @@ const (
 
 const (
 	LinuxSIGImageVersion string = "2022.11.02"
+	FipsSIGImageVersion  string = "2022.11.04"
 
 	// DO NOT MODIFY: used for freezing linux images with docker
 	FrozenLinuxSIGImageVersionForDocker string = "2022.08.29"
@@ -313,7 +314,7 @@ var (
 		ResourceGroup: AKSUbuntuResourceGroup,
 		Gallery:       AKSUbuntuGalleryName,
 		Definition:    "1804fipscontainerd",
-		Version:       LinuxSIGImageVersion,
+		Version:       FipsSIGImageVersion,
 	}
 
 	// not a typo, this image was generated on 2021.05.20 UTC and assigned this version
@@ -321,21 +322,21 @@ var (
 		ResourceGroup: AKSUbuntuResourceGroup,
 		Gallery:       AKSUbuntuGalleryName,
 		Definition:    "1804gen2fipscontainerd",
-		Version:       LinuxSIGImageVersion,
+		Version:       FipsSIGImageVersion,
 	}
 
 	SIGUbuntuFipsGPUContainerd1804ImageConfigTemplate = SigImageConfigTemplate{
 		ResourceGroup: AKSUbuntuResourceGroup,
 		Gallery:       AKSUbuntuGalleryName,
 		Definition:    "1804fipsgpucontainerd",
-		Version:       LinuxSIGImageVersion,
+		Version:       FipsSIGImageVersion,
 	}
 
 	SIGUbuntuFipsGPUContainerd1804Gen2ImageConfigTemplate = SigImageConfigTemplate{
 		ResourceGroup: AKSUbuntuResourceGroup,
 		Gallery:       AKSUbuntuGalleryName,
 		Definition:    "1804gen2fipsgpucontainerd",
-		Version:       LinuxSIGImageVersion,
+		Version:       FipsSIGImageVersion,
 	}
 
 	SIGUbuntuArm64Containerd1804Gen2ImageConfigTemplate = SigImageConfigTemplate{

--- a/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
+++ b/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
@@ -139,9 +139,6 @@ EOF
 installFIPS() {
     echo "Installing FIPS..."
     wait_for_apt_locks
-    
-    echo "purging unattended-upgrades in FIPS VHD..."
-    apt_get_purge 5 10 120 unattended-upgrades || exit 1
 
     # installing fips kernel doesn't remove non-fips kernel now, purge current linux-image-azure
     echo "purging linux-image-azure..."
@@ -151,15 +148,7 @@ installFIPS() {
         if [[ ${image} != "linux-image-$(uname -r)" ]]; then
             apt_get_purge 5 10 120 ${image} || exit 1
         fi
-        retrycmd_if_failure 120 5 25 apt-mark hold ${image} || exit 1
     done
-
-    echo "adding ua repository..."
-    retrycmd_if_failure 5 10 120 add-apt-repository -y ppa:ua-client/stable || exit $ERR_ADD_UA_APT_REPO
-    apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT
-
-    echo "installing ua tools..."
-    apt_get_install 5 10 120 ubuntu-advantage-tools || exit $ERR_UA_TOOLS_INSTALL_TIMEOUT
 
     echo "auto attaching ua..."
     retrycmd_if_failure 5 10 120 ua auto-attach || exit $ERR_AUTO_UA_ATTACH
@@ -172,25 +161,19 @@ installFIPS() {
 
     # 'ua status' for logging
     ua status
-    # new 'ua detach' removes fips-updates kernel entry from grub.cfg, backup it
-    cp -f /boot/grub/grub.cfg /tmp/
+
+    echo "detaching ua..."
+    retrycmd_if_failure 5 10 120 printf "y\nN" | ua detach || $ERR_UA_DETACH
 
     # now the fips packages/kernel are installed, clean up apt settings in the vhd,
     # the VMs created on customers' subscriptions don't have access to UA repo
-    echo "detaching ua..."
-    retrycmd_if_failure 5 10 120 ua detach --assume-yes || $ERR_UA_DETACH
-    mv -f /tmp/grub.cfg /boot/grub/
-    echo "removing ua tools..."
-    apt_get_purge 5 10 120 ubuntu-advantage-tools
-    rm -f /etc/apt/trusted.gpg.d/ua-client_ubuntu_stable.gpg
     rm -f /etc/apt/trusted.gpg.d/ubuntu-advantage-esm-apps.gpg
     rm -f /etc/apt/trusted.gpg.d/ubuntu-advantage-esm-infra-trusty.gpg
     rm -f /etc/apt/trusted.gpg.d/ubuntu-advantage-fips.gpg
-    rm -f /etc/apt/sources.list.d/ua-client-ubuntu-stable-bionic.list
     rm -f /etc/apt/sources.list.d/ubuntu-esm-apps.list
     rm -f /etc/apt/sources.list.d/ubuntu-esm-infra.list
-    rm -f /etc/apt/sources.list.d/ubuntu-fips.list
-    rm -f /etc/apt/auth.conf.d/80ubuntu-advantage
+    rm -f /etc/apt/sources.list.d/ubuntu-fips-updates.list
+    rm -f /etc/apt/auth.conf.d/*ubuntu-advantage
     apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT
 }
 


### PR DESCRIPTION
…ion or upgrading

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
1. UA tool is pre-installed in regular base os, no need to install ua tool
2. Provide right confirmation to the prompt of 'ua detach', in order that the first fips kernel entry in grub.cfg can survive arbitrary non-fips kernel package re-installation or upgrading just like good AKS FIPS VHDs some time back. There might be some UA behavior change on detaching.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
