### PR TITLE
fix: do not add IPv6DualStack to Windows kube-proxy feature-gates when K8s >= 1.25.0

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0
 	github.com/Azure/go-armbalancer v0.0.2
 	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df
-	github.com/sanity-io/litter v1.5.5
 	golang.org/x/crypto v0.6.0
 	k8s.io/api v0.26.2
 	k8s.io/apimachinery v0.26.2
@@ -26,6 +25,7 @@ require (
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.9.0 // indirect
+	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -56,6 +56,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v0.9.0 h1:UE9n9rkJF62
 github.com/AzureAD/microsoft-authentication-library-for-go v0.9.0/go.mod h1:kgDmCTgBzIEPFElEF+FK0SdjAor06dRq2Go927dnQ6o=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df h1:GSoSVRLoBaFpOOds6QyY1L8AX7uoY+Ln3BHc22W40X0=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
@@ -70,7 +72,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -211,7 +212,6 @@ github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzL
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.14.0 h1:nJdhIvne2eSX/XRAFV9PcvFFRbrjbcTUj0VP62TMhnw=
@@ -220,13 +220,10 @@ github.com/prometheus/client_model v0.3.0 h1:UBgGFHqYdG/TPFD1B1ogZywDqEkwp3fBMvq
 github.com/prometheus/common v0.37.0 h1:ccBbHCgIiT9uSoFY0vX8H3zsNR5eLt17/RQLUvn8pXE=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/sanity-io/litter v1.5.5 h1:iE+sBxPBzoK6uaEP5Lt3fHNgpKcHXc/A2HGETy0uJQo=
-github.com/sanity-io/litter v1.5.5/go.mod h1:9gzJgR2i4ZpjZHsKvUXIRQVk7P+yM3e+jAF7bU2UI5U=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0
-	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df
 	github.com/blang/semver v3.5.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.18
 
 require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0
+	github.com/Masterminds/semver v1.5.0
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest/to v0.4.0 h1:oXVqrxakqqV1UZdSazDOPOLvOIz+XA683u8EctwboHk=
 github.com/Azure/go-autorest/autorest/to v0.4.0/go.mod h1:fE8iZBn7LQR7zH/9XU2NcPR4o9jEImooCeWJcYV/zLE=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df h1:GSoSVRLoBaFpOOds6QyY1L8AX7uoY+Ln3BHc22W40X0=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest/to v0.4.0 h1:oXVqrxakqqV1UZdSazDOPOLvOIz+XA683u8EctwboHk=
 github.com/Azure/go-autorest/autorest/to v0.4.0/go.mod h1:fE8iZBn7LQR7zH/9XU2NcPR4o9jEImooCeWJcYV/zLE=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df h1:GSoSVRLoBaFpOOds6QyY1L8AX7uoY+Ln3BHc22W40X0=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=

--- a/pkg/agent/datamodel/const.go
+++ b/pkg/agent/datamodel/const.go
@@ -181,7 +181,7 @@ const (
 	OSSKUMariner    = "Mariner"
 )
 
-// Feature Flags
+// Feature Flags.
 const (
 	BlockOutboundInternet = "BlockOutboundInternet"
 	CSERunInBackground    = "CSERunInBackground"

--- a/pkg/agent/datamodel/const.go
+++ b/pkg/agent/datamodel/const.go
@@ -180,3 +180,12 @@ const (
 	OSSKUCBLMariner = "CBLMariner"
 	OSSKUMariner    = "Mariner"
 )
+
+// Feature Flags
+const (
+	BlockOutboundInternet = "BlockOutboundInternet"
+	CSERunInBackground    = "CSERunInBackground"
+	EnableIPv6DualStack   = "EnableIPv6DualStack"
+	EnableIPv6Only        = "EnableIPv6Only"
+	EnableWinDSR          = "EnableWinDSR"
+)

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 )
 
 // TypeMeta describes an individual API model object.

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Masterminds/semver"
 )
 
 // TypeMeta describes an individual API model object.
