### PR TITLE
chore: added check on Windows CSE for vmss type so we don't throw an error

### DIFF
--- a/staging/cse/windows/kubeletfunc.ps1
+++ b/staging/cse/windows/kubeletfunc.ps1
@@ -44,7 +44,7 @@ function Write-AzureConfig {
         $UseContainerD = $false
     )
 
-    if ( -Not $PrimaryAvailabilitySetName -And -Not $PrimaryScaleSetName ) {
+    if ( $VmType -eq "vmss" -And -Not $PrimaryAvailabilitySetName -And -Not $PrimaryScaleSetName ) {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_INVALID_PARAMETER_IN_AZURE_CONFIG -ErrorMessage "Either PrimaryAvailabilitySetName or PrimaryScaleSetName must be set"
     }
 


### PR DESCRIPTION
**What type of PR is this?**
chore

**What this PR does / why we need it**:

Adds a specific check for windows kubeletfunc.ps1 so that it only enforces requirement for PrimaryScaleSetName and PrimaryAvailabilitySetName when the VM type is "vmss".

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

Test result:

```json
{
    "authorization": {
        "action": "Microsoft.Compute/virtualMachines/extensions/write",
        "scope": "/subscriptions/<REDACTED>/resourcegroups/<REDACTED>/providers/Microsoft.Compute/virtualMachines/<REDACTED>/extensions/cse-agent-0"
    },
// (...)
    "status": {
        "value": "Succeeded",
        "localizedValue": "Succeeded"
    },
}
```

**Release note**:
```
none
```
