### PR TITLE
chore: use self-created 1es hosted pools to build windows vhd

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -2,7 +2,7 @@ name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)_$(BuildID)
 trigger: none
 
 pool:
-  name: ${POOL_NAME}
+  name: $(POOL_NAME)
 
 parameters:
 - name: build2019

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -2,7 +2,7 @@ name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)_$(BuildID)
 trigger: none
 
 pool:
-  name: 1ES-AKS-Elastic-DevInfra-Auto-TearDown-Pool
+  name: ${POOL_NAME}
 
 parameters:
 - name: build2019
@@ -43,7 +43,6 @@ stages:
             echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D4s_v3'
             echo '##vso[task.setvariable variable=CONTAINER_RUNTIME]docker'
             echo '##vso[task.setvariable variable=WINDOWS_SKU]2019'
-            echo '##vso[task.setvariable variable=VNET_RESOURCE_GROUP_NAME]vnet-2019-$(Build.BuildNumber)'
             echo '##vso[task.setvariable variable=WINDOWS_BASE_IMAGE_URL]$(WINDOWS_2019_BASE_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_NANO_IMAGE_URL]$(WINDOWS_2019_NANO_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_CORE_IMAGE_URL]$(WINDOWS_2019_CORE_IMAGE_URL)'
@@ -65,7 +64,6 @@ stages:
             echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D4s_v3'
             echo '##vso[task.setvariable variable=CONTAINER_RUNTIME]containerd'
             echo '##vso[task.setvariable variable=WINDOWS_SKU]2019-containerd'
-            echo '##vso[task.setvariable variable=VNET_RESOURCE_GROUP_NAME]vnet-2019-containerd-$(Build.BuildNumber)'
             echo '##vso[task.setvariable variable=WINDOWS_BASE_IMAGE_URL]$(WINDOWS_2019_BASE_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_NANO_IMAGE_URL]$(WINDOWS_2019_NANO_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_CORE_IMAGE_URL]$(WINDOWS_2019_CORE_IMAGE_URL)'
@@ -87,7 +85,6 @@ stages:
             echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D4s_v3'
             echo '##vso[task.setvariable variable=CONTAINER_RUNTIME]containerd'
             echo '##vso[task.setvariable variable=WINDOWS_SKU]2022-containerd'
-            echo '##vso[task.setvariable variable=VNET_RESOURCE_GROUP_NAME]vnet-2022-containerd-$(Build.BuildNumber)'
             echo '##vso[task.setvariable variable=WINDOWS_BASE_IMAGE_URL]$(WINDOWS_2022_BASE_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_NANO_IMAGE_URL]$(WINDOWS_2022_NANO_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_CORE_IMAGE_URL]$(WINDOWS_2022_CORE_IMAGE_URL)'
@@ -109,7 +106,6 @@ stages:
             echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D4s_v3'
             echo '##vso[task.setvariable variable=CONTAINER_RUNTIME]containerd'
             echo '##vso[task.setvariable variable=WINDOWS_SKU]2022-containerd-gen2'
-            echo '##vso[task.setvariable variable=VNET_RESOURCE_GROUP_NAME]vnet-2022-containerd-gen2-$(Build.BuildNumber)'
             echo '##vso[task.setvariable variable=WINDOWS_BASE_IMAGE_URL]$(WINDOWS_2022_GEN2_BASE_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_NANO_IMAGE_URL]$(WINDOWS_2022_NANO_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_CORE_IMAGE_URL]$(WINDOWS_2022_CORE_IMAGE_URL)'

--- a/.pipelines/.vsts-vhd-builder-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-windows.yaml
@@ -2,7 +2,7 @@ name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)_$(BuildID)
 trigger: none
 
 pool:
-  name: ${POOL_NAME}
+  name: $(POOL_NAME)
 
 parameters:
 - name: build2019

--- a/.pipelines/.vsts-vhd-builder-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-windows.yaml
@@ -2,7 +2,7 @@ name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)_$(BuildID)
 trigger: none
 
 pool:
-  name: 1ES-AKS-Elastic-DevInfra-Auto-TearDown-Pool
+  name: ${POOL_NAME}
 
 parameters:
 - name: build2019
