### PR TITLE
feat: specify the k8s version to support windows cse validation

### DIFF
--- a/.pipelines/templates/e2e-windows-template.yaml
+++ b/.pipelines/templates/e2e-windows-template.yaml
@@ -31,11 +31,17 @@ jobs:
         export WINDOWS_E2E_IMAGE=${{ parameters.windowsImage }}
         export WINDOWS_E2E_OSSKU=${{ parameters.windowsOSSKU }}
         export WINDOWS_E2E_VMSIZE=${{ parameters.windowsVMSize }}
-        export windowsPackageURL="https://acs-mirror.azureedge.net/kubernetes/v${KUBERNETES_VERSION}/windowszip/v${KUBERNETES_VERSION}-1int.zip"
-        if [[ -n "$WINDOWS_PACKAGE_URL" ]]; then
-          export windowsPackageURL="$WINDOWS_PACKAGE_URL"
+        if [[ -n "${WINDOWS_PACKAGE_URL}" ]]; then
+          export windowsPackageURL=$WINDOWS_PACKAGE_URL
+          export WINDOWS_PACKAGE_VERSION=$(echo $windowsPackageURL | grep -oP '(?<=/v)\d+\.\d+\.\d+' | head -1)
+          if [[ "${WINDOWS_PACKAGE_VERSION}" != "${KUBERNETES_VERSION}" ]]; then
+            echo "Windows package version $WINDOWS_PACKAGE_VERSION does not match with kubernetes version $KUBERNETES_VERSION. Invalid test scenario."
+            exit 1
+          fi
+        else
+          export windowsPackageURL="https://acs-mirror.azureedge.net/kubernetes/v${KUBERNETES_VERSION}/windowszip/v${KUBERNETES_VERSION}-1int.zip"
+          export WINDOWS_PACKAGE_VERSION=$KUBERNETES_VERSION
         fi
