### PR TITLE
fix: Disable Autobuilding AzureLinux cgroupv2 images

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -25,7 +25,7 @@ parameters:
 - name: buildAzureLinuxV2gen1
   displayName: Build AzureLinuxV2 Gen1
   type: boolean
-  default: true
+  default: false
 - name: buildMarinerV2gen2
   displayName: Build MarinerV2 Gen2
   type: boolean
@@ -33,7 +33,7 @@ parameters:
 - name: buildAzureLinuxV2gen2
   displayName: Build AzureLinuxV2 Gen2
   type: boolean
-  default: true
+  default: false
 - name: buildMarinerV2gen1fips
   displayName: Build MarinerV2 Gen1 FIPS 
   type: boolean
@@ -41,7 +41,7 @@ parameters:
 - name: buildAzureLinuxV2gen1fips
   displayName: Build AzureLinuxV2 Gen1 FIPS
   type: boolean
-  default: true
+  default: false
 - name: buildMarinerV2gen2fips
   displayName: Build MarinerV2 Gen2 FIPS 
   type: boolean
@@ -49,7 +49,7 @@ parameters:
 - name: buildAzureLinuxV2gen2fips
   displayName: Build AzureLinuxV2 Gen2 FIPS
   type: boolean
-  default: true
+  default: false
 - name: buildMarinerV2gen2kata
   displayName: Build MarinerV2 Gen2 Kata
   type: boolean
@@ -57,7 +57,7 @@ parameters:
 - name: buildAzureLinuxV2gen2kata
   displayName: Build AzureLinuxV2 Gen2 Kata
   type: boolean
-  default: true
+  default: false
 - name: buildMarinerV2ARM64
   displayName: Build MarinerV2 Gen2 - ARM64
   type: boolean
@@ -65,7 +65,7 @@ parameters:
 - name: buildAzureLinuxV2ARM64
   displayName: Build AzureLinuxV2 Gen2 - ARM64
   type: boolean
-  default: true
+  default: false
 - name: buildMarinerV2gen2TrustedLaunch
   displayName: Build MarinerV2 Gen2 - Trusted Launch
   type: boolean
@@ -73,7 +73,7 @@ parameters:
 - name: buildAzureLinuxV2gen2TrustedLaunch
   displayName: Build AzureLinuxV2 Gen2 - Trusted Launch
   type: boolean
-  default: true
+  default: false
 - name: buildMarinerV2gen2kataTrustedLaunch
   displayName: Build MarinerV2 Gen2 Kata - Trusted Launch
   type: boolean


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR is meant to disable autobuilding AzureLinux CgroupV2 images temporarily before all the corresponding RP changes are merged in. The behavior will be set back to autobuilding mode once all related changes are merged in and well tested. Meanwhile, the Azure Linux CgroupV2 VHDs will be manually selected to build and handled in a separate release.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
