### PR TITLE
chore: Update Windows base images with 2022.11B

### DIFF
--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -27,8 +27,8 @@ switch -Regex ($windowsSKU) {
         $global:patchIDs = @()
     }
     "2022*" {
-        $global:patchUrls = @("https://catalog.s.download.windowsupdate.com/d/msdownload/update/software/updt/2022/10/windows10.0-kb5018485-x64_13183a9eaf45a33f681d43fa80c1b283f213991c.msu")
-        $global:patchIDs = @("KB5018485")
+        $global:patchUrls = @()
+        $global:patchIDs = @()
     }
 }
 

--- a/vhdbuilder/packer/windows-image.env
+++ b/vhdbuilder/packer/windows-image.env
@@ -4,18 +4,18 @@
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core-smalldisk:latest
 WINDOWS_2019_BASE_IMAGE_SKU=2019-Datacenter-Core-smalldisk
-WINDOWS_2019_BASE_IMAGE_VERSION=17763.3534.221015
+WINDOWS_2019_BASE_IMAGE_VERSION=17763.3650.221105
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:2022-Datacenter-Core-smalldisk:latest
 WINDOWS_2022_BASE_IMAGE_SKU=2022-Datacenter-Core-smalldisk
-WINDOWS_2022_BASE_IMAGE_VERSION=20348.1131.221014
+WINDOWS_2022_BASE_IMAGE_VERSION=20348.1249.221105
 
 # CLI example to get all available image version under a SKU (suffix g2 for Gen 2):
 #   az vm image list --all --publisher  MicrosoftWindowsServer --offer WindowsServer --output table -s 2022-datacenter-core-smalldisk-g2
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:2022-datacenter-core-smalldisk-g2:latest
 WINDOWS_2022_GEN2_BASE_IMAGE_SKU=2022-datacenter-core-smalldisk-g2
-WINDOWS_2022_GEN2_BASE_IMAGE_VERSION=20348.1131.221014
+WINDOWS_2022_GEN2_BASE_IMAGE_VERSION=20348.1249.221105
 
 # Please uncomment the following lines and set a larger os disk size that is at least 30GB when your PR check-in fails
 # WINDOWS_2019_OS_DISK_SIZE_GB=30


### PR DESCRIPTION
**What type of PR is this?**
/kind build
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Windows security patch 2022-10B
- WS2019: [November 8, 2022—KB5019966 (OS Build 17763.3650)](https://support.microsoft.com/en-gb/topic/november-8-2022-kb5019966-os-build-17763-3650-b09dad62-5cd7-47cd-992f-b7d01f2956c1)
- WS2022: [November 8, 2022—KB5019081 (OS Build 20348.1249)](https://support.microsoft.com/en-us/topic/november-8-2022-kb5019081-os-build-20348-1249-14345324-e5d1-4710-a364-76d69d7aaa7c)

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
