### PR TITLE
fix: add sticky bit /opt/certs to prevent malicious deletes

### DIFF
--- a/vhdbuilder/packer/pre-install-dependencies.sh
+++ b/vhdbuilder/packer/pre-install-dependencies.sh
@@ -36,7 +36,7 @@ copyPackerFiles
 systemctlEnableAndStart disk_queue || exit 1
 
 mkdir /opt/certs
-chmod 666 /opt/certs
+chmod 1666 /opt/certs
 systemctlEnableAndStart update_certs.path || exit 1
 
 systemctlEnableAndStart ci-syslog-watcher.path || exit 1


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
CIS recommendations is that any world-writable directory should have the "sticky-bit" turned on, which will prevent deletion of files in that directory by anyone but the file owner. This change does that.

This has been buddy tested with the processes that create and delete certs.

**Requirements**:
- [x] uses [conventional commit messages]
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Release note**:
```
none
```
