### PR TITLE
test: default GIT_BRANCH to master so if a pipeline doesn't set it, we still get tests

### DIFF
--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -121,6 +121,7 @@ stages:
             -e ARCHITECTURE=${ARCHITECTURE} \
             -e ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH} \
             -e SGX_INSTALL=${SGX_INSTALL} \
+            -e GIT_BRANCH=$(Build.SourceBranch) \
             ${CONTAINER_IMAGE} make -f packer.mk test-building-vhd
           displayName: Run VHD Tests
         - task: PublishPipelineArtifact@0

--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -110,6 +110,8 @@ if [ "$OS_TYPE" == "Linux" ]; then
     ENABLE_FIPS="false"
   fi
 
+  # If the pipeline that called this didn't set a branch, default to master.
+  GIT_BRANCH="${GIT_BRANCH:-refs/heads/master}"
   SCRIPT_PATH="$CDIR/$LINUX_SCRIPT_PATH"
   for i in $(seq 1 3); do
     ret=$(az vm run-command invoke --command-id RunShellScript \


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Recently, we started using an environment variable `GIT_BRANCH` to specify the `AgentBaker` branch to use when running tests. We've seen some pipelines that don't set that variable though, which results in tests not being run.

This change does two things:
1. Passes `GIT_BRANCH` through to one such pipeline.
2. Defaults to using `master` so we get tests no matter what.

**Which issue(s) this PR fixes**:

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
