### PR TITLE
feat: add VHD build timestamp in official branches for reproducible VHDs

### DIFF
--- a/vhdbuilder/scripts/automate_version_bump.sh
+++ b/vhdbuilder/scripts/automate_version_bump.sh
@@ -102,7 +102,6 @@ cut_official_branch() {
 }
 
 set_git_config
-# find_current_image_version "pkg/agent/datamodel/linux_sig_version.json"
-# create_image_bump_pr
-# cut_official_branch
-find_and_write_build_timestamp
+find_current_image_version "pkg/agent/datamodel/linux_sig_version.json"
+create_image_bump_pr
+cut_official_branch

--- a/vhdbuilder/scripts/automate_version_bump.sh
+++ b/vhdbuilder/scripts/automate_version_bump.sh
@@ -101,7 +101,7 @@ cut_official_branch() {
     git checkout master
 }
 
-# set_git_config
+set_git_config
 # find_current_image_version "pkg/agent/datamodel/linux_sig_version.json"
 # create_image_bump_pr
 # cut_official_branch

--- a/vhdbuilder/scripts/automate_version_bump.sh
+++ b/vhdbuilder/scripts/automate_version_bump.sh
@@ -105,4 +105,4 @@ set_git_config
 # find_current_image_version "pkg/agent/datamodel/linux_sig_version.json"
 # create_image_bump_pr
 # cut_official_branch
-find_build_timestamp
+find_and_write_build_timestamp

--- a/vhdbuilder/scripts/automate_version_bump.sh
+++ b/vhdbuilder/scripts/automate_version_bump.sh
@@ -27,7 +27,7 @@ find_and_write_build_timestamp() {
     build_time=$(az pipelines runs show --id $first_build | jq -r ".queueTime")
     canonical_sanitized_timestamp=$(date -u -d "$build_time" "+%Y%m%dT%H%M%SZ")
     json_string="{\"build_timestamp\": \"$canonical_sanitized_timestamp\"}"
-    echo $json_string > ${new_image_version}_buld_timestamp.json
+    echo $json_string > vhdbuilder/${new_image_version}_build_timestamp.json
 }
 
 # This function finds the current SIG Image version from the input JSON file

--- a/vhdbuilder/scripts/automate_version_bump.sh
+++ b/vhdbuilder/scripts/automate_version_bump.sh
@@ -17,17 +17,17 @@ build_ids=$3
 branch_name=imageBump/$new_image_version
 pr_title="VHDVersion"
 
+# This function takes the build ID and reads the queue time.
+# It then sanitizes the queue time in the format that the Canonical snapshot endpoint expects, which is 20230727T000000Z 
+# Following that, it will write the timestamp to a JSON file to be consumed later in the event of a hotfix
+# This file is only written to an official branch, because the build timestamp will correspond with a particular VHD
 find_and_write_build_timestamp() {
-    # This function takes the build ID and reads the queue time.
-    # It then sanitizes the queue time in the format that the Canonical snapshot endpoint expects, which is 20230727T000000Z 
-    # Following that, it will write the timestamp to a JSON file to be consumed later in the event of a hotfix
-    # This file is only written to an official branch, because the build timestamp will correspond with a particular VHD
-
     first_build=$(echo "$build_ids" | cut -d' ' -f1)
     build_time=$(az pipelines runs show --id $first_build | jq -r ".queueTime")
     canonical_sanitized_timestamp=$(date -u -d "$build_time" "+%Y%m%dT%H%M%SZ")
+    # shellcheck disable=SC2089
     json_string="{\"build_timestamp\": \"$canonical_sanitized_timestamp\"}"
-    echo $json_string > vhdbuilder/${new_image_version}_build_timestamp.json
+    echo "$json_string" > vhdbuilder/${new_image_version}_build_timestamp.json
 }
 
 # This function finds the current SIG Image version from the input JSON file
@@ -82,17 +82,17 @@ cut_official_branch() {
     fi
     update_image_version
     git add .
-    git commit -m"chore: update image version in official branch"
+    git commit -m "chore: update image version in official branch"
 
     # Avoid including release notes in the official tag
     rm -rf vhdbuilder/release-notes
     git add .
-    git commit -m"chore: remove release notes in official branch"
+    git commit -m "chore: remove release notes in official branch"
     
     # Compute and store the VHD build timestamp for hotfixes
     find_and_write_build_timestamp
     git add .
-    git commit -m"chore: compute and store VHD build timestamp in official branch"
+    git commit -m "chore: compute and store VHD build timestamp in official branch"
 
     git push -u origin $official_branch_name
 


### PR DESCRIPTION
**What type of PR is this?**
This PR computes and stores VHD build timestamps in official branches during weekly automation runs to keep track of when a VHD build was run, to use the Canonical Snapshot service, in case the same VHD needs to be hotfixed later, thereby guaranteeing the same apt versions from when it was originally built.

Successful test run: https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=88140121&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=dee4e6ec-be1b-5671-4678-ab293b4004c5

Sample commit that creates the timestamp JSON file: https://github.com/Azure/AgentBaker/commit/b54f60aae914f90baf0e6b9a74398039455568a6

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
