### PR TITLE
chore: use custom build date for image version

### DIFF
--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -32,6 +32,11 @@ steps:
       else \
         echo "use release date as build date"; branchName=$(Build.SourceBranchName); BUILD_DATE=${branchName: -6}; \
       fi && \
+      echo "Default BUILD_DATE is $BUILD_DATE" && \
+      if [[ -n "${CUSTOM_BUILD_DATE}" ]]; then \
+        echo "set BUILD_DATE to ${CUSTOM_BUILD_DATE}"; \
+        BUILD_DATE=${CUSTOM_BUILD_DATE}; \
+      fi
       echo "Set build date to $BUILD_DATE" && \
       echo "##vso[task.setvariable variable=BUILD_DATE]$BUILD_DATE"
     displayName: Get Build Mode


### PR DESCRIPTION
**What type of PR is this?**
Override the existing build date with a custom preset date in case of build conflicts. $i.e.$ 2 or more concurrent windows vhd builds going for production.

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Addressing build image version conflicts.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
