### PR TITLE
chore: remove calico 3.24.0 and tigera 1.28.0

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -121,40 +121,35 @@
       "downloadURL": "mcr.microsoft.com/oss/calico/cni:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v3.24.6",
-        "v3.24.0"
+        "v3.24.6"
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/oss/calico/node:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v3.24.6",
-        "v3.24.0"
+        "v3.24.6"
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/oss/calico/typha:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v3.24.6",
-        "v3.24.0"
+        "v3.24.6"
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/oss/calico/pod2daemon-flexvol:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v3.24.6",
-        "v3.24.0"
+        "v3.24.6"
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/oss/calico/kube-controllers:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v3.24.6",
-        "v3.24.0"
+        "v3.24.6"
       ]
     },
     {
@@ -178,7 +173,6 @@
       "downloadURL": "mcr.microsoft.com/oss/tigera/operator:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.28.0",
         "v1.28.13"
       ]
     },

--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -164,7 +164,6 @@
       "downloadURL": "mcr.microsoft.com/oss/cilium/cilium:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "1.12.10-1",
         "1.12.10-2",
         "1.13.5"
       ]


### PR DESCRIPTION
**What type of PR is this?**
This PR removes calico 3.24.0 as it is no longer need by the supported tigera operator version as referenced here:
https://msazure.visualstudio.com/CloudNativeCompute/_git/aks-rp?path=/toolkit/versioning/manifests/addon/calico/tigera-operator.yaml&version=GC9f0ebe62d3323b7ea00125301434030f635ddd1c&_a=contents

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
