### PR TITLE
perf: increase packer disk tier, add img_sku tag

### DIFF
--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -53,10 +53,12 @@
         "SkipLinuxAzSecPack": "true",
         "os": "Linux",
         "now": "{{user `create_time`}}",
-        "createdBy": "aks-vhd-pipeline"
+        "createdBy": "aks-vhd-pipeline",
+        "image_sku": "{{user `img_sku`}}"
       },
       "location": "{{user `location`}}",
       "vm_size": "{{user `vm_size`}}",
+      "managed_image_storage_account_type": "Premium_LRS",
       "managed_image_os_disk_snapshot_name": "{{user `arm64_os_disk_snapshot_name`}}",
       "skip_create_image": "true",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -55,10 +55,12 @@
         "SkipLinuxAzSecPack": "true",
         "os": "Linux",
         "now": "{{user `create_time`}}",
-        "createdBy": "aks-vhd-pipeline"
+        "createdBy": "aks-vhd-pipeline",
+        "image_sku": "{{user `img_sku`}}"
       },
       "location": "{{user `location`}}",
       "vm_size": "{{user `vm_size`}}",
+      "managed_image_storage_account_type": "Premium_LRS",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
       "polling_duration_timeout": "1h",

--- a/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
@@ -56,10 +56,12 @@
         "SkipLinuxAzSecPack": "true",
         "os": "Linux",
         "now": "{{user `create_time`}}",
-        "createdBy": "aks-vhd-pipeline"
+        "createdBy": "aks-vhd-pipeline",
+        "image_sku": "{{user `img_sku`}}"
       },
       "location": "{{user `location`}}",
       "vm_size": "{{user `vm_size`}}",
+      "managed_image_storage_account_type": "Premium_LRS",
       "managed_image_os_disk_snapshot_name": "{{user `arm64_os_disk_snapshot_name`}}",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -55,10 +55,12 @@
         "SkipLinuxAzSecPack": "true",
         "os": "Linux",
         "now": "{{user `create_time`}}",
-        "createdBy": "aks-vhd-pipeline"
+        "createdBy": "aks-vhd-pipeline",
+        "image_sku": "{{user `img_sku`}}"
       },
       "location": "{{user `location`}}",
       "vm_size": "{{user `vm_size`}}",
+      "managed_image_storage_account_type": "Premium_LRS",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
       "polling_duration_timeout": "1h",


### PR DESCRIPTION
**What type of PR is this?**

/kind performance

**What this PR does / why we need it**:

This PR increases the disk tier used on the Packer VMs from Standard_LRS to Premium_LRS. The Premium SSDs have notable performance increases and will allow the VM to take full advantage of future parallelization efforts. 

Additionally, this PR adds `img_sku` to the Azure Tags section of the builder template. This enables a developer to more easily find the packer resource group (VM, Disk, NIC) that is building any specific VHD in order to monitor performance metrics. 

**Which issue(s) this PR fixes**:

Unsatisfactory VHD Build pipeline duration.

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
