### PR TITLE
feat: adding in windows dropgz to pre-cache list

### DIFF
--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -112,7 +112,9 @@ $global:imagesToPull += @(
     "mcr.microsoft.com/containernetworking/azure-cns:v1.4.51",
     "mcr.microsoft.com/containernetworking/azure-cns:v1.4.52",
     "mcr.microsoft.com/containernetworking/azure-cns:v1.5.15",
-    "mcr.microsoft.com/containernetworking/azure-cns:v1.5.17"
+    "mcr.microsoft.com/containernetworking/azure-cns:v1.5.17",
+    # Dropgz (init container to CNS). Owner: pjohnst5 (Paul Johnston)
+    "mcr.microsoft.com/containernetworking/cni-dropgz:v0.0.13"
 )
 
 $global:map = @{


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This pre-cache's Windows dropgz for AKS nodes
This Windows dropgz is only used in Overlay nodes in AKS for now, but asked by Abel to start caching it
