### PR TITLE
cleanup: suppress output when assigning root pw

### DIFF
--- a/parts/linux/cloud-init/artifacts/cis.sh
+++ b/parts/linux/cloud-init/artifacts/cis.sh
@@ -3,6 +3,7 @@
 source /home/packer/provision_source.sh
 
 assignRootPW() {
+    set +x
     if grep '^root:[!*]:' /etc/shadow; then
         VERSION=$(grep DISTRIB_RELEASE /etc/*-release | cut -f 2 -d "=")
         SALT=$(openssl rand -base64 5)
@@ -16,6 +17,7 @@ assignRootPW() {
 
         echo 'root:'$HASH | /usr/sbin/chpasswd -e || exit $ERR_CIS_ASSIGN_ROOT_PW
     fi
+    set -x
 }
 
 assignFilePermissions() {

--- a/pkg/templates/templates_generated.go
+++ b/pkg/templates/templates_generated.go
@@ -1881,6 +1881,7 @@ var _linuxCloudInitArtifactsCisSh = []byte(`#!/bin/bash
 source /home/packer/provision_source.sh
 
 assignRootPW() {
+    set +x
     if grep '^root:[!*]:' /etc/shadow; then
         VERSION=$(grep DISTRIB_RELEASE /etc/*-release | cut -f 2 -d "=")
         SALT=$(openssl rand -base64 5)
@@ -1894,6 +1895,7 @@ assignRootPW() {
 
         echo 'root:'$HASH | /usr/sbin/chpasswd -e || exit $ERR_CIS_ASSIGN_ROOT_PW
     fi
+    set -x
 }
 
 assignFilePermissions() {

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -272,8 +272,6 @@ string_replace() {
   echo ${1//\*/$2}
 }
 
-declare -a containerImagePids=()
-
 ContainerImages=$(jq ".ContainerImages" $COMPONENTS_FILEPATH | jq .[] --monochrome-output --compact-output)
 for imageToBePulled in ${ContainerImages[*]}; do
   downloadURL=$(echo "${imageToBePulled}" | jq .downloadURL -r)
@@ -297,11 +295,9 @@ for imageToBePulled in ${ContainerImages[*]}; do
 
   for version in ${versions}; do
     CONTAINER_IMAGE=$(string_replace $downloadURL $version)
-    pullContainerImage ${cliTool} ${CONTAINER_IMAGE} &
-    containerImagePids+=($!)
+    pullContainerImage ${cliTool} ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
   done
-  wait ${containerImagePids[@]}
 done
 
 watcher=$(jq '.ContainerImages[] | select(.downloadURL | contains("aks-node-ca-watcher"))' $COMPONENTS_FILEPATH)

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -272,6 +272,8 @@ string_replace() {
   echo ${1//\*/$2}
 }
 
+declare -a containerImagePids=()
+
 ContainerImages=$(jq ".ContainerImages" $COMPONENTS_FILEPATH | jq .[] --monochrome-output --compact-output)
 for imageToBePulled in ${ContainerImages[*]}; do
   downloadURL=$(echo "${imageToBePulled}" | jq .downloadURL -r)
@@ -295,9 +297,11 @@ for imageToBePulled in ${ContainerImages[*]}; do
 
   for version in ${versions}; do
     CONTAINER_IMAGE=$(string_replace $downloadURL $version)
-    pullContainerImage ${cliTool} ${CONTAINER_IMAGE}
+    pullContainerImage ${cliTool} ${CONTAINER_IMAGE} &
+    containerImagePids+=($!)
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
   done
+  wait ${containerImagePids[@]}
 done
 
 watcher=$(jq '.ContainerImages[] | select(.downloadURL | contains("aks-node-ca-watcher"))' $COMPONENTS_FILEPATH)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR suppresses output from the assignRootPW function in cis.sh. This will prevent sensitive information from showing up in build logs. 

**Which issue(s) this PR fixes**:

Prevents sensitive information from showing up in build logs.

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version