### PR TITLE
chore: prefetch dropgz v0.0.15 and azure-cns v1.5.23

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -45,6 +45,14 @@
         "v1.4.52",
         "v1.5.17",
         "v1.5.23"
+      ],
+      "prefetchOptimizations": [
+        {
+          "version": "v1.5.23",
+          "binaries": [
+            "usr/local/bin/azure-cns"
+          ]
+        }
       ]
     },
     {
@@ -57,7 +65,7 @@
       ],
       "prefetchOptimizations": [
         {
-          "version": "v0.1.1",
+          "version": "v0.0.15",
           "binaries": [
             "dropgz"
           ]


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Prefetch the versions of Azure CNS (v1.5.23) and dropgz (v0.0.15) used in K8s 1.28+.

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
