### PR TITLE
fix: Stop installing old loader

### DIFF
--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -27,7 +27,7 @@ installDeps() {
 
 installKataDeps() {
     if [[ $OS_VERSION == "2.0" ]]; then
-      for dnf_package in cargo opa parted qemu-img moby-runc python3-devel python3-pip kernel-mshv cloud-hypervisor kata-containers moby-containerd-cc; do
+      for dnf_package in cargo opa parted qemu-img moby-runc python3-devel python3-pip hvloader kernel-mshv cloud-hypervisor kata-containers moby-containerd-cc; do
         if ! dnf_install 30 1 600 $dnf_package; then
           exit $ERR_APT_INSTALL_TIMEOUT
         fi
@@ -69,10 +69,13 @@ installKataDeps() {
       rm kernel-uvm-devel-5.15.110.mshv2-1.cm2.x86_64.rpm
 
       echo "wget mshv packages"
+      wget "https://mitchzhu.blob.core.windows.net/public/mshv-bootloader-lx-25357.1.230428-1528.1.cm2.x86_64.rpm" -O mshv-bootloader-lx-25357.1.230428-1528.1.cm2.x86_64.rpm
       wget "https://mitchzhu.blob.core.windows.net/public/mshv-25357.1.230428-1528.2.cm2.x86_64.rpm" -O mshv-25357.1.230428-1528.2.cm2.x86_64.rpm
 
+      rpm -ihv mshv-bootloader-lx-25357.1.230428-1528.1.cm2.x86_64.rpm
       rpm -ihv mshv-25357.1.230428-1528.2.cm2.x86_64.rpm
 
+      rm mshv-bootloader-lx-25357.1.230428-1528.1.cm2.x86_64.rpm
       rm mshv-25357.1.230428-1528.2.cm2.x86_64.rpm
 
       echo "create snapshotter dir"

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -69,16 +69,10 @@ installKataDeps() {
       rm kernel-uvm-devel-5.15.110.mshv2-1.cm2.x86_64.rpm
 
       echo "wget mshv packages"
-      wget "https://mitchzhu.blob.core.windows.net/public/mshv-bootloader-25357.1.230428-1528.1.cm2.x86_64.rpm" -O mshv-bootloader-25357.1.230428-1528.1.cm2.x86_64.rpm
-      wget "https://mitchzhu.blob.core.windows.net/public/mshv-linuxloader-0.5.0-2.3.cm2.x86_64.rpm" -O mshv-linuxloader-0.5.0-2.3.cm2.x86_64.rpm
       wget "https://mitchzhu.blob.core.windows.net/public/mshv-25357.1.230428-1528.2.cm2.x86_64.rpm" -O mshv-25357.1.230428-1528.2.cm2.x86_64.rpm
 
-      rpm -ihv mshv-bootloader-25357.1.230428-1528.1.cm2.x86_64.rpm
-      rpm -ihv mshv-linuxloader-0.5.0-2.3.cm2.x86_64.rpm
       rpm -ihv mshv-25357.1.230428-1528.2.cm2.x86_64.rpm
 
-      rm mshv-bootloader-25357.1.230428-1528.1.cm2.x86_64.rpm
-      rm mshv-linuxloader-0.5.0-2.3.cm2.x86_64.rpm
       rm mshv-25357.1.230428-1528.2.cm2.x86_64.rpm
 
       echo "create snapshotter dir"

--- a/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
+++ b/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
@@ -147,11 +147,6 @@ setupMSHV() {
     # export ROOT=$(blkid | grep image-rootfs | grep -o -P '(?<=PARTUUID=).*' | cut -d ' ' -f1 | sed -e 's?"??g')
     # echo "KERNEL_CMDLINE=PARTUUID=$ROOT rd.auto=1 lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 init=/lib/systemd/systemd ro no-vmw-sta crashkernel=128M net.ifnames=0 plymouth.enable=0 systemd.legacy_systemd_cgroup_controller=yes systemd.unified_cgroup_hierarchy=0 audit=0 console=ttyS0,115200n8 earlyprintk" >> /boot/efi/linuxloader.conf
 
-    # echo "Contents of linuxloader after blkid"
-    # cat /boot/efi/linuxloader.conf
-    # Add DOM0 boot entry above default
-    sudo sed -i -e 's@menuentry "CBL-Mariner"@menuentry "Dom0_legacy" {\n    search --no-floppy --set=root --file /EFI/Microsoft/Boot/bootmgfw.efi\n        chainloader /EFI/Microsoft/Boot/bootmgfw.efi\n}\n\nmenuentry "CBL-Mariner"@'  /boot/grub2/grub.cfg
-
     SERVICE_FILEPATH="/etc/systemd/system/set-kataconfig.service"
     touch ${SERVICE_FILEPATH}
     cat << EOF > ${SERVICE_FILEPATH}

--- a/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
+++ b/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
@@ -147,6 +147,9 @@ setupMSHV() {
     # export ROOT=$(blkid | grep image-rootfs | grep -o -P '(?<=PARTUUID=).*' | cut -d ' ' -f1 | sed -e 's?"??g')
     # echo "KERNEL_CMDLINE=PARTUUID=$ROOT rd.auto=1 lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 init=/lib/systemd/systemd ro no-vmw-sta crashkernel=128M net.ifnames=0 plymouth.enable=0 systemd.legacy_systemd_cgroup_controller=yes systemd.unified_cgroup_hierarchy=0 audit=0 console=ttyS0,115200n8 earlyprintk" >> /boot/efi/linuxloader.conf
 
+    sudo sed -i -e 's@load_env -f \$bootprefix\/mariner.cfg@load_env -f \$bootprefix\/mariner-mshv.cfg\nload_env -f $bootprefix\/mariner.cfg\n@'  /boot/grub2/grub.cfg
+    sudo sed -i -e 's@menuentry "CBL-Mariner"@menuentry "Dom0" {\n    search --no-floppy --set=root --file /HvLoader.efi\n    chainloader /HvLoader.efi lxhvloader.dll MSHV_ROOT=\\\\Windows MSHV_ENABLE=TRUE MSHV_SCHEDULER_TYPE=ROOT MSHV_X2APIC_POLICY=DEFAULT\n    boot\n    linux $bootprefix/$mariner_linux_mshv root=$rootdevice $mariner_cmdline_mshv $systemd_cmdline\n    if [ -f /$mariner_initrd_mshv ]; then\n        initrd /$mariner_initrd_mshv\n    fi\n}\n\nmenuentry "CBL-Mariner"@'  /boot/grub2/grub.cfg
+
     SERVICE_FILEPATH="/etc/systemd/system/set-kataconfig.service"
     touch ${SERVICE_FILEPATH}
     cat << EOF > ${SERVICE_FILEPATH}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:
We are installing the old loader side-by-side with the new loader. Not needed for production AKS images. See bug https://microsoft.visualstudio.com/OS/_queries/edit/45063776/?triage=true

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```

https://dev.azure.com/mariner-org/mariner/_build/results?buildId=383282&view=results
