### PR TITLE
feat: support skipping legacy code CleanupNetwork in AKS Windows CSE

### DIFF
--- a/staging/cse/windows/kubernetesfunc.ps1
+++ b/staging/cse/windows/kubernetesfunc.ps1
@@ -105,6 +105,7 @@ function Write-KubeClusterConfig {
         HNSRemediator       = @{
             IntervalInMinutes = $Global:HNSRemediatorIntervalInMinutes;
         };
+        IsSkipCleanupNetwork = $global:IsSkipCleanupNetwork;
     }
 
     $Global:ClusterConfiguration | Add-Member -MemberType NoteProperty -Name Kubernetes -Value @{

--- a/staging/cse/windows/provisioningscripts/cleanupnetwork.ps1
+++ b/staging/cse/windows/provisioningscripts/cleanupnetwork.ps1
@@ -1,4 +1,14 @@
+# The cleanup process for `HNS Network` and `CNI data` should be consistent.
+
 $Global:ClusterConfiguration = ConvertFrom-Json ((Get-Content "c:\k\kubeclusterconfig.json" -ErrorAction Stop) | out-string)
+
+$global:IsSkipCleanupNetwork = [System.Convert]::ToBoolean($Global:ClusterConfiguration.Services.IsSkipCleanupNetwork)
+
+filter Timestamp { "$(Get-Date -Format o): $_" }
+
+function Write-Log($message) {
+    $message | Timestamp
+}
 
 $global:NetworkMode = "L2Bridge"
 $global:NetworkPlugin = $Global:ClusterConfiguration.Cni.Name
@@ -14,11 +24,11 @@ if ($global:NetworkPlugin -eq "azure") {
 $hnsNetwork = Get-HnsNetwork | ? Name -EQ $networkname
 if ($hnsNetwork) {
     # Cleanup all containers
-    Write-Host "Cleaning up containers"
+    Write-Log "Cleaning up containers"
     ctr.exe -n k8s.io c ls -q | ForEach-Object { ctr -n k8s.io tasks kill $_ }
     ctr.exe -n k8s.io c ls -q | ForEach-Object { ctr -n k8s.io c rm $_ }
     
-    Write-Host "Cleaning up persisted HNS policy lists"
+    Write-Log "Cleaning up persisted HNS policy lists"
     # Initially a workaround for https://github.com/kubernetes/kubernetes/pull/68923 in < 1.14,
     # and https://github.com/kubernetes/kubernetes/pull/78612 for <= 1.15
     #
@@ -29,16 +39,42 @@ if ($hnsNetwork) {
     # https://github.com/delulu/kubernetes/blob/524de768bb64b7adff76792ca3bf0f0ece1e849f/pkg/proxy/winkernel/proxier.go#L532
     Get-HnsPolicyList | Remove-HnsPolicyList
 
-    Write-Host "Cleaning up old HNS network found"
-    Remove-HnsNetwork $hnsNetwork
-    Start-Sleep 10
+    if ($global:IsSkipCleanupNetwork) {
+        Write-Log "Remove HNS Endpoint before removing HNS Network."
+        Get-HnsEndpoint | Remove-HnsEndpoint
+        Remove-HnsNetwork $hnsNetwork
+
+        Write-Log  "Count actively reserved port pools to log."
+        # Guarantee (10s <= wait time <= 60s) between HNS removal vs. creation for safety.
+        # Usually, it takes 10s to sleep like before, but it may take longer in some cases (e.g., COSMIC).
+        $maxIteration=6
+        $countPortPools = 1
+        For ($i=1; ($i -le $maxIteration -and $countPortPools -ne 0); $i++) {
+            try {
+                $countPortPools = (Invoke-HnsRequest -Method "GET" -Type "portpools" | Select-Object -ExpandProperty PortPoolAllocations | Where-Object -FilterScript {$_.RequiresHostPortReservation -eq "True" -and $_.PortRanges} | Select-Object -ExpandProperty PortRanges).Count
+                Write-Log "Waiting for HNS to release $countPortPools held port pools ($i/$maxIteration)..."
+            } catch {
+                Write-Log "Failed to get port pools. Error: $_"
+            }
+            Start-Sleep 10
+        }
+    } else {
+        # Legacy codes
+        Write-Log "Original code. Remove HNS Network and sleep 10s."
+        Remove-HnsNetwork $hnsNetwork
+        Start-Sleep 10
+    }
+
+    Write-Log "Cleaning up old HNS network completed"
+} else {
+    Write-Log "No hnsNetwork" # Log: No hnsNetwork when provisioning a new node
 }
 
 
 if ($global:NetworkPlugin -eq "azure") {
-    Write-Host "NetworkPlugin azure, starting kubelet."
+    Write-Log "NetworkPlugin azure, starting kubelet."
 
-    Write-Host "Cleaning stale CNI data"
+    Write-Log "Cleaning stale CNI data"
     # Kill all cni instances & stale data left by cni
     # Cleanup all files related to cni
     taskkill /IM azure-vnet.exe /f
@@ -64,7 +100,7 @@ if ($global:NetworkPlugin -eq "azure") {
 
     foreach ($file in $filesToRemove) {
         if (Test-Path $file) {
-            Write-Host "Deleting stale file at $file"
+            Write-Log "Deleting stale file at $file"
             Remove-Item $file
         }
     }

--- a/staging/cse/windows/provisioningscripts/kubeproxystart.ps1
+++ b/staging/cse/windows/provisioningscripts/kubeproxystart.ps1
@@ -1,6 +1,7 @@
 $Global:ClusterConfiguration = ConvertFrom-Json ((Get-Content "c:\k\kubeclusterconfig.json" -ErrorAction Stop) | out-string)
 $KubeproxyFeatureGates = $Global:ClusterConfiguration.Kubernetes.Kubeproxy.FeatureGates # This is the initial feature list passed in from aks-engine
 $KubernetesVersion = $Global:ClusterConfiguration.Kubernetes.Source.Release
+$global:IsSkipCleanupNetwork = [System.Convert]::ToBoolean($Global:ClusterConfiguration.Services.IsSkipCleanupNetwork)
 
 # comparison function for 2 semantic versions
 # returns 1 if Version1 > Version 2, -1 if Version1 < Version2, and 0 if equal
@@ -50,11 +51,16 @@ if ($Global:ClusterConfiguration.Kubernetes.Kubeproxy.ConfigArgs) {
     $global:KubeproxyArgList += $Global:ClusterConfiguration.Kubernetes.Kubeproxy.ConfigArgs
 }
 
-$hnsNetwork = Get-HnsNetwork | ? Name -EQ $KubeNetwork
-while (!$hnsNetwork) {
-    Write-Host "$(Get-Date -Format o) Waiting for Network [$KubeNetwork] to be created . . ."
-    Start-Sleep 10
+if ($global:IsSkipCleanupNetwork) {
+    Write-Host "Skipping legacy code: kube-proxy waits for network to be created"
+} else {
+    # Legacy codes
     $hnsNetwork = Get-HnsNetwork | ? Name -EQ $KubeNetwork
+    while (!$hnsNetwork) {
+        Write-Host "$(Get-Date -Format o) Waiting for Network [$KubeNetwork] to be created . . ."
+        Start-Sleep 10
+        $hnsNetwork = Get-HnsNetwork | ? Name -EQ $KubeNetwork
+    }
 }
 
 # enable WinDsr if WinDsr feature gate is enabled
@@ -81,13 +87,16 @@ if ($featureGateArgs -ne "") {
     $global:KubeproxyArgList += @("--feature-gates=" + $featureGateArgs)
 }
 
-#
-# cleanup the persisted policy lists
-#
-Import-Module $global:HNSModule
-# Workaround for https://github.com/kubernetes/kubernetes/pull/68923 in < 1.14,
-# and https://github.com/kubernetes/kubernetes/pull/78612 for <= 1.15
-Get-HnsPolicyList | Remove-HnsPolicyList
+if ($global:IsSkipCleanupNetwork) {
+    Write-Host "Skipping legacy code: kube-proxy Remove-HnsPolicyList"
+} else {
+    # Legacy codes
+    # cleanup the persisted policy lists
+    Import-Module $global:HNSModule
+    # Workaround for https://github.com/kubernetes/kubernetes/pull/68923 in < 1.14,
+    # and https://github.com/kubernetes/kubernetes/pull/78612 for <= 1.15
+    Get-HnsPolicyList | Remove-HnsPolicyList
+}
 
 # Use run-process.cs to set process priority class as 'AboveNormal'
 # Load a signed version of runprocess.dll if it exists for Azure SysLock compliance

--- a/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
+++ b/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
@@ -126,11 +126,8 @@ if ($IsDualStackEnabled) {
     Restart-HnsService
 }
 
-#
-# Perform cleanup
-#
-
-& "c:\k\cleanupnetwork.ps1"
+# Perform cleanup. It should run when node reset (node provsion and node restart)
+& "c:\k\cleanupnetwork.ps1" >> $global:LogPath
 
 #
 # Start Services


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

- kube-proxy upstream has the code for [waiting azure network](https://github.com/kubernetes/kubernetes/blob/11785bb815d58eb553be3a1fa305464c35d860cc/pkg/proxy/winkernel/proxier.go#L217-L225) which supported [1.22+](https://github.com/kubernetes/kubernetes/commit/d5d9327351de99e6068f62efb388a6ede38d944e)
- kube-proxy upstream has the code for [cleaning HNS policy](https://github.com/kubernetes/kubernetes/blob/fc7325fbec0fe379694e58b82e09f99f166c5e6d/pkg/proxy/winkernel/proxier.go#L685-L686) which supported [1.21+](https://github.com/kubernetes/kubernetes/commit/f3b9e8b10524abfddc52e06eb9a0040d2f1c09df)
- Retain HNS network which confirmed by Windows team and Upstream team
- Reuse toggle `NotRebootWindowsNode` to control it by PR https://github.com/Azure/AgentBaker/pull/4103

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
