### PR TITLE
fix: fix container image URL

### DIFF
--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -39,7 +39,7 @@
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-cns:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "1.4.52",
+        "v1.4.52",
         "v1.5.23",
         "v1.5.26"
       ],


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR adds "v" into the container image URL so that it can be successfully pulled from MCR. Commit 618fc60, made yesterday, updated container images, and left out the "v" in version for this container image. This is resulting in numerous ctr retries and an eventual timeout / failed pull.

**Which issue(s) this PR fixes**:

Failed container image pull.

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
