### PR TITLE
fix: Update Windows PauseImage to 3.9 in E2E test case

### DIFF
--- a/e2e/scenarios/windows/property-windows-template.json
+++ b/e2e/scenarios/windows/property-windows-template.json
@@ -69,7 +69,7 @@
         "windowsOffer": "aks-windows",
         "windowsPublisher": "microsoft-aks",
         "windowsSku": "",
-        "windowsPauseImageURL": "mcr.microsoft.com/oss/kubernetes/pause:3.6-hotfix.20220114",
+        "windowsPauseImageURL": "mcr.microsoft.com/oss/kubernetes/pause:3.9",
         "alwaysPullWindowsPauseImage": false
       }
     }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
We have updated Windows PauseImage to 3.9 in production so we need to update it in e2e too.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
