### PR TITLE
chore: remove old container versions from the components

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -25,7 +25,6 @@
       "downloadURL": "mcr.microsoft.com/oss/kubernetes/coredns:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.8.7",
         "v1.9.4",
         "v1.9.4-hotfix.20240327"
       ]
@@ -41,9 +40,6 @@
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-cns:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.4.50",
-        "v1.4.52",
-        "v1.5.17",
         "v1.5.23"
       ],
       "prefetchOptimizations": [
@@ -59,13 +55,11 @@
       "downloadURL": "mcr.microsoft.com/containernetworking/cni-dropgz:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v0.0.4.1",
-        "v0.0.15",
         "v0.1.1"
       ],
       "prefetchOptimizations": [
         {
-          "version": "v0.0.15",
+          "version": "v0.1.1",
           "binaries": [
             "dropgz"
           ]
@@ -90,8 +84,6 @@
       "downloadURL": "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.3.4-1",
-        "v1.4.1",
         "v1.4.2"
       ]
     },
@@ -99,7 +91,6 @@
       "downloadURL": "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.4.1",
         "v1.5.1"
       ]
     },
@@ -121,9 +112,6 @@
       "downloadURL": "mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-collector/images:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "6.8.4-main-02-14-2024-90d01292",
-        "6.8.4-main-02-14-2024-90d01292-targetallocator",
-        "6.8.4-main-02-14-2024-90d01292-cfg",
         "6.8.6-main-03-08-2024-fd4f13cb",
         "6.8.6-main-03-08-2024-fd4f13cb-targetallocator",
         "6.8.6-main-03-08-2024-fd4f13cb-cfg"
@@ -199,7 +187,6 @@
       "downloadURL": "mcr.microsoft.com/oss/cilium/operator-generic:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "1.13.10",
         "1.14.4"
       ]
     },
@@ -207,9 +194,6 @@
       "downloadURL": "mcr.microsoft.com/oss/cilium/cilium:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "1.13.10-1",
-        "1.13.10-2",
-        "1.14.4",
         "1.14.4-1"
       ]
     },
@@ -224,13 +208,6 @@
       "downloadURL": "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.26.19",
-        "v1.26.22",
-        "v1.27.13",
-        "v1.27.16",
-        "v1.28.5",
-        "v1.28.8",
-        "v1.29.0",
         "v1.29.3"
       ]
     },
@@ -245,7 +222,6 @@
       "downloadURL": "mcr.microsoft.com/aks/ip-masq-agent-v2:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v0.1.9",
         "v0.1.10"
       ]
     },
@@ -253,9 +229,6 @@
       "downloadURL": "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.26.9",
-        "v1.28.6",
-        "v1.29.3",
         "v1.29.4"
       ]
     },
@@ -263,11 +236,6 @@
       "downloadURL": "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.26.11",
-        "v1.28.9",
-        "v1.29.3",
-        "v1.29.4",
-        "v1.30.0",
         "v1.30.1"
       ]
     },
@@ -275,10 +243,6 @@
       "downloadURL": "mcr.microsoft.com/oss/kubernetes-csi/blob-csi:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.21.7",
-        "v1.22.5",
-        "v1.22.5-3",
-        "v1.23.3",
         "v1.23.4"
       ]
     },
@@ -286,8 +250,6 @@
       "downloadURL": "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v2.10.0",
-        "v2.11.0",
         "v2.12.0"
       ]
     },
@@ -295,8 +257,6 @@
       "downloadURL": "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v2.8.0",
-        "v2.9.0",
         "v2.10.0"
       ]
     },
@@ -304,7 +264,6 @@
       "downloadURL": "mcr.microsoft.com/oss/open-policy-agent/gatekeeper:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v3.14.1",
         "v3.14.0"
       ]
     },
@@ -322,16 +281,14 @@
       "downloadURL": "mcr.microsoft.com/azure-policy/policy-kubernetes-addon-prod:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "1.3.1",
