### PR TITLE
feat: optimize resize-osdrive to improve node provisioning time

### DIFF
--- a/staging/cse/windows/configfunc.ps1
+++ b/staging/cse/windows/configfunc.ps1
@@ -18,7 +18,7 @@ function Resize-OSDrive
         $osDrive = ((Get-WmiObject Win32_OperatingSystem -ErrorAction Stop).SystemDrive).TrimEnd(":")
 
         # Ensure the OS volume needs to be expanded, diskpart will fail if the partition is already expanded
-        $osDisk = Get-Volume $osDrive | Get-Partition | Get-Disk
+        $osDisk = Get-Partition -DriveLetter $osDrive | Get-Disk
         if ($osDisk.Size - $osDisk.AllocatedSize -gt 1GB)
         {
             # Create a diskpart script (text file) that will select the OS volume, extend it and exit.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Resize-OSDrive can be slow due to Get-PartitionSupportedSize, replacing that call with diskpart

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
While inspecting node provision time – Resize-OSDrive was taking over 2min in some cases, the Windows Storage team informed us that Get-PartitionSupportedSize can be a slow call as it not only gets the maximum size but also the minimum size which requires a call into defrag. This change replaces that call and uses diskpart for the resize operation.

Unit tested against 2019 and 2022, generation 1 and generation 2, across 7 sku sizes. Specific unit test used a CSE script of just the old/new resize function against the 30GB (smalldisk) OS version. All versions/sku's passed. I did not test integrated with the AKS CSE scripts (not sure how to do that). This unit test only observes small improvements due to the nature of the base image but proves the core functionality is stable.

@AbelHu also collected some data observing a significant improvement. For WS2019 an avg of 89.2 sec down to 8.85 sec, and WS2022 an avg of 79.4 sec down to 8.6 sec, and WS2022 Gen 2 an avg of 122.8 sec down to 13.4 sec.

**Release note**:
```
none
```