### PR TITLE
fix: refine Windows VHD build steps to reset ReofferUpdate.

### DIFF
--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -36,6 +36,7 @@ steps:
       if [[ -n ${SIG_GALLERY_NAME} && -n ${SIG_IMAGE_NAME_PREFIX} && -n ${SIG_IMAGE_VERSION} ]]; then \   
           sigImageName="${SIG_IMAGE_NAME_PREFIX}-${WINDOWS_SKU}"; \
           echo "##vso[task.setvariable variable=SIG_FOR_PRODUCTION]False"; \
+          echo "##vso[task.setvariable variable=SKIPVALIDATEREOFFERUPDATE]True"; \
       else
           sigImageName="windows-${WINDOWS_SKU}-$RANDOM"; \
           WS_SKU=$(echo $WINDOWS_SKU | tr '-' '_')
@@ -43,6 +44,7 @@ steps:
           echo "##vso[task.setvariable variable=SIG_GALLERY_NAME]$sigGalleryName"; \
           echo "##vso[task.setvariable variable=SIG_IMAGE_VERSION]1.0.0"; \
           echo "##vso[task.setvariable variable=SIG_FOR_PRODUCTION]True"; \
+          echo "##vso[task.setvariable variable=SKIPVALIDATEREOFFERUPDATE]False"; \
       fi
       echo "Set build mode to $m" && \
       echo "##vso[task.setvariable variable=SIG_IMAGE_NAME]$sigImageName" && \
@@ -122,6 +124,7 @@ steps:
       -e MANAGED_SIG_ID=${MANAGED_SIG_ID} \
       -e AZURE_LOCATION=${AZURE_BUILD_LOCATION} \
       -e WINDOWS_SKU=$(WINDOWS_SKU) \
+      -e SKIPVALIDATEREOFFERUPDATE=${SKIPVALIDATEREOFFERUPDATE} \
       -e OS_TYPE="Windows" \
       -e MODE=$(MODE) \
       -e FEATURE_FLAGS=${FEATURE_FLAGS} \

--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -771,6 +771,17 @@ function Get-LatestWindowsDefenderPlatformUpdate {
     }
 }
 
+function Log-ReofferUpdate {
+    try {
+        $result=(Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\Installed\Server.OS.amd64" -Name ReofferUpdate)
+        if ($result) {
+            Write-Log "ReofferUpdate is $($result.ReofferUpdate)"
+        }
+    } catch {
+        Write-Log "ReofferUpdate does not exist"
+    }
+}
+
 # Disable progress writers for this session to greatly speed up operations such as Invoke-WebRequest
 $ProgressPreference = 'SilentlyContinue'
 
@@ -784,12 +795,15 @@ try{
             Disable-WindowsUpdates
             Set-WinRmServiceDelayedStart
             Update-DefenderSignatures
-            Install-WindowsPatches
+            Log-ReofferUpdate
             Install-OpenSSH
+            Log-ReofferUpdate
+            Install-WindowsPatches
             Update-WindowsFeatures
         }
         "2" {
             Write-Log "Performing actions for provisioning phase 2"
+            Log-ReofferUpdate
             Set-WinRmServiceAutoStart
             Install-ContainerD
             Update-Registry
@@ -798,6 +812,7 @@ try{
             Get-PrivatePackagesToCacheOnVHD
             Remove-Item -Path c:\windows-vhd-configuration.ps1
             (New-Guid).Guid | Out-File -FilePath 'c:\vhd-id.txt'
+            Log-ReofferUpdate
         }
         default {
             Write-Log "Unable to determine provisiong phase... exiting"

--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -28,8 +28,8 @@ $global:defenderUpdateInfoUrl = "https://go.microsoft.com/fwlink/?linkid=870379&
 
 switch -Regex ($windowsSku) {
     "2019-containerd" {
-        $global:patchUrls = @()
-        $global:patchIDs = @()
+        $global:patchUrls = @("https://catalog.s.download.windowsupdate.com/d/msdownload/update/software/secu/2023/11/windows10.0-kb5032196-x64_07be38ad94320c193e1e66ee614f2a2c902c1964.msu")
+        $global:patchIDs = @("KB5032196")
 
         $global:imagesToPull = @(
             "mcr.microsoft.com/windows/servercore:ltsc2019",
@@ -37,8 +37,8 @@ switch -Regex ($windowsSku) {
         )
     }
     "2022-containerd*" {
-        $global:patchUrls = @()
-        $global:patchIDs = @()
+        $global:patchUrls = @("https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/secu/2023/11/windows10.0-kb5032198-x64_6ce4dd96ade8a19c876d53c85cbe7b3e26b0472b.msu")
+        $global:patchIDs = @("KB5032198")
 
         $global:imagesToPull = @(
             "mcr.microsoft.com/windows/servercore:ltsc2022",

--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -152,7 +152,7 @@ else
     --resource-group $RESOURCE_GROUP_NAME \
     --scripts @$SCRIPT_PATH \
     --output json \
-    --parameters "windowsSKU=${WINDOWS_SKU}")
+    --parameters "windowsSKU=${WINDOWS_SKU}" "skipValidateReofferUpdate=${SKIPVALIDATEREOFFERUPDATE}")
   # An example of failed run-command output:
   # {
   #   "value": [


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Refine Windows VHD build steps to reset ReofferUpdate. We have to install the latest security patch after installing OpenSSH to avoid that ReofferUpdate is set to 1.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
