### PR TITLE
fix: Add containerd service file to Mariner

### DIFF
--- a/parts/linux/cloud-init/artifacts/containerd.service
+++ b/parts/linux/cloud-init/artifacts/containerd.service
@@ -1,0 +1,22 @@
+# Explicitly configure containerd systemd service on Mariner AKS to maintain consistent
+# settings with the containerd.service file previously deployed during cloud-init.
+# Additionally set LimitNOFILE to the exact value "infinity" means on Ubuntu, eg "1048576".
+[Unit]
+Description=containerd daemon
+After=network.target
+[Service]
+ExecStartPre=/sbin/modprobe overlay
+ExecStart=/usr/bin/containerd
+Delegate=yes
+KillMode=process
+Restart=always
+# Explicitly set OOMScoreAdjust to make containerd unlikely to be oom killed
+OOMScoreAdjust=-999
+# Explicitly set LimitNOFILE to match what infinity means on Ubuntu AKS
+LimitNOFILE=1048576
+# Explicitly set LimitCORE, LimitNPROC, and TasksMax to infinity to match Ubuntu AKS
+LimitCORE=infinity
+TasksMax=infinity
+LimitNPROC=infinity
+[Install]
+WantedBy=multi-user.target

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -21,6 +21,7 @@
 // linux/cloud-init/artifacts/cis.sh
 // linux/cloud-init/artifacts/containerd-monitor.service
 // linux/cloud-init/artifacts/containerd-monitor.timer
+// linux/cloud-init/artifacts/containerd.service
 // linux/cloud-init/artifacts/containerd_exec_start.conf
 // linux/cloud-init/artifacts/crictl.yaml
 // linux/cloud-init/artifacts/cse_cmd.sh
