### PR TITLE
chore: use specified version of az cli as workaround

### DIFF
--- a/.pipelines/templates/e2e-windows-template.yaml
+++ b/.pipelines/templates/e2e-windows-template.yaml
@@ -84,6 +84,8 @@ jobs:
   steps:
     - download: current
       artifact: ${{ parameters.windowsImage }}-clusterConfig
+    - bash: pip install -Iv azure-cli==2.45.0 --extra-index-url https://azurecliprod.blob.core.windows.net/edge
+      displayName: use specified version of az cli
     - bash: |
         az login --service-principal -u $(AZURE_CLIENT_ID) -p $(AZURE_CLIENT_SECRET) --tenant $(AZURE_TENANT_ID)
         az account set -s $(AZURE_SUBSCRIPTION_ID)

--- a/.pipelines/templates/e2e-windows-template.yaml
+++ b/.pipelines/templates/e2e-windows-template.yaml
@@ -21,6 +21,8 @@ parameters:
 jobs:
 - job: Setup_Test_Cluster
   steps:
+    - bash: pip install -Iv azure-cli==2.45.0 --extra-index-url https://azurecliprod.blob.core.windows.net/edge
+      displayName: use specified version of az cli
     - bash: |
         az login --service-principal -u $(AZURE_CLIENT_ID) -p $(AZURE_CLIENT_SECRET) --tenant $(AZURE_TENANT_ID)
         az account set -s $(AZURE_SUBSCRIPTION_ID)


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Use specified version of az cli as workaround of the issue: "az aks get-versions" cannot return "default" field when azure-cli >= 2.50.0.
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
