### PR TITLE
chore: bump build_vhd to 2204_gen2_containerd

### DIFF
--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -39,13 +39,13 @@ stages:
         - bash: |
             echo '##vso[task.setvariable variable=DRY_RUN]True'
             echo '##vso[task.setvariable variable=OS_SKU]Ubuntu'
-            echo '##vso[task.setvariable variable=OS_VERSION]18.04'
+            echo '##vso[task.setvariable variable=OS_VERSION]22.04'
             echo '##vso[task.setvariable variable=IMG_PUBLISHER]Canonical'
-            echo '##vso[task.setvariable variable=IMG_OFFER]UbuntuServer'
-            echo '##vso[task.setvariable variable=IMG_SKU]18_04-LTS-GEN2'
+            echo '##vso[task.setvariable variable=IMG_OFFER]0001-com-ubuntu-server-jammy'
+            echo '##vso[task.setvariable variable=IMG_SKU]22_04-lts-gen2'
             echo '##vso[task.setvariable variable=IMG_VERSION]latest'
             echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
-            echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_DS2_v2'
+            echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D2s_v3'
             echo '##vso[task.setvariable variable=FEATURE_FLAGS]None'
             echo '##vso[task.setvariable variable=CONTAINER_RUNTIME]containerd'
             echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
@@ -54,7 +54,7 @@ stages:
           displayName: Setup Build Variables
         - template: ./templates/.builder-release-template.yaml
           parameters:
-            artifactName: 1804-gen2-containerd
+            artifactName: 2204-gen2-containerd
   - stage: build_gpu_vhd
     dependsOn: []
     jobs:


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

This PR changes 1 of the 3 VHDs used for the AB PR gate (1804_gen2_containerd => 2204_gen2_containerd).

**What this PR does / why we need it**:

This PR changes the PR gate so that when making a pull request, the pull request builds 2204_gen2_containerd instead of 1804_gen2_containerd, which is an older version that is used less by our customers.