### PR TITLE
fix: Wrong echo of Hyper-v generation in the Windows VHD build pipeline

### DIFF
--- a/packer.mk
+++ b/packer.mk
@@ -66,13 +66,13 @@ endif
 build-packer-windows:
 ifeq (${MODE},windowsVhdMode)
 ifeq (${SIG_FOR_PRODUCTION},True)
-ifeq (${HYPERV_GENRATION},V1)
+ifeq (${HYPERV_GENERATION},V1)
 	@echo "${MODE}: Building with Hyper-v generation 1 VM and save to Classic Storage Account"
 else
 	@echo "${MODE}: Building with Hyper-v generation 2 VM and save to Classic Storage Account"
 endif
 else
-ifeq (${HYPERV_GENRATION},V1)
+ifeq (${HYPERV_GENERATION},V1)
 	@echo "${MODE}: Building with Hyper-v generation 1 VM and save to Shared Image Gallery"
 else
 	@echo "${MODE}: Building with Hyper-v generation 2 VM and save to Shared Image Gallery"


### PR DESCRIPTION
**What type of PR is this?**
fix the wrong echo output of windowsvhdmode
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
`HYPERV_GENRATION` was incorrectly used in `packer.mk`. Output was always `Building with Hyper-v generation 2 VM and save to .....`

**Which issue(s) this PR fixes**:
Should use `HYPERV_GENERATION`.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
It does not affect the packer build. It's just an echo output typo.

**Release note**:
```
none
```
