### PR TITLE
chore: cache cilium 1.12.3

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -192,15 +192,16 @@
       "downloadURL": "mcr.microsoft.com/oss/cilium/operator-generic:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "1.12.2"
+        "1.12.2",
+        "1.12.3"
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/oss/cilium/cilium:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "1.12.2.2",
-        "1.12.2.3"
+        "1.12.2.3",
+        "1.12.3"
       ]
     },
     {


### PR DESCRIPTION
Add Cilium 1.12.3 for cilium/operator-generic and cilium/cilium

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)

**Special notes for your reviewer**:

Previous version 1.12.2.3 is still in use, but 1.12.2.2 is not.

**Release note**:
```
cache cilium/cilium and cilium/operator-generic version 1.12.3
```