@@ -774,6 +775,45 @@ func linuxCloudInitArtifactsContainerdMonitorTimer() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "linux/cloud-init/artifacts/containerd-monitor.timer", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _linuxCloudInitArtifactsContainerdService = []byte(`# Explicitly configure containerd systemd service on Mariner AKS to maintain consistent
+# settings with the containerd.service file previously deployed during cloud-init.
+# Additionally set LimitNOFILE to the exact value "infinity" means on Ubuntu, eg "1048576".
+[Unit]
+Description=containerd daemon
+After=network.target
+[Service]
+ExecStartPre=/sbin/modprobe overlay
+ExecStart=/usr/bin/containerd
+Delegate=yes
+KillMode=process
+Restart=always
+# Explicitly set OOMScoreAdjust to make containerd unlikely to be oom killed
+OOMScoreAdjust=-999
+# Explicitly set LimitNOFILE to match what infinity means on Ubuntu AKS
+LimitNOFILE=1048576
+# Explicitly set LimitCORE, LimitNPROC, and TasksMax to infinity to match Ubuntu AKS
+LimitCORE=infinity
+TasksMax=infinity
+LimitNPROC=infinity
+[Install]
+WantedBy=multi-user.target
+`)
+
+func linuxCloudInitArtifactsContainerdServiceBytes() ([]byte, error) {
+	return _linuxCloudInitArtifactsContainerdService, nil
+}
+
+func linuxCloudInitArtifactsContainerdService() (*asset, error) {
+	bytes, err := linuxCloudInitArtifactsContainerdServiceBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "linux/cloud-init/artifacts/containerd.service", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7354,6 +7394,7 @@ var _bindata = map[string]func() (*asset, error){
 	"linux/cloud-init/artifacts/cis.sh":                                    linuxCloudInitArtifactsCisSh,
 	"linux/cloud-init/artifacts/containerd-monitor.service":                linuxCloudInitArtifactsContainerdMonitorService,
 	"linux/cloud-init/artifacts/containerd-monitor.timer":                  linuxCloudInitArtifactsContainerdMonitorTimer,
+	"linux/cloud-init/artifacts/containerd.service":                        linuxCloudInitArtifactsContainerdService,
 	"linux/cloud-init/artifacts/containerd_exec_start.conf":                linuxCloudInitArtifactsContainerd_exec_startConf,
 	"linux/cloud-init/artifacts/crictl.yaml":                               linuxCloudInitArtifactsCrictlYaml,
 	"linux/cloud-init/artifacts/cse_cmd.sh":                                linuxCloudInitArtifactsCse_cmdSh,
@@ -7488,6 +7529,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"cis.sh":                                    &bintree{linuxCloudInitArtifactsCisSh, map[string]*bintree{}},
 				"containerd-monitor.service":                &bintree{linuxCloudInitArtifactsContainerdMonitorService, map[string]*bintree{}},
 				"containerd-monitor.timer":                  &bintree{linuxCloudInitArtifactsContainerdMonitorTimer, map[string]*bintree{}},
+				"containerd.service":                        &bintree{linuxCloudInitArtifactsContainerdService, map[string]*bintree{}},
 				"containerd_exec_start.conf":                &bintree{linuxCloudInitArtifactsContainerd_exec_startConf, map[string]*bintree{}},
 				"crictl.yaml":                               &bintree{linuxCloudInitArtifactsCrictlYaml, map[string]*bintree{}},
 				"cse_cmd.sh":                                &bintree{linuxCloudInitArtifactsCse_cmdSh, map[string]*bintree{}},

--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -43,6 +43,8 @@ copyPackerFiles() {
   CONTAINERD_MONITOR_SERVICE_DEST=/etc/systemd/system/containerd-monitor.service
   CONTAINERD_MONITOR_TIMER_SRC=/home/packer/containerd-monitor.timer
   CONTAINERD_MONITOR_TIMER_DEST=/etc/systemd/system/containerd-monitor.timer
+  CONTAINERD_SERVICE_SRC=/home/packer/containerd.service
+  CONTAINERD_SERVICE_DEST=/etc/systemd/system/containerd.service
   DOCKER_CLEAR_MOUNT_PROPAGATION_FLAGS_SRC=/home/packer/docker_clear_mount_propagation_flags.conf
   DOCKER_CLEAR_MOUNT_PROPAGATION_FLAGS_DEST=/etc/systemd/system/docker.service.d/clear_mount_propagation_flags.conf
   IPV6_NFTABLES_RULES_SRC=/home/packer/ipv6_nftables
@@ -241,6 +243,9 @@ copyPackerFiles() {
     cpAndMode $DOCKER_MONITOR_TIMER_SRC $DOCKER_MONITOR_TIMER_DEST 644
     cpAndMode $DOCKER_CLEAR_MOUNT_PROPAGATION_FLAGS_SRC $DOCKER_CLEAR_MOUNT_PROPAGATION_FLAGS_DEST 644
     cpAndMode $NVIDIA_MODPROBE_SERVICE_SRC $NVIDIA_MODPROBE_SERVICE_DEST 644
+  fi
+  if [[ $OS == $MARINER_OS_NAME ]]; then
+    cpAndMode $CONTAINERD_SERVICE_SRC $CONTAINERD_SERVICE_DEST 644
   fi
   if grep -q "fullgpu" <<< "$FEATURE_FLAGS"; then
     cpAndMode $NVIDIA_DOCKER_DAEMON_SRC $NVIDIA_DOCKER_DAEMON_DEST 644

--- a/vhdbuilder/packer/vhd-image-builder-mariner-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-gen2.json
@@ -426,6 +426,11 @@
     },
     {
       "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/containerd.service",
+      "destination": "/home/packer/containerd.service"
+    },
+    {
+      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/pam-d-common-auth",
       "destination": "/home/packer/pam-d-common-auth"
     },

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -430,6 +430,11 @@
     },
     {
       "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/containerd.service",
+      "destination": "/home/packer/containerd.service"
+    },
+    {
+      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/pam-d-common-auth",
       "destination": "/home/packer/pam-d-common-auth"
     },

--- a/vhdbuilder/packer/vhd-image-builder-mariner2-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner2-arm64.json
@@ -431,6 +431,11 @@
     },
     {
       "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/containerd.service",
+      "destination": "/home/packer/containerd.service"
+    },
+    {
+      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/pam-d-common-auth",
       "destination": "/home/packer/pam-d-common-auth"
     },

--- a/vhdbuilder/packer/vhd-image-builder-mariner2-gen2-kata.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner2-gen2-kata.json
@@ -437,6 +437,11 @@
     },
     {
       "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/containerd.service",
+      "destination": "/home/packer/containerd.service"
+    },
+    {
+      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/pam-d-common-auth",
       "destination": "/home/packer/pam-d-common-auth"
     },

--- a/vhdbuilder/packer/vhd-image-builder-mariner2-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner2-gen2.json
@@ -437,6 +437,11 @@
     },
     {
       "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/containerd.service",
+      "destination": "/home/packer/containerd.service"
+    },
+    {
+      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/pam-d-common-auth",
       "destination": "/home/packer/pam-d-common-auth"
     },


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Explicitly provide a containerd.service file customized for AKS in the VHD build for Mariner so that cloud-init does not need to deliver it.

This config also explicitly sets LimitNOFILE=1048576. This is because LimitNOFILE=infinity on Mariner means 1073741816, which has caused issues running some software in containers such as mysql5 and sshd. The value 1048576 matches the behavior on the Ubuntu AKS host.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
