### PR TITLE
chore: update Windows base images to 2023-7B with registry key

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -342,8 +342,8 @@ function Update-Registry {
     Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name EnableCompartmentNamespace -Value 1 -Type DWORD
 
     if ($env:WindowsSKU -Like '2019*') {
-        Write-Log "Enable a HNS fix (0x40) in 2022-11B and another HNS fix (0x10)"
-        $hnsControlFlag=0x50
+        Write-Log "Keep the HNS fix (0x10) even though it is enabled by default. Windows are still using HNSControlFlag and may need it in the future."
+        $hnsControlFlag=0x10
         $currentValue=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSControlFlag -ErrorAction Ignore)
         if (![string]::IsNullOrEmpty($currentValue)) {
             Write-Log "The current value of HNSControlFlag is $currentValue"
@@ -516,6 +516,32 @@ function Update-Registry {
             Write-Log "The current value of 3398685324 is $currentValue"
         }
         Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FeatureManagement\Overrides" -Name 3398685324 -Value 1 -Type DWORD
+
+        Write-Log "Enable 4 fixes in 2023-07B"
+
+        $currentValue=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HnsNodeToClusterIpv6 -ErrorAction Ignore)
+        if (![string]::IsNullOrEmpty($currentValue)) {
+            Write-Log "The current value of HnsNodeToClusterIpv6 is $currentValue"
+        }
+        Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HnsNodeToClusterIpv6 -Value 1 -Type DWORD
+
+        $currentValue=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSNpmIpsetLimitChange -ErrorAction Ignore)
+        if (![string]::IsNullOrEmpty($currentValue)) {
+            Write-Log "The current value of HNSNpmIpsetLimitChange is $currentValue"
+        }
+        Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSNpmIpsetLimitChange -Value 1 -Type DWORD
+
+        $currentValue=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSLbNatDupRuleChange -ErrorAction Ignore)
+        if (![string]::IsNullOrEmpty($currentValue)) {
+            Write-Log "The current value of HNSLbNatDupRuleChange is $currentValue"
+        }
+        Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSLbNatDupRuleChange -Value 1 -Type DWORD
+
+        $currentValue=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\VfpExt\Parameters" -Name VfpIpv6DipsPrintingIsEnabled -ErrorAction Ignore)
+        if (![string]::IsNullOrEmpty($currentValue)) {
+            Write-Log "The current value of VfpIpv6DipsPrintingIsEnabled is $currentValue"
+        }
+        Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\VfpExt\Parameters" -Name VfpIpv6DipsPrintingIsEnabled -Value 1 -Type DWORD
     }
 }
 

--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -234,7 +234,7 @@ function Test-RegistryAdded {
 
     if ($env:WindowsSKU -Like '2019*') {
         $result=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSControlFlag)
-        if (($result.HNSControlFlag -band 0x50) -ne 0x50) {
+        if (($result.HNSControlFlag -band 0x10) -ne 0x10) {
             Write-ErrorWithTimestamp "The registry for the two HNS fixes is not added"
             exit 1
         }
@@ -318,6 +318,26 @@ function Test-RegistryAdded {
         $result=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FeatureManagement\Overrides" -Name 3398685324)
         if ($result.3398685324 -ne 1) {
             Write-ErrorWithTimestamp "The registry for 3398685324 is not added"
+            exit 1
+        }
+        $result=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HnsNodeToClusterIpv6)
+        if ($result.HnsNodeToClusterIpv6 -ne 1) {
+            Write-ErrorWithTimestamp "The registry for HnsNodeToClusterIpv6 is not added"
+            exit 1
+        }
+        $result=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSNpmIpsetLimitChange)
+        if ($result.HNSNpmIpsetLimitChange -ne 1) {
+            Write-ErrorWithTimestamp "The registry for HNSNpmIpsetLimitChange is not added"
+            exit 1
+        }
+        $result=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSLbNatDupRuleChange)
+        if ($result.HNSLbNatDupRuleChange -ne 1) {
+            Write-ErrorWithTimestamp "The registry for HNSLbNatDupRuleChange is not added"
+            exit 1
+        }
+        $result=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\VfpExt\Parameters" -Name VfpIpv6DipsPrintingIsEnabled)
+        if ($result.VfpIpv6DipsPrintingIsEnabled -ne 1) {
+            Write-ErrorWithTimestamp "The registry for VfpIpv6DipsPrintingIsEnabled is not added"
             exit 1
         }
     }

--- a/vhdbuilder/packer/windows-image.env
+++ b/vhdbuilder/packer/windows-image.env
@@ -4,20 +4,19 @@
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core-smalldisk:latest
 WINDOWS_2019_BASE_IMAGE_SKU=2019-Datacenter-Core-smalldisk
-WINDOWS_2019_BASE_IMAGE_VERSION=17763.4499.230621
+WINDOWS_2019_BASE_IMAGE_VERSION=17763.4645.230707
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:2022-Datacenter-Core-smalldisk:latest
 WINDOWS_2022_BASE_IMAGE_SKU=2022-Datacenter-Core-smalldisk
-WINDOWS_2022_BASE_IMAGE_VERSION=20348.1787.230621
+WINDOWS_2022_BASE_IMAGE_VERSION=20348.1850.230707
 
 # CLI example to get all available image version under a SKU (suffix g2 for Gen 2):
 #   az vm image list --all --publisher  MicrosoftWindowsServer --offer WindowsServer --output table -s 2022-datacenter-core-smalldisk-g2
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:2022-datacenter-core-smalldisk-g2:latest
 WINDOWS_2022_GEN2_BASE_IMAGE_SKU=2022-datacenter-core-smalldisk-g2
-WINDOWS_2022_GEN2_BASE_IMAGE_VERSION=20348.1787.230621
+WINDOWS_2022_GEN2_BASE_IMAGE_VERSION=20348.1850.230707
 
 # Please uncomment the following lines and set a larger os disk size that is at least 30GB when your PR check-in fails
-# WINDOWS_2019_OS_DISK_SIZE_GB=30
 # WINDOWS_2019_CONTAINERD_OS_DISK_SIZE_GB=30
 WINDOWS_2022_CONTAINERD_OS_DISK_SIZE_GB=35

--- a/vhdbuilder/packer/write-release-notes-windows.ps1
+++ b/vhdbuilder/packer/write-release-notes-windows.ps1
@@ -91,6 +91,9 @@ $wuRegistryNames = @(
     "HnsNatAllowRuleUpdateChange",
     "HnsAclUpdateChange",
     "HnsNpmRefresh",
+    "HnsNodeToClusterIpv6",
+    "HNSNpmIpsetLimitChange",
+    "HNSLbNatDupRuleChange",
     "WcifsSOPCountDisabled",
     "3105872524",
     "2629306509",
@@ -98,6 +101,7 @@ $wuRegistryNames = @(
     "1995963020",
     "189519500",
     "VfpEvenPodDistributionIsEnabled",
+    "VfpIpv6DipsPrintingIsEnabled",
     "3230913164",
     "3398685324"
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
1. update Windows base images to 2023.06B
WS2019: [July 11, 2023—KB5028168 (OS Build 17763.4645)](https://support.microsoft.com/en-us/topic/july-11-2023-kb5028168-os-build-17763-4645-eff2d1e1-5f91-4d9a-aef1-ae26bdf51321)
WS2022: [July 11, 2023—KB5028171 (OS Build 20348.1850)](https://support.microsoft.com/en-us/topic/july-11-2023-kb5028171-os-build-20348-1850-65cc2bda-a4a5-450f-adcb-d57ff9eb9835)
2. setting registry keys to enable some fixes

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
