### PR TITLE
docs: move os-release earlier in vhd build log

### DIFF
--- a/vhdbuilder/packer/post-install-dependencies.sh
+++ b/vhdbuilder/packer/post-install-dependencies.sh
@@ -60,6 +60,10 @@ usage=${usage%.*}
 [ ${usage} -ge 99 ] && echo "ERROR: root partition on OS device (${os_device}) already passed 99% of the 30GB cap!" && exit 1
 [ ${usage} -ge 75 ] && echo "WARNING: root partition on OS device (${os_device}) already passed 75% of the 30GB cap!"
 
+echo -e "=== os-release Begin" >> ${VHD_LOGS_FILEPATH}
+cat /etc/os-release >> ${VHD_LOGS_FILEPATH}
+echo -e "=== os-release End" >> ${VHD_LOGS_FILEPATH}
+
 echo "Using kernel:" >> ${VHD_LOGS_FILEPATH}
 tee -a ${VHD_LOGS_FILEPATH} < /proc/version
 {
@@ -73,10 +77,6 @@ tee -a ${VHD_LOGS_FILEPATH} < /proc/version
   echo "Container runtime: ${CONTAINER_RUNTIME}"
   echo "FIPS enabled: ${ENABLE_FIPS}"
 } >> ${VHD_LOGS_FILEPATH}
-
-echo -e "=== os-release Begin" >> ${VHD_LOGS_FILEPATH}
-cat /etc/os-release >> ${VHD_LOGS_FILEPATH}
-echo -e "=== os-release End" >> ${VHD_LOGS_FILEPATH}
 
 if [[ $(isARM64) != 1 ]]; then
   # no asc-baseline-1.1.0-268.arm64.deb


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR moves the /etc/os-release info slightly higher in the VHD build log so that it will be included in the full [AKS release notes](https://github.com/Azure/AKS/blob/2023-09-10/vhd-notes/AzureLinux/202309.06.0.txt) txts. Typically "Install completed successfully on" and below is trimmed out for the main release notes.

This will help us more quickly correlate which Mariner release a given VHD was built with.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```