-        export WINDOWS_PACKAGE_VERSION=$(echo $windowsPackageURL | grep -oP '(?<=/v)\d+\.\d+\.\d+' | head -1)
         export K8S_VERSION=${WINDOWS_PACKAGE_VERSION//./}
         export WINDOWS_E2E_STORAGE_CONTAINER=${{ parameters.storageAccount }}-$K8S_VERSION
         mkdir -p $WINDOWS_E2E_IMAGE
@@ -77,11 +83,17 @@ jobs:
         export WINDOWS_E2E_IMAGE=${{ parameters.windowsImage }}
         export WINDOWS_DISTRO=${{ parameters.windowsDistro }}
         export WINDOWS_NODE_IMAGE_VERSION=${{ parameters.windowsNodeImageVersion }}
-        export windowsPackageURL="https://acs-mirror.azureedge.net/kubernetes/v${KUBERNETES_VERSION}/windowszip/v${KUBERNETES_VERSION}-1int.zip"
-        if [[ -n "$WINDOWS_PACKAGE_URL" ]]; then
-          export windowsPackageURL="$WINDOWS_PACKAGE_URL"
+        if [[ -n "${WINDOWS_PACKAGE_URL}" ]]; then
+          export windowsPackageURL=$WINDOWS_PACKAGE_URL
+          export WINDOWS_PACKAGE_VERSION=$(echo $windowsPackageURL | grep -oP '(?<=/v)\d+\.\d+\.\d+' | head -1)
+          if [[ "${WINDOWS_PACKAGE_VERSION}" != "${KUBERNETES_VERSION}" ]]; then
+            echo "Windows package version $WINDOWS_PACKAGE_VERSION does not match with kubernetes version $KUBERNETES_VERSION. Invalid test scenario."
+            exit 1
+          fi
+        else
+          export windowsPackageURL="https://acs-mirror.azureedge.net/kubernetes/v${KUBERNETES_VERSION}/windowszip/v${KUBERNETES_VERSION}-1int.zip"
+          export WINDOWS_PACKAGE_VERSION=$KUBERNETES_VERSION
         fi
-        export WINDOWS_PACKAGE_VERSION=$(echo $windowsPackageURL | grep -oP '(?<=/v)\d+\.\d+\.\d+' | head -1)
         export K8S_VERSION=${WINDOWS_PACKAGE_VERSION//./}
         mkdir -p $WINDOWS_E2E_IMAGE
         cp -a $(Pipeline.Workspace)/${{ parameters.windowsImage }}-clusterConfig/* $WINDOWS_E2E_IMAGE

--- a/.pipelines/templates/e2e-windows-template.yaml
+++ b/.pipelines/templates/e2e-windows-template.yaml
@@ -31,8 +31,13 @@ jobs:
         export WINDOWS_E2E_IMAGE=${{ parameters.windowsImage }}
         export WINDOWS_E2E_OSSKU=${{ parameters.windowsOSSKU }}
         export WINDOWS_E2E_VMSIZE=${{ parameters.windowsVMSize }}
-        K=${KUBERNETES_VERSION//./}
-        export WINDOWS_E2E_STORAGE_CONTAINER=${{ parameters.storageAccount }}-$K
+        export windowsPackageURL="https://acs-mirror.azureedge.net/kubernetes/v${KUBERNETES_VERSION}/windowszip/v${KUBERNETES_VERSION}-1int.zip"
+        if [[ -n "$WINDOWS_PACKAGE_URL" ]]; then
+          export windowsPackageURL="$WINDOWS_PACKAGE_URL"
+        fi
+        export WINDOWS_PACKAGE_VERSION=$(echo $windowsPackageURL | grep -oP '(?<=/v)\d+\.\d+\.\d+' | head -1)
+        export K8S_VERSION=${WINDOWS_PACKAGE_VERSION//./}
+        export WINDOWS_E2E_STORAGE_CONTAINER=${{ parameters.storageAccount }}-$K8S_VERSION
         mkdir -p $WINDOWS_E2E_IMAGE
         cp -r e2e/windows/* $WINDOWS_E2E_IMAGE
         go version
@@ -72,6 +77,12 @@ jobs:
         export WINDOWS_E2E_IMAGE=${{ parameters.windowsImage }}
         export WINDOWS_DISTRO=${{ parameters.windowsDistro }}
         export WINDOWS_NODE_IMAGE_VERSION=${{ parameters.windowsNodeImageVersion }}
+        export windowsPackageURL="https://acs-mirror.azureedge.net/kubernetes/v${KUBERNETES_VERSION}/windowszip/v${KUBERNETES_VERSION}-1int.zip"
+        if [[ -n "$WINDOWS_PACKAGE_URL" ]]; then
+          export windowsPackageURL="$WINDOWS_PACKAGE_URL"
+        fi
+        export WINDOWS_PACKAGE_VERSION=$(echo $windowsPackageURL | grep -oP '(?<=/v)\d+\.\d+\.\d+' | head -1)
+        export K8S_VERSION=${WINDOWS_PACKAGE_VERSION//./}
         mkdir -p $WINDOWS_E2E_IMAGE
         cp -a $(Pipeline.Workspace)/${{ parameters.windowsImage }}-clusterConfig/* $WINDOWS_E2E_IMAGE
         cd $WINDOWS_E2E_IMAGE

--- a/.pipelines/templates/e2e-windows-template.yaml
+++ b/.pipelines/templates/e2e-windows-template.yaml
@@ -31,7 +31,8 @@ jobs:
         export WINDOWS_E2E_IMAGE=${{ parameters.windowsImage }}
         export WINDOWS_E2E_OSSKU=${{ parameters.windowsOSSKU }}
         export WINDOWS_E2E_VMSIZE=${{ parameters.windowsVMSize }}
-        export WINDOWS_E2E_STORAGE_ACCOUNT=${{ parameters.storageAccount }}
+        K=${KUBERNETES_VERSION//./}
+        export WINDOWS_E2E_STORAGE_ACCOUNT=${{ parameters.storageAccount }}$K
         mkdir -p $WINDOWS_E2E_IMAGE
         cp -r e2e/windows/* $WINDOWS_E2E_IMAGE
         go version

--- a/.pipelines/templates/e2e-windows-template.yaml
+++ b/.pipelines/templates/e2e-windows-template.yaml
@@ -32,7 +32,7 @@ jobs:
         export WINDOWS_E2E_OSSKU=${{ parameters.windowsOSSKU }}
         export WINDOWS_E2E_VMSIZE=${{ parameters.windowsVMSize }}
         K=${KUBERNETES_VERSION//./}
-        export WINDOWS_E2E_STORAGE_ACCOUNT=${{ parameters.storageAccount }}$K
+        export WINDOWS_E2E_STORAGE_CONTAINER=${{ parameters.storageAccount }}-$K
         mkdir -p $WINDOWS_E2E_IMAGE
         cp -r e2e/windows/* $WINDOWS_E2E_IMAGE
         go version

--- a/.pipelines/templates/e2e-windows-template.yaml
+++ b/.pipelines/templates/e2e-windows-template.yaml
@@ -44,7 +44,7 @@ jobs:
           fi
         else
           if [[ -z "${KUBERNETES_VERSION}" ]]; then
-            KUBERNETES_VERSION=$(az aks get-versions -l eastus --query "orchestrators[?default==\`true\`].orchestratorVersion" -otsv)
+            KUBERNETES_VERSION=$(az aks get-versions -l $LOCATION --query "orchestrators[?default==\`true\`].orchestratorVersion" -otsv)
             echo "Using default kubernetes version ${KUBERNETES_VERSION} for the windows package"
           fi
           export windowsPackageURL="https://acs-mirror.azureedge.net/kubernetes/v${KUBERNETES_VERSION}/windowszip/v${KUBERNETES_VERSION}-1int.zip"
@@ -96,7 +96,7 @@ jobs:
           export WINDOWS_PACKAGE_VERSION=$(echo $windowsPackageURL | grep -oP '(?<=/v)\d+\.\d+\.\d+' | head -1)
         else
           if [[ -z "${KUBERNETES_VERSION}" ]]; then
-            KUBERNETES_VERSION=$(az aks get-versions -l eastus --query "orchestrators[?default==\`true\`].orchestratorVersion" -otsv)
+            KUBERNETES_VERSION=$(az aks get-versions -l $LOCATION --query "orchestrators[?default==\`true\`].orchestratorVersion" -otsv)
             echo "Using default kubernetes version ${KUBERNETES_VERSION} for the windows package"
           fi
           export windowsPackageURL="https://acs-mirror.azureedge.net/kubernetes/v${KUBERNETES_VERSION}/windowszip/v${KUBERNETES_VERSION}-1int.zip"

--- a/.pipelines/templates/e2e-windows-template.yaml
+++ b/.pipelines/templates/e2e-windows-template.yaml
@@ -34,11 +34,19 @@ jobs:
         if [[ -n "${WINDOWS_PACKAGE_URL}" ]]; then
           export windowsPackageURL=$WINDOWS_PACKAGE_URL
           export WINDOWS_PACKAGE_VERSION=$(echo $windowsPackageURL | grep -oP '(?<=/v)\d+\.\d+\.\d+' | head -1)
+          if [[ -z "${KUBERNETES_VERSION}" ]]; then
+            echo "You must set KUBERNETES_VERSION when setting WINDOWS_PACKAGE_URL"
+            exit 1
+          fi
           if [[ "${WINDOWS_PACKAGE_VERSION}" != "${KUBERNETES_VERSION}" ]]; then
             echo "Windows package version $WINDOWS_PACKAGE_VERSION does not match with kubernetes version $KUBERNETES_VERSION. Invalid test scenario."
             exit 1
           fi
         else
+          if [[ -z "${KUBERNETES_VERSION}" ]]; then
+            KUBERNETES_VERSION=$(az aks get-versions -l eastus --query "orchestrators[?default==\`true\`].orchestratorVersion" -otsv)
+            echo "Using default kubernetes version ${KUBERNETES_VERSION} for the windows package"
+          fi
           export windowsPackageURL="https://acs-mirror.azureedge.net/kubernetes/v${KUBERNETES_VERSION}/windowszip/v${KUBERNETES_VERSION}-1int.zip"
           export WINDOWS_PACKAGE_VERSION=$KUBERNETES_VERSION
         fi
@@ -87,6 +95,10 @@ jobs:
           export windowsPackageURL=$WINDOWS_PACKAGE_URL
           export WINDOWS_PACKAGE_VERSION=$(echo $windowsPackageURL | grep -oP '(?<=/v)\d+\.\d+\.\d+' | head -1)
         else
+          if [[ -z "${KUBERNETES_VERSION}" ]]; then
+            KUBERNETES_VERSION=$(az aks get-versions -l eastus --query "orchestrators[?default==\`true\`].orchestratorVersion" -otsv)
+            echo "Using default kubernetes version ${KUBERNETES_VERSION} for the windows package"
+          fi
           export windowsPackageURL="https://acs-mirror.azureedge.net/kubernetes/v${KUBERNETES_VERSION}/windowszip/v${KUBERNETES_VERSION}-1int.zip"
           export WINDOWS_PACKAGE_VERSION=$KUBERNETES_VERSION
         fi

--- a/.pipelines/templates/e2e-windows-template.yaml
+++ b/.pipelines/templates/e2e-windows-template.yaml
@@ -86,10 +86,6 @@ jobs:
         if [[ -n "${WINDOWS_PACKAGE_URL}" ]]; then
           export windowsPackageURL=$WINDOWS_PACKAGE_URL
           export WINDOWS_PACKAGE_VERSION=$(echo $windowsPackageURL | grep -oP '(?<=/v)\d+\.\d+\.\d+' | head -1)
-          if [[ "${WINDOWS_PACKAGE_VERSION}" != "${KUBERNETES_VERSION}" ]]; then
-            echo "Windows package version $WINDOWS_PACKAGE_VERSION does not match with kubernetes version $KUBERNETES_VERSION. Invalid test scenario."
-            exit 1
-          fi
         else
           export windowsPackageURL="https://acs-mirror.azureedge.net/kubernetes/v${KUBERNETES_VERSION}/windowszip/v${KUBERNETES_VERSION}-1int.zip"
           export WINDOWS_PACKAGE_VERSION=$KUBERNETES_VERSION

--- a/e2e/windows/e2e-create-windows-nodepool.sh
+++ b/e2e/windows/e2e-create-windows-nodepool.sh
@@ -6,10 +6,8 @@ source e2e-helper.sh
 
 log "Starting to create windows nodepool"
 
-if [[ "$RESOURCE_GROUP_NAME" == *"windows"*  ]]; then
-    K8S_VERSION=$(echo $KUBERNETES_VERSION | tr '.' '-')
-    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME"-"$WINDOWS_E2E_IMAGE"-"$K8S_VERSION"
-fi
+K8S_VERSION=$(echo $KUBERNETES_VERSION | tr '.' '-')
+RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME"-"$WINDOWS_E2E_IMAGE"-"$K8S_VERSION"
 
 out=$(az aks nodepool list --cluster-name $CLUSTER_NAME -g $RESOURCE_GROUP_NAME | jq '.[].name')
 

--- a/e2e/windows/e2e-create-windows-nodepool.sh
+++ b/e2e/windows/e2e-create-windows-nodepool.sh
@@ -7,7 +7,8 @@ source e2e-helper.sh
 log "Starting to create windows nodepool"
 
 if [[ "$RESOURCE_GROUP_NAME" == *"windows"*  ]]; then
-    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME"-"$WINDOWS_E2E_IMAGE"-v2
+    K8S_VERSION=$(echo $KUBERNETES_VERSION | tr '.' '-')
+    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME"-"$WINDOWS_E2E_IMAGE"-"$K8S_VERSION"
 fi
 
 out=$(az aks nodepool list --cluster-name $CLUSTER_NAME -g $RESOURCE_GROUP_NAME | jq '.[].name')

--- a/e2e/windows/e2e-create-windows-nodepool.sh
+++ b/e2e/windows/e2e-create-windows-nodepool.sh
@@ -6,8 +6,11 @@ source e2e-helper.sh
 
 log "Starting to create windows nodepool"
 
-K8S_VERSION=$(echo $KUBERNETES_VERSION | tr '.' '-')
-RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME"-"$WINDOWS_E2E_IMAGE"-"$K8S_VERSION"
+if echo "$windowsPackageURL" | grep -q "hotfix"; then
+    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME-$WINDOWS_E2E_IMAGE-$K8S_VERSION-h"
+else
+    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME-$WINDOWS_E2E_IMAGE-$K8S_VERSION"
+fi
 
 out=$(az aks nodepool list --cluster-name $CLUSTER_NAME -g $RESOURCE_GROUP_NAME | jq '.[].name')
 

--- a/e2e/windows/e2e-create-windows-nodepool.sh
+++ b/e2e/windows/e2e-create-windows-nodepool.sh
@@ -6,11 +6,7 @@ source e2e-helper.sh
 
 log "Starting to create windows nodepool"
 
-if echo "$windowsPackageURL" | grep -q "hotfix"; then
-    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME-$WINDOWS_E2E_IMAGE-$K8S_VERSION-h"
-else
-    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME-$WINDOWS_E2E_IMAGE-$K8S_VERSION"
-fi
+RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME-$WINDOWS_E2E_IMAGE-$K8S_VERSION"
 
 out=$(az aks nodepool list --cluster-name $CLUSTER_NAME -g $RESOURCE_GROUP_NAME | jq '.[].name')
 

--- a/e2e/windows/e2e-scenario.sh
+++ b/e2e/windows/e2e-scenario.sh
@@ -137,9 +137,7 @@ EOF
 # Removed the "network-plugin" tag o.w. kubelet error for 1.24.0+ contains "failed to parse kubelet flag: unknown flag: --network-plugin"
 # "network-plugin" works for 1.23.15 and below (you won't see this parsing error in kubelet.err.log)
 jq --arg clientCrt "$clientCertificate" --arg vmssName $DEPLOYMENT_VMSS_NAME 'del(.KubeletConfig."--pod-manifest-path") | del(.KubeletConfig."--pod-max-pids") | del(.KubeletConfig."--protect-kernel-defaults") | del(.KubeletConfig."--tls-cert-file") | del(.KubeletConfig."--tls-private-key-file") | del(.KubeletConfig."--network-plugin") | .ContainerService.properties.certificateProfile += {"clientCertificate": $clientCrt} | .PrimaryScaleSetName=$vmssName' nodebootstrapping_config.json > $WINDOWS_E2E_IMAGE-nodebootstrapping_config_for_windows.json
-cat $WINDOWS_E2E_IMAGE-nodebootstrapping_config_for_windows.json
 jq -s '.[0] * .[1]' $WINDOWS_E2E_IMAGE-nodebootstrapping_config_for_windows.json scenarios/$SCENARIO_NAME/$WINDOWS_E2E_IMAGE-property-$SCENARIO_NAME.json > scenarios/$SCENARIO_NAME/$WINDOWS_E2E_IMAGE-nbc-$SCENARIO_NAME.json
-cat scenarios/$SCENARIO_NAME/$WINDOWS_E2E_IMAGE-nbc-$SCENARIO_NAME.json
 
 go test -tags bash_e2e -run TestE2EWindows
 
@@ -282,9 +280,8 @@ else
     waitForDeleteStartTime=$(date +%s)
 
     # Only delete node and vmss since we reuse the resource group and cluster now
-    # Commenting to check kubernetes version of the node
-    # kubectl delete node $VMSS_INSTANCE_NAME
-    # az vmss delete -g $(jq -r .group $SCENARIO_NAME-vmss.json) -n $(jq -r .vmss $SCENARIO_NAME-vmss.json)
+    kubectl delete node $VMSS_INSTANCE_NAME
+    az vmss delete -g $(jq -r .group $SCENARIO_NAME-vmss.json) -n $(jq -r .vmss $SCENARIO_NAME-vmss.json)
 
     waitForDeleteEndTime=$(date +%s)
     log "Waited $((waitForDeleteEndTime-waitForDeleteStartTime)) seconds to delete VMSS and node"   

--- a/e2e/windows/e2e-scenario.sh
+++ b/e2e/windows/e2e-scenario.sh
@@ -97,6 +97,10 @@ log "Upload cse packages done"
 
 log "Scenario is $SCENARIO_NAME"
 export orchestratorVersion=$KUBERNETES_VERSION
+export windowsPackageURL="https://acs-mirror.azureedge.net/kubernetes/v${orchestratorVersion}/windowszip/v${orchestratorVersion}-1int.zip"
+if [[ -n "$WINDOWS_PACKAGE_URL" ]]; then
+    export windowsPackageURL="$WINDOWS_PACKAGE_URL"
+fi
 
 # Generate vmss cse deployment config for windows nodepool testing
 envsubst < scenarios/$SCENARIO_NAME/property-$SCENARIO_NAME-template.json > scenarios/$SCENARIO_NAME/$WINDOWS_E2E_IMAGE-property-$SCENARIO_NAME.json
@@ -190,7 +194,9 @@ else
 fi
 
 log "Collect cse log"
-collect-logs
+collect-logs 
+
+cat $SCENARIO_NAME-vmss.json
 
 VMSS_INSTANCE_NAME=$(az vmss list-instances \
                     -n ${DEPLOYMENT_VMSS_NAME} \

--- a/e2e/windows/e2e-scenario.sh
+++ b/e2e/windows/e2e-scenario.sh
@@ -151,7 +151,6 @@ NETWORK_PROPERTIES=$(jq -c '.resources[0].properties.virtualMachineProfile.netwo
 CUSTOM_DATA=$(cat scenarios/$SCENARIO_NAME/$WINDOWS_E2E_IMAGE-$SCENARIO_NAME-cloud-init.txt)
 CSE_CMD=$(cat scenarios/$SCENARIO_NAME/$WINDOWS_E2E_IMAGE-$SCENARIO_NAME-cseCmd)
 
-# Customize the windows vmss deployment given the template windows_vmss_template
 jq --argjson JsonForVnet "$WINDOWS_VNET" \
     --argjson JsonForLB "$WINDOWS_LOADBALANCER" \
     --argjson JsonForIdentity "$WINDOWS_IDENTITY" \

--- a/e2e/windows/e2e-scenario.sh
+++ b/e2e/windows/e2e-scenario.sh
@@ -100,7 +100,6 @@ export orchestratorVersion=$KUBERNETES_VERSION
 
 # Generate vmss cse deployment config for windows nodepool testing
 envsubst < scenarios/$SCENARIO_NAME/property-$SCENARIO_NAME-template.json > scenarios/$SCENARIO_NAME/$WINDOWS_E2E_IMAGE-property-$SCENARIO_NAME.json
-cat scenarios/"$SCENARIO_NAME"/"$WINDOWS_E2E_IMAGE"-property-"$SCENARIO_NAME".json
 
 set +x
 WINDOWS_PASSWORD=$({
@@ -130,23 +129,8 @@ tee $SCENARIO_NAME-vmss.json > /dev/null <<EOF
 }
 EOF
 
-# Save $WINDOWS_E2E_IMAGE-nodebootstrapping_config_for_windows.json from the node bootstrapping config generated from e2e-starter.sh
-# Removed the "network-plugin" tag o.w. kubelet error for 1.24.0+ contains "failed to parse kubelet flag: unknown flag: --network-plugin"
-# "network-plugin" works for 1.23.15 and below (won't see this parsing error in kubelet.err.log)
-jq --arg clientCrt "$clientCertificate" --arg vmssName $DEPLOYMENT_VMSS_NAME \
-'del(.KubeletConfig."--pod-manifest-path") | del(.KubeletConfig."--pod-max-pids") | 
-del(.KubeletConfig."--protect-kernel-defaults") | del(.KubeletConfig."--tls-cert-file") | 
-del(.KubeletConfig."--tls-private-key-file") | del(.KubeletConfig."--network-plugin") | 
-.ContainerService.properties.certificateProfile += {"clientCertificate": $clientCrt} | 
-.PrimaryScaleSetName=$vmssName' nodebootstrapping_config.json > $WINDOWS_E2E_IMAGE-nodebootstrapping_config_for_windows.json
-cat "${WINDOWS_E2E_IMAGE}"-nodebootstrapping_config_for_windows.json
-
-# Produce a finalized managed cluster config (nbc?) given 
-# 1. the node bootstrapping config from e2e-starter (kubeconfig)
-# 2. the vmss cse deployment config generated from this file (windows package \in k8s components)
-jq -s '.[0] * .[1]' $WINDOWS_E2E_IMAGE-nodebootstrapping_config_for_windows.json \
- scenarios/$SCENARIO_NAME/$WINDOWS_E2E_IMAGE-property-$SCENARIO_NAME.json > scenarios/$SCENARIO_NAME/$WINDOWS_E2E_IMAGE-nbc-$SCENARIO_NAME.json
-cat scenarios/"${SCENARIO_NAME}"/"${WINDOWS_E2E_IMAGE}"-nbc-"${SCENARIO_NAME}".json
+jq --arg clientCrt "$clientCertificate" --arg vmssName $DEPLOYMENT_VMSS_NAME 'del(.KubeletConfig."--pod-manifest-path") | del(.KubeletConfig."--pod-max-pids") | del(.KubeletConfig."--protect-kernel-defaults") | del(.KubeletConfig."--tls-cert-file") | del(.KubeletConfig."--tls-private-key-file") | .ContainerService.properties.certificateProfile += {"clientCertificate": $clientCrt} | .PrimaryScaleSetName=$vmssName' nodebootstrapping_config.json > $WINDOWS_E2E_IMAGE-nodebootstrapping_config_for_windows.json
+jq -s '.[0] * .[1]' $WINDOWS_E2E_IMAGE-nodebootstrapping_config_for_windows.json scenarios/$SCENARIO_NAME/$WINDOWS_E2E_IMAGE-property-$SCENARIO_NAME.json > scenarios/$SCENARIO_NAME/$WINDOWS_E2E_IMAGE-nbc-$SCENARIO_NAME.json
 
 go test -tags bash_e2e -run TestE2EWindows
 
@@ -180,18 +164,8 @@ jq --argjson JsonForVnet "$WINDOWS_VNET" \
     --arg ValueForCustomData "$CUSTOM_DATA" \
     --arg ValueForCSECmd "$CSE_CMD" \
     --arg ValueForVMSS "$DEPLOYMENT_VMSS_NAME" \
-    '.parameters += $JsonForVnet | .parameters += $JsonForLB | 
-    .parameters.galleries_AKSWindows_externalid.defaultValue=$ValueForImageExternalID | 
-    .resources[0] += $JsonForIdentity | .resources[0] += $JsonForSKU | 
-	.resources[0].properties.virtualMachineProfile.storageProfile+=$JsonForOSDisk | 
-    .resources[0].properties.virtualMachineProfile.networkProfile.networkInterfaceConfigurations[0] += $JsonForNetwork | 
-    .resources[0].properties.virtualMachineProfile.storageProfile.imageReference.id=$ValueForImageReference |
-    .resources[0].properties.virtualMachineProfile.osProfile.adminPassword=$ValueForAdminPassword | 
-    .resources[0].properties.virtualMachineProfile.osProfile.customData=$ValueForCustomData | 
-    .resources[0].properties.virtualMachineProfile.extensionProfile.extensions[0].properties.settings.commandToExecute=$ValueForCSECmd | 
-    .parameters.virtualMachineScaleSets_akswin30_name.defaultValue=$ValueForVMSS' \
-windows_vmss_template.json > $DEPLOYMENT_VMSS_NAME-deployment.json
-cat "${DEPLOYMENT_VMSS_NAME}"-deployment.json
+    '.parameters += $JsonForVnet | .parameters += $JsonForLB | .parameters.galleries_AKSWindows_externalid.defaultValue=$ValueForImageExternalID | .resources[0] += $JsonForIdentity | .resources[0] += $JsonForSKU | .resources[0].properties.virtualMachineProfile.storageProfile+=$JsonForOSDisk | .resources[0].properties.virtualMachineProfile.networkProfile.networkInterfaceConfigurations[0] += $JsonForNetwork | .resources[0].properties.virtualMachineProfile.storageProfile.imageReference.id=$ValueForImageReference | .resources[0].properties.virtualMachineProfile.osProfile.adminPassword=$ValueForAdminPassword | .resources[0].properties.virtualMachineProfile.osProfile.customData=$ValueForCustomData | .resources[0].properties.virtualMachineProfile.extensionProfile.extensions[0].properties.settings.commandToExecute=$ValueForCSECmd | .parameters.virtualMachineScaleSets_akswin30_name.defaultValue=$ValueForVMSS' \
+    windows_vmss_template.json > $DEPLOYMENT_VMSS_NAME-deployment.json
 
 retval=0
 set +e
@@ -215,7 +189,9 @@ else
 fi
 
 log "Collect cse log"
-collect-logs 
+collect-logs
+
+cat $SCENARIO_NAME-vmss.json
 
 VMSS_INSTANCE_NAME=$(az vmss list-instances \
                     -n ${DEPLOYMENT_VMSS_NAME} \
@@ -226,8 +202,7 @@ export VMSS_INSTANCE_NAME
 
 # Sleep to let the automatic upgrade of the VM finish
 waitForNodeStartTime=$(date +%s)
-# change to 3 temporarily (previously: 10)
-for i in $(seq 1 3); do
+for i in $(seq 1 10); do
     set +e
     kubectl get nodes | grep $VMSS_INSTANCE_NAME
     retval=$?
@@ -268,8 +243,7 @@ kubectl apply -f pod-windows.yaml
 
 # Sleep to let Pod Status=Running
 waitForPodStartTime=$(date +%s)
-# change to 3 temporarily (previously: 20)
-for i in $(seq 1 3); do
+for i in $(seq 1 20); do
     set +e
     kubectl get pods -o wide | grep $POD_NAME
     kubectl get pods -o wide | grep $POD_NAME | grep 'Running'
@@ -300,8 +274,8 @@ else
     waitForDeleteStartTime=$(date +%s)
 
     # Only delete node and vmss since we reuse the resource group and cluster now
-    # kubectl delete node $VMSS_INSTANCE_NAME
-    # az vmss delete -g $(jq -r .group $SCENARIO_NAME-vmss.json) -n $(jq -r .vmss $SCENARIO_NAME-vmss.json)
+    kubectl delete node $VMSS_INSTANCE_NAME
+    az vmss delete -g $(jq -r .group $SCENARIO_NAME-vmss.json) -n $(jq -r .vmss $SCENARIO_NAME-vmss.json)
 
     waitForDeleteEndTime=$(date +%s)
     log "Waited $((waitForDeleteEndTime-waitForDeleteStartTime)) seconds to delete VMSS and node"   

--- a/e2e/windows/e2e-scenario.sh
+++ b/e2e/windows/e2e-scenario.sh
@@ -43,11 +43,7 @@ collect-logs() {
     set -x
 }
 
-if echo "$windowsPackageURL" | grep -q "hotfix"; then
-    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME-$WINDOWS_E2E_IMAGE-$K8S_VERSION-h"
-else
-    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME-$WINDOWS_E2E_IMAGE-$K8S_VERSION"
-fi
+RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME-$WINDOWS_E2E_IMAGE-$K8S_VERSION"
 
 DEPLOYMENT_VMSS_NAME="$(mktemp -u winXXXXX | tr '[:upper:]' '[:lower:]')"
 export DEPLOYMENT_VMSS_NAME
@@ -99,7 +95,6 @@ fi
 log "Upload cse packages done"
 
 log "Scenario is $SCENARIO_NAME"
-log "Windows package url is $windowsPackageURL"
 log "Windows package version is $WINDOWS_PACKAGE_VERSION"
 
 # Generate vmss cse deployment config for windows nodepool testing

--- a/e2e/windows/e2e-starter.sh
+++ b/e2e/windows/e2e-starter.sh
@@ -95,7 +95,7 @@ if [ "$create_cluster" == "true" ]; then
     fi
 fi
 download_linux_file_from_storage_account
-log "Download linux file from SA done"
+log "Download of linux file from storage account completed"
 
 set +x
 addJsonToFile "apiserverCrt" "$(cat apiserver.crt)"
@@ -115,7 +115,6 @@ getMSIResourceID
 addJsonToFile "mcRGName" $MC_RESOURCE_GROUP_NAME
 addJsonToFile "clusterID" $CLUSTER_ID
 addJsonToFile "subID" $SUBSCRIPTION_ID
-addJsonToFile "orchestratorVersion" $KUBERNETES_VERSION
 
 set +x
 # shellcheck disable=SC2091

--- a/e2e/windows/e2e-starter.sh
+++ b/e2e/windows/e2e-starter.sh
@@ -8,10 +8,8 @@ log "Starting e2e tests"
 
 # Create a resource group for the cluster
 log "Creating resource group"
-if [[ "$RESOURCE_GROUP_NAME" == *"windows"*  ]]; then
-    K8S_VERSION=$(echo $KUBERNETES_VERSION | tr '.' '-')
-    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME"-"$WINDOWS_E2E_IMAGE"-"$K8S_VERSION"
-fi
+K8S_VERSION=$(echo $KUBERNETES_VERSION | tr '.' '-')
+RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME"-"$WINDOWS_E2E_IMAGE"-"$K8S_VERSION"
 
 rgStartTime=$(date +%s)
 az group create -l $LOCATION -n $RESOURCE_GROUP_NAME --subscription $SUBSCRIPTION_ID -ojson
@@ -119,8 +117,5 @@ set +x
 # shellcheck disable=SC2091
 $(jq -r 'keys[] as $k | "export \($k)=\(.[$k])"' fields.json)
 envsubst < percluster_template.json > percluster_config.json
-cat percluster_config.json
 
 jq -s '.[0] * .[1]' nodebootstrapping_template.json percluster_config.json > nodebootstrapping_config.json
-log "Node bootstrapping configuration done"
-cat nodebootstrapping_config.json

--- a/e2e/windows/e2e-starter.sh
+++ b/e2e/windows/e2e-starter.sh
@@ -117,5 +117,4 @@ set +x
 # shellcheck disable=SC2091
 $(jq -r 'keys[] as $k | "export \($k)=\(.[$k])"' fields.json)
 envsubst < percluster_template.json > percluster_config.json
-
 jq -s '.[0] * .[1]' nodebootstrapping_template.json percluster_config.json > nodebootstrapping_config.json

--- a/e2e/windows/e2e-starter.sh
+++ b/e2e/windows/e2e-starter.sh
@@ -85,13 +85,14 @@ MC_VMSS_NAME=$(az vmss list -g $MC_RESOURCE_GROUP_NAME --query "[?contains(name,
 CLUSTER_ID=$(echo $MC_VMSS_NAME | cut -d '-' -f3)
 
 if [ "$create_cluster" == "true" ]; then
-    create_storage_account
+    create_storage_container
     upload_linux_file_to_storage_account
     if [ "$WINDOWS_E2E_IMAGE" == "2019-containerd" ]; then
         cleanupOutdatedFiles
     fi
 fi
 download_linux_file_from_storage_account
+log "Download linux file from SA done"
 
 set +x
 addJsonToFile "apiserverCrt" "$(cat apiserver.crt)"
@@ -118,3 +119,4 @@ set +x
 $(jq -r 'keys[] as $k | "export \($k)=\(.[$k])"' fields.json)
 envsubst < percluster_template.json > percluster_config.json
 jq -s '.[0] * .[1]' nodebootstrapping_template.json percluster_config.json > nodebootstrapping_config.json
+log "Node bootstrapping config generated"

--- a/e2e/windows/e2e-starter.sh
+++ b/e2e/windows/e2e-starter.sh
@@ -8,7 +8,10 @@ log "Starting e2e tests"
 
 # Create a resource group for the cluster
 log "Creating resource group"
-RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME"-"$WINDOWS_E2E_IMAGE"-v2
+if [[ "$RESOURCE_GROUP_NAME" == *"windows"*  ]]; then
+    K8S_VERSION=$(echo $KUBERNETES_VERSION | tr '.' '-')
+    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME"-"$WINDOWS_E2E_IMAGE"-"$K8S_VERSION"
+fi
 
 rgStartTime=$(date +%s)
 az group create -l $LOCATION -n $RESOURCE_GROUP_NAME --subscription $SUBSCRIPTION_ID -ojson
@@ -53,7 +56,7 @@ if [ "$create_cluster" == "true" ]; then
     clusterCreateStartTime=$(date +%s)
     retval=0
     
-    az aks create -g $RESOURCE_GROUP_NAME -n $CLUSTER_NAME --node-count 1 --generate-ssh-keys --network-plugin azure -ojson || retval=$?
+    az aks create -g $RESOURCE_GROUP_NAME -n $CLUSTER_NAME --node-count 1 --generate-ssh-keys --network-plugin azure --kubernetes-version $KUBERNETES_VERSION -ojson || retval=$?
 
     if [ "$retval" -ne 0  ]; then
         log "Other pipelines may be creating cluster $CLUSTER_NAME, waiting for ready"
@@ -110,9 +113,14 @@ getMSIResourceID
 addJsonToFile "mcRGName" $MC_RESOURCE_GROUP_NAME
 addJsonToFile "clusterID" $CLUSTER_ID
 addJsonToFile "subID" $SUBSCRIPTION_ID
+addJsonToFile "orchestratorVersion" $KUBERNETES_VERSION
 
 set +x
 # shellcheck disable=SC2091
 $(jq -r 'keys[] as $k | "export \($k)=\(.[$k])"' fields.json)
 envsubst < percluster_template.json > percluster_config.json
+cat percluster_config.json
+
 jq -s '.[0] * .[1]' nodebootstrapping_template.json percluster_config.json > nodebootstrapping_config.json
+log "Node bootstrapping configuration done"
+cat nodebootstrapping_config.json

--- a/e2e/windows/e2e-starter.sh
+++ b/e2e/windows/e2e-starter.sh
@@ -8,8 +8,11 @@ log "Starting e2e tests"
 
 # Create a resource group for the cluster
 log "Creating resource group"
-K8S_VERSION=$(echo $KUBERNETES_VERSION | tr '.' '-')
-RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME"-"$WINDOWS_E2E_IMAGE"-"$K8S_VERSION"
+if echo "$windowsPackageURL" | grep -q "hotfix"; then
+    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME-$WINDOWS_E2E_IMAGE-$K8S_VERSION-h"
+else
+    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME-$WINDOWS_E2E_IMAGE-$K8S_VERSION"
+fi
 
 rgStartTime=$(date +%s)
 az group create -l $LOCATION -n $RESOURCE_GROUP_NAME --subscription $SUBSCRIPTION_ID -ojson
@@ -54,7 +57,7 @@ if [ "$create_cluster" == "true" ]; then
     clusterCreateStartTime=$(date +%s)
     retval=0
     
-    az aks create -g $RESOURCE_GROUP_NAME -n $CLUSTER_NAME --node-count 1 --generate-ssh-keys --network-plugin azure --kubernetes-version $KUBERNETES_VERSION -ojson || retval=$?
+    az aks create -g $RESOURCE_GROUP_NAME -n $CLUSTER_NAME --node-count 1 --generate-ssh-keys --network-plugin azure -ojson || retval=$?
 
     if [ "$retval" -ne 0  ]; then
         log "Other pipelines may be creating cluster $CLUSTER_NAME, waiting for ready"

--- a/e2e/windows/e2e-starter.sh
+++ b/e2e/windows/e2e-starter.sh
@@ -8,11 +8,7 @@ log "Starting e2e tests"
 
 # Create a resource group for the cluster
 log "Creating resource group"
-if echo "$windowsPackageURL" | grep -q "hotfix"; then
-    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME-$WINDOWS_E2E_IMAGE-$K8S_VERSION-h"
-else
-    RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME-$WINDOWS_E2E_IMAGE-$K8S_VERSION"
-fi
+RESOURCE_GROUP_NAME="$RESOURCE_GROUP_NAME-$WINDOWS_E2E_IMAGE-$K8S_VERSION"
 
 rgStartTime=$(date +%s)
 az group create -l $LOCATION -n $RESOURCE_GROUP_NAME --subscription $SUBSCRIPTION_ID -ojson

--- a/e2e/windows/nodebootstrapping_template.json
+++ b/e2e/windows/nodebootstrapping_template.json
@@ -8,11 +8,11 @@
         "properties": {
             "orchestratorProfile": {
                 "orchestratorType": "Kubernetes",
-                "orchestratorVersion": "1.24.0",
+                "orchestratorVersion": "1.24.9",
                 "kubernetesConfig": {
                     "networkPlugin": "kubenet",
-                    "customKubeProxyImage": "mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.24.0.1",
-                    "customKubeBinaryURL": "https://acs-mirror.azureedge.net/kubernetes/v1.24.0/binaries/kubernetes-node-linux-amd64.tar.gz",
+                    "customKubeProxyImage": "mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.24.9.1",
+                    "customKubeBinaryURL": "https://acs-mirror.azureedge.net/kubernetes/v1.24.9/binaries/kubernetes-node-linux-amd64.tar.gz",
                     "useInstanceMetadata": true,
                     "cloudProviderBackoffMode": "v2",
                     "cloudProviderBackoff": true,
@@ -95,7 +95,7 @@
             "containerdDownloadURLBase": "https://storage.googleapis.com/cri-containerd-release/",
             "csiProxyDownloadURL": "https://acs-mirror.azureedge.net/csi-proxy/v0.1.0/binaries/csi-proxy.tar.gz",
             "windowsProvisioningScriptsPackageURL": "https://acs-mirror.azureedge.net/aks-engine/windows/provisioning/signedscripts-v0.2.2.zip",
-            "windowsPauseImageURL": "mcr.microsoft.com/oss/kubernetes/pause:1.4.0",
+            "windowsPauseImageURL": "mcr.microsoft.com/oss/kubernetes/pause:3.9",
             "cseScriptsPackageURL": "https://acs-mirror.azureedge.net/aks/windows/cse/csescripts-v0.0.1.zip",
             "cniARM64PluginsDownloadURL": "https://acs-mirror.azureedge.net/cni-plugins/v0.8.7/binaries/cni-plugins-linux-arm64-v0.8.7.tgz",
             "vnetCNIARM64LinuxPluginsDownloadURL": "https://acs-mirror.azureedge.net/azure-cni/v1.4.13/binaries/azure-vnet-cni-linux-arm64-v1.4.14.tgz"
@@ -105,7 +105,7 @@
         }
     },
     "K8sComponents": {
-        "PodInfraContainerImageURL": "mcr.microsoft.com/oss/kubernetes/pause:3.5",
+        "PodInfraContainerImageURL": "mcr.microsoft.com/oss/kubernetes/pause:3.9",
         "HyperkubeImageURL": "mcr.microsoft.com/oss/kubernetes/",
         "WindowsPackageURL": "windowspackage"
     },
@@ -168,7 +168,7 @@
         "--max-pods": "110",
         "--network-plugin": "kubenet",
         "--node-status-update-frequency": "10s",
-        "--pod-infra-container-image": "mcr.microsoft.com/oss/kubernetes/pause:3.5",
+        "--pod-infra-container-image": "mcr.microsoft.com/oss/kubernetes/pause:3.9",
         "--pod-manifest-path": "/etc/kubernetes/manifests",
         "--pod-max-pids": "-1",
         "--protect-kernel-defaults": "true",

--- a/e2e/windows/nodebootstrapping_template.json
+++ b/e2e/windows/nodebootstrapping_template.json
@@ -156,6 +156,7 @@
         "--cloud-provider": "azure",
         "--cluster-dns": "10.0.0.10",
         "--cluster-domain": "cluster.local",
+        "--dynamic-config-dir": "/var/lib/kubelet",
         "--enforce-node-allocatable": "pods",
         "--event-qps": "0",
         "--eviction-hard": "memory.available\u003c750Mi,nodefs.available\u003c10%,nodefs.inodesFree\u003c5%",

--- a/e2e/windows/nodebootstrapping_template.json
+++ b/e2e/windows/nodebootstrapping_template.json
@@ -95,7 +95,7 @@
             "containerdDownloadURLBase": "https://storage.googleapis.com/cri-containerd-release/",
             "csiProxyDownloadURL": "https://acs-mirror.azureedge.net/csi-proxy/v0.1.0/binaries/csi-proxy.tar.gz",
             "windowsProvisioningScriptsPackageURL": "https://acs-mirror.azureedge.net/aks-engine/windows/provisioning/signedscripts-v0.2.2.zip",
-            "windowsPauseImageURL": "mcr.microsoft.com/oss/kubernetes/pause:3.9",
+            "windowsPauseImageURL": "mcr.microsoft.com/oss/kubernetes/pause:1.4.0",
             "cseScriptsPackageURL": "https://acs-mirror.azureedge.net/aks/windows/cse/csescripts-v0.0.1.zip",
             "cniARM64PluginsDownloadURL": "https://acs-mirror.azureedge.net/cni-plugins/v0.8.7/binaries/cni-plugins-linux-arm64-v0.8.7.tgz",
             "vnetCNIARM64LinuxPluginsDownloadURL": "https://acs-mirror.azureedge.net/azure-cni/v1.4.13/binaries/azure-vnet-cni-linux-arm64-v1.4.14.tgz"
@@ -105,7 +105,7 @@
         }
     },
     "K8sComponents": {
-        "PodInfraContainerImageURL": "mcr.microsoft.com/oss/kubernetes/pause:3.9",
+        "PodInfraContainerImageURL": "mcr.microsoft.com/oss/kubernetes/pause:3.5",
         "HyperkubeImageURL": "mcr.microsoft.com/oss/kubernetes/",
         "WindowsPackageURL": "windowspackage"
     },
@@ -168,7 +168,7 @@
         "--max-pods": "110",
         "--network-plugin": "kubenet",
         "--node-status-update-frequency": "10s",
-        "--pod-infra-container-image": "mcr.microsoft.com/oss/kubernetes/pause:3.9",
+        "--pod-infra-container-image": "mcr.microsoft.com/oss/kubernetes/pause:3.5",
         "--pod-manifest-path": "/etc/kubernetes/manifests",
         "--pod-max-pids": "-1",
         "--protect-kernel-defaults": "true",

--- a/e2e/windows/nodebootstrapping_template.json
+++ b/e2e/windows/nodebootstrapping_template.json
@@ -8,11 +8,11 @@
         "properties": {
             "orchestratorProfile": {
                 "orchestratorType": "Kubernetes",
-                "orchestratorVersion": "1.24.9",
+                "orchestratorVersion": "1.24.0",
                 "kubernetesConfig": {
                     "networkPlugin": "kubenet",
-                    "customKubeProxyImage": "mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.24.9.1",
-                    "customKubeBinaryURL": "https://acs-mirror.azureedge.net/kubernetes/v1.24.9/binaries/kubernetes-node-linux-amd64.tar.gz",
+                    "customKubeProxyImage": "mcr.microsoft.com/oss/kubernetes/kube-proxy:v1.24.0.1",
+                    "customKubeBinaryURL": "https://acs-mirror.azureedge.net/kubernetes/v1.24.0/binaries/kubernetes-node-linux-amd64.tar.gz",
                     "useInstanceMetadata": true,
                     "cloudProviderBackoffMode": "v2",
                     "cloudProviderBackoff": true,

--- a/e2e/windows/nodebootstrapping_template.json
+++ b/e2e/windows/nodebootstrapping_template.json
@@ -156,7 +156,6 @@
         "--cloud-provider": "azure",
         "--cluster-dns": "10.0.0.10",
         "--cluster-domain": "cluster.local",
-        "--dynamic-config-dir": "/var/lib/kubelet",
         "--enforce-node-allocatable": "pods",
         "--event-qps": "0",
         "--eviction-hard": "memory.available\u003c750Mi,nodefs.available\u003c10%,nodefs.inodesFree\u003c5%",

--- a/e2e/windows/scenarios/windows/property-windows-template.json
+++ b/e2e/windows/scenarios/windows/property-windows-template.json
@@ -92,7 +92,7 @@
     "--cloud-provider": "external",
     "--enforce-node-allocatable": "\"\"\"\"",
     "--eviction-hard": "\"\"\"\"",
-    "--feature-gates": "CSIMigration=true,CSIMigrationAzureDisk=true,CSIMigrationAzureFile=true,DelegateFSGroupToCSIDriver=true",
+    "--feature-gates": "CSIMigration=true,CSIMigrationAzureDisk=true,CSIMigrationAzureFile=true,DelegateFSGroupToCSIDriver=true,DynamicKubeletConfig=false",
     "--hairpin-mode": "promiscuous-bridge",
     "--kube-reserved": "cpu=100m,memory=3891Mi",
     "--kubeconfig": "c:\\k\\config",

--- a/e2e/windows/scenarios/windows/property-windows-template.json
+++ b/e2e/windows/scenarios/windows/property-windows-template.json
@@ -61,7 +61,7 @@
     }
   },
   "K8sComponents": {
-    "WindowsPackageURL": "https://acs-mirror.azureedge.net/kubernetes/v${orchestratorVersion}/windowszip/v${orchestratorVersion}-1int.zip"
+    "WindowsPackageURL": "${windowsPackageURL}"
   },
   "AgentPoolProfile": {
     "name": "winnp",

--- a/e2e/windows/scenarios/windows/property-windows-template.json
+++ b/e2e/windows/scenarios/windows/property-windows-template.json
@@ -3,7 +3,7 @@
     "properties": {
       "orchestratorProfile": {
         "orchestratorType": "Kubernetes",
-        "orchestratorVersion": "1.23.12",
+        "orchestratorVersion": "${orchestratorVersion}",
         "kubernetesConfig": {
           "networkPlugin": "azure",
           "loadBalancerSku": "Standard",
@@ -44,7 +44,7 @@
       },
       "windowsProfile": {
         "cseScriptsPackageURL": "${csePackageURL}",
-        "csiProxyURL": "https://acs-mirror.azureedge.net/csi-proxy/v0.2.2/binaries/csi-proxy-v0.2.2.tar.gz",
+        "csiProxyURL": "https://acs-mirror.azureedge.net/csi-proxy/v1.0.2/binaries/csi-proxy-v1.0.2.tar.gz",
         "enableAutomaticUpdates": false,
         "enableCSIProxy": true,
         "hnsRemediatorIntervalInMinutes": 1,
@@ -61,7 +61,7 @@
     }
   },
   "K8sComponents": {
-    "WindowsPackageURL": "https://acs-mirror.azureedge.net/kubernetes/v1.23.12/windowszip/v1.23.12-1int.zip"
+    "WindowsPackageURL": "https://acs-mirror.azureedge.net/kubernetes/v${orchestratorVersion}/windowszip/v${orchestratorVersion}-1int.zip"
   },
   "AgentPoolProfile": {
     "name": "winnp",
@@ -97,7 +97,6 @@
     "--kube-reserved": "cpu=100m,memory=3891Mi",
     "--kubeconfig": "c:\\k\\config",
     "--max-pods": "30",
-    "--network-plugin": "azure",
     "--pod-infra-container-image": "kubletwin/pause",
     "--resolv-conf": "\"\"\"\"",
     "--rotate-certificates": "true",

--- a/e2e/windows/scenarios/windows/property-windows-template.json
+++ b/e2e/windows/scenarios/windows/property-windows-template.json
@@ -44,7 +44,7 @@
       },
       "windowsProfile": {
         "cseScriptsPackageURL": "${csePackageURL}",
-        "csiProxyURL": "https://acs-mirror.azureedge.net/csi-proxy/v1.0.2/binaries/csi-proxy-v1.0.2.tar.gz",
+        "csiProxyURL": "https://acs-mirror.azureedge.net/csi-proxy/v0.2.2/binaries/csi-proxy-v0.2.2.tar.gz",
         "enableAutomaticUpdates": false,
         "enableCSIProxy": true,
         "hnsRemediatorIntervalInMinutes": 1,
@@ -92,7 +92,7 @@
     "--cloud-provider": "external",
     "--enforce-node-allocatable": "\"\"\"\"",
     "--eviction-hard": "\"\"\"\"",
-    "--feature-gates": "CSIMigration=true,CSIMigrationAzureDisk=true,CSIMigrationAzureFile=true,DelegateFSGroupToCSIDriver=true,DynamicKubeletConfig=false",
+    "--feature-gates": "CSIMigration=true,CSIMigrationAzureDisk=true,CSIMigrationAzureFile=true,DelegateFSGroupToCSIDriver=true",
     "--hairpin-mode": "promiscuous-bridge",
     "--kube-reserved": "cpu=100m,memory=3891Mi",
     "--kubeconfig": "c:\\k\\config",


### PR DESCRIPTION
**What type of PR is this?**
Support to specify the k8s version since some feature may need the latest k8s version to validate.



<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
To validate latest windows cse package on the latest k8s version.

To achieve this
- The resource group name will contain the version string and the cluster will be created with the specified k8s version.
- The windows vmss deployment will be associated with the set k8s version by updating `WindowsPackageURL` of `k8scomponents` in the template `property-windows-template.json` which is for generating windows cse related files i.e. CustomData file and CSECmd file.



**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:
```
none
```
