### PR TITLE
chore: [Azure NPM] bump v1.4.45.1 for upcoming release

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -52,8 +52,7 @@
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-npm:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.4.32",
-        "v1.4.45"
+        "v1.4.45.1"
       ]
     },
     {


### PR DESCRIPTION
Previously cached images are not in-use in prod. v1.4.45.1 is in canary and will soon be released to all regions.