@@ -44,7 +44,6 @@ stages:
             echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D4s_v3'
             echo '##vso[task.setvariable variable=CONTAINER_RUNTIME]docker'
             echo '##vso[task.setvariable variable=WINDOWS_SKU]2019'
-            echo '##vso[task.setvariable variable=VNET_RESOURCE_GROUP_NAME]vnet-2019-$(Build.BuildNumber)'
             echo '##vso[task.setvariable variable=WINDOWS_BASE_IMAGE_URL]$(WINDOWS_2019_BASE_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_NANO_IMAGE_URL]$(WINDOWS_2019_NANO_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_CORE_IMAGE_URL]$(WINDOWS_2019_CORE_IMAGE_URL)'
@@ -67,7 +66,6 @@ stages:
             echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D4s_v3'
             echo '##vso[task.setvariable variable=CONTAINER_RUNTIME]containerd'
             echo '##vso[task.setvariable variable=WINDOWS_SKU]2019-containerd'
-            echo '##vso[task.setvariable variable=VNET_RESOURCE_GROUP_NAME]vnet-2019-containerd-$(Build.BuildNumber)'
             echo '##vso[task.setvariable variable=WINDOWS_BASE_IMAGE_URL]$(WINDOWS_2019_BASE_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_NANO_IMAGE_URL]$(WINDOWS_2019_NANO_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_CORE_IMAGE_URL]$(WINDOWS_2019_CORE_IMAGE_URL)'
@@ -90,7 +88,6 @@ stages:
             echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D4s_v3'
             echo '##vso[task.setvariable variable=CONTAINER_RUNTIME]containerd'
             echo '##vso[task.setvariable variable=WINDOWS_SKU]2022-containerd'
-            echo '##vso[task.setvariable variable=VNET_RESOURCE_GROUP_NAME]vnet-2022-containerd-$(Build.BuildNumber)'
             echo '##vso[task.setvariable variable=WINDOWS_BASE_IMAGE_URL]$(WINDOWS_2022_BASE_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_NANO_IMAGE_URL]$(WINDOWS_2022_NANO_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_CORE_IMAGE_URL]$(WINDOWS_2022_CORE_IMAGE_URL)'
@@ -113,7 +110,6 @@ stages:
             echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D4s_v3'
             echo '##vso[task.setvariable variable=CONTAINER_RUNTIME]containerd'
             echo '##vso[task.setvariable variable=WINDOWS_SKU]2022-containerd-gen2'
-            echo '##vso[task.setvariable variable=VNET_RESOURCE_GROUP_NAME]vnet-2022-containerd-gen2-$(Build.BuildNumber)'
             echo '##vso[task.setvariable variable=WINDOWS_BASE_IMAGE_URL]$(WINDOWS_2022_GEN2_BASE_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_NANO_IMAGE_URL]$(WINDOWS_2022_NANO_IMAGE_URL)'
             echo '##vso[task.setvariable variable=WINDOWS_CORE_IMAGE_URL]$(WINDOWS_2022_CORE_IMAGE_URL)'

--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -394,7 +394,8 @@ cat <<EOF > vhdbuilder/packer/settings.json
   "windows_sigmode_source_image_name": "${windows_sigmode_source_image_name}",
   "windows_sigmode_source_image_version": "${windows_sigmode_source_image_version}",
   "vnet_name": "nodesig-pool-vnet",
-  "subnet_name": "packer"
+  "subnet_name": "packer",
+  "vnet_resource_group_name": "nodesigtest-agent-pool"
 }
 EOF
 

--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -36,35 +36,6 @@ if [ -z "$rg_id" ]; then
 	az group create --name $AZURE_RESOURCE_GROUP_NAME --location ${AZURE_LOCATION}
 fi
 
