### PR TITLE
chore: remove old container versions from the components

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -25,8 +25,6 @@
       "downloadURL": "mcr.microsoft.com/oss/kubernetes/coredns:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.8.7",
-        "v1.9.4",
         "v1.9.4-hotfix.20240327"
       ]
     },
@@ -41,8 +39,7 @@
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-cns:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.4.50",
-        "v1.4.52",
+        "1.4.52",
         "v1.5.23",
         "v1.5.26"
       ],
@@ -65,9 +62,9 @@
       "downloadURL": "mcr.microsoft.com/containernetworking/cni-dropgz:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v0.0.4.1",
         "v0.0.15",
-        "v0.1.3"
+        "v0.1.3",
+        "v0.0.4.1"
       ],
       "prefetchOptimizations": [
         {
@@ -102,8 +99,6 @@
       "downloadURL": "mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.3.4-1",
-        "v1.4.2",
         "v1.4.2-1",
         "v1.4.3"
       ]
@@ -112,9 +107,8 @@
       "downloadURL": "mcr.microsoft.com/oss/azure/secrets-store/provider-azure:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.4.1",
-        "v1.5.1",
-        "v1.5.2"
+        "v1.5.2",
+        "v1.5.1"
       ]
     },
     {
@@ -135,9 +129,6 @@
       "downloadURL": "mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-collector/images:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "6.8.6-main-03-08-2024-fd4f13cb",
-        "6.8.6-main-03-08-2024-fd4f13cb-targetallocator",
-        "6.8.6-main-03-08-2024-fd4f13cb-cfg",
         "6.8.7-main-04-09-2024-82adbf97",
         "6.8.7-main-04-09-2024-82adbf97-targetallocator",
         "6.8.7-main-04-09-2024-82adbf97-cfg"
@@ -258,7 +249,6 @@
       "downloadURL": "mcr.microsoft.com/aks/ip-masq-agent-v2:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v0.1.9",
         "v0.1.10"
       ]
     },


### PR DESCRIPTION
This should remove about 1.8GB from the VHD.

The image sizes (according to crictl images) are:
        Image                                                                   Version
13.9MB  mcr.microsoft.com/oss/kubernetes/coredns                                1.9.4
13.9MB  mcr.microsoft.com/oss/kubernetes/coredns                                v1.8.7
162MB   mcr.microsoft.com/containernetworking/azure-cns                         v1.4.50
171MB   mcr.microsoft.com/containernetworking/azure-cns                         v1.4.52
172MB   mcr.microsoft.com/containernetworking/azure-cns                         v1.5.17
12MB    mcr.microsoft.com/oss/azure/secrets-store/provider-azure                v1.4.1
72.2MB  mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver               v1.3.4-1
66.5MB  mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver               v1.4.1
275MB   mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-colle6.8.4-main-02-14-2024-90d01292
85.9MB  mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-colle6.8.4-main-02-14-2024-90d01292-cfg
58.8MB  mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-colle6.8.4-main-02-14-2024-90d01292-targetallocator
184MB   mcr.microsoft.com/oss/cilium/cilium                                     1.13.10-1
190MB   mcr.microsoft.com/oss/cilium/cilium                                     1.13.10-2
193MB   mcr.microsoft.com/oss/cilium/cilium                                     1.14.4
17.3MB  mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager               v1.26.19
17.6MB  mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager               v1.27.13
17.9MB  mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager               v1.28.5
20.5MB  mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager               v1.29.0
19.2MB  mcr.microsoft.com/aks/ip-masq-agent-v2                                  v0.1.9
89.3MB  mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi                      v1.26.11
9.58MB  mcr.microsoft.com/oss/kubernetes-csi/livenessprobe                      v2.10.0
9.82MB  mcr.microsoft.com/oss/kubernetes-csi/livenessprobe                      v2.11.0
10.9MB  mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar          v2.10.0
10.5MB  mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar          v2.8.0


**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [X ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->

**Special notes for your reviewer**:

This is a pretty blunt PR - it just removes old versions of the containers. I didn't check if they were in use, or if newer versions are available.

**Release note**:
```
Remove old container images to reduce image size.
```
