### PR TITLE
feat: allow the use of environment variables for packer vnet setup

### DIFF
--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -16,18 +16,28 @@ else
 fi
 
 if [ -z "${POOL_NAME}" ]; then
-	echo "POOL_NAME is not set, can't compute vnet_rg_name for packer templates"
+	echo "POOL_NAME is not set, can't compute VNET_RG_NAME for packer templates"
 	exit 1
 fi
 
-vnet_rg_name=""
-if [[ "${POOL_NAME}" == *nodesigprod* ]]; then
-	vnet_rg_name="nodesigprod-agent-pool"
-else
-	vnet_rg_name="nodesigtest-agent-pool"
+if [ -z "${VNET_RG_NAME}" ]; then 
+	VNET_RG_NAME=""
+	if [[ "${POOL_NAME}" == *nodesigprod* ]]; then
+		VNET_RG_NAME="nodesigprod-agent-pool"
+	else
+		VNET_RG_NAME="nodesigtest-agent-pool"
+	fi
 fi
 
-echo "vnet_rg_name set to: ${vnet_rg_name}"
+if [ -z "${VNET_NAME}" ]; then
+	VNET_NAME="nodesig-pool-vnet"
+fi
+
+if [ -z "${SUBNET_NAME}" ]; then
+	SUBNET_NAME="packer"
+fi
+
+echo "VNET_RG_NAME set to: ${VNET_RG_NAME}"
 
 echo "CAPTURED_SIG_VERSION set to: ${CAPTURED_SIG_VERSION}"
 
@@ -370,9 +380,9 @@ cat <<EOF > vhdbuilder/packer/settings.json
   "windows_sigmode_source_gallery_name": "${windows_sigmode_source_gallery_name}",
   "windows_sigmode_source_image_name": "${windows_sigmode_source_image_name}",
   "windows_sigmode_source_image_version": "${windows_sigmode_source_image_version}",
-  "vnet_name": "nodesig-pool-vnet",
-  "subnet_name": "packer",
-  "vnet_resource_group_name": "${vnet_rg_name}"
+  "vnet_name": "${VNET_NAME}",
+  "subnet_name": "${SUBNET_NAME}",
+  "vnet_resource_group_name": "${VNET_RG_NAME}"
 }
 EOF
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Allow for setting of the VNET_RG_NAME, VNET_NAME, and SUBNET_NAME via environment variables. To allow for independent testing.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
Linux build : [[Link](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=79740785&view=results)]
Windows build : [[Link](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=79740801&view=results)]

**Release note**:
```
none
```
