### PR TITLE
fix: false negative when testing coredump settings

### DIFF
--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -484,7 +484,7 @@ testCoreDumpSettings() {
   #   A section heading -- this file is only supposed to have '[Coredump]'
   #   Settings, which take the form 'NAME=VALUE', where values can be empty or strings, and strings
   #   is pretty loose (more or less any printable character).
-  testSettingFileFormat $test $settings_file '^(#|$)' '^\[Coredump\]$' '^[A-Z_]+=[^[:cntrl:]]*$'
+  testSettingFileFormat $test $settings_file '^(#|$)' '^\[Coredump\]$' '^[A-Za-z_]+=[^[:cntrl:]]*$'
 
   # Look for the settings we specifically set in <repo-root>/parts/linux/cloud-init/artifacts/cis.sh
   # and ensure they're set to the values we expect.
@@ -630,7 +630,7 @@ testSettingFileFormat() {
 
     if [ $valid -eq 0 ]; then
       any_invalid=1
-      err $test "Invalid line $line_num in $settings_file: '$line'" >>/dev/stderr
+      err $test "Invalid line $line_num in $settings_file: '$line'"
     fi
 
     valid=0


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In a [recent change](https://github.com/Azure/AgentBaker/pull/3123), we introduced a test to make sure `/etc/systemd/coredump.conf` is formatted correctly, but the regex was wrong and only allowed capital letters. This fixes that.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

