### PR TITLE
perf: add async rg delete to packer template

### DIFF
--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -57,7 +57,8 @@
       "skip_create_image": "true",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
-      "user_assigned_managed_identities": "{{user `linux_msi_resource_ids`}}"
+      "user_assigned_managed_identities": "{{user `linux_msi_resource_ids`}}",
+      "async_resourcegroup_delete": "true"
     }
   ],
   "provisioners": [

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -67,7 +67,8 @@
           "{{user `location`}}"
         ]
       },
-      "user_assigned_managed_identities": "{{user `linux_msi_resource_ids`}}"
+      "user_assigned_managed_identities": "{{user `linux_msi_resource_ids`}}",
+      "async_resourcegroup_delete": "true"
     }
   ],
   "provisioners": [

--- a/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
@@ -60,7 +60,8 @@
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
       "skip_create_image": "true",
-      "user_assigned_managed_identities": "{{user `linux_msi_resource_ids`}}"
+      "user_assigned_managed_identities": "{{user `linux_msi_resource_ids`}}",
+      "async_resourcegroup_delete": "true"
     }
   ],
   "provisioners": [

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -67,7 +67,8 @@
           "{{user `location`}}"
         ]
       },
-      "user_assigned_managed_identities": "{{user `linux_msi_resource_ids`}}"
+      "user_assigned_managed_identities": "{{user `linux_msi_resource_ids`}}",
+      "async_resourcegroup_delete": "true"
     }
   ],
   "provisioners": [


### PR DESCRIPTION
**What type of PR is this?**

/kind performance

**What this PR does / why we need it**:

This PR adds the `async_resourcegroup_delete` boolean to the packer build templates. This change results in the packer tool asynchronously deleting the temporary packer resource group instead of waiting to confirm it is deleted at the end of the builds. 

The clean up packer generated resources step of the VHD builds already has a fail-safe in place to ensure temporary packer resource group deletion for each VHD. It always results in ResourceGroupNotFound because the packer tool ensures its deletion before this step in pipeline has been reached. By using this boolean, we can make use of that fail-safe and save roughly 15 seconds on build times if the process executes perfectly, and possibly more time if packer has issues confirming resource group deletion due to network or other issues.

**Which issue(s) this PR fixes**:

Unsatisfactory VHD Build times.

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version