### PR TITLE
[Draft] fix: get supportable versions in backfill

### DIFF
--- a/e2e/windows/e2e-helper.sh
+++ b/e2e/windows/e2e-helper.sh
@@ -19,8 +19,10 @@ exec_on_host() {
 backfill_clean_storage_container() {
     set +x
     # Get supported kubernetes versions
-    versions=$(az aks get-versions --location $LOCATION --query "orchestrators[].orchestratorVersion" -o tsv)
+    versions=$(az aks get-versions --location $LOCATION --query "values[].patchVersions" | jq '.[] | keys[]')
+    echo "versions are $versions"
     k8s_versions=${versions//./}
+    echo "k8s_versions are $k8s_versions"
 
     # Get container names e.g. akswinstore2022-1256 (for this $container_version would be "1256")
     container_names=$(az storage container list --account-name $STORAGE_ACCOUNT_NAME --account-key $MAPPED_ACCOUNT_KEY --query "[?starts_with(name, 'akswinstore')].name" -o tsv)


### PR DESCRIPTION
**What type of PR is this?**
Get supportable k8s versions in the container backfill phase.

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

/kind fix

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
The old command 
`$(az aks get-versions --location $LOCATION --query "orchestrators[].orchestratorVersion" -o tsv)` does not work after the upgrade of azure cli.

**Which issue(s) this PR fixes**:
The new json output returned by `az aks get-versions` contains only `patchVersions` but not the original `orchestratorVersions`. This PR adapts to this new change.
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
Do not review.

**Release note**:
```
none
```
