### PR TITLE
fix: change default umask to enforce correct permissions when creating users

### DIFF
--- a/parts/linux/cloud-init/artifacts/cis.sh
+++ b/parts/linux/cloud-init/artifacts/cis.sh
@@ -153,11 +153,16 @@ configureCoreDump() {
     replaceOrAppendCoreDump ProcessSizeMax 0
 }
 
+fixDefaultUmaskForAccountCreation() {
+    replaceOrAppendLoginDefs UMASK 027
+}
+
 applyCIS() {
     setPWExpiration
     assignRootPW
     assignFilePermissions
     configureCoreDump
+    fixDefaultUmaskForAccountCreation
 }
 
 applyCIS

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -777,11 +777,16 @@ configureCoreDump() {
     replaceOrAppendCoreDump ProcessSizeMax 0
 }
 
+fixDefaultUmaskForAccountCreation() {
+    replaceOrAppendLoginDefs UMASK 027
+}
+
 applyCIS() {
     setPWExpiration
     assignRootPW
     assignFilePermissions
     configureCoreDump
+    fixDefaultUmaskForAccountCreation
 }
 
 applyCIS

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -377,6 +377,7 @@ testLoginDefs() {
   echo "$test: Checking specific settings in $settings_file"
   testSetting $test $settings_file PASS_MAX_DAYS '^[[:space:]]*PASS_MAX_DAYS[[:space:]]' ' ' 90
   testSetting $test $settings_file PASS_MIN_DAYS '^[[:space:]]*PASS_MIN_DAYS[[:space:]]+' ' ' 7
+  testSetting $test $settings_file UMASK '^[[:space:]]*UMASK[[:space:]]+' ' ' 027
 
   echo "$test:Finish"
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
CIS recommendation is to have the default `umask` set to `027` or more restrictive. They also recommend all user home directories have mode of `750` or more restrictive. This is a partial fix that sets the `UMASK` to `027` in `/etc/login.defs`, which will make user creation (like `azureuser`) create directories with `750`. The rest of the work on `umask` will come directly from `CBL-Mariner`.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Release note**:
```
none
```
