### PR TITLE
fix: trim timestamp from go version

### DIFF
--- a/.pipelines/.vsts-vhd-automation.yaml
+++ b/.pipelines/.vsts-vhd-automation.yaml
@@ -21,7 +21,7 @@ steps:
 - bash: |
         echo "Removing existing go environment"
         sudo rm -r /usr/local/go
-        GOLANG_VERSION=$(curl -s 'https://go.dev/VERSION?m=text')
+        GOLANG_VERSION=$(curl -s 'https://go.dev/VERSION?m=text' | head -n 1)
         echo "Downloading ${GOLANG_VERSION}"
         curl -O "https://dl.google.com/go/${GOLANG_VERSION}.linux-amd64.tar.gz"
 


### PR DESCRIPTION
seems like they changed the format:

```bash
root@Ubuntu-2204-jammy-amd64-base ~ # curl -s 'https://go.dev/VERSION?m=text'
go1.21.0
time 2023-08-04T20:14:06Z
root@Ubuntu-2204-jammy-amd64-base ~ # curl -s 'https://go.dev/VERSION?m=text' | head -n 1
go1.21.0
```

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
