### PR TITLE
feat: Log DNS servers in Windows CSE script

### DIFF
--- a/staging/cse/windows/azurecnifunc.ps1
+++ b/staging/cse/windows/azurecnifunc.ps1
@@ -408,6 +408,14 @@ function New-ExternalHnsNetwork
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_MANAGEMENT_IP_NOT_EXIST -ErrorMessage "Failed to find $managementIP after creating $externalNetwork network"
     }
     Write-Log "It took $($StopWatch.Elapsed.Seconds) seconds to create the $externalNetwork network."
+
+    Write-Log "Log network adapter info after creating $externalNetwork network"
+    Get-NetIPConfiguration -AllCompartments -ErrorAction Ignore
+
+    $dnsServers=Get-DnsClientServerAddress -ErrorAction Ignore
+    if ($dnsServers) {
+        Write-Log "DNS Servers are: $($dnsServers.ServerAddresses)"
+    }
 }
 
 function Get-HnsPsm1


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Log DNS servers in Windows CSE script

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
You can find the cse logs in https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=70062277&view=artifacts&pathAsName=false&type=publishedArtifacts
```
2023-03-14T08:09:10.2567712+00:00: It took 6 seconds to create the ext network.
2023-03-14T08:09:10.2567712+00:00: Log network adapter info after creating ext network
ComputerName         : winj53ma000000
InterfaceAlias       : vEthernet (Ethernet 2)
InterfaceIndex       : 9
InterfaceDescription : Hyper-V Virtual Ethernet Adapter
CompartmentId        : 1
NetAdapter           : MSFT_NetAdapter (CreationClassName = "MSFT_NetAdapter", DeviceID = 
                       "{0FBC1F80-70F4-4E19-BA6D-BAB0FFE16C6E}", SystemCreationClassName = "CIM_NetworkPort", 
                       SystemName = "winj53ma000000")
NetCompartment       : MSFT_NetCompartment (InstanceID = ";55;")
NetIPv6Interface     : MSFT_NetIPInterface (Name = "C55??55;", CreationClassName = "", SystemCreationClassName = "", 
                       SystemName = "")
NetIPv4Interface     : MSFT_NetIPInterface (Name = "C55?55;", CreationClassName = "", SystemCreationClassName = "", 
                       SystemName = "")
NetProfile           : MSFT_NetConnectionProfile (InstanceID = "{0FBC1F80-70F4-4E19-BA6D-BAB0FFE16C6E}")
AllIPAddresses       : {10.224.0.64, fe80::e40f:2fe9:43b2:c3d1%9}
IPv6Address          : {}
IPv6TemporaryAddress : {}
IPv6LinkLocalAddress : {fe80::e40f:2fe9:43b2:c3d1%9}
IPv4Address          : {10.224.0.64}
IPv6DefaultGateway   : 
IPv4DefaultGateway   : {MSFT_NetRoute (InstanceID = ":8:8:8:9:55C55;:8???8:8;55;")}
DNSServer            : {MSFT_DNSClientServerAddress (Name = "9", CreationClassName = "", SystemCreationClassName = "", 
                       SystemName = "23"), MSFT_DNSClientServerAddress (Name = "9", CreationClassName = "", 
                       SystemCreationClassName = "", SystemName = "2")}
Detailed             : False

2023-03-14T08:09:13.0725318+00:00: DNS Servers are: 168.63.129.16 fec0:0:0:ffff::1 fec0:0:0:ffff::2 fec0:0:0:ffff::3
```

**Release note**:
```
none
```
