### PR TITLE
test: use git branch from build for tests

### DIFF
--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -115,6 +115,7 @@ steps:
         -e ARCHITECTURE=${ARCHITECTURE} \
         -e ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH} \
         -e SGX_INSTALL=${SGX_INSTALL} \
+        -e GIT_BRANCH=$(Build.SourceBranch) \
         ${CONTAINER_IMAGE} make -f packer.mk test-building-vhd
     displayName: Run VHD Tests
   - task: PublishPipelineArtifact@0

--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -116,7 +116,7 @@ if [ "$OS_TYPE" == "Linux" ]; then
       --name $VM_NAME \
       --resource-group $RESOURCE_GROUP_NAME \
       --scripts @$SCRIPT_PATH \
-      --parameters ${CONTAINER_RUNTIME} ${OS_VERSION} ${ENABLE_FIPS} ${OS_SKU}) && break
+      --parameters ${CONTAINER_RUNTIME} ${OS_VERSION} ${ENABLE_FIPS} ${OS_SKU} ${GIT_BRANCH}) && break
     echo "${i}: retrying az vm run-command"
   done
   # The error message for a Linux VM run-command is as follows:


### PR DESCRIPTION
DRAFT -- IGNORE

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
In `linux-vhd-content-test.sh`, we clone `AgentBaker` to source a couple helper files. However, we clone `master`, which means that we can't test updating those files, and we can't iterate on adding tests that we would want to keep in other files in repo.

This change takes the git branch to clone on the command-line of the test script, passing it in through the pipeline in `run-tests.sh`.

Note that this is the second attempt at this. The [first](https://github.com/Azure/AgentBaker/pull/3342) used a simpler method that doesn't work for pull request branches.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Release note**:
```
none
```
