### PR TITLE
fix: disable coredump storage and backtraces

### DIFF
--- a/parts/linux/cloud-init/artifacts/cis.sh
+++ b/parts/linux/cloud-init/artifacts/cis.sh
@@ -133,10 +133,31 @@ setPWExpiration() {
     replaceOrAppendUserAdd INACTIVE 30
 }
 
+# Creates the search pattern and setting lines for the core dump settings, and calls through
+# to do the replacement. Note that this uses extended regular expressions, so both
+# grep and sed need to be called as such.
+#
+# The search pattern is:
+#  '^#{0,1} {0,1}' -- Line starts with 0 or 1 '#' followed by 0 or 1 space
+#  '${1}='         -- Then the setting name followed by '='
+#  '.*$'           -- Then 0 or nore of any character which is the end of the line.
+#
+# This is based on a combination of the syntax for the file (https://www.man7.org/linux/man-pages/man5/coredump.conf.5.html)
+# and real examples we've found.
+replaceOrAppendCoreDump() {
+    replaceOrAppendSetting "^#{0,1} {0,1}${1}=.*$" "${1}=${2}" /etc/systemd/coredump.conf
+}
+
+configureCoreDump() {
+    replaceOrAppendCoreDump Storage none
+    replaceOrAppendCoreDump ProcessSizeMax 0
+}
+
 applyCIS() {
     setPWExpiration
     assignRootPW
     assignFilePermissions
+    configureCoreDump
 }
 
 applyCIS

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -757,10 +757,31 @@ setPWExpiration() {
     replaceOrAppendUserAdd INACTIVE 30
 }
 
+# Creates the search pattern and setting lines for the core dump settings, and calls through
+# to do the replacement. Note that this uses extended regular expressions, so both
+# grep and sed need to be called as such.
+#
+# The search pattern is:
+#  '^#{0,1} {0,1}' -- Line starts with 0 or 1 '#' followed by 0 or 1 space
+#  '${1}='         -- Then the setting name followed by '='
+#  '.*$'           -- Then 0 or nore of any character which is the end of the line.
+#
+# This is based on a combination of the syntax for the file (https://www.man7.org/linux/man-pages/man5/coredump.conf.5.html)
+# and real examples we've found.
+replaceOrAppendCoreDump() {
+    replaceOrAppendSetting "^#{0,1} {0,1}${1}=.*$" "${1}=${2}" /etc/systemd/coredump.conf
+}
+
+configureCoreDump() {
+    replaceOrAppendCoreDump Storage none
+    replaceOrAppendCoreDump ProcessSizeMax 0
+}
+
 applyCIS() {
     setPWExpiration
     assignRootPW
     assignFilePermissions
+    configureCoreDump
 }
 
 applyCIS

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -470,6 +470,30 @@ testCronPermissions() {
   echo "$test:Finish"
 }
 
+# Tests that /etc/systemd/coredump.conf is set correctly, per the function
+# configureCoreDump in <repo-root>/parts/linux/cloud-init/artifacts/cis.sh.
+testCoreDumpSettings() {
+  local test="testCoreDumpSettings"
+  local settings_file=/etc/systemd/coredump.conf
+  echo "$test:Start"
+
+  # Existence and format check. The man page https://www.man7.org/linux/man-pages/man5/coredump.conf.5.html
+  # doesn't really state the format of the file, but show that each line must be one o:
+  #   A comment starting with '#'.
+  #   A section heading -- this file is only supposed to have '[Coredump]'
+  #   Settings, which take the form 'NAME=VALUE', where values can be empty or strings, and strings
+  #   is pretty loose (more or less any printable character).
+  testSettingFileFormat $test $settings_file '^(#|$)' '^\[Coredump\]$' '^[A-Z_]+=[^[:cntrl:]]*$'
+
+  # Look for the settings we specifically set in <repo-root>/parts/linux/cloud-init/artifacts/cis.sh
+  # and ensure they're set to the values we expect.
+  echo "$test: Checking specific settings in $settings_file"
+  testSetting $test $settings_file 'Storage' '^Storage=' '=' 'none'
+  testSetting $test $settings_file 'ProcessSizeMax' '^ProcessSizeMax=' '=' '0'
+
+  echo "$test:Finish"
+}
+
 # Checks a single file or directory's permissions.
 # Parameters:
 #  test: The name of the test.
@@ -647,3 +671,4 @@ testLoginDefs
 testUserAdd
 testNetworkSettings
 testCronPermissions
+testCoreDumpSettings


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
CIS recommendations is to turn off storing any coredumps and to turn off backtraces in them. Since we don't actually use coredumps on the systems we build, this makes sense and will have no impact.

**Requirements**:
- [x] uses [conventional commit messages]
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Release note**:
```
none
```
