### PR TITLE
chore: cache Cilium 1.12.5

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -200,7 +200,7 @@
       "amd64OnlyVersions": [],
       "multiArchVersions": [
         "1.12.2",
-        "1.12.3"
+        "1.12.5"
       ]
     },
     {
@@ -208,7 +208,7 @@
       "amd64OnlyVersions": [],
       "multiArchVersions": [
         "1.12.2.3",
-        "1.12.3"
+        "1.12.5"
       ]
     },
     {


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Cilium released patch version 1.12.5 before we were able to deploy 1.12.3. Cache 1.12.5 so we can update to the latest patch version.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)

**Special notes for your reviewer**:

Version 1.12.2 is currently used in AKS, but 1.12.3 is not.

**Release note**:
```
Cache images for Cilium 1.12.5
```
