### PR TITLE
perf: parallelize abe2e cluster creation + some more caching

### DIFF
--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -12,13 +12,42 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"k8s.io/apimachinery/pkg/util/errors"
 )
 
 const (
 	managedClusterResourceType = "Microsoft.ContainerService/managedClusters"
 )
 
-type paramCache map[string]map[string]string
+type clusterParameters map[string]string
+
+type clusterConfig struct {
+	cluster      *armcontainerservice.ManagedCluster
+	kube         *kubeclient
+	parameters   clusterParameters
+	subnetId     string
+	isNewCluster bool
+}
+
+// Returns true if the cluster is configured with Azure CNI
+func (c clusterConfig) isAzureCNI() (bool, error) {
+	if c.cluster.Properties.NetworkProfile != nil {
+		return *c.cluster.Properties.NetworkProfile.NetworkPlugin == armcontainerservice.NetworkPluginAzure, nil
+	}
+	return false, fmt.Errorf("cluster network profile was nil: %+v", c.cluster)
+}
+
+// Returns the maximum number of pods per node of the cluster's agentpool
+func (c clusterConfig) maxPodsPerNode() (int, error) {
+	if len(c.cluster.Properties.AgentPoolProfiles) > 0 {
+		return int(*c.cluster.Properties.AgentPoolProfiles[0].MaxPods), nil
+	}
+	return 0, fmt.Errorf("cluster agentpool profiles were nil or empty: %+v", c.cluster)
+}
+
+func (c clusterConfig) needsPreparation() bool {
+	return c.kube == nil || c.parameters == nil || c.subnetId == ""
+}
 
 func isExistingResourceGroup(ctx context.Context, cloud *azureClient, resourceGroupName string) (bool, error) {
 	rgExistence, err := cloud.resourceGroupClient.CheckExistence(ctx, resourceGroupName, nil)
@@ -149,8 +178,8 @@ func getClusterSubnetID(ctx context.Context, cloud *azureClient, location, mcRes
 	return "", fmt.Errorf("failed to find aks vnet")
 }
 
-func listClusters(ctx context.Context, t *testing.T, cloud *azureClient, resourceGroupName string) ([]*armcontainerservice.ManagedCluster, error) {
-	clusters := []*armcontainerservice.ManagedCluster{}
+func getInitialClusterConfigs(ctx context.Context, t *testing.T, cloud *azureClient, resourceGroupName string) ([]clusterConfig, error) {
+	var configs []clusterConfig
 	pager := cloud.resourceClient.NewListByResourceGroupPager(resourceGroupName, nil)
 
 	for pager.More() {
@@ -178,22 +207,78 @@ func listClusters(ctx context.Context, t *testing.T, cloud *azureClient, resourc
 				}
 
 				t.Logf("found agentbaker e2e cluster: %q", *cluster.Name)
-				clusters = append(clusters, &cluster.ManagedCluster)
+				configs = append(configs, clusterConfig{cluster: &cluster.ManagedCluster})
 			}
 		}
 	}
 
-	return clusters, nil
+	return configs, nil
 }
 
