### PR TITLE
feat: validate the free space in AKS Windows VHDs

### DIFF
--- a/vhdbuilder/packer/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/configure-windows-vhd.ps1
@@ -743,6 +743,10 @@ function Get-SystemDriveDiskInfo {
     foreach($disk in $disksInfo) {
         if ($disk.DeviceID -eq "C:") {
             Write-Log "Disk C: Free space: $($disk.FreeSpace), Total size: $($disk.Size)"
+
+            if ($disk.FreeSpace -lt $global:lowestFreeSpace) {
+                throw "Disk C: Free space is less than $($global:lowestFreeSpace)"
+            }
         }
     }
 }

--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -8,6 +8,9 @@ if (-not ($validSKU -contains $windowsSKU)) {
     throw "Unsupported windows image SKU: $windowsSKU"
 }
 
+# We need to guarantee that the node provisioning will not fail because the vhd is full before resize-osdisk is called in AKS Windows CSE script.
+$global:lowestFreeSpace = 2*1024*1024*1024 # 2GB
+
 # defaultContainerdPackageUrl refers to the stable containerd package used to pull and cache container images
 # Add cache for another containerd version which is not installed by default
 $global:defaultContainerdPackageUrl = "https://acs-mirror.azureedge.net/containerd/windows/v1.6.21-azure.1/binaries/containerd-v1.6.21-azure.1-windows-amd64.tar.gz"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Validate the free space in AKS Windows VHDs. Based on below logs in building AKS Windows VHDs in the past months, we set `$global:lowestFreeSpace` to `2GB`. It can avoid that the node provisioning fails because the disk is full before resize-osdisk is called in AKS Windows CSE script.

```
2023-10B: azure-arm: 2023-10-11T02:05:47.3821397+00:00: Disk C: Free space: 2870341632, Total size: 37054574592
2023-11B: azure-arm: 2023-11-15T04:24:35.6762674+00:00: Disk C: Free space: 7530057728, Total size: 37054574592
2023-12B: azure-arm: 2023-12-13T07:15:49.5874780+00:00: Disk C: Free space: 4424978432, Total size: 37054574592
2024-01B: azure-arm: 2024-01-10T06:19:45.8406506+00:00: Disk C: Free space: 4901367808, Total size: 37054574592
2024-01B: azure-arm: 2024-02-02T03:28:36.7695401+00:00: Disk C: Free space: 2284965888, Total size: 37054574592
```

Test logs in https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=88314843&view=logs&j=da83e503-f0a7-5e39-4c4e-547ddc065d07&t=c25eccdb-c467-51a1-7682-f93363e2409c:
```
    azure-arm: 2024-02-27T08:28:37.9559130+00:00: Get Disk info
    azure-arm: 2024-02-27T08:28:38.5497165+00:00: Disk C: Free space: 2969219072, Total size: 37054574592
    azure-arm: Disk C: Free space is less than 3221225472
    azure-arm: At C:\Windows\Temp\script-65dd8fe0-a38c-bcf7-1892-c8d74ee7a310.ps1:748 char:17
    azure-arm: + ...             throw "Disk C: Free space is less than $($global:lowestFr ...
    azure-arm: +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    azure-arm:     + CategoryInfo          : OperationStopped: (Disk C: Free sp...than 3221225472:String) [], RuntimeException
    azure-arm:     + FullyQualifiedErrorId : Disk C: Free space is less than 3221225472
    azure-arm:
==> azure-arm: Provisioning step had errors: Running the cleanup provisioner, if present...
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
