### PR TITLE
fix: replace password-related settings properly

### DIFF
--- a/parts/linux/cloud-init/artifacts/cis.sh
+++ b/parts/linux/cloud-init/artifacts/cis.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
 assignRootPW() {
-  if grep '^root:[!*]:' /etc/shadow; then
-    VERSION=$(grep DISTRIB_RELEASE /etc/*-release| cut -f 2 -d "=")
-    SALT=$(openssl rand -base64 5)
-    SECRET=$(openssl rand -base64 37)
-    CMD="import crypt, getpass, pwd; print(crypt.crypt('$SECRET', '\$6\$$SALT\$'))"
-    if [[ "${VERSION}" == "22.04" ]]; then
-      HASH=$(python3 -c "$CMD")
-    else
-      HASH=$(python -c "$CMD")
-    fi
+    if grep '^root:[!*]:' /etc/shadow; then
+        VERSION=$(grep DISTRIB_RELEASE /etc/*-release | cut -f 2 -d "=")
+        SALT=$(openssl rand -base64 5)
+        SECRET=$(openssl rand -base64 37)
+        CMD="import crypt, getpass, pwd; print(crypt.crypt('$SECRET', '\$6\$$SALT\$'))"
+        if [[ "${VERSION}" == "22.04" ]]; then
+            HASH=$(python3 -c "$CMD")
+        else
+            HASH=$(python -c "$CMD")
+        fi
 
-    echo 'root:'$HASH | /usr/sbin/chpasswd -e || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
-  fi
+        echo 'root:'$HASH | /usr/sbin/chpasswd -e || exit $ERR_CIS_ASSIGN_ROOT_PW
+    fi
 }
 
 assignFilePermissions() {
@@ -59,29 +59,75 @@ assignFilePermissions() {
         chmod 0600 /etc/crontab || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     fi
     for filepath in /etc/cron.hourly /etc/cron.daily /etc/cron.weekly /etc/cron.monthly /etc/cron.d; do
-      chmod 0600 $filepath || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
+        chmod 0600 $filepath || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     done
 }
 
+# Helper function to replace or append settings to a setting file.
+# This abstracts the general logic of:
+#   1. Search for the setting (via a pattern passed in).
+#   2. If it's there, replace it with desired setting line; otherwise append it to the end of the file.
+#   3. Validate that there is now exactly one instance of the setting, and that it is the one we want.
+replaceOrAppendSetting() {
+    local SEARCH_PATTERN=$1
+    local SETTING_LINE=$2
+    local FILE=$3
+
+    # Search and replace/append.
+    if grep -E "$SEARCH_PATTERN" "$FILE" >/dev/null; then
+        sed -E -i "s|${SEARCH_PATTERN}|${SETTING_LINE}|g" "$FILE" || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
+    else
+        echo -e "\n${SETTING_LINE}" >>"$FILE"
+    fi
+
+    # After replacement/append, there should be exactly one line that sets the setting,
+    # and it must have the value we want.
+    # If not, then there's something wrong with this script.
+    if [[ $(grep -E "$SEARCH_PATTERN" "$FILE") != "$SETTING_LINE" ]]; then
+        echo "replacement was wrong"
+        exit $ERR_CIS_APPLY_PASSWORD_CONFIG
+    fi
+}
+
+# Creates the search pattern and setting lines for login.defs settings, and calls through
+# to do the replacement. Note that this uses extended regular expressions, so both
+# grep and sed need to be called as such.
+#
+# The search pattern is:
+#   '^#{0,1} {0,1}' -- Line starts with 0 or 1 '#' followed by 0 or 1 space
+#   '${1}\s+'       -- Then the setting name followed by one or more whitespace characters
+#   '[0-9]+$'       -- Then one more more number, which is the setting value, which is the end of the line.
+#
+# This is based on a combination of the syntax for the file and real examples we've found.
+replaceOrAppendLoginDefs() {
+    replaceOrAppendSetting "^#{0,1} {0,1}${1}\s+[0-9]+$" "${1} ${2}" /etc/login.defs
+}
+
+# Creates the search pattern and setting lines for useradd default settings, and calls through
+# to do the replacement. Note that this uses extended regular expressions, so both
+# grep and sed need to be called as such.
+#
+# The search pattern is:
+#   '^#{0,1} {0,1}' -- Line starts with 0 or 1 '#' followed by 0 or 1 space
+#   '${1}='         -- Then the setting name followed by '='
+#   '.*$'           -- Then 0 or nore of any character which is the end of the line.
+#                      Note that this allows for a setting value to be there or not.
+#
+# This is based on a combination of the syntax for the file and real examples we've found.
+replaceOrAppendUserAdd() {
+    replaceOrAppendSetting "^#{0,1} {0,1}${1}=.*$" "${1}=${2}" /etc/default/useradd
+}
+
 setPWExpiration() {
-  sed -i "s|PASS_MAX_DAYS||g" /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'PASS_MAX_DAYS' /etc/login.defs && exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  sed -i "s|PASS_MIN_DAYS||g" /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'PASS_MIN_DAYS' /etc/login.defs && exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  sed -i "s|INACTIVE=||g" /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'INACTIVE=' /etc/default/useradd && exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  echo 'PASS_MAX_DAYS 90' >> /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'PASS_MAX_DAYS 90' /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  echo 'PASS_MIN_DAYS 7' >> /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'PASS_MIN_DAYS 7' /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  echo 'INACTIVE=30' >> /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'INACTIVE=30' /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
+    replaceOrAppendLoginDefs PASS_MAX_DAYS 90
+    replaceOrAppendLoginDefs PASS_MIN_DAYS 7
+    replaceOrAppendUserAdd INACTIVE 30
 }
 
 applyCIS() {
-  setPWExpiration
-  assignRootPW
-  assignFilePermissions
+    setPWExpiration
+    assignRootPW
+    assignFilePermissions
 }
 
 applyCIS

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -625,19 +625,19 @@ func linuxCloudInitArtifactsCiSyslogWatcherSh() (*asset, error) {
 var _linuxCloudInitArtifactsCisSh = []byte(`#!/bin/bash
 
 assignRootPW() {
-  if grep '^root:[!*]:' /etc/shadow; then
-    VERSION=$(grep DISTRIB_RELEASE /etc/*-release| cut -f 2 -d "=")
-    SALT=$(openssl rand -base64 5)
-    SECRET=$(openssl rand -base64 37)
-    CMD="import crypt, getpass, pwd; print(crypt.crypt('$SECRET', '\$6\$$SALT\$'))"
-    if [[ "${VERSION}" == "22.04" ]]; then
-      HASH=$(python3 -c "$CMD")
-    else
-      HASH=$(python -c "$CMD")
-    fi
+    if grep '^root:[!*]:' /etc/shadow; then
+        VERSION=$(grep DISTRIB_RELEASE /etc/*-release | cut -f 2 -d "=")
+        SALT=$(openssl rand -base64 5)
+        SECRET=$(openssl rand -base64 37)
+        CMD="import crypt, getpass, pwd; print(crypt.crypt('$SECRET', '\$6\$$SALT\$'))"
+        if [[ "${VERSION}" == "22.04" ]]; then
+            HASH=$(python3 -c "$CMD")
+        else
+            HASH=$(python -c "$CMD")
+        fi
 
-    echo 'root:'$HASH | /usr/sbin/chpasswd -e || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
-  fi
+        echo 'root:'$HASH | /usr/sbin/chpasswd -e || exit $ERR_CIS_ASSIGN_ROOT_PW
+    fi
 }
 
 assignFilePermissions() {
@@ -683,29 +683,75 @@ assignFilePermissions() {
         chmod 0600 /etc/crontab || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     fi
     for filepath in /etc/cron.hourly /etc/cron.daily /etc/cron.weekly /etc/cron.monthly /etc/cron.d; do
-      chmod 0600 $filepath || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
+        chmod 0600 $filepath || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     done
 }
 
+# Helper function to replace or append settings to a setting file.
+# This abstracts the general logic of:
+#   1. Search for the setting (via a pattern passed in).
+#   2. If it's there, replace it with desired setting line; otherwise append it to the end of the file.
+#   3. Validate that there is now exactly one instance of the setting, and that it is the one we want.
+replaceOrAppendSetting() {
+    local SEARCH_PATTERN=$1
+    local SETTING_LINE=$2
+    local FILE=$3
+
+    # Search and replace/append.
+    if grep -E "$SEARCH_PATTERN" "$FILE" >/dev/null; then
+        sed -E -i "s|${SEARCH_PATTERN}|${SETTING_LINE}|g" "$FILE" || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
+    else
+        echo -e "\n${SETTING_LINE}" >>"$FILE"
+    fi
+
+    # After replacement/append, there should be exactly one line that sets the setting,
+    # and it must have the value we want.
+    # If not, then there's something wrong with this script.
+    if [[ $(grep -E "$SEARCH_PATTERN" "$FILE") != "$SETTING_LINE" ]]; then
+        echo "replacement was wrong"
+        exit $ERR_CIS_APPLY_PASSWORD_CONFIG
+    fi
+}
+
+# Creates the search pattern and setting lines for login.defs settings, and calls through
+# to do the replacement. Note that this uses extended regular expressions, so both
+# grep and sed need to be called as such.
+#
+# The search pattern is:
+#   '^#{0,1} {0,1}' -- Line starts with 0 or 1 '#' followed by 0 or 1 space
+#   '${1}\s+'       -- Then the setting name followed by one or more whitespace characters
+#   '[0-9]+$'       -- Then one more more number, which is the setting value, which is the end of the line.
+#
+# This is based on a combination of the syntax for the file and real examples we've found.
+replaceOrAppendLoginDefs() {
+    replaceOrAppendSetting "^#{0,1} {0,1}${1}\s+[0-9]+$" "${1} ${2}" /etc/login.defs
+}
+
+# Creates the search pattern and setting lines for useradd default settings, and calls through
+# to do the replacement. Note that this uses extended regular expressions, so both
+# grep and sed need to be called as such.
+#
+# The search pattern is:
+#   '^#{0,1} {0,1}' -- Line starts with 0 or 1 '#' followed by 0 or 1 space
+#   '${1}='         -- Then the setting name followed by '='
+#   '.*$'           -- Then 0 or nore of any character which is the end of the line.
+#                      Note that this allows for a setting value to be there or not.
+#
+# This is based on a combination of the syntax for the file and real examples we've found.
+replaceOrAppendUserAdd() {
+    replaceOrAppendSetting "^#{0,1} {0,1}${1}=.*$" "${1}=${2}" /etc/default/useradd
+}
+
 setPWExpiration() {
-  sed -i "s|PASS_MAX_DAYS||g" /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'PASS_MAX_DAYS' /etc/login.defs && exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  sed -i "s|PASS_MIN_DAYS||g" /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'PASS_MIN_DAYS' /etc/login.defs && exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  sed -i "s|INACTIVE=||g" /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'INACTIVE=' /etc/default/useradd && exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  echo 'PASS_MAX_DAYS 90' >> /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'PASS_MAX_DAYS 90' /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  echo 'PASS_MIN_DAYS 7' >> /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'PASS_MIN_DAYS 7' /etc/login.defs || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  echo 'INACTIVE=30' >> /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
-  grep 'INACTIVE=30' /etc/default/useradd || exit $ERR_CIS_APPLY_PASSWORD_CONFIG
+    replaceOrAppendLoginDefs PASS_MAX_DAYS 90
+    replaceOrAppendLoginDefs PASS_MIN_DAYS 7
+    replaceOrAppendUserAdd INACTIVE 30
 }
 
 applyCIS() {
-  setPWExpiration
-  assignRootPW
-  assignFilePermissions
+    setPWExpiration
+    assignRootPW
+    assignFilePermissions
 }
 
 applyCIS

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -19,7 +19,7 @@ testFilesDownloaded() {
     return
   fi
   echo "$test:Start"
-  filesToDownload=$(jq .DownloadFiles[] --monochrome-output --compact-output < $COMPONENTS_FILEPATH)
+  filesToDownload=$(jq .DownloadFiles[] --monochrome-output --compact-output <$COMPONENTS_FILEPATH)
 
   for fileToDownload in ${filesToDownload[*]}; do
     fileName=$(echo "${fileToDownload}" | jq .fileName -r)
@@ -205,7 +205,7 @@ testChrony() {
   date --set "27 Feb 2021"
   for i in $(seq 1 10); do
     newDate=$(date +%s)
-    if (( $newDate > $initialDate)); then
+    if (($newDate > $initialDate)); then
       echo "$os_chrony readjusted the system time correctly"
       break
     fi
@@ -224,23 +224,23 @@ testFips() {
   os_version=$1
   enable_fips=$2
 
-  if [[ ( ${os_version} == "18.04" || ${os_version} == "20.04" ) && ${enable_fips,,} == "true" ]]; then
+  if [[ (${os_version} == "18.04" || ${os_version} == "20.04") && ${enable_fips,,} == "true" ]]; then
     kernel=$(uname -r)
     if [[ -f /proc/sys/crypto/fips_enabled ]]; then
-        fips_enabled=$(cat /proc/sys/crypto/fips_enabled)
-        if [[ "${fips_enabled}" == "1" ]]; then
-          echo "FIPS is enabled."
-        else
-          err $test "content of /proc/sys/crypto/fips_enabled is not 1."
-        fi
+      fips_enabled=$(cat /proc/sys/crypto/fips_enabled)
+      if [[ "${fips_enabled}" == "1" ]]; then
+        echo "FIPS is enabled."
+      else
+        err $test "content of /proc/sys/crypto/fips_enabled is not 1."
+      fi
     else
-        err $test "FIPS is not enabled."
+      err $test "FIPS is not enabled."
     fi
 
     if [[ -f /usr/src/linux-headers-${kernel}/Makefile ]]; then
-        echo "fips header files exist."
+      echo "fips header files exist."
     else
-        err $test "fips header files don't exist."
+      err $test "fips header files don't exist."
     fi
   fi
 
@@ -252,18 +252,18 @@ testKubeBinariesPresent() {
   echo "$test:Start"
   containerRuntime=$1
   binaryDir=/usr/local/bin
-  k8sVersions="$(jq -r .kubernetes.versions[] < /opt/azure/manifest.json)"
+  k8sVersions="$(jq -r .kubernetes.versions[] </opt/azure/manifest.json)"
   for patchedK8sVersion in ${k8sVersions}; do
     # Only need to store k8s components >= 1.19 for containerd VHDs
     if (($(echo ${patchedK8sVersion} | cut -d"." -f2) < 19)) && [[ ${containerRuntime} == "containerd" ]]; then
       continue
     fi
     # strip the last .1 as that is for base image patch for hyperkube
-    if grep -iq hotfix <<< ${patchedK8sVersion}; then
+    if grep -iq hotfix <<<${patchedK8sVersion}; then
       # shellcheck disable=SC2006
-      patchedK8sVersion=`echo ${patchedK8sVersion} | cut -d"." -f1,2,3,4`;
+      patchedK8sVersion=$(echo ${patchedK8sVersion} | cut -d"." -f1,2,3,4)
     else
-      patchedK8sVersion=`echo ${patchedK8sVersion} | cut -d"." -f1,2,3`;
+      patchedK8sVersion=$(echo ${patchedK8sVersion} | cut -d"." -f1,2,3)
     fi
     k8sVersion=$(echo ${patchedK8sVersion} | cut -d"_" -f1 | cut -d"-" -f1 | cut -d"." -f1,2,3)
     kubeletDownloadLocation="$binaryDir/kubelet-$k8sVersion"
@@ -299,7 +299,7 @@ testKubeProxyImagesPulled() {
   test="testKubeProxyImagesPulled"
   echo "$test:Start"
   containerRuntime=$1
-  containerdKubeProxyImages=$(jq .containerdKubeProxyImages < ${KUBE_PROXY_IMAGES_FILEPATH})
+  containerdKubeProxyImages=$(jq .containerdKubeProxyImages <${KUBE_PROXY_IMAGES_FILEPATH})
 
   if [ $containerRuntime == 'containerd' ]; then
     testImagesPulled containerd "$containerdKubeProxyImages"
@@ -314,13 +314,13 @@ testKubeProxyImagesPulled() {
 testCriticalTools() {
   test="testCriticalTools"
   echo "$test:Start"
-  if ! nc -h 2> /dev/null; then
+  if ! nc -h 2>/dev/null; then
     err $test "nc is not installed"
   else
     echo $test "nc is installed"
   fi
 
-  if ! nslookup -version 2> /dev/null; then
+  if ! nslookup -version 2>/dev/null; then
     err $test "nslookup is not installed"
   else
     echo $test "nslookup is installed"
@@ -333,7 +333,7 @@ testCustomCAScriptExecutable() {
   test="testCustomCAScriptExecutable"
   permissions=$(stat -c "%a" /opt/scripts/update_certs.sh)
   if [ "$permissions" != "755" ]; then
-      err $test "/opt/scripts/update_certs.sh has incorrect permissions"
+    err $test "/opt/scripts/update_certs.sh has incorrect permissions"
   fi
   echo "$test:Finish"
 }
@@ -349,12 +349,174 @@ testCustomCATimerNotStarted() {
 testVHDBuildLogsExist() {
   test="testVHDBuildLogsExist"
   if [ -f $VHD_LOGS_FILEPATH ]; then
-      echo "detected vhd logs file"
+    echo "detected vhd logs file"
   else
-      err $test "File $VHD_LOGS_FILEPATH not found"
-      exit $ERR_VHD_FILE_NOT_FOUND
+    err $test "File $VHD_LOGS_FILEPATH not found"
+    exit $ERR_VHD_FILE_NOT_FOUND
   fi
   echo "$test:Finish"
+}
+
+# Ensures that /etc/login.defs is valid. This is a best-effort test, as we aren't going to
+# re-implement everything that uses this file.
+testLoginDefs() {
+  test="testLoginDefs"
+  local settings_file=/etc/login.defs
+  echo "$test:Start"
+
+  # Existence and format check. Based on https://man7.org/linux/man-pages/man5/login.defs.5.html,
+  # we expect the file to have lines that are either a comment or "NAME VALUE" pairs. Arbitrary whitespace
+  # is allowed before NAME and between NAME and VALUE. NAME seems tobe upper-case and '_'.
+  # all-caps and include letters and '_'. Values can be anything, so we make sure they're printable.
+  testSettingFileFormat $test $settings_file '^[[:space:]]*(#|$)' '^[[:space:]]*[A-Z_]+[[:space:]]+[^[:cntrl:]]+$'
+
+  # Look for the settings we specifically set in <repo-root>/parts/linux/cloud-init/artifacts/cis.sh
+  # and ensure they're set to the values we expect.
+  echo "$test: Checking specific settings in $settings_file"
+  testSetting $test $settings_file PASS_MAX_DAYS '^[[:space:]]*PASS_MAX_DAYS[[:space:]]' ' ' 90
+  testSetting $test $settings_file PASS_MIN_DAYS '^[[:space:]]*PASS_MIN_DAYS[[:space:]]+' ' ' 7
+
+  echo "$test:Finish"
+}
+
+# Ensures that /etc/default/useradd is valid. This is a best-effort test, as we aren't going to
+# re-implement everything that uses this file.
+testUserAdd() {
+  test="testUserAdd"
+  local settings_file=/etc/default/useradd
+  echo "$test:Start"
+
+  # Existence and format check. The man page https://www.man7.org/linux/man-pages/man8/useradd.8.html
+  # doesn't really state the format of the file, but experimentation and examples show that each
+  # line must be a comment or 'NAME=VALUE', where values can be empty or strings, and strings
+  # is pretty loose (any printable character).
+  testSettingFileFormat $test $settings_file '^[[:space:]]*(#|$)' '^[A-Z_]+=[^[:cntrl:]]*$'
+
+  # Look for the settings we specifically set in <repo-root>/parts/linux/cloud-init/artifacts/cis.sh
+  # and ensure they're set to the values we expect.
+  echo "$test: Checking specific settings in $settings_file"
+  testSetting $test $settings_file INACTIVE '^INACTIVE=' '=' 30
+
+  # Double-check that the setting we set is actually used by useradd.
+  # Disable shellcheck warning about using '$?' in an if statement because we don't want
+  # the return value anyway and the ways it suggests reorganizing the if statement
+  # actually confuse it even more.
+  echo "$test: Checking that INACTIVE is used by useradd"
+  useradd -D | grep -E -v "^INACTIVE=30$" >/dev/null
+  # shellcheck disable=SC2181
+  if [ $? -ne 0 ]; then
+    err $test "useradd is not using INACTIVE=30 from $settings_file"
+  fi
+  echo "$test: useradd is using INACTIVE=30 from $settings_file"
+
+  echo "$test:Finish"
+}
+
+# Tests a setting file's format. This is a simple, line-by line check.
+# Parameters:
+#  test: The name of the test.
+#  settings_file: The path to the settings file.
+#  Remaining parameters are regexes used for validation.
+#
+#  The file will be tested for existence, then each line of the file is expected
+#  to match at least one of the regexes.
+#
+#  Any lines that match none of the regexes are printed to stderr.
+#  Returns 0 if all lines are valid, 1 otherwise.
+testSettingFileFormat() {
+  local test="$1"
+  local settings_file="$2"
+  shift 2
+
+  # If the file doesn't exist, everything is broken.
+  echo "$test: Checking existence of $settings_file"
+  if [ ! -f $settings_file ]; then
+    err $test "File $settings_file not found"
+    return 1
+  fi
+  echo "$test: $settings_file exists"
+
+  # Loop through each line in the file.
+  # For each line, each regex is checked. If none match, the line is invalid.
+  echo "$test: Checking format of $settings_file"
+  local line_num=1
+  local line
+  local regex
+  local valid=0
+  local any_invalid=0
+  while read -r line; do
+    line_num=$((line_num + 1))
+    for regex in "$@"; do
+      if [[ "$line" =~ $regex ]]; then
+        valid=1
+        break
+      fi
+    done
+
+    if [ $valid -eq 0 ]; then
+      any_invalid=1
+      err $test "Invalid line $line_num in $settings_file: '$line'" >>/dev/stderr
+    fi
+
+    valid=0
+  done <$settings_file
+
+  if [ $any_invalid -eq 0 ]; then
+    echo "$test: $settings_file is valid"
+  fi
+
+  return $any_invalid
+}
+
+# Tests an individual setting in a settings file, ensuring it's set with the correct value.
+# Note: This assumes the file format is generally correct (see function testSettingFileFormat).
+# Parameters:
+#  test: The name of the test.
+#  settings_file: The path to the settings file.
+#  setting_name: The name of the setting to check.
+#  setting_line_regex: A regex that matches the line that contains the setting. This should be
+#                      setting-specific -- if you want to check setting 'FOO', this should look
+#                      specifically for 'FOO' in the line.
+#  setting_value_awk_separator: The separator to use when parsing the setting value from the line.
+#                               This is used in an awk command, so it should be a single character.
+#  expected_value: The expected value of the setting.
+testSetting() {
+  local test="$1"
+  local settings_file="$2"
+  local setting_name="$3"
+  local setting_line_regex="$4"
+  local setting_value_awk_separator="$5"
+  local expected_value="$6"
+
+  echo "$test: Checking setting '$setting_name' has value '$expected_value' in $settings_file"
+  # Get the lines that match the setting name. Note that this will come with the line number.
+  local value_lines=
+  value_lines=$(grep -E -n "${setting_line_regex}" "${settings_file}")
+
+  # If the setting isn't present, that's an error.
+  if [ -z "$value_lines" ]; then
+    err $test "Setting '$setting_name' not found in $settings_file"
+    return 1
+  fi
+
+  # If the setting is present more than once, that's an error.
+  if [ $(echo "$value_lines" | wc -l) -gt 1 ]; then
+    err $test "Setting '$setting_name' found more than once in $settings_file. See below for lines."
+    echo "$value_lines" >>/dev/stderr
+    return 1
+  fi
+
+  # Get the value of the setting and test it. To do this we must strip out the line number. We also
+  # trim leading and trailing whitespace around the value with xargs.
+  local value=
+  value=$(echo "$value_lines" | sed -E 's/^([0-9]+:)//' | awk -F "$setting_value_awk_separator" '{print $2}' | xargs)
+  if [ "$value" != "$expected_value" ]; then
+    err $test "Setting '$setting_name' has value '$value' in $settings_file, expected '$expected_value'"
+    return 1
+  fi
+
+  echo "$test: Setting '$setting_name' has value correct value '$expected_value' in $settings_file"
+  return 0
 }
 
 err() {
@@ -377,3 +539,5 @@ testKubeProxyImagesPulled $CONTAINER_RUNTIME
 testImagesRetagged $CONTAINER_RUNTIME
 testCustomCAScriptExecutable
 testCustomCATimerNotStarted
+testLoginDefs
+testUserAdd


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We have code that modifies `/etc/default/useradd` `/etc/login.defs` to bring them into compliance with CIS benchmarks. However, the script does some weird things to those files and in the case of `mariner` actually fails to set the `INACTIVE` setting in `/etc/useradd`.

This change fixes the script to modify settings in place or append them, taking into account the fact that a file may not have a trailing new-line.

I also normalized the tab length in the file, which was different in different functions.

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
Here's the mariner `/etc/default/useradd` before this change. You can see that `INACTIVE` isn't actually set and `CREATE_MAIL_SPOOL` is corrupted.
```
# useradd defaults file
GROUP=100
HOME=/home
-1
EXPIRE=
SHELL=/bin/bash
SKEL=/etc/skel
CREATE_MAIL_SPOOL=noINACTIVE=30
```

Here it is with these changes:
```
# useradd defaults file
GROUP=100
HOME=/home
INACTIVE=30
EXPIRE=
SHELL=/bin/bash
SKEL=/etc/skel
CREATE_MAIL_SPOOL=no
```

`/etc/login.defs` is a much larger file, as is `/etc/default/useradd` on ubuntu. You can see both files from before/after on mariner and ubuntu in this zip file:
[cis-fix-password-settings.zip](https://github.com/Azure/AgentBaker/files/11227106/cis-fix-password-settings.zip)


**Release note**:
```
none
```