@@ -1014,10 +1015,11 @@ in Windows nodes.
 func (p *Properties) GetKubeProxyFeatureGatesWindowsArguments() string {
 	featureGates := map[string]bool{}
 
-	if p.FeatureFlags.IsFeatureEnabled("EnableIPv6DualStack") {
+	if p.FeatureFlags.IsFeatureEnabled(EnableIPv6DualStack) &&
+		p.OrchestratorProfile.VersionSupportsFeatureFlag(EnableIPv6DualStack) {
 		featureGates["IPv6DualStack"] = true
 	}
-	if p.FeatureFlags.IsFeatureEnabled("EnableWinDSR") {
+	if p.FeatureFlags.IsFeatureEnabled(EnableWinDSR) {
 		// WinOverlay must be set to false.
 		featureGates["WinDSR"] = true
 		featureGates["WinOverlay"] = false
@@ -1111,6 +1113,36 @@ func (o *OrchestratorProfile) IsNoneCNI() bool {
 		return strings.EqualFold(o.KubernetesConfig.NetworkPlugin, NetworkPluginNone)
 	}
 	return false
+}
+
+func (o *OrchestratorProfile) VersionSupportsFeatureFlag(flag string) bool {
+	switch flag {
+	case EnableIPv6DualStack:
+		// unversioned will retrun true to maintain backwards compatibility
+		// IPv6DualStack flag was removed in 1.25.0 and is enabled by default
+		// since 1.21. It is supported between 1.15-1.24
+		// https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/
+		return o == nil || o.OrchestratorVersion == "" || o.VersionIs(">= 1.15.0 < 1.25.0")
+	default:
+		return false
+	}
+}
+
+// VersionIs takes a constraint expression to validate
+// the OrchestratorVersion meets this constraint. Examples
+// of expressions are `>= 1.24` or `!= 1.25.4`.
+// More info: https://github.com/Masterminds/semver#checking-version-constraints
+func (o *OrchestratorProfile) VersionIs(expr string) bool {
+	if o == nil || o.OrchestratorVersion == "" {
+		return false
+	}
+
+	version := semver.MustParse(o.OrchestratorVersion)
+	constraint, _ := semver.NewConstraint(expr)
+	if constraint == nil {
+		return false
+	}
+	return constraint.Check(version)
 }
 
 // IsCSIProxyEnabled returns true if csi proxy service should be enable for Windows nodes.
@@ -1226,15 +1258,15 @@ func (o *OrchestratorProfile) IsKubernetes() bool {
 func (f *FeatureFlags) IsFeatureEnabled(feature string) bool {
 	if f != nil {
 		switch feature {
-		case "CSERunInBackground":
+		case CSERunInBackground:
 			return f.EnableCSERunInBackground
-		case "BlockOutboundInternet":
+		case BlockOutboundInternet:
 			return f.BlockOutboundInternet
-		case "EnableIPv6DualStack":
+		case EnableIPv6DualStack:
 			return f.EnableIPv6DualStack
-		case "EnableIPv6Only":
+		case EnableIPv6Only:
 			return f.EnableIPv6Only
-		case "EnableWinDSR":
+		case EnableWinDSR:
 			return f.EnableWinDSR
 		default:
 			return false

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -1120,8 +1120,8 @@ func (o *OrchestratorProfile) VersionSupportsFeatureFlag(flag string) bool {
 	case EnableIPv6DualStack:
 		// unversioned will retrun true to maintain backwards compatibility
 		// IPv6DualStack flag was removed in 1.25.0 and is enabled by default
-		// since 1.21. It is supported between 1.15-1.24
-		// https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/
+		// since 1.21. It is supported between 1.15-1.24.
+		// https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/.
 		return o == nil || o.OrchestratorVersion == "" || o.VersionIs(">= 1.15.0 < 1.25.0")
 	default:
 		return false
@@ -1131,7 +1131,7 @@ func (o *OrchestratorProfile) VersionSupportsFeatureFlag(flag string) bool {
 // VersionIs takes a constraint expression to validate
 // the OrchestratorVersion meets this constraint. Examples
 // of expressions are `>= 1.24` or `!= 1.25.4`.
-// More info: https://github.com/Masterminds/semver#checking-version-constraints
+// More info: https://github.com/Masterminds/semver#checking-version-constraints.
 func (o *OrchestratorProfile) VersionIs(expr string) bool {
 	if o == nil || o.OrchestratorVersion == "" {
 		return false

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -1664,6 +1664,18 @@ func TestGetKubeProxyFeatureGatesWindowsArguments(t *testing.T) {
 			expectedFeatureGates: "",
 		},
 		{
+			name: "IPV6 enabled and version has feature gate (>= 1.15 < 1.25)",
+			properties: &Properties{
+				FeatureFlags: &FeatureFlags{
+					EnableIPv6DualStack: true,
+				},
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorVersion: "1.24.12",
+				},
+			},
+			expectedFeatureGates: "\"IPv6DualStack=true\"",
+		},
+		{
 			name: "IPV6 enabled but version does not have feature gate",
 			properties: &Properties{
 				FeatureFlags: &FeatureFlags{

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -1640,6 +1640,43 @@ func TestGetKubeProxyFeatureGatesWindowsArguments(t *testing.T) {
 			expectedFeatureGates: "\"IPv6DualStack=true\"",
 		},
 		{
+			name: "IPV6 enabled but version does not have feature gate (too old)",
+			properties: &Properties{
+				FeatureFlags: &FeatureFlags{
+					EnableIPv6DualStack: true,
+				},
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorVersion: "1.11.0",
+				},
+			},
+			expectedFeatureGates: "",
+		},
+		{
+			name: "IPV6 enabled but version does not have feature gate",
+			properties: &Properties{
+				FeatureFlags: &FeatureFlags{
+					EnableIPv6DualStack: true,
+				},
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorVersion: "1.25.0",
+				},
+			},
+			expectedFeatureGates: "",
+		},
+		{
+			name: "IPV6 enabled but version does not have feature gate",
+			properties: &Properties{
+				FeatureFlags: &FeatureFlags{
+					EnableIPv6DualStack: true,
+					EnableWinDSR:        true,
+				},
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorVersion: "1.25.0",
+				},
+			},
+			expectedFeatureGates: "\"WinDSR=true\", \"WinOverlay=false\"",
+		},
+		{
 			name: "WinDSR enabled",
 			properties: &Properties{
 				FeatureFlags: &FeatureFlags{

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -1677,6 +1677,19 @@ func TestGetKubeProxyFeatureGatesWindowsArguments(t *testing.T) {
 			expectedFeatureGates: "\"WinDSR=true\", \"WinOverlay=false\"",
 		},
 		{
+			name: "IPv6 enabled but version does not have feature gate",
+			properties: &Properties{
+				FeatureFlags: &FeatureFlags{
+					EnableIPv6DualStack: true,
+					EnableWinDSR:        true,
+				},
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorVersion: "1.26.2",
+				},
+			},
+			expectedFeatureGates: "\"WinDSR=true\", \"WinOverlay=false\"",
+		},
+		{
 			name: "WinDSR enabled",
 			properties: &Properties{
 				FeatureFlags: &FeatureFlags{

--- a/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
+++ b/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
@@ -15,7 +15,12 @@ $global:NetworkMode = "L2Bridge"
 $global:NetworkPlugin = $Global:ClusterConfiguration.Cni.Name
 $global:ContainerRuntime = $Global:ClusterConfiguration.Cri.Name
 $UseContainerD = ($global:ContainerRuntime -eq "containerd")
-$IsDualStackEnabled = $Global:ClusterConfiguration.Kubernetes.Kubeproxy.FeatureGates -contains "IPv6DualStack=true"
+# if dual-stack is enabled, the clusterCidr will have an IPv6 CIDR in the comma separated list
+# we can split the entire string by ":" to get a count of how many ":" there are. If there are
+# at least 3 groups (which means there are at least 2 ":") then we know there is an IPv6 CIDR
+# in the list. We cannot just rely on `ClusterCidr -like "*::*" because there are IPv6 CIDRs that
+# don't have "::", e.g. fe80:0:0:0:0:0:0:0/64
+$IsDualStackEnabled = ($Global:ClusterConfiguration.Kubernetes.Network.ClusterCidr -split ":").Count -ge 3
 
 $global:HNSModule = "c:\k\hns.psm1"
 if ($global:ContainerRuntime -eq "containerd") {

--- a/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
+++ b/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
@@ -20,7 +20,8 @@ $UseContainerD = ($global:ContainerRuntime -eq "containerd")
 # at least 3 groups (which means there are at least 2 ":") then we know there is an IPv6 CIDR
 # in the list. We cannot just rely on `ClusterCidr -like "*::*" because there are IPv6 CIDRs that
 # don't have "::", e.g. fe80:0:0:0:0:0:0:0/64
-$IsDualStackEnabled = ($Global:ClusterConfiguration.Kubernetes.Network.ClusterCidr -split ":").Count -ge 3
+$IsDualStackEnabled = ($Global:ClusterConfiguration.Kubernetes.Kubeproxy.FeatureGates -contains "IPv6DualStack=true") -Or `
+                        (($Global:ClusterConfiguration.Kubernetes.Network.ClusterCidr -split ":").Count -ge 3)
 
 $global:HNSModule = "c:\k\hns.psm1"
 if ($global:ContainerRuntime -eq "containerd") {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

`IPv6DualStack` is removed from the Kubernetes FeatureFlag set
in 1.25.0 and has been enabled by default since 1.21.0. There are
some other places in CSE that depend on the feature flag being part
of the config so this change is just to remove it from kube-proxy's
list of args so it doesn't crash at startup.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
