### PR TITLE
fix: Remove vfpOutput.txt before generating new logs

### DIFF
--- a/staging/cse/windows/provisioningscripts/loggenerator.ps1
+++ b/staging/cse/windows/provisioningscripts/loggenerator.ps1
@@ -49,8 +49,8 @@ function Collect-OldLogFiles {
         Remove-Item $_
     }
 
-    $kubeproxyOldLogFiles=Get-ChildItem (Join-Path $Folder $LogFilePattern)
-    $kubeproxyOldLogFiles | Foreach-Object {
+    $oldLogFiles=Get-ChildItem (Join-Path $Folder $LogFilePattern)
+    $oldLogFiles | Foreach-Object {
         $fileName = [IO.Path]::GetFileName($_)
         Create-SymbolLinkFile -SrcFile $_ -DestFile (Join-Path $aksLogFolder $fileName)
     }
@@ -118,6 +118,9 @@ $miscLogFiles | Foreach-Object {
 $dumpVfpPoliciesScript="C:\k\debug\dumpVfpPolicies.ps1"
 if (Test-Path $dumpVfpPoliciesScript) {
     Write-Log "Genearting vfpOutput.txt"
+    # Remove the old log since dumpVfpPolicies.ps1 always append the new logs
+    # Ignore the error if the file does not exist
+    Remove-Item -ErrorAction Ignore (Join-Path $aksLogFolder 'vfpOutput.txt')
     PowerShell -ExecutionPolicy Unrestricted -command "$dumpVfpPoliciesScript -switchName L2Bridge -outfile (Join-Path $aksLogFolder 'vfpOutput.txt')"
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
dumpVfpPolicies.ps1 always appends logs to the file instead of overriding the file.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
