### PR TITLE
docs: fix the wrong folder structure after extracting the test Windows CSE script package

### DIFF
--- a/staging/cse/windows/README
+++ b/staging/cse/windows/README
@@ -39,7 +39,7 @@ pushd aks-windows-cse
 	popd
 	
 	pushd provisioningscripts
-		files=("cleanupnetwork.ps1" "hnsremediator.ps1" "hostsconfigagent.ps1" "kubeletstart.ps1" "kubeproxystart.ps1" "loggenerator.ps1" "runprocess.dll" "windowslogscleanup.ps1" "windowsnodereset.ps1" "windowssecuretls.ps1")
+		files=("cleanupnetwork.ps1" "hnsremediator.ps1" "hostsconfigagent.ps1" "kubeletstart.ps1" "kubeproxystart.ps1" "loggenerator.ps1" "windowslogscleanup.ps1" "windowsnodereset.ps1" "windowssecuretls.ps1")
 		for file in ${files[@]}; do
 		    echo "Downloading $file from $url/provisioningscripts/$file"
 		   curl -O "$url/provisioningscripts/$file"

--- a/staging/cse/windows/README
+++ b/staging/cse/windows/README
@@ -45,8 +45,9 @@ pushd aks-windows-cse
 		   curl -O "$url/provisioningscripts/$file"
 		done
 	popd
+
+	zip -r "../aks-windows-cse-scripts-$testCseVersion.zip" *
 popd
-zip -r "aks-windows-cse-scripts-$testCseVersion.zip" aks-windows-cse/*
 ```
 1. Upload the test package to an Azure storage container
 1. Test it with AKS RP in the toggle `windows-cse-package-url.yaml`


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Need to update the command to build the test Windows CSE script package. The original command will generate an unexpected folder `aks-windows-cse` after extracting the test Windows CSE script package
```
2023-05-15T08:52:31.8084661+00:00: Downloaded file https://.../aks-windows-cse-scripts-v0.0.24.1.zip to c:\csescripts.zip
2023-05-15T08:52:32.9218162+00:00: Set ExitCode to 1 and exit. Error: The term 'c:\AzureData\windows\azurecnifunc.ps1' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.

```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
