### PR TITLE
feat: add a distro which maps to AKS VHD with the oldest version (2022.10.03)

### DIFF
--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -276,6 +276,9 @@ const (
 	// DO NOT MODIFY: used for freezing linux images with docker.
 	FrozenLinuxSIGImageVersionForDocker string = "2022.08.29"
 
+	// DO NOT MODIFY: used for freezing linux images for Egress test.
+	FrozenLinuxSIGImageVersionForEgressTest string = "2022.10.03"
+
 	// We do not use AKS Windows image versions in AgentBaker. These fake values are only used for unit tests.
 	Windows2019SIGImageVersion string = "17763.2019.221114"
 	Windows2022SIGImageVersion string = "20348.2022.221114"
@@ -466,6 +469,13 @@ var (
 		Version:       "202306.30.0",
 	}
 
+	SIGUbuntuEgressContainerd2204Gen2ImageConfigTemplate = SigImageConfigTemplate{
+		ResourceGroup: AKSUbuntuResourceGroup,
+		Gallery:       AKSUbuntuGalleryName,
+		Definition:    "2204gen2containerd",
+		Version:       FrozenLinuxSIGImageVersionForEgressTest,
+	}
+
 	SIGCBLMarinerV1ImageConfigTemplate = SigImageConfigTemplate{
 		ResourceGroup: AKSCBLMarinerResourceGroup,
 		Gallery:       AKSCBLMarinerGalleryName,
@@ -580,6 +590,7 @@ func getSigUbuntuImageConfigMapWithOpts(opts ...SigImageConfigOpt) map[Distro]Si
 		AKSUbuntuContainerd2204TLGen2:      SIGUbuntuContainerd2204TLGen2ImageConfigTemplate.WithOptions(opts...),
 		AKSUbuntuMinimalContainerd2204:     SIGUbuntuMinimalContainerd2204ImageConfigTemplate.WithOptions(opts...),
 		AKSUbuntuMinimalContainerd2204Gen2: SIGUbuntuMinimalContainerd2204Gen2ImageConfigTemplate.WithOptions(opts...),
+		AKSUbuntuEgressContainerd2204Gen2:  SIGUbuntuEgressContainerd2204Gen2ImageConfigTemplate.WithOptions(opts...),
 	}
 }
 func getSigCBLMarinerImageConfigMapWithOpts(opts ...SigImageConfigOpt) map[Distro]SigImageConfig {

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -43,7 +43,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(sigConfig.SigTenantID).To(Equal("sometenantid"))
 		Expect(sigConfig.SubscriptionID).To(Equal("somesubid"))
 
-		Expect(len(sigConfig.SigUbuntuImageConfig)).To(Equal(20))
+		Expect(len(sigConfig.SigUbuntuImageConfig)).To(Equal(21))
 
 		aksUbuntuGPU1804Gen2 := sigConfig.SigUbuntuImageConfig[AKSUbuntuGPU1804Gen2]
 		Expect(aksUbuntuGPU1804Gen2.ResourceGroup).To(Equal("resourcegroup"))
@@ -182,5 +182,11 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(aksUbuntuMinimalContainerd2204Gen2.Gallery).To(Equal("aksubuntu"))
 		Expect(aksUbuntuMinimalContainerd2204Gen2.Definition).To(Equal("2204gen2minimalcontainerd"))
 		Expect(aksUbuntuMinimalContainerd2204Gen2.Version).To(Equal("202306.30.0"))
+
+		aksUbuntuEgressContainerd2204Gen2 := sigConfig.SigUbuntuImageConfig[AKSUbuntuEgressContainerd2204Gen2]
+		Expect(aksUbuntuEgressContainerd2204Gen2.ResourceGroup).To(Equal("resourcegroup"))
+		Expect(aksUbuntuEgressContainerd2204Gen2.Gallery).To(Equal("aksubuntu"))
+		Expect(aksUbuntuEgressContainerd2204Gen2.Definition).To(Equal("2204gen2containerd"))
+		Expect(aksUbuntuEgressContainerd2204Gen2.Version).To(Equal("2022.10.03"))
 	})
 })

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -172,6 +172,7 @@ const (
 	AKSUbuntuContainerd2204TLGen2       Distro = "aks-ubuntu-containerd-22.04-tl-gen2"
 	AKSUbuntuMinimalContainerd2204      Distro = "aks-ubuntu-minimal-containerd-22.04"
 	AKSUbuntuMinimalContainerd2204Gen2  Distro = "aks-ubuntu-minimal-containerd-22.04-gen2"
+	AKSUbuntuEgressContainerd2204Gen2   Distro = "aks-ubuntu-egress-containerd-22.04-gen2"
 
 	RHEL              Distro = "rhel"
 	CoreOS            Distro = "coreos"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The AKS EgressLockdown E2E test is currently using a 18.04 AKS VHD. This PR is to add a distro for 22.04. We use the oldest version 2022.10.03 so that the latest image and binaries are not cached in the VHD. Then the EgressLockdown E2E test will download image and binaries during creating nodes.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
