### PR TITLE
fix: set umask in a way that cis audits recognize

### DIFF
--- a/parts/linux/cloud-init/artifacts/cis.sh
+++ b/parts/linux/cloud-init/artifacts/cis.sh
@@ -157,8 +157,22 @@ configureCoreDump() {
     replaceOrAppendCoreDump ProcessSizeMax 0
 }
 
-fixDefaultUmaskForAccountCreation() {
+fixUmaskSettings() {
+    # CIS requires the default UMASK for account creation to be set to 027, so change that in /etc/login.defs.
     replaceOrAppendLoginDefs UMASK 027
+
+    # It also requires that nothing in etc/profile.d sets umask to anything less restrictive than that.
+    # Mariner sets umask directly in /etc/profile after sourcing everything in /etc/profile.d. But it also has /etc/profile.d/umask.sh
+    # which sets umask (but is then ignored). We don't want to simply delete /etc/profile.d/umask.sh, because if we take an update to
+    # the package that supplies it, it would just be copied over again.
+    # This is complicated by an oddity/bug in the auditing script cis uses, which will flag line in a file with the work umask in the file name
+    # that doesn't set umask correctly. So we can't just comment out all the lines or have any comments that explain what we're doing.
+    # So since we can't delete the file, we just overwrite it with the correct umask setting. This duplicates what /etc/profile does, but
+    # it does no harm and works with the tools.
+    local umask_sh="/etc/profile.d/umask.sh"
+    if [[ "${OS}" == "${MARINER_OS_NAME}" && "${OS_VERSION}" == "2.0" && -f "${umask_sh}" ]]; then
+        echo "umask 027" >${umask_sh}
+    fi
 }
 
 function maskNfsServer() {
@@ -195,7 +209,7 @@ applyCIS() {
     assignRootPW
     assignFilePermissions
     configureCoreDump
-    fixDefaultUmaskForAccountCreation
+    fixUmaskSettings
     maskNfsServer
     addFailLockDir
 }

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -1379,8 +1379,22 @@ configureCoreDump() {
     replaceOrAppendCoreDump ProcessSizeMax 0
 }
 
-fixDefaultUmaskForAccountCreation() {
+fixUmaskSettings() {
+    # CIS requires the default UMASK for account creation to be set to 027, so change that in /etc/login.defs.
     replaceOrAppendLoginDefs UMASK 027
+
+    # It also requires that nothing in etc/profile.d sets umask to anything less restrictive than that.
+    # Mariner sets umask directly in /etc/profile after sourcing everything in /etc/profile.d. But it also has /etc/profile.d/umask.sh
+    # which sets umask (but is then ignored). We don't want to simply delete /etc/profile.d/umask.sh, because if we take an update to
+    # the package that supplies it, it would just be copied over again.
+    # This is complicated by an oddity/bug in the auditing script cis uses, which will flag line in a file with the work umask in the file name
+    # that doesn't set umask correctly. So we can't just comment out all the lines or have any comments that explain what we're doing.
+    # So since we can't delete the file, we just overwrite it with the correct umask setting. This duplicates what /etc/profile does, but
+    # it does no harm and works with the tools.
+    local umask_sh="/etc/profile.d/umask.sh"
+    if [[ "${OS}" == "${MARINER_OS_NAME}" && "${OS_VERSION}" == "2.0" && -f "${umask_sh}" ]]; then
+        echo "umask 027" >${umask_sh}
+    fi
 }
 
 function maskNfsServer() {
@@ -1417,7 +1431,7 @@ applyCIS() {
     assignRootPW
     assignFilePermissions
     configureCoreDump
-    fixDefaultUmaskForAccountCreation
+    fixUmaskSettings
     maskNfsServer
     addFailLockDir
 }

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -476,6 +476,28 @@ testNetworkSettings() {
   echo "$test:End"
 }
 
+# Ensures that the content /etc/profile.d/umask.sh is correct, per code in
+# <repo-root>/parts/linux/cloud-init/artifacts/cis.sh
+testUmaskSettings() {
+  local test="testUmaskSettings"
+  local settings_file=/etc/profile.d/umask.sh
+  local expected_settings_file_content='umask 027'
+  echo "$test:Start"
+
+  # If the settings file exists, it must just be a single line that sets umask properly.
+  if [[ -f "${settings_file}" && -s "${settings_file}" ]]; then
+    echo "${test}: Checking that ${settings_file} contains '${expected_settings_file_content}'"
+
+    if ! diff "${settings_file}" <(echo "${expected_settings_file_content}") ; then
+      err $test "The content of the file '${settings_file}' must exactly match '${expected_settings_file_content}'. See above for differences"
+    fi
+  else
+    echo "${test}: Settings file '${settings_file}' does not exist or is empty, so not testing contents."
+  fi
+
+  echo "$test:End"
+}
+
 # Tests that the modes on the cron-related files and directories in /etc are set correctly, per the
 # function assignFilePermissions in <repo-root>/parts/linux/cloud-init/artifacts/cis.sh.
 testCronPermissions() {
@@ -832,3 +854,4 @@ testCoreDumpSettings
 testNfsServerService
 testPamDSettings $OS_SKU $OS_VERSION
 testPam $OS_SKU $OS_VERSION
+testUmaskSettings


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
For CIS compliance, we need `umask` set to `027`. And, due to the CIS tooling, we need to not set it to anything else anywhere in `/etc/profile.d/`. This had initially been fixed in CBL-Mariner, but that was reverted because it broke some customers. Since we know that for AKS, we already technically have it set to `027` via `/etc/profile`, it's safe to make a change to work with the CIS tooling.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
