### PR TITLE
test: use correct resource group name for vmss cleanup

### DIFF
--- a/e2e/nsenter.go
+++ b/e2e/nsenter.go
@@ -30,7 +30,7 @@ const (
 	listVMSSNetworkInterfaceURLTemplate = "https://management.azure.com/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%d/networkInterfaces?api-version=2018-10-01"
 )
 
-func extractLogsFromVM(ctx context.Context, t *testing.T, cloud *azureClient, kube *kubeclient, subscription, resourceGroupName, clusterName, vmssName, sshPrivateKey string) (map[string]string, error) {
+func extractLogsFromVM(ctx context.Context, t *testing.T, cloud *azureClient, kube *kubeclient, subscription, vmssName, sshPrivateKey string) (map[string]string, error) {
 	pl := cloud.coreClient.Pipeline()
 	url := fmt.Sprintf(listVMSSNetworkInterfaceURLTemplate,
 		subscription,
@@ -206,7 +206,7 @@ func ensureDebugDaemonset(ctx context.Context, kube *kubeclient, resourceGroupNa
 	return nil
 }
 
-func ensureTestNginxpod(ctx context.Context, kube *kubeclient, nodeName string) error {
+func ensureTestNginxPod(ctx context.Context, kube *kubeclient, nodeName string) error {
 	manifest := getNginxPodTemplate(nodeName)
 	var obj corev1.Pod
 

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -80,15 +80,19 @@ func Test_All(t *testing.T) {
 			t.Logf("vmss name: %q", vmssName)
 
 			cleanup := func() {
+				t.Log("deleting vmss", vmssName)
 				poller, err := cloud.vmssClient.BeginDelete(ctx, suiteConfig.resourceGroupName, vmssName, nil)
 				if err != nil {
+					t.Log("error deleting vmss", vmssName)
 					t.Error(err)
 					return
 				}
 				_, err = poller.PollUntilDone(ctx, nil)
 				if err != nil {
+					t.Log("error polling deleting vmss", vmssName)
 					t.Error(err)
 				}
+				t.Log("finished deleting vmss", vmssName)
 			}
 
 			defer cleanup()
@@ -100,8 +104,10 @@ func Test_All(t *testing.T) {
 			}
 
 			debug := func() {
-				_, err = extractLogsFromVM(ctx, t, cloud, kube, suiteConfig.subscription, suiteConfig.resourceGroupName, suiteConfig.clusterName, vmssName, string(sshPrivateKeyBytes))
+				t.Log(" extracting logs")
+				_, err = extractLogsFromVM(ctx, t, cloud, kube, suiteConfig.subscription, vmssName, string(sshPrivateKeyBytes))
 				if err != nil {
+					t.Log("error extracting logs")
 					t.Error(err)
 				}
 			}
@@ -109,17 +115,20 @@ func Test_All(t *testing.T) {
 
 			nodeName, err := waitUntilNodeReady(ctx, kube, vmssName)
 			if err != nil {
+				t.Log("error waiting for node ready")
 				t.Fatal(err)
 				return
 			}
 
-			err = ensureTestNginxpod(ctx, kube, nodeName)
+			err = ensureTestNginxPod(ctx, kube, nodeName)
 			if err != nil {
+				t.Log("error waiting for pod ready")
 				t.Fatal(err)
 			}
 
 			err = ensurePodDeleted(ctx, kube, nodeName)
 			if err != nil {
+				t.Log("error waiting for pod deleted")
 				t.Error(err)
 			}
 		})


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
