### PR TITLE
chore: cache azure-cni and azure-ipam

### DIFF
--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -37,11 +37,25 @@
       ]
     },
     {
+      "downloadURL": "mcr.microsoft.com/containernetworking/azure-cni:*",
+      "amd64OnlyVersions": [],
+      "multiArchVersions": [
+        "v1.5.28"
+      ],
+      "prefetchOptimizations": [
+        {
+          "version": "v1.5.28",
+          "binaries": [
+            "dropgz"
+          ]
+        }
+      ]
+    },
+    {
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-cns:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
         "v1.4.52",
-        "v1.5.23",
         "v1.5.26"
       ],
       "prefetchOptimizations": [
@@ -60,24 +74,31 @@
       ]
     },
     {
-      "downloadURL": "mcr.microsoft.com/containernetworking/cni-dropgz:*",
+      "downloadURL": "mcr.microsoft.com/containernetworking/azure-ipam:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v0.0.15",
-        "v0.1.3",
-        "v0.0.20",
-        "v0.1.4",
-        "v0.0.4.1"
+        "v0.2.0"
       ],
       "prefetchOptimizations": [
         {
-          "version": "v0.0.15",
+          "version": "v0.2.0",
           "binaries": [
             "dropgz"
           ]
-        },
+        }
+      ]
+    },
+    {
+      "downloadURL": "mcr.microsoft.com/containernetworking/cni-dropgz:*",
+      "amd64OnlyVersions": [],
+      "multiArchVersions": [
+        "v0.0.13",
+        "v0.0.20",
+        "v0.1.4"
+      ],
+      "prefetchOptimizations": [
         {
-          "version": "v0.1.3",
+          "version": "v0.0.13",
           "binaries": [
             "dropgz"
           ]

--- a/pkg/agent/vhd/cache/cache_test.go
+++ b/pkg/agent/vhd/cache/cache_test.go
@@ -8,7 +8,7 @@ import (
 var _ = Describe("cache suite", func() {
 	Context("get cached data", func() {
 		It("should have the correct manifest and components data cached", func() {
-			//TODO: improve test logic
+			// TODO: improve test logic
 			manifest, err := getManifest()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -18,7 +18,7 @@ var _ = Describe("cache suite", func() {
 			// The indices are hardcoded based on the current components.json.
 			// Add new components to the bottom of components.json, or update the indices.
 			pauseIndx := 2
-			azureCNSIndx := 5
+			azureCNSIndx := 6
 			cniPluginIndx := 0
 			azureCNIIndx := 1
 

--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -107,9 +107,9 @@ $global:imagesToPull += @(
     # CNS (Container Networking Service) Owner: jaer-tsun (Jaeryn)
     "mcr.microsoft.com/containernetworking/azure-cns:v1.4.52",
     "mcr.microsoft.com/containernetworking/azure-cns:v1.5.26",
-    # Dropgz (init container to CNS). Owner: pjohnst5 (Paul Johnston)
-    "mcr.microsoft.com/containernetworking/cni-dropgz:v0.1.3"
+    # CNI installer for azure-vnet. Owner: evanbaker
     "mcr.microsoft.com/containernetworking/cni-dropgz:v0.1.4"
+    "mcr.microsoft.com/containernetworking/azure-cni:v1.5.26"
 )
 
 $global:map = @{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Caches `azure-cni` and `azure-ipam`, which replace and deprecate `cni-dropgz` as the preferred containers for installing the CNI plugins in AKS.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
https://github.com/Azure/azure-container-networking/issues/2333

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
