### PR TITLE
chore: cache cni and dropgz for hotfix

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -45,6 +45,7 @@
       "amd64OnlyVersions": [],
       "multiArchVersions": [
         "v0.0.4",
+        "v0.0.4.1",
         "v0.0.9"
       ]
     },
@@ -313,6 +314,7 @@
       "downloadURL": "https://acs-mirror.azureedge.net/azure-cni/v*/binaries",
       "versions": [
         "1.5.5",
+        "1.4.43.1",
         "1.4.43"
       ]
     },
@@ -322,15 +324,7 @@
       "downloadURL": "https://acs-mirror.azureedge.net/azure-cni/v*/binaries",
       "versions": [
         "1.5.5",
-        "1.4.43"
-      ]
-    },
-    {
-      "fileName": "azure-vnet-cni-overlay-linux-amd64-v*",
-      "downloadLocation": "/opt/cni/downloads",
-      "downloadURL": "https://acs-mirror.azureedge.net/azure-cni/v*/binaries",
-      "versions": [
-        "1.5.5",
+        "1.4.43.1",
         "1.4.43"
       ]
     },


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
remove cache of overlay cni since it's being installed via dropgz

cache [dropgz v0.0.4.1](https://github.com/Azure/azure-container-networking/releases/tag/dropgz%2Fv0.0.4.1) ([cni v1.4.39.1](https://github.com/Azure/azure-container-networking/releases/tag/v1.4.39.1)) and [cni v1.4.43.1](https://github.com/Azure/azure-container-networking/releases/tag/v1.4.43.1)



**Which issue(s) this PR fixes**:
https://github.com/Azure/azure-container-networking/issues/2156

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
