### PR TITLE
fix: typos in testCronPermissions

### DIFF
--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -504,7 +504,7 @@ testCronPermissions() {
   local test="testCronPermissions"
   echo "$test:Start"
 
-  declare -A required_pathss=(
+  declare -A required_paths=(
     ['/etc/cron.allow']=640
     ['/etc/cron.hourly']=600
     ['/etc/cron.daily']=600
@@ -522,7 +522,7 @@ testCronPermissions() {
   )
 
   echo "$test: Checking required paths"
-  for path in "${!required_path[@]}"; do
+  for path in "${!required_paths[@]}"; do
     checkPathPermissions $test $path ${required_paths[$path]} 1
   done
 


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
When I introduced tests for permissions on `cron`-related files, I had a typo in the array name for a set of files to check, which resulted in not actually checking the permissions on those files. Turns out the script that set the permissions worked properly, so there wasn't a bug -- this is a test-only issue.

**Which issue(s) this PR fixes**:

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
