### PR TITLE
test: remove dependency on diff from tests

### DIFF
--- a/parts/linux/cloud-init/artifacts/cis.sh
+++ b/parts/linux/cloud-init/artifacts/cis.sh
@@ -169,9 +169,10 @@ fixUmaskSettings() {
     # that doesn't set umask correctly. So we can't just comment out all the lines or have any comments that explain what we're doing.
     # So since we can't delete the file, we just overwrite it with the correct umask setting. This duplicates what /etc/profile does, but
     # it does no harm and works with the tools.
+    # Note that we use printf to avoid a trailing newline.
     local umask_sh="/etc/profile.d/umask.sh"
     if [[ "${OS}" == "${MARINER_OS_NAME}" && "${OS_VERSION}" == "2.0" && -f "${umask_sh}" ]]; then
-        echo "umask 027" >${umask_sh}
+        printf "umask 027" >${umask_sh}
     fi
 }
 

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -1371,9 +1371,10 @@ fixUmaskSettings() {
     # that doesn't set umask correctly. So we can't just comment out all the lines or have any comments that explain what we're doing.
     # So since we can't delete the file, we just overwrite it with the correct umask setting. This duplicates what /etc/profile does, but
     # it does no harm and works with the tools.
+    # Note that we use printf to avoid a trailing newline.
     local umask_sh="/etc/profile.d/umask.sh"
     if [[ "${OS}" == "${MARINER_OS_NAME}" && "${OS_VERSION}" == "2.0" && -f "${umask_sh}" ]]; then
-        echo "umask 027" >${umask_sh}
+        printf "umask 027" >${umask_sh}
     fi
 }
 

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -479,23 +479,30 @@ testNetworkSettings() {
 # Ensures that the content /etc/profile.d/umask.sh is correct, per code in
 # <repo-root>/parts/linux/cloud-init/artifacts/cis.sh
 testUmaskSettings() {
-  local test="testUmaskSettings"
-  local settings_file=/etc/profile.d/umask.sh
-  local expected_settings_file_content='umask 027'
-  echo "$test:Start"
+    local test="testUmaskSettings"
+    local settings_file=/etc/profile.d/umask.sh
+    local expected_settings_file_content='umask 027'
+    echo "$test:Start"
 
-  # If the settings file exists, it must just be a single line that sets umask properly.
-  if [[ -f "${settings_file}" && -s "${settings_file}" ]]; then
-    echo "${test}: Checking that ${settings_file} contains '${expected_settings_file_content}'"
+    # If the settings file exists, it must just be a single line that sets umask properly.
+    if [[ -f "${settings_file}" ]]; then
+        echo "${test}: Checking that the contents of ${settings_file} is exactly '${expected_settings_file_content}'"
 
-    if ! diff "${settings_file}" <(echo "${expected_settings_file_content}") ; then
-      err $test "The content of the file '${settings_file}' must exactly match '${expected_settings_file_content}'. See above for differences"
+        # Command substitution (like file_contents=$(cat "${settings_file}")) strips trailing newlines, so we use mapfile instead.
+        # This creates an array of the lines in the file, and then we join them back together by expanding the array into a single string.
+        local file_contents_array=()
+        mapfile <"${settings_file}" file_contents_array
+        local file_contents="${file_contents_array[*]}"
+        if [[ "${file_contents}" != "${expected_settings_file_content}" ]]; then
+            err $test "The content of the file '${settings_file}' is '${file_contents}', which does not exactly match '${expected_settings_file_content}'. "
+        else
+            echo "${test}: The content of the file '${settings_file}' exactly matches the expected contents '${expected_settings_file_content}'."
+        fi
+    else
+        echo "${test}: Settings file '${settings_file}' does not exist, so not testing contents."
     fi
-  else
-    echo "${test}: Settings file '${settings_file}' does not exist or is empty, so not testing contents."
-  fi
 
-  echo "$test:End"
+    echo "$test:End"
 }
 
 # Tests that the modes on the cron-related files and directories in /etc are set correctly, per the


### PR DESCRIPTION
**What type of PR is this?**
/kind test
/kind regression

**What this PR does / why we need it**:
A recently introduced test used the `diff` utility, which isn't installed by default on our mariner images.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
In addition to normal checkin pipelines, I also ran a mariner-specific pipeline to test with the most recent build of mariner: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=398811&view=results


**Release note**:
```
none
```
