### PR TITLE
feat: collect calico-system and tigera-operator logs

### DIFF
--- a/parts/linux/cloud-init/artifacts/sync-container-logs.sh
+++ b/parts/linux/cloud-init/artifacts/sync-container-logs.sh
@@ -39,7 +39,7 @@ while true; do
 done &
 
 # Manually sync all matching logs once
-for CONTAINER_LOG_FILE in $(compgen -G "$SRC/*_kube-system_*.log"); do
+for CONTAINER_LOG_FILE in $(compgen -G "$SRC/*_@(kube-system|tigera-operator|calico-system)_*.log"); do
    echo "Linking $CONTAINER_LOG_FILE"
    /bin/ln -Lf $CONTAINER_LOG_FILE $DST/
 done
@@ -48,7 +48,7 @@ echo "Starting inotifywait..."
 # Monitor for changes
 inotifywait -q -m -r -e delete,create $SRC | while read DIRECTORY EVENT FILE; do
     case $FILE in
-        *_kube-system_*.log)
+        *_@(kube-system|tigera-operator|calico-system)_*.log)
             case $EVENT in
                 CREATE*)
                     echo "Linking $FILE"

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -6932,7 +6932,7 @@ while true; do
 done &
 
 # Manually sync all matching logs once
-for CONTAINER_LOG_FILE in $(compgen -G "$SRC/*_kube-system_*.log"); do
+for CONTAINER_LOG_FILE in $(compgen -G "$SRC/*_@(kube-system|tigera-operator|calico-system)_*.log"); do
    echo "Linking $CONTAINER_LOG_FILE"
    /bin/ln -Lf $CONTAINER_LOG_FILE $DST/
 done
@@ -6941,7 +6941,7 @@ echo "Starting inotifywait..."
 # Monitor for changes
 inotifywait -q -m -r -e delete,create $SRC | while read DIRECTORY EVENT FILE; do
     case $FILE in
-        *_kube-system_*.log)
+        *_@(kube-system|tigera-operator|calico-system)_*.log)
             case $EVENT in
                 CREATE*)
                     echo "Linking $FILE"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add calico-system and tigera-operator namespaces to container logs collected by sync-container-logs.sh script. This will be used by AKS on-call to troubleshoot issues in clusters with Calico enabled.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
Collect logs from containers in calico-system and tigera-operator namespaces.
```