-        "1.3.0"
+        "1.3.1"
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/azure-policy/policy-kubernetes-webhook:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "1.3.1",
-        "1.3.0"
+        "1.3.1"
       ]
     },
     {


### PR DESCRIPTION
This should remove about 3.8GB from the VHD.

The image sizes (according to crictl images) are:

13.9MB  mcr.microsoft.com/oss/kubernetes/coredns                                        v1.8.7
162MB   mcr.microsoft.com/containernetworking/azure-cns                                 v1.4.50
171MB   mcr.microsoft.com/containernetworking/azure-cns                                 v1.4.52
172MB   mcr.microsoft.com/containernetworking/azure-cns                                 v1.5.17
76.8MB  mcr.microsoft.com/containernetworking/cni-dropgz                                v0.0.15
68.4MB  mcr.microsoft.com/containernetworking/cni-dropgz                                v0.0.4.1
12MB    mcr.microsoft.com/oss/azure/secrets-store/provider-azure                        v1.4.1
72.2MB  mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver                       v1.3.4-1
66.5MB  mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver                       v1.4.1
275MB   mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-collector/ima6.8.4-main-02-14-2024-90d01292
85.9MB  mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-collector/ima6.8.4-main-02-14-2024-90d01292-cfg
58.8MB  mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-collector/ima6.8.4-main-02-14-2024-90d01292-targetallocator
22.7MB  mcr.microsoft.com/oss/cilium/operator-generic                                   1.13.10
184MB   mcr.microsoft.com/oss/cilium/cilium                                             1.13.10-1
190MB   mcr.microsoft.com/oss/cilium/cilium                                             1.13.10-2
193MB   mcr.microsoft.com/oss/cilium/cilium                                             1.14.4
17.1MB  mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager                       v1.26.14
17.3MB  mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager                       v1.26.19
17.6MB  mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager                       v1.27.13
17.4MB  mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager                       v1.27.8
17.8MB  mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager                       v1.28.0
17.9MB  mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager                       v1.28.5
20.5MB  mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager                       v1.29.0
19.2MB  mcr.microsoft.com/aks/ip-masq-agent-v2                                          v0.1.9
57.8MB  mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi                              v1.26.8
57.7MB  mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi                              v1.26.9
58.1MB  mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi                              v1.28.5
59.1MB  mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi                              v1.28.6
59.1MB  mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi                              v1.29.2
60.4MB  mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi                              v1.29.3
89.3MB  mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi                              v1.26.11
102MB   mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi                              v1.26.11-2
119MB   mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi                              v1.28.9
122MB   mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi                              v1.29.3
128MB   mcr.microsoft.com/oss/kubernetes-csi/blob-csi                                   v1.21.7
145MB   mcr.microsoft.com/oss/kubernetes-csi/blob-csi                                   v1.21.7-2
151MB   mcr.microsoft.com/oss/kubernetes-csi/blob-csi                                   v1.22.5
170MB   mcr.microsoft.com/oss/kubernetes-csi/blob-csi                                   v1.22.5-3
184MB   mcr.microsoft.com/oss/kubernetes-csi/blob-csi                                   v1.23.3
202MB   mcr.microsoft.com/oss/kubernetes-csi/blob-csi                                   v1.23.3-3
9.58MB  mcr.microsoft.com/oss/kubernetes-csi/livenessprobe                              v2.10.0
9.82MB  mcr.microsoft.com/oss/kubernetes-csi/livenessprobe                              v2.11.0
10.9MB  mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar                  v2.10.0
10.5MB  mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar                  v2.8.0
39.2MB  mcr.microsoft.com/oss/open-policy-agent/gatekeeper                              v3.14.0
30.8MB  mcr.microsoft.com/azure-policy/policy-kubernetes-addon-prod                     1.3.0
25.3MB  mcr.microsoft.com/azure-policy/policy-kubernetes-webhook                        1.3.0

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [X ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->

**Special notes for your reviewer**:

This is a pretty blunt PR - it just removes old versions of the containers. I didn't check if they were in use, or if newer versions are available.

**Release note**:
```
Remove old container images to reduce image size.
```
