### PR TITLE
Edit containerd snapshot size calculation

### DIFF
--- a/staging/cse/windows/debug/collect-windows-logs.ps1
+++ b/staging/cse/windows/debug/collect-windows-logs.ps1
@@ -241,12 +241,25 @@ if ($enableAll -or $enableContainerdInfo) {
 }
 
 if ($enableAll -or $enableSnapshotSize) {
-  Write-Host "Collecting container snapshot size using DU tool"
-  if (Test-Path "C:\aks-tools\DU\du.exe") {
-    C:\aks-tools\DU\du.exe /accepteula
-    C:\aks-tools\DU\du.exe -l 1 C:\ProgramData\containerd\root\io.containerd.snapshotter.v1.windows\snapshots\ > "$ENV:TEMP\$timeStamp-du-snapshot-folder-size.txt"
-    $paths += "$ENV:TEMP\$timeStamp-du-snapshot-folder-size.txt"
+  Write-Host "Collecting actual size of snapshot (without sparse file sizes included)"
+
+  $snapshotPath = "C:\ProgramData\containerd\root\io.containerd.snapshotter.v1.windows\snapshots\"
+  $snapshotSizesResultFilePath = "$ENV:TEMP\$timeStamp-all-snapshot-folder-size.txt"
+  $listOfSnapshotFolders = Get-ChildItem $snapshotPath | Where-Object {$_.PSIsContainer -eq $true} | Sort-Object
+  $totalSize = 0
+  foreach ($i in $listOfSnapshotFolders) {
+  	$folderSize = 0   
+  	Get-ChildItem -Path $i.FullName -recurse -Attributes !SparseFile | Where-Object {$_.PSIsContainer -eq $false} | ForEach-Object {
+  		$folderSize = $folderSize + $_.Length
+  	}
+  	$output = "Sum of " + $i.FullName + " is " + ($folderSize/1MB) + "MB"
+	$totalSize = $totalSize + $folderSize
+    	Add-Content -Path $snapshotSizesResultFilePath -Value $output
   }
+  $outputTotalSize = "Total size of all snapshots: " + ($totalSize/1MB) + "MB"
+  Add-Content -Path $snapshotSizesResultFilePath -Value $outputTotalSize
+  $paths += $snapshotSizesResultFilePath
+
   Copy-Item 'C:\ProgramData\containerd\root\io.containerd.snapshotter.v1.windows\metadata.db' "$ENV:TEMP\$timeStamp-snpashot-metadata.db"
   $paths += "$ENV:TEMP\$timeStamp-snpashot-metadata.db"
 } else {


### PR DESCRIPTION
**What type of PR is this?**


/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
du.exe which was used to calculate the snapshot folder sizes was not accurate. Changing that to include a script to do the calculation.
The changes have been tested with the modified collect-windows-logs.ps1 script on an AKS windows node.

Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```
