### PR TITLE
feat: add system startup task to expand os volume

### DIFF
--- a/staging/cse/windows/configfunc.ps1
+++ b/staging/cse/windows/configfunc.ps1
@@ -23,11 +23,14 @@ function Resize-OSDrive
         $osDisk = Get-Partition -DriveLetter $osDrive | Get-Disk
         if ($osDisk.Size - $osDisk.AllocatedSize -gt 1GB)
         {
+            Write-Log "Expanding the OS volume"
             # Create a diskpart script (text file) that will select the OS volume, extend it and exit.
             $diskpartScriptPath = [String]::Format("{0}\\diskpart_extendOSVol.script", $env:temp)
             [String]::Format("select volume {0}`nextend`nexit", $osDrive) | Out-File -Encoding "UTF8" $diskpartScriptPath
             Invoke-Executable -Executable "diskpart.exe" -ArgList @("/s", $diskpartScriptPath) -ExitCode $global:WINDOWS_CSE_ERROR_RESIZE_OS_DRIVE
             Remove-Item -Path $diskpartScriptPath -Force
+        } else {
+            Write-Log "No need to expand the OS volume due to ScheduledTask executed before CSE."
         }
     } catch {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_RESIZE_OS_DRIVE -ErrorMessage "Failed to resize os drive. Error: $_"

--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -11,6 +11,9 @@ if (-not ($validSKU -contains $windowsSKU)) {
 # We use the same temp dir for all temp tools that will be used for vhd build
 $global:aksTempDir = "c:\akstemp"
 
+# We use the same dir for all tools that will be used in AKS Windows nodes
+$global:aksToolsDir = "c:\aks-tools"
+
 # We need to guarantee that the node provisioning will not fail because the vhd is full before resize-osdisk is called in AKS Windows CSE script.
 $global:lowestFreeSpace = 2*1024*1024*1024 # 2GB
 

--- a/vhdbuilder/packer/test/windows-vhd-content-test.ps1
+++ b/vhdbuilder/packer/test/windows-vhd-content-test.ps1
@@ -544,6 +544,17 @@ function Test-ToolsToCacheOnVHD {
     }
 }
 
+function Test-ExpandVolumeTask {
+    $osDrive = ((Get-WmiObject Win32_OperatingSystem -ErrorAction Stop).SystemDrive).TrimEnd(":")
+    $osDisk = Get-Partition -DriveLetter $osDrive | Get-Disk
+    $osDiskSize = $osDisk.Size 
+    $osDiskAllocatedSize = $osDisk.AllocatedSize
+    if ($osDiskSize -ne $osDiskAllocatedSize) {
+        Write-ErrorWithTimestamp "The OS disk size $osDiskSize is not equal to the allocated size $osDiskAllocatedSize"
+        exit 1
+    }
+}
+
 function Test-SSHDConfig {
     # user must be the name in `TEST_VM_ADMIN_USERNAME="azureuser"` in vhdbuilder/packer/test/run-test.sh
     $result=$(sshd -T -C user=azureuser)
@@ -566,4 +577,5 @@ Test-AzureExtensions
 Test-ExcludeUDPSourcePort
 Test-WindowsDefenderPlatformUpdate
 Test-ToolsToCacheOnVHD
+Test-ExpandVolumeTask
 Remove-Item -Path c:\windows-vhd-configuration.ps1

--- a/vhdbuilder/packer/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows-vhd-builder-sig.json
@@ -108,6 +108,18 @@
             "type": "windows-restart"
         },
         {
+            "elevated_user": "packer",
+            "elevated_password": "{{.WinRMPassword}}",
+            "environment_vars": [
+                "ProvisioningPhase=3",
+                "WindowsSKU={{user `windows_sku`}}"
+            ],
+            "type": "powershell",
+            "scripts": [
+                "vhdbuilder/packer/configure-windows-vhd.ps1"
+            ]
+        },
+        {
             "type": "file",
             "direction": "upload",
             "source": "vhdbuilder/notice_windows.txt",


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Before it, CSE extension is responsible for expanding os volume, but other extensions may run predates CSE, result in extension installation failure due to insufficient free space.
After it, VHD registers system startup task to expand os volume which run predates all extensions.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
