### PR TITLE
feat: optimize resize-osdrive replacing get-partitionsupportedsize with diskpart

### DIFF
--- a/staging/cse/windows/configfunc.ps1
+++ b/staging/cse/windows/configfunc.ps1
@@ -11,15 +11,21 @@ function Set-TelemetrySetting
 }
 
 # Resize the system partition to the max available size. Azure can resize a managed disk, but the VM still needs to extend the partition boundary
+# This approach was recommended by the Windows Storage team to avoid performance delay when calling Get-PartitionSupportedSize
 function Resize-OSDrive
 {
     try {
         $osDrive = ((Get-WmiObject Win32_OperatingSystem -ErrorAction Stop).SystemDrive).TrimEnd(":")
-        $size = (Get-Partition -DriveLetter $osDrive -ErrorAction Stop).Size
-        $maxSize = (Get-PartitionSupportedSize -DriveLetter $osDrive -ErrorAction Stop).SizeMax
-        if ($size -lt $maxSize)
+
+        # Ensure the OS volume needs to be expanded, diskpart will fail if the partition is already expanded
+        $osDisk = Get-Partition -DriveLetter $osDrive | Get-Disk
+        if ($osDisk.Size - $osDisk.AllocatedSize -gt 1GB)
         {
-            Resize-Partition -DriveLetter $osDrive -Size $maxSize -ErrorAction Stop
+            # Create a diskpart script (text file) that will select the OS volume, extend it and exit.
+            $diskpartScriptPath = [String]::Format("{0}\\diskpart_extendOSVol.script", $env:temp)
+            [String]::Format("select volume {0}`nextend`nexit", $osDrive) | Out-File -Encoding "UTF8" $diskpartScriptPath
+            Invoke-Executable -Executable "diskpart.exe" -ArgList @("/s", $diskpartScriptPath) -ExitCode $global:WINDOWS_CSE_ERROR_RESIZE_OS_DRIVE
+            Remove-Item -Path $diskpartScriptPath -Force
         }
     } catch {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_RESIZE_OS_DRIVE -ErrorMessage "Failed to resize os drive. Error: $_"


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Resize-OSDrive can be slow due to Get-PartitionSupportedSize, replacing that call with diskpart

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
While inspecting node provision time – Resize-OSDrive was taking over 2min in some cases, the Windows Storage team informed us that Get-PartitionSupportedSize can be a slow call as it not only gets the maximum size but also the minimum size which requires a call into defrag. This change replaces that call and uses diskpart for the resize operation.

Unit tested against 2019 and 2022, generation 1 and generation 2, across 7 sku sizes. Specific unit test used a CSE script of just the old/new resize function against the 30GB (smalldisk) OS version. All versions/sku's passed. I did not test integrated with the AKS CSE scripts (not sure how to do that). This unit test only observes small improvements due to the nature of the base image but proves the core functionality is stable.

@AbelHu also collected some data observing a significant improvement. For WS2019 an avg of 89.2 sec down to 8.85 sec, and WS2022 an avg of 79.4 sec down to 8.6 sec, and WS2022 Gen 2 an avg of 122.8 sec down to 13.4 sec.

While inspecting node provision time – Resize-OSDrive was taking over 2min in some cases, the Windows Storage team informed us that Get-PartitionSupportedSize can be a slow call as it not only gets the maximum size but also the minimum size which requires a call into defrag. This change removes that call and uses diskpart for the resize operation.

**Release note**:
```
none
```
