### PR TITLE
fix undesired sig versions/galleries cleanup in backfill deletion

### DIFF
--- a/vhdbuilder/packer/backfill-cleanup.sh
+++ b/vhdbuilder/packer/backfill-cleanup.sh
@@ -55,7 +55,6 @@ if [[ -n "${AZURE_RESOURCE_GROUP_NAME}" ]]; then
         echo "Finding sig image versions associated with ${image_definition} in gallery ${gallery}"
         old_image_versions=$(az sig image-version list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${gallery} -i ${image_definition} | jq --arg dl $deadline -r '.[] | select(.tags.now < $dl).name')
         for old_image_version in $old_image_versions; do
-            az sig image-version show -e $old_image_version -i ${image_definition} -r ${gallery} -g ${AZURE_RESOURCE_GROUP_NAME} | jq .id
             echo "Deleting sig image-version ${old_image_version} ${image_definition} from gallery ${gallery} rg ${AZURE_RESOURCE_GROUP_NAME}"
             az sig image-version delete -e $old_image_version -i ${image_definition} -r ${gallery} -g ${AZURE_RESOURCE_GROUP_NAME}
         done

--- a/vhdbuilder/packer/backfill-cleanup.sh
+++ b/vhdbuilder/packer/backfill-cleanup.sh
@@ -53,15 +53,15 @@ if [[ -n "${AZURE_RESOURCE_GROUP_NAME}" ]]; then
     image_defs=$(az sig image-definition list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${gallery} | jq -r '.[] | select(.osType == "Windows").name')
     for image_definition in $image_defs; do
         echo "Finding sig image versions associated with ${image_definition} in gallery ${gallery}"
-        image_versions=$(az sig image-version list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${gallery} -i ${image_definition} | jq --arg dl $deadline -r '.[] | select(.tags.now < $dl).name')
-        for image_version in $image_versions; do
-            az sig image-version show -e $image_version -i ${image_definition} -r ${gallery} -g ${AZURE_RESOURCE_GROUP_NAME} | jq .id
-            echo "Deleting sig image-version ${image_version} ${image_definition} from gallery ${gallery} rg ${AZURE_RESOURCE_GROUP_NAME}"
-            az sig image-version delete -e $image_version -i ${image_definition} -r ${gallery} -g ${AZURE_RESOURCE_GROUP_NAME}
+        old_image_versions=$(az sig image-version list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${gallery} -i ${image_definition} | jq --arg dl $deadline -r '.[] | select(.tags.now < $dl).name')
+        for old_image_version in $old_image_versions; do
+            az sig image-version show -e $old_image_version -i ${image_definition} -r ${gallery} -g ${AZURE_RESOURCE_GROUP_NAME} | jq .id
+            echo "Deleting sig image-version ${old_image_version} ${image_definition} from gallery ${gallery} rg ${AZURE_RESOURCE_GROUP_NAME}"
+            az sig image-version delete -e $old_image_version -i ${image_definition} -r ${gallery} -g ${AZURE_RESOURCE_GROUP_NAME}
         done
-        image_versions=$(az sig image-version list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${gallery} -i ${image_definition})
-        # clean the image-definition if ALL associated sig versions have been deleted
-        if [[ "$image_versions" == "[]" ]]; then
+        cur_image_versions=$(az sig image-version list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${gallery} -i ${image_definition})
+        # clean the image-definition if the current image versions are empty after cleaning older ones provided they exist
+        if [[ -n "${old_image_versions}" ]] && [[ "${cur_image_versions}" == "[]" ]]; then
           echo "Deleting sig image-definition ${image_definition} from gallery ${gallery} rg ${AZURE_RESOURCE_GROUP_NAME}"
           az sig image-definition delete --gallery-image-definition ${image_definition} -r ${gallery} -g ${AZURE_RESOURCE_GROUP_NAME}
         fi

--- a/vhdbuilder/packer/backfill-cleanup.sh
+++ b/vhdbuilder/packer/backfill-cleanup.sh
@@ -60,7 +60,10 @@ if [[ -n "${AZURE_RESOURCE_GROUP_NAME}" ]]; then
     else
       continue
     fi
+
     due_date=$(date +%y%m%d -d "7 days ago")
+    echo "create_date is ${create_date}"
+    echo "due_date is ${due_date}"
     # clean the entire SIG resources if it's one week ago
     if [[ $create_date < $due_date ]]; then
       echo "Deleting gallery ${gallery}"

--- a/vhdbuilder/packer/backfill-cleanup.sh
+++ b/vhdbuilder/packer/backfill-cleanup.sh
@@ -66,11 +66,28 @@ if [[ -n "${AZURE_RESOURCE_GROUP_NAME}" ]]; then
     echo "due_date is ${due_date}"
     # clean the entire SIG resources if it's one week ago
     if [[ $create_date < $due_date ]]; then
-      echo "Deleting gallery ${gallery}"
-      az sig delete --gallery-name ${gallery} --resource-group ${AZURE_RESOURCE_GROUP_NAME}
+      echo "Finding sig image definitions from gallery ${gallery}"
       image_defs=$(az sig image-definition list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${gallery} | jq -r '.[] | select(.osType == "Windows").name')
