### PR TITLE
chore: update npm linux to v1.5.23

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -67,7 +67,7 @@
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-npm:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.4.45.3"
+        "v1.5.23"
       ]
     },
     {


### PR DESCRIPTION
**What type of PR is this?** NPM Version Update

**What this PR does / why we need it**: Updates the NPM Linux image version from v1.4.45.3 to v1.5.23 to address Ubuntu repo updates/CVEs, remove building and publishing NPM images with certs/private keys, and aligns NPM's minor version with CNS/CNI versions.

**Release note**: https://github.com/Azure/azure-container-networking/releases/tag/v1.5.23