### PR TITLE
fix: Don't add Vnet CIDRs to CNI Conflist if AzureCNIOverlay is Enabled 1/2

### DIFF
--- a/staging/cse/windows/azurecnifunc.ps1
+++ b/staging/cse/windows/azurecnifunc.ps1
@@ -83,17 +83,18 @@ function Set-AzureCNIConfig
     } else {
         # Fill in DNS information for kubernetes.
         $exceptionAddresses = @()
-        if (!$IsAzureCNIOverlayEnabled) {
-            if ($IsDualStackEnabled){
-                $subnetToPass = $KubeClusterCIDR -split ","
-                $exceptionAddresses += $subnetToPass[0]
-            } else {
-                $exceptionAddresses += $KubeClusterCIDR
-            }
+        if ($IsDualStackEnabled){
+            $subnetToPass = $KubeClusterCIDR -split ","
+            $exceptionAddresses += $subnetToPass[0]
+        } else {
+            $exceptionAddresses += $KubeClusterCIDR
         }
-        $vnetCIDRs = $VNetCIDR -split ","
-        foreach ($cidr in $vnetCIDRs) {
-            $exceptionAddresses += $cidr
+
+        if (!$IsAzureCNIOverlayEnabled) {
+            $vnetCIDRs = $VNetCIDR -split ","
+            foreach ($cidr in $vnetCIDRs) {
+                $exceptionAddresses += $cidr
+            }
         }
 
         $osBuildNumber = (get-wmiobject win32_operatingsystem).BuildNumber

--- a/staging/cse/windows/azurecnifunc.tests.suites/AzureCNI.Overlay.conflist
+++ b/staging/cse/windows/azurecnifunc.tests.suites/AzureCNI.Overlay.conflist
@@ -29,7 +29,7 @@
                     "Value": {
                         "Type": "OutBoundNAT",
                         "ExceptionList": [
-                            "10.224.1.0/12"
+                            "10.224.0.0/12"
                         ]
                     }
                 },


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Don't add VnetCidrs to exceptionlist when network plugin mode is overlay

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [X] tested upgrade from previous version

**Special notes for your reviewer**:
Tested e2e with AKS-RP

**Release note**:
```
none
```