-      if [[ -n "${image_defs}" ]]; then 
-        echo "Still having SIG image-definitions"
+      for image_definition in $image_defs; do
+          echo "Finding sig image versions associated with ${image_definition} in gallery ${gallery}"
+          image_versions=$(az sig image-version list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${gallery} -i ${image_definition} | jq -r '.[].name')
+          for image_version in $image_versions; do
+              echo "Deleting sig image-version ${image_version} ${image_definition} from gallery ${gallery} rg ${AZURE_RESOURCE_GROUP_NAME}"
+              az sig image-version delete -e $image_version -i ${image_definition} -r ${gallery} -g ${AZURE_RESOURCE_GROUP_NAME}
+          done
+          image_versions=$(az sig image-version list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${gallery} -i ${image_definition} | jq -r '.[].name')
+          echo "image versions are $image_versions"
+          if [[ -z "${image_versions}" ]]; then
+            echo "Deleting sig image-definition ${image_definition} from gallery ${gallery} rg ${AZURE_RESOURCE_GROUP_NAME}"
+            az sig image-definition delete --gallery-image-definition ${image_definition} -r ${gallery} -g ${AZURE_RESOURCE_GROUP_NAME}
+          fi
+      done
+      image_defs=$(az sig image-definition list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${gallery} | jq -r '.[] | select(.osType == "Windows").name')
+
+      # clean the gallery if ALL sig image-definitions have been deleted
+      if [[ -z $image_defs ]]; then
+        echo "Deleting gallery ${gallery}"
+        az sig delete --gallery-name ${gallery} --resource-group ${AZURE_RESOURCE_GROUP_NAME}
       fi
     fi
   done

--- a/vhdbuilder/packer/backfill-cleanup.sh
+++ b/vhdbuilder/packer/backfill-cleanup.sh
@@ -84,11 +84,12 @@ if [[ -n "${AZURE_RESOURCE_GROUP_NAME}" ]]; then
       done
       image_defs=$(az sig image-definition list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${gallery} | jq -r '.[] | select(.osType == "Windows").name')
 
-      # clean the gallery if ALL sig image-definitions have been deleted
-      if [[ -z $image_defs ]]; then
-        echo "Deleting gallery ${gallery}"
-        az sig delete --gallery-name ${gallery} --resource-group ${AZURE_RESOURCE_GROUP_NAME}
+      if [[ -n $image_defs ]]; then
+        echo $image_defs
       fi
+      
+      echo "Deleting gallery ${gallery}"
+      az sig delete --gallery-name ${gallery} --resource-group ${AZURE_RESOURCE_GROUP_NAME}
     fi
   done
 fi

--- a/vhdbuilder/packer/backfill-cleanup.sh
+++ b/vhdbuilder/packer/backfill-cleanup.sh
@@ -51,12 +51,12 @@ if [[ -n "${AZURE_RESOURCE_GROUP_NAME}" ]]; then
   for gallery in $gallery_list; do
     if [[ "${gallery}" =~ WS2019Gallery* ]]; then
       create_date=${gallery:13:6}
-    elif [[ "${gallery_name}" =~ WS2019_containerdGallery* ]]; then
-      create_date=${gallery_name:24:6}
-    elif [[ "${gallery_name}" =~ WS2022_containerdGallery* ]]; then
-      create_date=${gallery_name:24:6}
-    elif [[ "${gallery_name}" =~ WS2022_containerd_gen2Gallery* ]]; then
-      create_date=${gallery_name:29:6}
+    elif [[ "${gallery}" =~ WS2019_containerdGallery* ]]; then
+      create_date=${gallery:24:6}
+    elif [[ "${gallery}" =~ WS2022_containerdGallery* ]]; then
+      create_date=${gallery:24:6}
+    elif [[ "${gallery}" =~ WS2022_containerd_gen2Gallery* ]]; then
+      create_date=${gallery:29:6}
     else
       continue
     fi

--- a/vhdbuilder/packer/backfill-cleanup.sh
+++ b/vhdbuilder/packer/backfill-cleanup.sh
@@ -50,13 +50,13 @@ if [[ -n "${AZURE_RESOURCE_GROUP_NAME}" ]]; then
   gallery_list=$(az sig list -g ${AZURE_RESOURCE_GROUP_NAME} | jq -r '.[] | select(.name != "AKSWindows") | .name')
   for gallery in $gallery_list; do
     if [[ "${gallery}" =~ WS2019Gallery* ]]; then
-      create_date=${gallery:13:12}
+      create_date=${gallery:13:6}
     elif [[ "${gallery_name}" =~ WS2019_containerdGallery* ]]; then
-      create_date=${gallery_name:24:12}
+      create_date=${gallery_name:24:6}
     elif [[ "${gallery_name}" =~ WS2022_containerdGallery* ]]; then
-      create_date=${gallery_name:24:12}
+      create_date=${gallery_name:24:6}
     elif [[ "${gallery_name}" =~ WS2022_containerd_gen2Gallery* ]]; then
-      create_date=${gallery_name:29:12}
+      create_date=${gallery_name:29:6}
     else
       continue
     fi


### PR DESCRIPTION
**What type of PR is this?**
Fix the following issue

- backfill deletion step tries to free a sig image-def/gallery that is being used.

- This might happen when the current pipeline build creates a sig gallery & image-def but has not yet created a sig version (sig version would be empty). Or better yet, say there's another concurrent pipeline build just created a sig gallery & image def w/o attaching any sig versions.

Need to add some sort of check to see if the image def has older sig versions and if they can be reduced. If that's the case, the sig image-def can then be safely removed, hence the same about the sig gallery. o.w. we shouldn't delete the sig version => delete the sig image-def => delete the sig gallery if that makes sense.

/kind fix

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
fix the backfill deletion step

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
check build results of parallel-running pipelines (_pipeline that stay roughly close in start time_)

**Release note**:
```
none
```