-if [ -n "${VNET_RESOURCE_GROUP_NAME}" ]; then
-	VIRTUAL_NETWORK_NAME="vnet"
-	VIRTUAL_NETWORK_SUBNET_NAME="subnet"
-	NETWORK_SECURITY_GROUP_NAME="nsg"
-
-	echo "creating resource group ${VNET_RESOURCE_GROUP_NAME}, location ${AZURE_LOCATION} for VNET"
-	az group create --name ${VNET_RESOURCE_GROUP_NAME} --location ${AZURE_LOCATION} \
-		--tags 'os=Windows' 'createdBy=aks-vhd-pipeline' 'SkipASMAzSecPack=True'
-
-	echo "creating new network security group ${NETWORK_SECURITY_GROUP_NAME}"
-	az network nsg create --name $NETWORK_SECURITY_GROUP_NAME --resource-group ${VNET_RESOURCE_GROUP_NAME} --location ${AZURE_LOCATION} \
-		--tags 'os=Windows' 'createdBy=aks-vhd-pipeline' 'SkipNRMSMgmt=13854625'
-	echo "creating nsg rule to allow WinRM with ssl"
-	az network nsg rule create --resource-group ${VNET_RESOURCE_GROUP_NAME} --nsg-name $NETWORK_SECURITY_GROUP_NAME -n AllowWinRM --priority 100 \
-		--source-address-prefixes '*' --source-port-ranges '*' \
-		--destination-address-prefixes '*' --destination-port-ranges 5986 --access Allow \
-		--protocol Tcp --description "Allow all inbound to WinRM with SSL 5986."
-	echo "creating default nsg rule to deny all internet inbound"
-	az network nsg rule create --resource-group ${VNET_RESOURCE_GROUP_NAME} --nsg-name $NETWORK_SECURITY_GROUP_NAME -n DenyAll --priority 4096 \
-		--source-address-prefixes '*' --source-port-ranges '*' \
-		--destination-address-prefixes '*' --destination-port-ranges '*' --access Deny \
-		--protocol '*' --description "Deny all inbound by default"
-
-	echo "creating new vnet ${VIRTUAL_NETWORK_NAME}, subnet ${VIRTUAL_NETWORK_SUBNET_NAME}"
-	az network vnet create --resource-group ${VNET_RESOURCE_GROUP_NAME} --name $VIRTUAL_NETWORK_NAME --address-prefix 10.0.0.0/16 \
-		--subnet-name $VIRTUAL_NETWORK_SUBNET_NAME --subnet-prefix 10.0.0.0/24 --network-security-group $NETWORK_SECURITY_GROUP_NAME \
-		--tags 'os=Windows' 'createdBy=aks-vhd-pipeline' 'SkipASMAzSecPack=True'
-fi
-
 avail=$(az storage account check-name -n ${STORAGE_ACCOUNT_NAME} -o json | jq -r .nameAvailable)
 if $avail ; then
 	echo "creating new storage account ${STORAGE_ACCOUNT_NAME}"

--- a/vhdbuilder/packer/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows-vhd-builder-sig.json
@@ -18,8 +18,9 @@
         "sig_gallery_name": "{{env `SIG_GALLERY_NAME`}}",
         "sig_image_name": "{{env `SIG_IMAGE_NAME`}}",
         "sig_image_version": "{{env `SIG_IMAGE_VERSION`}}",
