### PR TITLE
fix: typo in aks-log-collector glob pattern for cilium-cni

### DIFF
--- a/parts/linux/cloud-init/artifacts/aks-log-collector.sh
+++ b/parts/linux/cloud-init/artifacts/aks-log-collector.sh
@@ -175,7 +175,7 @@ GLOBS+=(/var/log/azure-cni*)
 GLOBS+=(/var/log/azure-cns*)
 GLOBS+=(/var/log/azure-ipam*)
 GLOBS+=(/var/log/azure-vnet*)
-GLOBS+=(/var/log/cillium-cni*)
+GLOBS+=(/var/log/cilium-cni*)
 GLOBS+=(/var/run/azure-vnet*)
 GLOBS+=(/var/run/azure-cns*)
 

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -779,7 +779,7 @@ GLOBS+=(/var/log/azure-cni*)
 GLOBS+=(/var/log/azure-cns*)
 GLOBS+=(/var/log/azure-ipam*)
 GLOBS+=(/var/log/azure-vnet*)
-GLOBS+=(/var/log/cillium-cni*)
+GLOBS+=(/var/log/cilium-cni*)
 GLOBS+=(/var/run/azure-vnet*)
 GLOBS+=(/var/run/azure-cns*)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Collect from /var/log/cilium-cni* instead of /var/log/cillium-cni* (one 'l' in cilium).

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
Update aks-log-collector script with correct glob pattern for cilium-cni logs.
```
