### PR TITLE
fix: fix branch name in Windows release notes

### DIFF
--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -42,6 +42,8 @@ steps:
     displayName: Get Build Mode
 
   - script: |
+      branch=$(Build.SourceBranch)
+      branch=$(echo "${branch}" | sed 's/refs\/heads\///g')
       echo MODE=$(MODE) && \
       docker run --rm \
       -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
@@ -54,7 +56,7 @@ steps:
       -e AZURE_RESOURCE_GROUP_NAME=${AZURE_BUILD_RESOURCE_GROUP_NAME} \
       -e AZURE_LOCATION=${AZURE_BUILD_LOCATION} \
       -e AZURE_VM_SIZE=${AZURE_VM_SIZE} \
-      -e GIT_BRANCH=$(Build.SourceBranchName) \
+      -e GIT_BRANCH=$branch \
       -e GIT_REPO=$(Build.Repository.Uri) \
       -e GIT_VERSION=$(Build.SourceVersion) \
       -e BUILD_ID=$(Build.BuildId) \


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
fix branch name in Windows release notes

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services. We only remove refs/heads when it is built from a branch. It is by design that we do not update build branch if the build is from a PR. We should not merge any release notes with `Build Branch: refs/pull/3626/merge`.
<html>
<body>
<!--StartFragment-->

Build.SourceBranch | The branch of the triggering repo the build was queued for. Some examples:Git repo branch: refs/heads/mainGit repo pull request: refs/pull/1/mergeTFVC repo branch: $/teamproject/mainTFVC repo gated check-in: Gated_2016-06-06_05.20.51.4369;username@live.comTFVC repo shelveset build: myshelveset;username@live.comWhen your pipeline is triggered by a tag: refs/tags/your-tag-nameWhen you use this variable in your build number format, the forward slash characters (/) are replaced with underscore characters _).Note: In TFVC, if you're running a gated check-in build or manually building a shelveset, you can't use this variable in your build number format. | Yes
-- | -- | --
Build.SourceBranchName | The name of the branch in the triggering repo the build was queued for.Git repo branch, pull request, or tag: The last path segment in the ref. For example, in refs/heads/main this value is main. In refs/heads/feature/tools this value is tools. In refs/tags/your-tag-name this value is your-tag-name.TFVC repo branch: The last path segment in the root server path for the workspace. For example, in $/teamproject/main this value is main.TFVC repo gated check-in or shelveset build is the name of the shelveset. For example, Gated_2016-06-06_05.20.51.4369;username@live.com or myshelveset;username@live.com.Note: In TFVC, if you're running a gated check-in build or manually building a shelveset, you can't use this variable in your build number format.

<!--EndFragment-->
</body>
</html>

**Release note**:
```
none
```
