### PR TITLE
test: clone the branch from the build rather main for testing

### DIFF
--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -115,6 +115,7 @@ steps:
         -e ARCHITECTURE=${ARCHITECTURE} \
         -e ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH} \
         -e SGX_INSTALL=${SGX_INSTALL} \
+        -e GIT_BRANCH=$(Build.SourceBranch) \
         ${CONTAINER_IMAGE} make -f packer.mk test-building-vhd
     displayName: Run VHD Tests
   - task: PublishPipelineArtifact@0

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1,16 +1,25 @@
 #!/bin/bash
-git clone https://github.com/Azure/AgentBaker.git 2>/dev/null
-source ./AgentBaker/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh 2>/dev/null
-source ./AgentBaker/parts/linux/cloud-init/artifacts/cse_helpers.sh 2>/dev/null
 COMPONENTS_FILEPATH=/opt/azure/components.json
 KUBE_PROXY_IMAGES_FILEPATH=/opt/azure/kube-proxy-images.json
 MANIFEST_FILEPATH=/opt/azure/manifest.json
 VHD_LOGS_FILEPATH=/opt/azure/vhd-install.complete
 THIS_DIR="$(cd "$(dirname ${BASH_SOURCE[0]})" && pwd)"
+
 CONTAINER_RUNTIME="$1"
 OS_VERSION="$2"
 ENABLE_FIPS="$3"
 OS_SKU="$4"
+GIT_BRANCH="$5"
+
+# Clone the repo and checkout the branch provided.
+# The git branch comes in as refs/heads/<branch-name> but we need to checkout
+# <branch-name>, so we strip out the refs/heads/ part.
+GIT_BRANCH=${GIT_BRANCH#refs/heads/}
+echo "Cloning AgentBaker repo and checking out branch ${GIT_BRANCH}"
+git clone --quiet --single-branch --branch "${GIT_BRANCH}" https://github.com/Azure/AgentBaker.git
+
+source ./AgentBaker/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh 2>/dev/null
+source ./AgentBaker/parts/linux/cloud-init/artifacts/cse_helpers.sh 2>/dev/null
 
 testFilesDownloaded() {
   test="testFilesDownloaded"

--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -116,7 +116,7 @@ if [ "$OS_TYPE" == "Linux" ]; then
       --name $VM_NAME \
       --resource-group $RESOURCE_GROUP_NAME \
       --scripts @$SCRIPT_PATH \
-      --parameters ${CONTAINER_RUNTIME} ${OS_VERSION} ${ENABLE_FIPS} ${OS_SKU}) && break
+      --parameters ${CONTAINER_RUNTIME} ${OS_VERSION} ${ENABLE_FIPS} ${OS_SKU} ${GIT_BRANCH}) && break
     echo "${i}: retrying az vm run-command"
   done
   # The error message for a Linux VM run-command is as follows:


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
In `linux-vhd-content-test.sh`, we clone `AgentBaker` to source a couple helper files. However, we clone `master`, which means that we can't test updating those files, and we can't iterate on adding tests that we would want to keep in other files in repo.

This change takes the git branch to clone on the command-line of the test script, passing it in through the pipeline in `run-tests.sh`.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Release note**:
```
none
```
