### PR TITLE
chore: Update RegKey HNSControlFlag when disable Windows OutboundNAT

### DIFF
--- a/staging/cse/windows/azurecnifunc.ps1
+++ b/staging/cse/windows/azurecnifunc.ps1
@@ -71,10 +71,13 @@ function Set-AzureCNIConfig
         $currentValue=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSControlFlag -ErrorAction Ignore)
         if (![string]::IsNullOrEmpty($currentValue)) {
             Write-Log "The current value of HNSControlFlag is $currentValue"
-            # -band (-bnot $hnsControlFlag) set the bit to 0 if the bit is 1
-            $hnsControlFlag=([int]$currentValue.HNSControlFlag -band (-bnot $hnsControlFlag))
-            Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSControlFlag -Type DWORD -Value $hnsControlFlag
+            # Set the bit to 0 if the bit is 1
+            if ([int]$currentValue.HNSControlFlag -band $hnsControlFlag) {
+                $hnsControlFlag=([int]$currentValue.HNSControlFlag -bxor $hnsControlFlag)
+                Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSControlFlag -Type DWORD -Value $hnsControlFlag
+            }
         } else {
+            # Set 0 to disable all features under HNSControlFlag (0x10 defaults enable)
             Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSControlFlag -Type DWORD -Value 0
         }
     } else {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
The feature ```DisableOutboundNAT``` is incompatible with an existing ```HNSControlFlag```.
Update RegKey to disable ```HNSControlFlag``` to keep feature ```DisableOutboundNAT``` working.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
Tested in the standalone environment.

**Release note**:
```
none
```
