### PR TITLE
fix: remove deprecated feature gate when default k8s version is 1.28

### DIFF
--- a/e2e/windows/scenarios/windows/property-windows-template.json
+++ b/e2e/windows/scenarios/windows/property-windows-template.json
@@ -92,7 +92,7 @@
     "--cloud-provider": "external",
     "--enforce-node-allocatable": "\"\"\"\"",
     "--eviction-hard": "\"\"\"\"",
-    "--feature-gates": "DelegateFSGroupToCSIDriver=true,DynamicKubeletConfig=false",
+    "--feature-gates": "DynamicKubeletConfig=false",
     "--hairpin-mode": "promiscuous-bridge",
     "--kube-reserved": "cpu=100m,memory=3891Mi",
     "--kubeconfig": "c:\\k\\config",


### PR DESCRIPTION
**What type of PR is this?**
/kind fix
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
remove deprecated feature gate when default k8s version is 1.28

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