-        "vnet_resource_group_name": "{{env `VNET_RESOURCE_GROUP_NAME`}}",
-        "windows_patch_url": "{{env `WINDOWS_PATCH_URL`}}"
+        "windows_patch_url": "{{env `WINDOWS_PATCH_URL`}}",
+        "vnet_name": "{{env `VNET_NAME`}}",
+        "subnet_name": "{{env `SUBNET_NAME`}}"
     },
     "builders": [
         {
@@ -67,10 +68,9 @@
                 "createdBy": "aks-vhd-pipeline",
                 "SkipASMAzSecPack": "True"
             },
-            "virtual_network_resource_group_name": "{{user `vnet_resource_group_name`}}",
-            "virtual_network_name": "vnet",
-            "virtual_network_subnet_name": "subnet",
-            "private_virtual_network_with_public_ip": "true"
+            "virtual_network_resource_group_name": "nodesigtest-agent-pool",
+            "virtual_network_name": "{{user `vnet_name`}}",
+            "virtual_network_subnet_name": "{{user `subnet_name`}}"
         }
     ],
     "provisioners": [

--- a/vhdbuilder/packer/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows-vhd-builder-sig.json
@@ -20,7 +20,8 @@
         "sig_image_version": "{{env `SIG_IMAGE_VERSION`}}",
         "windows_patch_url": "{{env `WINDOWS_PATCH_URL`}}",
         "vnet_name": "{{env `VNET_NAME`}}",
-        "subnet_name": "{{env `SUBNET_NAME`}}"
+        "subnet_name": "{{env `SUBNET_NAME`}}",
+        "vnet_resource_group_name": "{{env `VNET_RESOURCE_GROUP_NAME`}}"
     },
     "builders": [
         {
@@ -68,7 +69,7 @@
                 "createdBy": "aks-vhd-pipeline",
                 "SkipASMAzSecPack": "True"
             },
-            "virtual_network_resource_group_name": "nodesigtest-agent-pool",
+            "virtual_network_resource_group_name": "{{user `vnet_resource_group_name`}}",
             "virtual_network_name": "{{user `vnet_name`}}",
             "virtual_network_subnet_name": "{{user `subnet_name`}}"
         }

--- a/vhdbuilder/packer/windows-vhd-builder.json
+++ b/vhdbuilder/packer/windows-vhd-builder.json
@@ -17,7 +17,8 @@
         "windows_image_version": "{{env `WINDOWS_IMAGE_VERSION`}}",
         "windows_patch_url": "{{env `WINDOWS_PATCH_URL`}}",
         "vnet_name": "{{env `VNET_NAME`}}",
-        "subnet_name": "{{env `SUBNET_NAME`}}"
+        "subnet_name": "{{env `SUBNET_NAME`}}",
+        "vnet_resource_group_name": "{{env `VNET_RESOURCE_GROUP_NAME`}}"
     },
     "builders": [
         {
@@ -50,7 +51,7 @@
                 "createdBy": "aks-vhd-pipeline",
                 "SkipASMAzSecPack": "True"
             },
-            "virtual_network_resource_group_name": "nodesigtest-agent-pool",
+            "virtual_network_resource_group_name": "{{user `vnet_resource_group_name`}}",
             "virtual_network_name": "{{user `vnet_name`}}",
             "virtual_network_subnet_name": "{{user `subnet_name`}}"
         }

--- a/vhdbuilder/packer/windows-vhd-builder.json
+++ b/vhdbuilder/packer/windows-vhd-builder.json
@@ -15,8 +15,9 @@
         "vm_size": "{{env `AZURE_VM_SIZE`}}",
         "windows_image_sku": "{{env `WINDOWS_IMAGE_SKU`}}",
         "windows_image_version": "{{env `WINDOWS_IMAGE_VERSION`}}",
-        "vnet_resource_group_name": "{{env `VNET_RESOURCE_GROUP_NAME`}}",
-        "windows_patch_url": "{{env `WINDOWS_PATCH_URL`}}"
+        "windows_patch_url": "{{env `WINDOWS_PATCH_URL`}}",
+        "vnet_name": "{{env `VNET_NAME`}}",
+        "subnet_name": "{{env `SUBNET_NAME`}}"
     },
     "builders": [
         {
@@ -49,10 +50,9 @@
                 "createdBy": "aks-vhd-pipeline",
                 "SkipASMAzSecPack": "True"
             },
-            "virtual_network_resource_group_name": "{{user `vnet_resource_group_name`}}",
-            "virtual_network_name": "vnet",
-            "virtual_network_subnet_name": "subnet",
-            "private_virtual_network_with_public_ip": "true"
+            "virtual_network_resource_group_name": "nodesigtest-agent-pool",
+            "virtual_network_name": "{{user `vnet_name`}}",
+            "virtual_network_subnet_name": "{{user `subnet_name`}}"
         }
     ],
     "provisioners": [


### PR DESCRIPTION
**What type of PR is this?**
/kind improvement

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Use self-created 1es hosted pools to build windows vhd so that we do not need to create security exception to expose WinRM port 5986 in the sub “AKS VHD Image Release”

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
