### PR TITLE
Fix: Move MSI identity to env vars to be optional

### DIFF
--- a/vhdbuilder/packer/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows-vhd-builder-sig.json
@@ -20,7 +20,8 @@
         "windows_patch_url": "{{env `WINDOWS_PATCH_URL`}}",
         "vnet_name": "{{env `VNET_NAME`}}",
         "subnet_name": "{{env `SUBNET_NAME`}}",
-        "vnet_resource_group_name": "{{env `VNET_RESOURCE_GROUP_NAME`}}"
+        "vnet_resource_group_name": "{{env `VNET_RESOURCE_GROUP_NAME`}}",
+        "windows_msi_resource_string": "{{env `WINDOWS_MSI_RESOURCE_STRING`}}"
     },
     "builders": [
         {
@@ -68,10 +69,7 @@
             },
             "virtual_network_resource_group_name": "{{user `vnet_resource_group_name`}}",
             "virtual_network_name": "{{user `vnet_name`}}",
-            "virtual_network_subnet_name": "{{user `subnet_name`}}",
-            "user_assigned_managed_identities": [
-                "{{user `windows_msi_resource_string`}}"
-            ]
+            "virtual_network_subnet_name": "{{user `subnet_name`}}"
         }
     ],
     "provisioners": [


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/Azure/AgentBaker/issues/3810

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

Changes MSI variable from builder vars to env variables. You would need to make sure your CI is configured accordingly.
 This keeps existing behaviour where:
```
            "client_id": "{{user `client_id`}}",
            "client_secret": "{{user `client_secret`}}",
            "tenant_id": "{{user `tenant_id`}}",
            "subscription_id": "{{user `subscription_id`}}",
 ```
 are used to interact with azure subscription, and MSI is only used for private packages pulling and ONLY if packages are provided. Else it skips the step. 

The only unknown in this flow for external consumer is "what is in those private packages and will image will function as AKS node without them?"?


**Release note**:
```
none
```
