### PR TITLE
fix: revert #3196 clean up old packages and kernel versions when buil…

### DIFF
--- a/vhdbuilder/packer/post-install-dependencies.sh
+++ b/vhdbuilder/packer/post-install-dependencies.sh
@@ -33,9 +33,6 @@ if [[ $OS == $UBUNTU_OS_NAME ]]; then
   retrycmd_if_failure 10 2 60 apt-get -y autoremove --purge || exit 1
   retrycmd_if_failure 10 2 60 apt-get -y clean || exit 1
 elif [[ $OS == $MARINER_OS_NAME ]]; then
-  current_kernel_version="$(uname -r | cut -d. -f-4)"
-  kernel_packages_to_remove=$(rpm -qa | grep "kernel" | grep -v $current_kernel_version)
-  retrycmd_if_failure 10 2 60 dnf -y autoremove $kernel_packages_to_remove || exit 1
   retrycmd_if_failure 10 2 60 dnf -y autoremove || exit 1 # remove all other unused packages
 fi
 


### PR DESCRIPTION
…ding Mariner

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
The feature #3196  removes more packages than intended, related to the new ordering of the reboot step in the packer templates and unintentionally removing the installkernel package. This causes an issue with provisioning. This PR will revert this feature until we are able to properly introduce a fix.


**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
[Pipeline run of current issue](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=364448&view=logs&j=13a072b1-40aa-5105-34d4-8783ea0e19cb&t=2f39a1b3-8b9b-548e-d10a-5551cb4f4df3&l=170)
[Pipeline run of this PR](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=73661833&view=results)

**Release note**:
```
none
```
