### PR TITLE
chore: update Windows base images to 2023-8B with registry key

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -548,6 +548,27 @@ function Update-Registry {
             Write-Log "The current value of VfpIpv6DipsPrintingIsEnabled is $currentValue"
         }
         Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\VfpExt\Parameters" -Name VfpIpv6DipsPrintingIsEnabled -Value 1 -Type DWORD
+
+        Write-Log "Enable 3 fixes in 2023-08B"
+
+        $currentValue=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSUpdatePolicyForEndpointChange -ErrorAction Ignore)
+        if (![string]::IsNullOrEmpty($currentValue)) {
+            Write-Log "The current value of HNSUpdatePolicyForEndpointChange is $currentValue"
+        }
+        Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSUpdatePolicyForEndpointChange -Value 1 -Type DWORD
+
+        $currentValue=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSFixExtensionUponRehydration -ErrorAction Ignore)
+        if (![string]::IsNullOrEmpty($currentValue)) {
+            Write-Log "The current value of HNSFixExtensionUponRehydration is $currentValue"
+        }
+        Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSFixExtensionUponRehydration -Value 1 -Type DWORD
+
+        $currentValue=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FeatureManagement\Overrides" -Name 87798413 -ErrorAction Ignore)
+        if (![string]::IsNullOrEmpty($currentValue)) {
+            Write-Log "The current value of 87798413 is $currentValue"
+        }
+        Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FeatureManagement\Overrides" -Name 87798413 -Value 1 -Type DWORD
+
     }
 }
 

--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -331,6 +331,21 @@ function Test-RegistryAdded {
             Write-ErrorWithTimestamp "The registry for VfpIpv6DipsPrintingIsEnabled is not added"
             exit 1
         }
+        $result=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSUpdatePolicyForEndpointChange)
+        if ($result.HNSUpdatePolicyForEndpointChange -ne 1) {
+            Write-ErrorWithTimestamp "The registry for HNSUpdatePolicyForEndpointChange is not added"
+            exit 1
+        }
+        $result=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name HNSFixExtensionUponRehydration)
+        if ($result.HNSFixExtensionUponRehydration -ne 1) {
+            Write-ErrorWithTimestamp "The registry for HNSFixExtensionUponRehydration is not added"
+            exit 1
+        }
+        $result=(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FeatureManagement\Overrides" -Name 87798413)
+        if ($result.87798413 -ne 1) {
+            Write-ErrorWithTimestamp "The registry for 87798413 is not added"
+            exit 1
+        }
     }
 }
 

--- a/vhdbuilder/packer/windows-image.env
+++ b/vhdbuilder/packer/windows-image.env
@@ -4,18 +4,18 @@
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core-smalldisk:latest
 WINDOWS_2019_BASE_IMAGE_SKU=2019-Datacenter-Core-smalldisk
-WINDOWS_2019_BASE_IMAGE_VERSION=17763.4645.230707
+WINDOWS_2019_BASE_IMAGE_VERSION=17763.4737.230802
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:2022-Datacenter-Core-smalldisk:latest
 WINDOWS_2022_BASE_IMAGE_SKU=2022-Datacenter-Core-smalldisk
-WINDOWS_2022_BASE_IMAGE_VERSION=20348.1850.230707
+WINDOWS_2022_BASE_IMAGE_VERSION=20348.1906.230803
 
 # CLI example to get all available image version under a SKU (suffix g2 for Gen 2):
 #   az vm image list --all --publisher  MicrosoftWindowsServer --offer WindowsServer --output table -s 2022-datacenter-core-smalldisk-g2
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:2022-datacenter-core-smalldisk-g2:latest
 WINDOWS_2022_GEN2_BASE_IMAGE_SKU=2022-datacenter-core-smalldisk-g2
-WINDOWS_2022_GEN2_BASE_IMAGE_VERSION=20348.1850.230707
+WINDOWS_2022_GEN2_BASE_IMAGE_VERSION=20348.1906.230803
 
 # Please uncomment the following lines and set a larger os disk size that is at least 30GB when your PR check-in fails
 # WINDOWS_2019_CONTAINERD_OS_DISK_SIZE_GB=30

--- a/vhdbuilder/packer/write-release-notes-windows.ps1
+++ b/vhdbuilder/packer/write-release-notes-windows.ps1
@@ -90,10 +90,12 @@ $wuRegistryNames = @(
     "HnsPolicyUpdateChange",
     "HnsNatAllowRuleUpdateChange",
     "HnsAclUpdateChange",
+    "HNSFixExtensionUponRehydration",
     "HnsNpmRefresh",
     "HnsNodeToClusterIpv6",
     "HNSNpmIpsetLimitChange",
     "HNSLbNatDupRuleChange",
+    "HNSUpdatePolicyForEndpointChange",
     "WcifsSOPCountDisabled",
     "3105872524",
     "2629306509",
@@ -103,7 +105,8 @@ $wuRegistryNames = @(
     "VfpEvenPodDistributionIsEnabled",
     "VfpIpv6DipsPrintingIsEnabled",
     "3230913164",
-    "3398685324"
+    "3398685324",
+    "87798413"
 )
 
 foreach ($key in $wuRegistryKeys) {


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
1. update Windows base images to 2023.08B
WS2019: [August 8, 2023-KB5029247 (OS Build 17763.4737)](https://support.microsoft.com/en-us/topic/august-8-2023-kb5029247-os-build-17763-4737-9f99a6da-ef38-4744-aef2-df38365f9203)
WS2022: [August 8, 2023-KB5029250 (OS Build 20348.1906)](https://support.microsoft.com/en-us/topic/august-8-2023-kb5029250-os-build-20348-1906-2db4a1ac-8e18-443e-b4d6-ee17435cf94c)
2. setting registry keys to enable some fixes

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