-func getViableClusters(scenario *scenario.Scenario, clusters []*armcontainerservice.ManagedCluster) []*armcontainerservice.ManagedCluster {
-	viableClusters := []*armcontainerservice.ManagedCluster{}
-	for _, cluster := range clusters {
-		if scenario.Config.ClusterSelector(cluster) {
-			viableClusters = append(viableClusters, cluster)
+func hasViableConfig(scenario *scenario.Scenario, clusterConfigs []clusterConfig) bool {
+	for _, config := range clusterConfigs {
+		if scenario.Config.ClusterSelector(config.cluster) {
+			return true
 		}
 	}
-	return viableClusters
+	return false
+}
+
+func createMissingClusters(
+	ctx context.Context,
+	t *testing.T,
+	r *mrand.Rand,
+	cloud *azureClient,
+	suiteConfig *suiteConfig,
+	scenarios scenario.Table,
+	clusterConfigs *[]clusterConfig) error {
+	var newConfigs []clusterConfig
+	for _, scenario := range scenarios {
+		if !hasViableConfig(scenario, *clusterConfigs) && !hasViableConfig(scenario, newConfigs) {
+			newClusterModel := getNewClusterModelForScenario(generateClusterName(r), suiteConfig.location, scenario)
+			newConfigs = append(newConfigs, clusterConfig{cluster: &newClusterModel, isNewCluster: true})
+		}
+	}
+
+	var createFuncs []func() error
+	for i, c := range newConfigs {
+		config := c
+		idx := i
+		createFunc := func() error {
+			clusterName := *config.cluster.Name
+
+			log.Printf("creating cluster %q...", clusterName)
+			liveCluster, err := createNewCluster(ctx, cloud, suiteConfig.resourceGroupName, config.cluster)
+			if err != nil {
+				return fmt.Errorf("unable to create new cluster: %w", err)
+			}
+
+			if liveCluster.Properties == nil {
+				return fmt.Errorf("newly created cluster model has nil properties:\n%+v", liveCluster)
+			}
+
+			log.Printf("preparing cluster %q for testing...", clusterName)
+			kube, subnetId, clusterParams, err := prepareClusterForTests(ctx, t, cloud, suiteConfig, liveCluster)
+			if err != nil {
+				return fmt.Errorf("unable to prepare viable cluster for testing: %s", err)
+			}
+
+			newConfigs[idx].cluster = liveCluster
+			newConfigs[idx].kube = kube
+			newConfigs[idx].parameters = clusterParams
+			newConfigs[idx].subnetId = subnetId
+			return nil
+		}
+
+		createFuncs = append(createFuncs, createFunc)
+	}
+
+	if err := errors.AggregateGoroutines(createFuncs...); err != nil {
+		return fmt.Errorf("at least one cluster creation routine returned an error:\n%w", err)
+	}
+
+	*clusterConfigs = append(*clusterConfigs, newConfigs...)
+	return nil
 }
 
 func mustChooseCluster(
@@ -203,91 +288,57 @@ func mustChooseCluster(
 	cloud *azureClient,
 	suiteConfig *suiteConfig,
 	scenario *scenario.Scenario,
-	clusters *[]*armcontainerservice.ManagedCluster,
-	paramCache paramCache) (*kubeclient, *armcontainerservice.ManagedCluster, map[string]string, string) {
-	var (
-		chosenKubeClient    *kubeclient
-		chosenCluster       *armcontainerservice.ManagedCluster
-		chosenClusterParams map[string]string
-		chosenSubnetID      string
-	)
-
-	viableClusters := getViableClusters(scenario, *clusters)
-
-	if len(viableClusters) == 0 {
-		t.Logf("unable to find viable test cluster for scenario %q, attempting to create a new one...", scenario.Name)
-		clusterBaseModel := getBaseClusterModel(
-			fmt.Sprintf(testClusterNameTemplate, randomLowercaseString(r, 5)),
-			suiteConfig.location,
-		)
-		scenario.Config.ClusterMutator(&clusterBaseModel)
-
-		cluster, err := createNewCluster(ctx, cloud, suiteConfig.resourceGroupName, &clusterBaseModel)
-		if err != nil {
-			t.Fatalf("unable to create new cluster: %s", err)
-		}
-
-		if cluster.Properties == nil {
-			t.Fatalf("newly created cluster model has nil properties:\n%+v", cluster)
-		}
-
-		kube, subnetID, clusterParams, err := prepareClusterForTests(ctx, t, cloud, suiteConfig, cluster, paramCache)
-		if err != nil {
-			t.Fatalf("unable to prepare new cluster for test: %s", err)
-		}
-
-		*clusters = append(*clusters, cluster)
-
-		chosenCluster = cluster
-		chosenKubeClient = kube
-		chosenSubnetID = subnetID
-		chosenClusterParams = clusterParams
-	} else {
-		for _, viableCluster := range viableClusters {
-			var cluster *armcontainerservice.ManagedCluster
-
-			needRecreate, err := validateExistingClusterState(ctx, t, cloud, suiteConfig.resourceGroupName, viableCluster)
-			if err != nil {
-				t.Logf("unable to validate state of viable cluster %q: %s", *viableCluster.Name, err)
-				continue
-			}
-
-			if needRecreate {
-				t.Logf("viable cluster %q is in a bad state, attempting to recreate...", *viableCluster.Name)
-
-				newCluster, err := createNewCluster(ctx, cloud, suiteConfig.resourceGroupName, viableCluster)
-				if err != nil {
-					t.Logf("unable to recreate viable cluster %q: %s", *viableCluster.Name, err)
+	clusterConfigs []clusterConfig) clusterConfig {
+	var chosenConfig clusterConfig
+	for i := range clusterConfigs {
+		config := &clusterConfigs[i]
+		if scenario.Config.ClusterSelector(config.cluster) {
+			// only validate + prep the cluster for testing if we didn't just create it and it hasn't already been prepared
+			if !config.isNewCluster && config.needsPreparation() {
+				if err := validateAndPrepareCluster(ctx, t, cloud, suiteConfig, config); err != nil {
+					t.Logf("unable to validate and preprare cluster %q: %s", *config.cluster.Name, err)
 					continue
 				}
-				cluster = newCluster
-			} else {
-				cluster = viableCluster
 			}
-
-			kube, subnetID, clusterParams, err := prepareClusterForTests(ctx, t, cloud, suiteConfig, cluster, paramCache)
-			if err != nil {
-				t.Logf("unable to prepare viable cluster for testing: %s", err)
-				continue
-			}
-
-			chosenCluster = cluster
-			chosenKubeClient = kube
-			chosenSubnetID = subnetID
-			chosenClusterParams = clusterParams
+			chosenConfig = *config
 			break
 		}
 	}
 
-	if chosenCluster == nil {
+	if chosenConfig.cluster == nil || chosenConfig.needsPreparation() {
 		t.Fatalf("unable to successfully choose a cluster for scenario %q", scenario.Name)
 	}
 
-	if chosenCluster.Properties.NodeResourceGroup == nil {
-		t.Fatalf("tried to chose a cluster without a node resource group:\n%+v", *chosenCluster)
+	if chosenConfig.cluster.Properties.NodeResourceGroup == nil {
+		t.Fatalf("tried to chose a cluster without a node resource group:\n%+v", *chosenConfig.cluster)
 	}
 
-	return chosenKubeClient, chosenCluster, chosenClusterParams, chosenSubnetID
+	return chosenConfig
+}
+
+func validateAndPrepareCluster(ctx context.Context, t *testing.T, cloud *azureClient, suiteConfig *suiteConfig, config *clusterConfig) error {
+	needRecreate, err := validateExistingClusterState(ctx, t, cloud, suiteConfig.resourceGroupName, config.cluster)
+	if err != nil {
+		return err
+	}
+
+	if needRecreate {
+		t.Logf("cluster %q is in a bad state, attempting to recreate...", *config.cluster.Name)
+		config.cluster, err = createNewCluster(ctx, cloud, suiteConfig.resourceGroupName, config.cluster)
+		if err != nil {
+			return err
+		}
+	}
+
+	kube, subnetId, clusterParams, err := prepareClusterForTests(ctx, t, cloud, suiteConfig, config.cluster)
+	if err != nil {
+		return err
+	}
+
+	config.kube = kube
+	config.parameters = clusterParams
+	config.subnetId = subnetId
+	return nil
 }
 
 func prepareClusterForTests(
@@ -295,11 +346,10 @@ func prepareClusterForTests(
 	t *testing.T,
 	cloud *azureClient,
 	suiteConfig *suiteConfig,
-	cluster *armcontainerservice.ManagedCluster,
-	paramCache paramCache) (*kubeclient, string, map[string]string, error) {
+	cluster *armcontainerservice.ManagedCluster) (*kubeclient, string, clusterParameters, error) {
 	clusterName := *cluster.Name
 
-	subnetID, err := getClusterSubnetID(ctx, cloud, suiteConfig.location, *cluster.Properties.NodeResourceGroup, clusterName)
+	subnetId, err := getClusterSubnetID(ctx, cloud, suiteConfig.location, *cluster.Properties.NodeResourceGroup, clusterName)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("unable get subnet ID of cluster %q: %w", clusterName, err)
 	}
@@ -313,26 +363,24 @@ func prepareClusterForTests(
 		return nil, "", nil, fmt.Errorf("unable to ensure debug damonset of viable cluster %q: %w", clusterName, err)
 	}
 
-	clusterParams, err := getClusterParametersWithCache(ctx, t, kube, clusterName, paramCache)
+	clusterParams, err := pollExtractClusterParameters(ctx, t, kube)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("unable to get cluster paramters: %w", err)
+		return nil, "", nil, fmt.Errorf("unable to extract cluster parameters from %q: %w", clusterName, err)
 	}
 
-	return kube, subnetID, clusterParams, nil
+	return kube, subnetId, clusterParams, nil
 }
 
-func getClusterParametersWithCache(ctx context.Context, t *testing.T, kube *kubeclient, clusterName string, paramCache paramCache) (map[string]string, error) {
-	cachedParams, ok := paramCache[clusterName]
-	if !ok {
-		params, err := pollExtractClusterParameters(ctx, t, kube)
-		if err != nil {
-			return nil, fmt.Errorf("unable to extract cluster parameters from %q: %w", clusterName, err)
-		}
-		paramCache[clusterName] = params
-		return params, nil
-	} else {
-		return cachedParams, nil
+func getNewClusterModelForScenario(clusterName, location string, scenario *scenario.Scenario) armcontainerservice.ManagedCluster {
+	baseModel := getBaseClusterModel(clusterName, location)
+	if scenario.ClusterMutator != nil {
+		scenario.ClusterMutator(&baseModel)
 	}
+	return baseModel
+}
+
+func generateClusterName(r *mrand.Rand) string {
+	return fmt.Sprintf(testClusterNameTemplate, randomLowercaseString(r, 5))
 }
 
 func getBaseClusterModel(clusterName, location string) armcontainerservice.ManagedCluster {

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -61,7 +61,7 @@ func extractLogsFromVM(ctx context.Context, t *testing.T, vmssName, privateIP, s
 		"kubelet.log":                          "journalctl -u kubelet",
 	}
 
-	podName, err := getDebugPodName(opts.kube)
+	podName, err := getDebugPodName(opts.clusterConfig.kube)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get debug pod name: %w", err)
 	}
@@ -70,7 +70,7 @@ func extractLogsFromVM(ctx context.Context, t *testing.T, vmssName, privateIP, s
 	for file, sourceCmd := range commandList {
 		t.Logf("executing command on remote VM at %s of VMSS %s: %q", privateIP, vmssName, sourceCmd)
 
-		execResult, err := execOnVM(ctx, opts.kube, privateIP, podName, sshPrivateKey, sourceCmd)
+		execResult, err := execOnVM(ctx, opts.clusterConfig.kube, privateIP, podName, sshPrivateKey, sourceCmd)
 		if execResult != nil {
 			execResult.dumpStderr()
 		}

--- a/e2e/opts.go
+++ b/e2e/opts.go
@@ -1,38 +1,15 @@
 package e2e_test
 
 import (
-	"fmt"
-
 	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/Azure/agentbakere2e/scenario"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice"
 )
 
 type scenarioRunOpts struct {
+	clusterConfig clusterConfig
 	cloud         *azureClient
-	kube          *kubeclient
 	suiteConfig   *suiteConfig
 	scenario      *scenario.Scenario
-	chosenCluster *armcontainerservice.ManagedCluster
 	nbc           *datamodel.NodeBootstrappingConfiguration
-	subnetID      string
 	loggingDir    string
-}
-
-// Returns true if the scenario's chosen cluster is configured with Azure CNI
-func (opts *scenarioRunOpts) isChosenClusterAzureCNI() (bool, error) {
-	cluster := opts.chosenCluster
-	if cluster.Properties.NetworkProfile != nil {
-		return *cluster.Properties.NetworkProfile.NetworkPlugin == armcontainerservice.NetworkPluginAzure, nil
-	}
-	return false, fmt.Errorf("cluster network profile was nil:\n%+v", opts.chosenCluster)
-}
-
-// Returns the maximum number of pods per node of the chosen cluster's agentpool
-func (opts *scenarioRunOpts) chosenClusterMaxPodsPerNode() (int, error) {
-	cluster := opts.chosenCluster
-	if len(cluster.Properties.AgentPoolProfiles) > 0 {
-		return int(*cluster.Properties.AgentPoolProfiles[0].MaxPods), nil
-	}
-	return 0, fmt.Errorf("cluster agentpool profiles were nil or empty:\n%+v", opts.chosenCluster)
 }

--- a/e2e/pollers.go
+++ b/e2e/pollers.go
@@ -16,8 +16,8 @@ const (
 	// Polling intervals
 	execOnVMPollInterval                 = 10 * time.Second
 	execOnPodPollInterval                = 10 * time.Second
-	extractClusterParametersPollInterval = 15 * time.Second
-	extractVMLogsPollInterval            = 15 * time.Second
+	extractClusterParametersPollInterval = 10 * time.Second
+	extractVMLogsPollInterval            = 10 * time.Second
 	getVMPrivateIPAddressPollInterval    = 5 * time.Second
 	waitUntilPodRunningPollInterval      = 5 * time.Second
 	waitUntilPodDeletedPollInterval      = 5 * time.Second
@@ -137,7 +137,7 @@ func pollExtractVMLogs(ctx context.Context, t *testing.T, vmssName, privateIP st
 func pollGetVMPrivateIP(ctx context.Context, vmssName string, opts *scenarioRunOpts) (string, error) {
 	var vmPrivateIP string
 	err := wait.PollImmediateWithContext(ctx, getVMPrivateIPAddressPollInterval, getVMPrivateIPAddressPollingTimeout, func(ctx context.Context) (bool, error) {
-		pip, err := getVMPrivateIPAddress(ctx, opts.cloud, opts.suiteConfig.subscription, *opts.chosenCluster.Properties.NodeResourceGroup, vmssName)
+		pip, err := getVMPrivateIPAddress(ctx, opts.cloud, opts.suiteConfig.subscription, *opts.clusterConfig.cluster.Properties.NodeResourceGroup, vmssName)
 		if err != nil {
 			log.Printf("encountered an error while getting VM private IP address: %s", err)
 			return false, nil

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -35,7 +35,7 @@ func Test_All(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	scenarioTable := scenario.InitScenarioTable(t, suiteConfig.scenariosToRun)
+	scenarios := scenario.InitScenarioTable(t, suiteConfig.scenariosToRun)
 
 	cloud, err := newAzureClient(suiteConfig.subscription)
 	if err != nil {
@@ -46,22 +46,24 @@ func Test_All(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	clusters, err := listClusters(ctx, t, cloud, suiteConfig.resourceGroupName)
+	clusterConfigs, err := getInitialClusterConfigs(ctx, t, cloud, suiteConfig.resourceGroupName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	paramCache := paramCache{}
+	if err := createMissingClusters(ctx, t, r, cloud, suiteConfig, scenarios, &clusterConfigs); err != nil {
+		t.Fatal(err)
+	}
 
-	for _, scenario := range scenarioTable {
+	for _, scenario := range scenarios {
 		scenario := scenario
 
-		kube, cluster, clusterParams, subnetID := mustChooseCluster(ctx, t, r, cloud, suiteConfig, scenario, &clusters, paramCache)
+		chosenConfig := mustChooseCluster(ctx, t, r, cloud, suiteConfig, scenario, clusterConfigs)
 
-		clusterName := *cluster.Name
+		clusterName := *chosenConfig.cluster.Name
 		t.Logf("chose cluster: %q", clusterName)
 
-		baseConfig, err := getBaseNodeBootstrappingConfiguration(ctx, t, cloud, suiteConfig, clusterParams)
+		baseConfig, err := getBaseNodeBootstrappingConfiguration(ctx, t, cloud, suiteConfig, chosenConfig.parameters)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -86,13 +88,11 @@ func Test_All(t *testing.T) {
 			}
 
 			opts := &scenarioRunOpts{
+				clusterConfig: chosenConfig,
 				cloud:         cloud,
-				kube:          kube,
 				suiteConfig:   suiteConfig,
 				scenario:      scenario,
-				chosenCluster: cluster,
 				nbc:           nbc,
-				subnetID:      subnetID,
 				loggingDir:    caseLogsDir,
 			}
 
@@ -147,17 +147,17 @@ func runScenario(ctx context.Context, t *testing.T, r *mrand.Rand, opts *scenari
 	// Only perform node readiness/pod-related checks when VMSS creation succeeded
 	if vmssSucceeded {
 		t.Log("vmss creation succeded, proceeding with node readiness and pod checks...")
-		nodeName, err := validateNodeHealth(ctx, t, opts.kube, vmssName)
+		nodeName, err := validateNodeHealth(ctx, t, opts.clusterConfig.kube, vmssName)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		if opts.nbc.AgentPoolProfile.WorkloadRuntime == datamodel.WasmWasi {
 			t.Log("wasm scenario: running wasm validation...")
-			if err := ensureWasmRuntimeClasses(ctx, opts.kube); err != nil {
+			if err := ensureWasmRuntimeClasses(ctx, opts.clusterConfig.kube); err != nil {
 				t.Fatalf("unable to ensure wasm RuntimeClasses: %s", err)
 			}
-			if err := validateWasm(ctx, opts.kube, nodeName, string(privateKeyBytes)); err != nil {
+			if err := validateWasm(ctx, opts.clusterConfig.kube, nodeName, string(privateKeyBytes)); err != nil {
 				t.Fatalf("unable to validate wasm: %s", err)
 			}
 		}
@@ -185,7 +185,7 @@ func bootstrapVMSS(ctx context.Context, t *testing.T, r *mrand.Rand, opts *scena
 
 	cleanupVMSS := func() {
 		t.Log("deleting vmss", vmssName)
-		poller, err := opts.cloud.vmssClient.BeginDelete(ctx, *opts.chosenCluster.Properties.NodeResourceGroup, vmssName, nil)
+		poller, err := opts.cloud.vmssClient.BeginDelete(ctx, *opts.clusterConfig.cluster.Properties.NodeResourceGroup, vmssName, nil)
 		if err != nil {
 			t.Error("error deleting vmss", vmssName, err)
 			return

--- a/e2e/template.go
+++ b/e2e/template.go
@@ -444,7 +444,7 @@ func baseTemplate() *datamodel.NodeBootstrappingConfiguration {
 	}
 }
 
-func getBaseNodeBootstrappingConfiguration(ctx context.Context, t *testing.T, cloud *azureClient, suiteConfig *suiteConfig, clusterParams map[string]string) (*datamodel.NodeBootstrappingConfiguration, error) {
+func getBaseNodeBootstrappingConfiguration(ctx context.Context, t *testing.T, cloud *azureClient, suiteConfig *suiteConfig, clusterParams clusterParameters) (*datamodel.NodeBootstrappingConfiguration, error) {
 	nbc := baseTemplate()
 	nbc.ContainerService.Properties.CertificateProfile.CaCertificate = clusterParams["/etc/kubernetes/certs/ca.crt"]
 

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -63,7 +63,7 @@ func validateWasm(ctx context.Context, kube *kubeclient, nodeName, privateKey st
 }
 
 func runLiveVMValidators(ctx context.Context, t *testing.T, vmssName, privateIP, sshPrivateKey string, opts *scenarioRunOpts) error {
-	podName, err := getDebugPodName(opts.kube)
+	podName, err := getDebugPodName(opts.clusterConfig.kube)
 	if err != nil {
 		return fmt.Errorf("unable to get debug pod name: %w", err)
 	}
@@ -78,7 +78,7 @@ func runLiveVMValidators(ctx context.Context, t *testing.T, vmssName, privateIP,
 		command := validator.Command
 		log.Printf("running live VM validator: %q", desc)
 
-		execResult, err := pollExecOnVM(ctx, opts.kube, privateIP, podName, sshPrivateKey, command)
+		execResult, err := pollExecOnVM(ctx, opts.clusterConfig.kube, privateIP, podName, sshPrivateKey, command)
 		if err != nil {
 			return fmt.Errorf("unable to execute validator command %q: %w", command, err)
 		}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**What this PR does / why we need it**:

speeds up abe2e in cases where numerous clusters need to be created to support the chosen scenarios by parallelizing this process - added a little more caching in cases where new clusters are created as well

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
