### PR TITLE
fix: Tweak modification of kata image menuentries to support new loader

### DIFF
--- a/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
+++ b/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
@@ -137,8 +137,8 @@ EOF
 
 enableMarinerKata() {
     # Enable the mshv boot path
-    sudo sed -i -e 's@menuentry "CBL-Mariner"@menuentry "Dom0" {\n    search --no-floppy --set=root --file /EFI/Microsoft/Boot/bootmgfw.efi\n        chainloader /EFI/Microsoft/Boot/bootmgfw.efi\n}\n\nmenuentry "CBL-Mariner"@'  /boot/grub2/grub.cfg
-
+    sudo sed -i -e 's@load_env -f \$bootprefix\/mariner.cfg@load_env -f \$bootprefix\/mariner-mshv.cfg\nload_env -f $bootprefix\/mariner.cfg\n@'  /boot/grub2/grub.cfg
+    sudo sed -i -e 's@menuentry "CBL-Mariner"@menuentry "Dom0" {\n    search --no-floppy --set=root --file /HvLoader.efi\n    chainloader /HvLoader.efi lxhvloader.dll MSHV_ROOT=\\\\Windows MSHV_ENABLE=1 MSHV_SCHEDULER_TYPE=ROOT MSHV_X2APIC_POLICY=DEFAULT\n    boot\n    linux /$mariner_linux_mshv root=$rootdevice $mariner_cmdline_mshv $systemd_cmdline\n    if [ -f /$mariner_initrd_mshv ]; then\n        initrd /$mariner_initrd_mshv\n    fi\n}\n\nmenuentry "CBL-Mariner"@'  /boot/grub2/grub.cfg
     # kata-osbuilder-generate is responsible for triggering the kata-osbuilder.sh script, which uses
     # dracut to generate an initrd for the nested VM using binaries from the Mariner host OS.
     systemctlEnableAndStart kata-osbuilder-generate

--- a/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
+++ b/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
@@ -137,7 +137,6 @@ EOF
 
 enableMarinerKata() {
     # Enable the mshv boot path
-    sudo sed -i -e 's@load_env -f \$bootprefix\/mariner.cfg@load_env -f \$bootprefix\/mariner-mshv.cfg\nload_env -f $bootprefix\/mariner.cfg\n@'  /boot/grub2/grub.cfg
     sudo sed -i -e 's@menuentry "CBL-Mariner"@menuentry "Dom0" {\n    search --no-floppy --set=root --file /HvLoader.efi\n    chainloader /HvLoader.efi lxhvloader.dll MSHV_ROOT=\\\\Windows MSHV_ENABLE=1 MSHV_SCHEDULER_TYPE=ROOT MSHV_X2APIC_POLICY=DEFAULT\n    boot\n    linux /$mariner_linux_mshv root=$rootdevice $mariner_cmdline_mshv $systemd_cmdline\n    if [ -f /$mariner_initrd_mshv ]; then\n        initrd /$mariner_initrd_mshv\n    fi\n}\n\nmenuentry "CBL-Mariner"@'  /boot/grub2/grub.cfg
     # kata-osbuilder-generate is responsible for triggering the kata-osbuilder.sh script, which uses
     # dracut to generate an initrd for the nested VM using binaries from the Mariner host OS.


### PR DESCRIPTION
**What type of PR is this?**
/kind fix

**What this PR does / why we need it**:
When the next Mariner image is published with the new loader, it is expected to break on the AKS-side. 

Swap the menuentry splicing for Mariner kata images from the old loader implementation to the new lxhvloader one. 

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
