### PR TITLE
fix: disable cramfs

### DIFF
--- a/parts/linux/cloud-init/artifacts/modprobe-CIS.conf
+++ b/parts/linux/cloud-init/artifacts/modprobe-CIS.conf
@@ -7,7 +7,9 @@ install rds /bin/true
 # 3.5.4 Ensure TIPC is disabled
 install tipc /bin/true
 # 1.1.1.1 Ensure mounting of cramfs filesystems is disabled
+# Mariner AKS CIS Benchmark: Ensure mounting of cramfs filesystems is disabled
 install cramfs /bin/true
+blacklist cramfs
 # 1.1.1.2 Ensure mounting of freevxfs filesystems is disabled
 install freevxfs /bin/true
 # 1.1.1.3 Ensure mounting of jffs2 filesystems is disabled

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -4372,7 +4372,9 @@ install rds /bin/true
 # 3.5.4 Ensure TIPC is disabled
 install tipc /bin/true
 # 1.1.1.1 Ensure mounting of cramfs filesystems is disabled
+# Mariner AKS CIS Benchmark: Ensure mounting of cramfs filesystems is disabled
 install cramfs /bin/true
+blacklist cramfs
 # 1.1.1.2 Ensure mounting of freevxfs filesystems is disabled
 install freevxfs /bin/true
 # 1.1.1.3 Ensure mounting of jffs2 filesystems is disabled
@@ -4380,7 +4382,8 @@ install jffs2 /bin/true
 # 1.1.1.4 Ensure mounting of hfs filesystems is disabled
 install hfs /bin/true
 # 1.1.1.5 Ensure mounting of hfsplus filesystems is disabled
-install hfsplus /bin/true`)
+install hfsplus /bin/true
+`)
 
 func linuxCloudInitArtifactsModprobeCisConfBytes() ([]byte, error) {
 	return _linuxCloudInitArtifactsModprobeCisConf, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently, `cramfs` is disabled by making it not actually load (loading command is `/bin/true`). As a defense-in-depth, the CIS recommendation is to further disable it by "blacklisting" it. This change does that.

**Requirements**:
- [x] uses [conventional commit messages]
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Release note**:
```
none
```
