### PR TITLE
fix: ensure cron.allow exists and that it and cron.deny have appropri…

### DIFF
--- a/parts/linux/cloud-init/artifacts/cis.sh
+++ b/parts/linux/cloud-init/artifacts/cis.sh
@@ -61,6 +61,15 @@ assignFilePermissions() {
     for filepath in /etc/cron.hourly /etc/cron.daily /etc/cron.weekly /etc/cron.monthly /etc/cron.d; do
         chmod 0600 $filepath || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     done
+
+    # Docs: https://www.man7.org/linux/man-pages/man1/crontab.1.html
+    # If cron.allow exists, then cron.deny is ignored. To minimize who can use cron, we
+    # always want cron.allow and will default it to empty if it doesn't exist.
+    # We also need to set appropriate permissions on it.
+    # Since it will be ignored anyway, we delete cron.deny.
+    touch /etc/cron.allow || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
+    chmod 640 /etc/cron.allow || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
+    rm -rf /etc/cron.deny || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
 }
 
 # Helper function to replace or append settings to a setting file.

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -685,6 +685,15 @@ assignFilePermissions() {
     for filepath in /etc/cron.hourly /etc/cron.daily /etc/cron.weekly /etc/cron.monthly /etc/cron.d; do
         chmod 0600 $filepath || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     done
+
+    # Docs: https://www.man7.org/linux/man-pages/man1/crontab.1.html
+    # If cron.allow exists, then cron.deny is ignored. To minimize who can use cron, we
+    # always want cron.allow and will default it to empty if it doesn't exist.
+    # We also need to set appropriate permissions on it.
+    # Since it will be ignored anyway, we delete cron.deny.
+    touch /etc/cron.allow || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
+    chmod 640 /etc/cron.allow || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
+    rm -rf /etc/cron.deny || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
 }
 
 # Helper function to replace or append settings to a setting file.

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -236,13 +236,13 @@ testFips() {
     else
       err $test "FIPS is not enabled."
     fi
-    
+
     if [[ ${os_version} == "18.04" || ${os_version} == "20.04" ]]; then
-        if [[ -f /usr/src/linux-headers-${kernel}/Makefile ]]; then
-            echo "fips header files exist."
-        else
-            err $test "fips header files don't exist."
-        fi
+      if [[ -f /usr/src/linux-headers-${kernel}/Makefile ]]; then
+        echo "fips header files exist."
+      else
+        err $test "fips header files don't exist."
+      fi
     fi
   fi
 
@@ -429,6 +429,93 @@ testNetworkSettings() {
   echo "$test:End"
 }
 
+# Tests that the modes on the cron-related files and directories in /etc are set correctly, per the
+# function assignFilePermissions in <repo-root>/parts/linux/cloud-init/artifacts/cis.sh.
+testCronPermissions() {
+  local test="testCronPermissions"
+  echo "$test:Start"
+
+  declare -A required_pathss=(
+    ['/etc/cron.allow']=640
+    ['/etc/cron.hourly']=600
+    ['/etc/cron.daily']=600
+    ['/etc/cron.weekly']=600
+    ['/etc/cron.monthly']=600
+    ['/etc/cron.d']=600
+  )
+
+  declare -A optional_paths=(
+    ['/etc/crontab']=600
+  )
+
+  declare -a disallowed_paths=(
+    '/etc/cron.deny'
+  )
+
+  echo "$test: Checking required paths"
+  for path in "${!required_path[@]}"; do
+    checkPathPermissions $test $path ${required_paths[$path]} 1
+  done
+
+  echo "$test: Checking optional paths"
+  for path in "${!optional_paths[@]}"; do
+    checkPathPermissions $test $path ${optional_paths[$path]} 0
+  done
+
+  echo "$test: Checking disallowed paths"
+  for path in "${disallowed_paths[@]}"; do
+    checkPathDoesNotExist $test $path
+  done
+
+  echo "$test:Finish"
+}
+
+# Checks a single file or directory's permissions.
+# Parameters:
+#  test: The name of the test.
+#  path: The path to check.
+#  expected_perms: The expected permissions.
+#  required: If 1, the path must exist. If 0, the path is optional.
+function checkPathPermissions() {
+  local test="$1"
+  local path="$2"
+  local expected_perms="$3"
+  local required="$4"
+
+  echo "$test: Checking permissions for '$path'"
+  if [ ! -e "$path" ]; then
+    if [ "$required" -eq 1 ]; then
+      err $test "Required path '$path' does not exist"
+    else
+      echo "$test: Optional path '$path' does not exist"
+    fi
+  else
+    local actual_perms=
+    actual_perms=$(stat -c %a $path)
+    if [ "$actual_perms" != "$expected_perms" ]; then
+      err $test "Path '$path' has permissions $actual_perms; expected $expected_perms"
+    else
+      echo "$test: $path has correct permissions $actual_perms"
+    fi
+  fi
+}
+
+# Checks that a single file or directory does not exist.
+# Parameters:
+#  test: The name of the test.
+#  path: The path to check.
+function checkPathDoesNotExist() {
+  local test="$1"
+  local path="$2"
+
+  echo "$test: Checking that '$path' does not exist"
+  if [ -e "$path" ]; then
+    err $test "Path '$path' exists"
+  else
+    echo "$test: $path correctly does not exist"
+  fi
+}
+
 # Tests a setting file's format. This is a simple, line-by line check.
 # Parameters:
 #  test: The name of the test.
@@ -559,3 +646,4 @@ testCustomCATimerNotStarted
 testLoginDefs
 testUserAdd
 testNetworkSettings
+testCronPermissions


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently, we have an `/etc/cron.deny` file, but that actually opens up `cron` usage to any user not in that file. This is against CIS recommendations. We also find that permissions on the existing `/ect/cron.deny` are too permissions.

To fix this, we do two things.
1. Create an empty file `/etc/cron.allow`, which locks down `cron` usage.
2. Set appropriate permissions for both `/etc/cron.allow` and `/etc/cron.deny`.

**Requirements**:
- [x] uses [conventional commit messages]
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Release note**:
```
none
```
