### PR TITLE
fix: linux: install bpftrace for marier via dnf

### DIFF
--- a/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
+++ b/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
@@ -14,6 +14,12 @@ installBcc() {
     dnf_install 120 5 25 bcc-examples || exit $ERR_BCC_INSTALL_TIMEOUT
 }
 
+installBpftrace() {
+    echo "Installing bpftrace ..."
+    dnf_makecache || exit $ERR_APT_UPDATE_TIMEOUT
+    dnf_install 120 5 25 bpftrace || exit $ERR_BCC_INSTALL_TIMEOUT
+}
+
 addMarinerNvidiaRepo() {
     if [[ $OS_VERSION == "2.0" ]]; then 
         MARINER_NVIDIA_REPO_FILEPATH="/etc/yum.repos.d/mariner-nvidia.repo"

--- a/vhdbuilder/scripts/linux/tool_installs.sh
+++ b/vhdbuilder/scripts/linux/tool_installs.sh
@@ -9,34 +9,6 @@ ERR_BPFTRACE_TOOLS_DOWNLOAD_FAIL=172 {{/* Failed to download bpftrace default pr
 BPFTRACE_DOWNLOADS_DIR="/opt/bpftrace/downloads"
 UBUNTU_CODENAME=$(lsb_release -c -s)
 
-installBpftrace() {
-    local version="v0.9.4"
-    local bpftrace_bin="bpftrace"
-    local bpftrace_tools="bpftrace-tools.tar"
-    local bpftrace_url="https://upstreamartifacts.azureedge.net/$bpftrace_bin/$version"
-    local bpftrace_filepath="/usr/local/bin/$bpftrace_bin"
-    local tools_filepath="/usr/local/share/$bpftrace_bin"
-    if [[ -f "$bpftrace_filepath" ]]; then
-        installed_version="$($bpftrace_bin -V | cut -d' ' -f2)"
-        if [[ "$version" == "$installed_version" ]]; then
-            return
-        fi
-        rm "$bpftrace_filepath"
-        if [[ -d "$tools_filepath" ]]; then
-            rm -r  "$tools_filepath"
-        fi
-    fi
-    mkdir -p "$tools_filepath"
-    install_dir="$BPFTRACE_DOWNLOADS_DIR/$version"
-    mkdir -p "$install_dir"
-    download_path="$install_dir/$bpftrace_tools"
-    retrycmd_if_failure 30 5 60 curl -fSL -o "$bpftrace_filepath" "$bpftrace_url/$bpftrace_bin" || exit $ERR_BPFTRACE_BIN_DOWNLOAD_FAIL
-    retrycmd_if_failure 30 5 60 curl -fSL -o "$download_path" "$bpftrace_url/$bpftrace_tools" || exit $ERR_BPFTRACE_TOOLS_DOWNLOAD_FAIL
-    tar -xvf "$download_path" -C "$tools_filepath"
-    chmod +x "$bpftrace_filepath"
-    chmod -R +x "$tools_filepath/tools"
-}
-
 ensureGPUDrivers() {
     configGPUDrivers
     systemctlEnableAndStart nvidia-modprobe || exit $ERR_GPU_DRIVERS_START_FAIL

--- a/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
+++ b/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
@@ -16,6 +16,7 @@ ERR_STOP_OR_DISABLE_NTP_TIMEOUT=13 {{/* Timeout waiting for ntp stop */}}
 ERR_CHRONY_INSTALL_TIMEOUT=14 {{/*Unable to install CHRONY */}}
 ERR_CHRONY_START_TIMEOUT=15 {{/* Unable to start CHRONY */}}
 
+
 echo "Sourcing tool_installs_ubuntu.sh"
 
 installAscBaseline() {
@@ -66,6 +67,34 @@ installBcc() {
     else
         apt_get_purge 120 5 300 bison cmake flex libedit-dev libllvm6.0 llvm-6.0-dev libclang-6.0-dev zlib1g-dev libelf-dev libfl-dev || exit $ERR_BCC_INSTALL_TIMEOUT
     fi
+}
+
+installBpftrace() {
+    local version="v0.9.4"
+    local bpftrace_bin="bpftrace"
+    local bpftrace_tools="bpftrace-tools.tar"
+    local bpftrace_url="https://upstreamartifacts.azureedge.net/$bpftrace_bin/$version"
+    local bpftrace_filepath="/usr/local/bin/$bpftrace_bin"
+    local tools_filepath="/usr/local/share/$bpftrace_bin"
+    if [[ -f "$bpftrace_filepath" ]]; then
+        installed_version="$($bpftrace_bin -V | cut -d' ' -f2)"
+        if [[ "$version" == "$installed_version" ]]; then
+            return
+        fi
+        rm "$bpftrace_filepath"
+        if [[ -d "$tools_filepath" ]]; then
+            rm -r  "$tools_filepath"
+        fi
+    fi
+    mkdir -p "$tools_filepath"
+    install_dir="$BPFTRACE_DOWNLOADS_DIR/$version"
+    mkdir -p "$install_dir"
+    download_path="$install_dir/$bpftrace_tools"
+    retrycmd_if_failure 30 5 60 curl -fSL -o "$bpftrace_filepath" "$bpftrace_url/$bpftrace_bin" || exit $ERR_BPFTRACE_BIN_DOWNLOAD_FAIL
+    retrycmd_if_failure 30 5 60 curl -fSL -o "$download_path" "$bpftrace_url/$bpftrace_tools" || exit $ERR_BPFTRACE_TOOLS_DOWNLOAD_FAIL
+    tar -xvf "$download_path" -C "$tools_filepath"
+    chmod +x "$bpftrace_filepath"
+    chmod -R +x "$tools_filepath/tools"
 }
 
 disableNtpAndTimesyncdInstallChrony() {


### PR DESCRIPTION
Install bpftrace via dnf for mariner instead of
installing from binary

**What type of PR is this?**
/kind cleanup




**What this PR does / why we need it**:
Install `bpftrace` in mariner using `dnf` instead of installing a binary.

**Which issue(s) this PR fixes**:

Fixes # NA

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
