### PR TITLE
Added check on Windows CSE for vmss type so we don't throw an error.

### DIFF
--- a/staging/cse/windows/kubeletfunc.ps1
+++ b/staging/cse/windows/kubeletfunc.ps1
@@ -44,7 +44,7 @@ function Write-AzureConfig {
         $UseContainerD = $false
     )
 
-    if ( -Not $PrimaryAvailabilitySetName -And -Not $PrimaryScaleSetName ) {
+    if ( $VmType -eq "vmss" -And -Not $PrimaryAvailabilitySetName -And -Not $PrimaryScaleSetName ) {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_INVALID_PARAMETER_IN_AZURE_CONFIG -ErrorMessage "Either PrimaryAvailabilitySetName or PrimaryScaleSetName must be set"
     }
 


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
Adds a specific check for windows kubeletfunc.ps1 so that it only enforces requirement for PrimaryScaleSetName and PrimaryAvailabilitySetName when the VM type is "vmss".

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
