### PR TITLE
fix: false negative when testing pamD settings on ubuntu

### DIFF
--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -521,24 +521,35 @@ testNfsServerService() {
 # Tests that the pam.d settings are set correctly, per the function
 # addFailLockDir in <repo-root>/parts/linux/cloud-init/artifacts/cis.sh.
 testPamDSettings() {
+  local os_sku="${1}"
+  local os_version="${2}"
   local test="testPamDSettings"
   local settings_file=/etc/security/faillock.conf
   echo "$test:Start"
 
-  # Existence and format check. The man page https://www.man7.org/linux/man-pages/man5/faillock.conf.5.html
-  # describes the following format for each line:
-  #   Comments start with '#'.
-  #   Blank lines are ignored.
-  #   Lines are of in two forms:
-  #       'setting = value', where settings are lower-case and include '_'
-  #       'setting'
-  #   Whitespace at beginning and end of line, along with around the '=' is ignored.
-  testSettingFileFormat $test $settings_file '^(#|$)' '^[[:space:]]*$' '^[[:space:]]*[a-z_][[:space:]]*' '^[[:space:]]*[a-z_]+[[:space::]]*=[^[:cntrl:]]*$'
+  # We only want to run this test on Mariner 2.0
+  # So if it's anything else, report that we're skipping the test and bail.
+  if [[ "${os_sku}" != "CBLMariner" || "${os_version}" != "2.0" ]]; then
+    echo "$test: Skipping test on ${os_sku} ${os_version}"
+  else
 
-  # Look for the setting we specifically set in <repo-root>/parts/linux/cloud-init/artifacts/cis.sh
-  # and ensure it's set to the values we expect.
-  echo "$test: Checking specific settings in $settings_file"
-  testSetting $test $settings_file 'dir' '^[[:space:]]*dir[[:space:]]*=' '=' '/var/log/faillock'
+    # Existence and format check. The man page https://www.man7.org/linux/man-pages/man5/faillock.conf.5.html
+    # describes the following format for each line:
+    #   Comments start with '#'.
+    #   Blank lines are ignored.
+    #   Lines are of in two forms:
+    #       'setting = value', where settings are lower-case and include '_'
+    #       'setting'
+    #   Whitespace at beginning and end of line, along with around the '=' is ignored.
+    testSettingFileFormat $test $settings_file '^(#|$)' '^[[:space:]]*$' '^[[:space:]]*[a-z_][[:space:]]*' '^[[:space:]]*[a-z_]+[[:space::]]*=[^[:cntrl:]]*$'
+
+    # Look for the setting we specifically set in <repo-root>/parts/linux/cloud-init/artifacts/cis.sh
+    # and ensure it's set to the values we expect.
+    echo "$test: Checking specific settings in $settings_file"
+    testSetting $test $settings_file 'dir' '^[[:space:]]*dir[[:space:]]*=' '=' '/var/log/faillock'
+  fi
+
+  echo "$test:Finish"
 }
 
 # Checks a single file or directory's permissions.
@@ -720,4 +731,4 @@ testNetworkSettings
 testCronPermissions
 testCoreDumpSettings
 testNfsServerService
-testPamDSettings
+testPamDSettings $OS_SKU $OS_VERSION


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The PamD tests were only ever meant to be run against Mariner 2.0. Somewhere along the way, that guard was deleted and the tests as checked in run against all os/version combinations. This change makes them only run against Mariner 2.0.
**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
