### PR TITLE
fix cluster recreation logic

### DIFF
--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -6,30 +6,64 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 )
 
 func setupCluster(ctx context.Context, cloud *azureClient, location, resourceGroupName, clusterName string) error {
-	aksCluster, err := cloud.aksClient.Get(ctx, resourceGroupName, clusterName, nil)
+	var needNewCluster bool
+
+	rgExistence, err := cloud.resourceGroupClient.CheckExistence(ctx, resourceGroupName, nil)
 	if err != nil {
-		return fmt.Errorf("failed to get aks cluster: %q", err)
+		return fmt.Errorf("failed to get AB E2E RG %q: %q", resourceGroupName, err)
 	}
 
-	rgExistence, err := cloud.resourceGroupClient.CheckExistence(ctx, agentbakerTestResourceGroupName, nil)
-	if err != nil {
-		return fmt.Errorf("failed to get MC RG: %q", err)
+	if !rgExistence.Success {
+		needNewCluster = true
+		_, err := cloud.resourceGroupClient.CreateOrUpdate(
+			ctx,
+			resourceGroupName,
+			armresources.ResourceGroup{
+				Location: to.Ptr("eastus"),
+				Name:     to.Ptr(resourceGroupName),
+			},
+			nil)
+
+		if err != nil {
+			return fmt.Errorf("failed to create AB E2E RG %q: %q", resourceGroupName, err)
+		}
 	}
 
-	if !rgExistence.Success || aksCluster.Properties == nil || aksCluster.Properties.ProvisioningState == nil || *aksCluster.Properties.ProvisioningState == "Failed" {
-		poller, err := cloud.aksClient.BeginDelete(ctx, resourceGroupName, clusterName, nil)
+	if !needNewCluster {
+		aksCluster, err := cloud.aksClient.Get(ctx, resourceGroupName, clusterName, nil)
 		if err != nil {
-			return fmt.Errorf("failed to start aks cluster deletion: %q", err)
+			if !isResourceNotFoundError(err) {
+				return fmt.Errorf("failed to get aks cluster %q: %q", clusterName, err)
+			}
+			needNewCluster = true
 		}
 
-		_, err = poller.PollUntilDone(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("failed to wait for aks cluster deletion: %q", err)
-		}
+		if !needNewCluster {
+			rgExistence, err := cloud.resourceGroupClient.CheckExistence(ctx, agentbakerTestClusterMCResourceGroupName, nil)
+			if err != nil {
+				return fmt.Errorf("failed to get test cluster MC RG %q: %q", agentbakerTestClusterMCResourceGroupName, err)
+			}
 
+			if !rgExistence.Success || aksCluster.Properties == nil || aksCluster.Properties.ProvisioningState == nil || *aksCluster.Properties.ProvisioningState == "Failed" {
+				needNewCluster = true
+				poller, err := cloud.aksClient.BeginDelete(ctx, resourceGroupName, clusterName, nil)
+				if err != nil {
+					return fmt.Errorf("failed to start aks cluster %q deletion: %q", clusterName, err)
+				}
+
+				_, err = poller.PollUntilDone(ctx, nil)
+				if err != nil {
+					return fmt.Errorf("failed to wait for aks cluster %q deletion: %q", clusterName, err)
+				}
+			}
+		}
+	}
+
+	if needNewCluster {
 		pollerResp, err := cloud.aksClient.BeginCreateOrUpdate(
 			ctx,
 			resourceGroupName,
@@ -44,8 +78,6 @@ func setupCluster(ctx context.Context, cloud *azureClient, location, resourceGro
 							Count:        to.Ptr[int32](1),
 							VMSize:       to.Ptr("Standard_DS2_v2"),
 							MaxPods:      to.Ptr[int32](110),
-							MinCount:     to.Ptr[int32](1),
-							MaxCount:     to.Ptr[int32](100),
 							OSType:       to.Ptr(armcontainerservice.OSTypeLinux),
 							Type:         to.Ptr(armcontainerservice.AgentPoolTypeVirtualMachineScaleSets),
 							Mode:         to.Ptr(armcontainerservice.AgentPoolModeSystem),
@@ -55,6 +87,9 @@ func setupCluster(ctx context.Context, cloud *azureClient, location, resourceGro
 					NetworkProfile: &armcontainerservice.NetworkProfile{
 						NetworkPlugin: to.Ptr(armcontainerservice.NetworkPluginKubenet),
 					},
+				},
+				Identity: &armcontainerservice.ManagedClusterIdentity{
+					Type: to.Ptr(armcontainerservice.ResourceIdentityType("SystemAssigned")),
 				},
 			},
 			nil,
@@ -74,7 +109,7 @@ func setupCluster(ctx context.Context, cloud *azureClient, location, resourceGro
 }
 
 func getClusterSubnetID(ctx context.Context, cloud *azureClient, location, resourceGroupName, clusterName string) (string, error) {
-	pager := cloud.vnetClient.NewListPager(agentbakerTestResourceGroupName, nil)
+	pager := cloud.vnetClient.NewListPager(agentbakerTestClusterMCResourceGroupName, nil)
 
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/e2e/const.go
+++ b/e2e/const.go
@@ -1,7 +1,7 @@
 package e2e_test
 
 const (
-	agentbakerTestResourceGroupName = "MC_agentbaker-e2e-tests_agentbaker-e2e-test-cluster_eastus"
-	defaultAzureTokenScope          = "https://management.azure.com/.default"
-	defaultNamespace                = "default"
+	agentbakerTestClusterMCResourceGroupName = "MC_agentbaker-e2e-tests_agentbaker-e2e-test-cluster_eastus"
+	defaultAzureTokenScope                   = "https://management.azure.com/.default"
+	defaultNamespace                         = "default"
 )

--- a/e2e/errors.go
+++ b/e2e/errors.go
@@ -1,0 +1,20 @@
+package e2e_test
+
+import "strings"
+
+const (
+	vmExtensionProvisioningErrorCode = "VMExtensionProvisioningError"
+	resourceNotFoundErrorCode        = "ResourceNotFound"
+)
+
+func isVMExtensionProvisioningError(err error) bool {
+	return errorHasSubstring(err, vmExtensionProvisioningErrorCode)
+}
+
+func isResourceNotFoundError(err error) bool {
+	return errorHasSubstring(err, resourceNotFoundErrorCode)
+}
+
+func errorHasSubstring(err error, substring string) bool {
+	return err != nil && strings.Contains(err.Error(), substring)
+}

--- a/e2e/nsenter.go
+++ b/e2e/nsenter.go
@@ -33,7 +33,7 @@ func extractLogsFromVM(ctx context.Context, t *testing.T, cloud *azureClient, ku
 	pl := cloud.coreClient.Pipeline()
 	url := fmt.Sprintf(listVMSSNetworkInterfaceURLTemplate,
 		subscription,
-		agentbakerTestResourceGroupName,
+		agentbakerTestClusterMCResourceGroupName,
 		vmssName,
 		0,
 	)

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -96,7 +96,7 @@ func Test_All(t *testing.T) {
 
 			cleanupVMSS := func() {
 				t.Log("deleting vmss", vmssName)
-				poller, err := cloud.vmssClient.BeginDelete(ctx, agentbakerTestResourceGroupName, vmssName, nil)
+				poller, err := cloud.vmssClient.BeginDelete(ctx, agentbakerTestClusterMCResourceGroupName, vmssName, nil)
 				if err != nil {
 					t.Error("error deleting vmss", vmssName, err)
 					return

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -7,15 +7,10 @@ import (
 	"encoding/pem"
 	"fmt"
 	mrand "math/rand"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	"golang.org/x/crypto/ssh"
-)
-
-const (
-	vmExtensionProvisioningErrorCode = "VMExtensionProvisioningError"
 )
 
 // Returns a newly generated RSA public/private key pair with the private key in PEM format
@@ -62,7 +57,7 @@ func createVMSSWithPayload(ctx context.Context, publicKeyBytes []byte, cloud *az
 
 	pollerResp, err := cloud.vmssClient.BeginCreateOrUpdate(
 		ctx,
-		agentbakerTestResourceGroupName,
+		agentbakerTestClusterMCResourceGroupName,
 		name,
 		model,
 		nil,
@@ -167,8 +162,4 @@ func getBaseVMSSModel(name, location, subnetID, sshPublicKey, customData, cseCmd
 			},
 		},
 	}
-}
-
-func isVMExtensionProvisioningError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), vmExtensionProvisioningErrorCode)
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind regression
-->

**What this PR does / why we need it**:
Fixes cluster recreation logic within the new AB E2E go implementation. Specifically, the testing code will now create a new cluster if the 'agentbaker-e2e-test-cluster' in 'agentbaker-e2e-tests' RG does not already exist when the test is run. It will check for both RG and cluster existence to determine whether or not a new cluster needs to be created.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2916

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
