### PR TITLE
feat: Add initial UVM build pipeline definition file for the Mariner Kata AKS work stream

### DIFF
--- a/.pipelines/.vsts-kata-uvm-builder.yaml
+++ b/.pipelines/.vsts-kata-uvm-builder.yaml
@@ -1,0 +1,16 @@
+name: $(Date:yyyyMMdd)$(Rev:.r)_$(Build.SourceBranchName)_$(BuildID)
+trigger: none
+
+pool:
+  name: $(POOL_NAME)
+
+stages:
+  - stage: build_uvm
+    dependsOn: []
+    jobs:
+    - job: build
+      timeoutInMinutes: 180
+      steps:
+        - bash: |
+            echo "Initial placeholder"
+          displayName: Placeholder task


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds a minimal template for instantiating a pipeline for building Mariner AKS Kata Utility VM (UVM) collaterals. These collaterals will later be used as input for AgentBaker when transforming a standard Mariner Marketplace image into a Mariner Kata AKS image.

**Special notes for your reviewer**:
- Internal documents on planned implementation tasks and a dev proposal for the Mariner Kata AKS work stream exist