### PR TITLE
chore: cache busybox in VHD

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -32,6 +32,13 @@
       ]
     },
     {
+      "downloadURL": "mcr.microsoft.com/mirror/docker/library/busybox:*",
+      "amd64OnlyVersions": [],
+      "multiArchVersions": [
+        "1.35"
+      ]
+    },
+    {
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-cns:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

In AKS kubernetes version 1.25 and later, kube-proxy init container runs busybox:1.35. We used to use the kube-proxy image, but had to switch when upstream started building from distroless.

The busybox image is 4.27 MB. This is downloaded by almost every AKS node on startup, so I think we should cache it in the VHD.

**Which issue(s) this PR fixes**:

Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
cache busybox 1.35 in the VHD for kube-proxy init container
```
