### PR TITLE
perf: enable shallow replication

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -141,7 +141,7 @@ parameters:
 
 variables:
 - name: CONTAINER_IMAGE
-  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.1'
+  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.0'
   
 pool:
   name: $(POOL_NAME)

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -27,7 +27,7 @@ pool:
 
 variables:
 - name: CONTAINER_IMAGE
-  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.1'
+  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.0'
 
 stages:
   - stage: build_vhd

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -156,7 +156,7 @@ steps:
       PKR_RG_NAME="$(cat packer-output | grep "ResourceGroupName" | cut -d "'" -f 2 | head -1)" && \
       captured_sig_version="$(cat vhdbuilder/packer/settings.json | grep "captured_sig_version" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
       IMPORTED_IMAGE_NAME="$(cat vhdbuilder/packer/settings.json | grep "imported_image_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
-      ARM64_OS_DISK_SNAPSHOT_NAME="$(cat vhdbuilder/packer/settings.json | grep "arm64_os_disk_snapshot_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
+      OS_DISK_SNAPSHOT_NAME="$(cat vhdbuilder/packer/settings.json | grep "os_disk_snapshot_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
       SIG_IMAGE_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_image_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
       IMAGE_NAME="${SIG_IMAGE_NAME}-${captured_sig_version}" && \
       PRIVATE_PACKAGES_URL="$(cat vhdbuilder/packer/settings.json | grep "private_packages_url" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
@@ -176,7 +176,7 @@ steps:
       -e SIG_GALLERY_NAME=${SIG_GALLERY_NAME} \
       -e SIG_IMAGE_NAME=${SIG_IMAGE_NAME} \
       -e ARCHITECTURE=${ARCHITECTURE} \
-      -e ARM64_OS_DISK_SNAPSHOT_NAME=${ARM64_OS_DISK_SNAPSHOT_NAME} \
+      -e OS_DISK_SNAPSHOT_NAME=${OS_DISK_SNAPSHOT_NAME} \
       -e PRIVATE_PACKAGES_URL="${PRIVATE_PACKAGES_URL}" \
       -e LINUX_MSI_RESOURCE_ID=${AZURE_MSI_RESOURCE_ID} \
       ${CONTAINER_IMAGE} make -f packer.mk cleanup

--- a/packer.mk
+++ b/packer.mk
@@ -30,8 +30,13 @@ else
 	$(error HYPERV_GENERATION was invalid ${HYPERV_GENERATION})
 endif
 ifeq (${OS_SKU},Ubuntu)
+ifeq (${IMG_SKU},20_04-lts-cvm)
+	@echo "Using packer template file: vhd-image-builder-cvm.json"
+	@packer build -var-file=vhdbuilder/packer/settings.json vhdbuilder/packer/vhd-image-builder-cvm.json
+else
 	@echo "Using packer template file: vhd-image-builder-base.json"
 	@packer build -var-file=vhdbuilder/packer/settings.json vhdbuilder/packer/vhd-image-builder-base.json
+endif
 else ifeq (${OS_SKU},CBLMariner)
 	@echo "Using packer template file vhd-image-builder-mariner.json"
 	@packer build -var-file=vhdbuilder/packer/settings.json vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -40,6 +45,12 @@ else ifeq (${OS_SKU},AzureLinux)
 	@packer build -var-file=vhdbuilder/packer/settings.json vhdbuilder/packer/vhd-image-builder-mariner.json
 else
 	$(error OS_SKU was invalid ${OS_SKU})
+endif
+ifneq (${IMG_SKU},20_04-lts-cvm)
+	@echo "${MODE}: Not a confidential VM. Converting os disk snapshot to SIG using convert-osdisk-snapshot-to-sig.sh and shallow replication."
+	@./vhdbuilder/packer/convert-osdisk-snapshot-to-sig.sh
+else
+	@echo "Confidential VM. Using packer JSON template to publish to SIG with full replication."
 endif
 endif
 

--- a/vhdbuilder/packer/cleanup.sh
+++ b/vhdbuilder/packer/cleanup.sh
@@ -97,11 +97,11 @@ if [[ "${MODE}" == "windowsVhdMode" && "$SIG_FOR_PRODUCTION" == "True" ]]; then
   fi
 fi
 
-#clean up arm64 OS disk snapshot
-if [[ "${MODE}" == "linuxVhdMode" ]] && [[ ${ARCHITECTURE,,} == "arm64" ]] && [ -n "${ARM64_OS_DISK_SNAPSHOT_NAME}" ]; then
-  id=$(az snapshot show -n ${ARM64_OS_DISK_SNAPSHOT_NAME} -g ${AZURE_RESOURCE_GROUP_NAME} | jq .id)
+#clean up OS disk snapshot
+if [[ "${MODE}" == "linuxVhdMode" ]] && [ -n "${OS_DISK_SNAPSHOT_NAME}" ]; then
+  id=$(az snapshot show -n ${OS_DISK_SNAPSHOT_NAME} -g ${AZURE_RESOURCE_GROUP_NAME} | jq .id)
   if [ -n "$id" ]; then
-    az snapshot delete -n ${ARM64_OS_DISK_SNAPSHOT_NAME} -g ${AZURE_RESOURCE_GROUP_NAME}
+    az snapshot delete -n ${OS_DISK_SNAPSHOT_NAME} -g ${AZURE_RESOURCE_GROUP_NAME}
   fi
 fi
 

--- a/vhdbuilder/packer/convert-osdisk-snapshot-to-sig.sh
+++ b/vhdbuilder/packer/convert-osdisk-snapshot-to-sig.sh
@@ -14,7 +14,7 @@ do
     fi
 done
 
-ARM64_OS_DISK_SNAPSHOT_NAME="$(grep "arm64_os_disk_snapshot_name" ./vhdbuilder/packer/settings.json | awk -F':' '{print $2}' | awk -F'"' '{print $2}')"
+OS_DISK_SNAPSHOT_NAME="$(grep "os_disk_snapshot_name" ./vhdbuilder/packer/settings.json | awk -F':' '{print $2}' | awk -F'"' '{print $2}')"
 CAPTURED_SIG_VERSION="$(grep "captured_sig_version" ./vhdbuilder/packer/settings.json | awk -F':' '{print $2}' | awk -F'"' '{print $2}')"
 SIG_IMAGE_NAME="$(grep "sig_image_name" ./vhdbuilder/packer/settings.json | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
 echo "ManagedImageSharedImageGalleryId: /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/${SIG_IMAGE_NAME}/versions/${CAPTURED_SIG_VERSION}"
@@ -27,8 +27,8 @@ ARCH_STRING=""
 fi
 
 time_now=$(echo ${CAPTURED_SIG_VERSION} | cut -d '.' -f2)
-disk_snapshot_id="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/snapshots/${ARM64_OS_DISK_SNAPSHOT_NAME}"
-az snapshot update --resource-group ${AZURE_RESOURCE_GROUP_NAME} -n ${ARM64_OS_DISK_SNAPSHOT_NAME} ${ARCH_STRING}
+disk_snapshot_id="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/snapshots/${OS_DISK_SNAPSHOT_NAME}"
+az snapshot update --resource-group ${AZURE_RESOURCE_GROUP_NAME} -n ${OS_DISK_SNAPSHOT_NAME} ${ARCH_STRING}
 az sig image-version create --location $AZURE_LOCATION --resource-group ${AZURE_RESOURCE_GROUP_NAME} --gallery-name PackerSigGalleryEastUS \
      --gallery-image-definition ${SIG_IMAGE_NAME} --gallery-image-version ${CAPTURED_SIG_VERSION} \
      --os-snapshot ${disk_snapshot_id} --tags now=${time_now} --replication-mode Shallow

--- a/vhdbuilder/packer/convert-osdisk-snapshot-to-sig.sh
+++ b/vhdbuilder/packer/convert-osdisk-snapshot-to-sig.sh
@@ -19,9 +19,16 @@ CAPTURED_SIG_VERSION="$(grep "captured_sig_version" ./vhdbuilder/packer/settings
 SIG_IMAGE_NAME="$(grep "sig_image_name" ./vhdbuilder/packer/settings.json | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
 echo "ManagedImageSharedImageGalleryId: /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/${SIG_IMAGE_NAME}/versions/${CAPTURED_SIG_VERSION}"
 
+ARCH_STRING=""
+if [[ "${ARCHITECTURE,,}" == "arm64" ]]; then
+ARCH_STRING+="--architecture Arm64"
+elif 
+ARCH_STRING=""
+fi
+
 time_now=$(echo ${CAPTURED_SIG_VERSION} | cut -d '.' -f2)
 disk_snapshot_id="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/snapshots/${ARM64_OS_DISK_SNAPSHOT_NAME}"
-az snapshot update --resource-group ${AZURE_RESOURCE_GROUP_NAME} -n ${ARM64_OS_DISK_SNAPSHOT_NAME} --architecture Arm64
+az snapshot update --resource-group ${AZURE_RESOURCE_GROUP_NAME} -n ${ARM64_OS_DISK_SNAPSHOT_NAME} ${ARCH_STRING}
 az sig image-version create --location $AZURE_LOCATION --resource-group ${AZURE_RESOURCE_GROUP_NAME} --gallery-name PackerSigGalleryEastUS \
      --gallery-image-definition ${SIG_IMAGE_NAME} --gallery-image-version ${CAPTURED_SIG_VERSION} \
-     --os-snapshot ${disk_snapshot_id} --tags now=${time_now}
+     --os-snapshot ${disk_snapshot_id} --tags now=${time_now} --replication-mode Shallow

--- a/vhdbuilder/packer/convert-osdisk-snapshot-to-sig.sh
+++ b/vhdbuilder/packer/convert-osdisk-snapshot-to-sig.sh
@@ -21,9 +21,9 @@ echo "ManagedImageSharedImageGalleryId: /subscriptions/${SUBSCRIPTION_ID}/resour
 
 ARCH_STRING=""
 if [[ "${ARCHITECTURE,,}" == "arm64" ]]; then
-ARCH_STRING+="--architecture Arm64"
-elif 
-ARCH_STRING=""
+  ARCH_STRING+="--architecture Arm64"
+else 
+  ARCH_STRING=""
 fi
 
 time_now=$(echo ${CAPTURED_SIG_VERSION} | cut -d '.' -f2)

--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -105,9 +105,11 @@ if [[ "${MODE}" == "linuxVhdMode" ]]; then
 	fi
 fi
 
-if [[ ${ARCHITECTURE,,} == "arm64" ]]; then
-  ARM64_OS_DISK_SNAPSHOT_NAME="arm64_osdisk_snapshot_${CREATE_TIME}_$RANDOM"
-  SIG_IMAGE_NAME=${SIG_IMAGE_NAME//./}Arm64
+if [[ "$MODE" == "linuxVhdMode" && "${IMG_SKU}" != "20_04-lts-cvm" ]]; then
+  OS_DISK_SNAPSHOT_NAME="osdisk_snapshot_${CREATE_TIME}_$RANDOM"
+  if [[ ${ARCHITECTURE,,} == "arm64" ]]; then
+  	SIG_IMAGE_NAME=${SIG_IMAGE_NAME//./}Arm64
+  fi
   # Only az published after April 06 2022 supports --architecture for command 'az sig image-definition create...'
   azversion=$(az version | jq '."azure-cli"' | tr -d '"')
   if [[ "${azversion}" < "2.35.0" ]]; then

--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -378,7 +378,7 @@ cat <<EOF > vhdbuilder/packer/settings.json
   "imported_image_name": "${IMPORTED_IMAGE_NAME}",
   "sig_image_name":  "${SIG_IMAGE_NAME}",
   "sig_gallery_name": "${SIG_GALLERY_NAME}",
-  "arm64_os_disk_snapshot_name": "${ARM64_OS_DISK_SNAPSHOT_NAME}",
+  "os_disk_snapshot_name": "${OS_DISK_SNAPSHOT_NAME}",
   "captured_sig_version": "${CAPTURED_SIG_VERSION}",
   "os_disk_size_gb": "${os_disk_size_gb}",
   "nano_image_url": "${windows_nanoserver_image_url}",

--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -53,7 +53,7 @@
       "location": "{{user `location`}}",
       "vm_size": "{{user `vm_size`}}",
       "managed_image_storage_account_type": "Premium_LRS",
-      "managed_image_os_disk_snapshot_name": "{{user `arm64_os_disk_snapshot_name`}}",
+      "managed_image_os_disk_snapshot_name": "{{user `os_disk_snapshot_name`}}",
       "skip_create_image": "true",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",

--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -14,7 +14,7 @@
     "hyperv_generation": "{{env `HYPERV_GENERATION`}}",
     "container_runtime": "{{env `CONTAINER_RUNTIME`}}",
     "teleportd_plugin_download_url": "{{env `TELEPORTD_PLUGIN_DOWNLOAD_URL`}}",
-    "arm64_os_disk_snapshot_name": "{{env `${ARM64_OS_DISK_SNAPSHOT_NAME`}}",
+    "os_disk_snapshot_name": "{{env `${OS_DISK_SNAPSHOT_NAME`}}",
     "captured_sig_version": "{{env `${CAPTURED_SIG_VERSION`}}",
     "enable_fips": "{{env `ENABLE_FIPS`}}",
     "img_publisher": "{{env `IMG_PUBLISHER`}}",

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -17,6 +17,7 @@
     "sig_image_version": "{{env `SIG_IMAGE_VERSION`}}",
     "container_runtime": "{{env `CONTAINER_RUNTIME`}}",
     "teleportd_plugin_download_url": "{{env `TELEPORTD_PLUGIN_DOWNLOAD_URL`}}",
+    "os_disk_snapshot_name": "{{env `${OS_DISK_SNAPSHOT_NAME`}}",
     "captured_sig_version": "{{env `${CAPTURED_SIG_VERSION`}}",
     "enable_fips": "{{env `ENABLE_FIPS`}}",
     "img_publisher": "{{env `IMG_PUBLISHER`}}",

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -55,18 +55,10 @@
       "location": "{{user `location`}}",
       "vm_size": "{{user `vm_size`}}",
       "managed_image_storage_account_type": "Premium_LRS",
+      "managed_image_os_disk_snapshot_name": "{{user `os_disk_snapshot_name`}}",
+      "skip_create_image": "true",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
-      "polling_duration_timeout": "1h",
-      "shared_image_gallery_destination": {
-        "resource_group": "{{user `resource_group_name`}}",
-        "gallery_name": "{{user `sig_gallery_name`}}",
-        "image_name": "{{user `sig_image_name`}}",
-        "image_version": "{{user `captured_sig_version`}}",
-        "replication_regions": [
-          "{{user `location`}}"
-        ]
-      },
       "user_assigned_managed_identities": "{{user `linux_msi_resource_ids`}}"
     }
   ],

--- a/vhdbuilder/packer/vhd-image-builder-cvm.json
+++ b/vhdbuilder/packer/vhd-image-builder-cvm.json
@@ -1,0 +1,642 @@
+{
+  "variables": {
+    "subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
+    "location": "{{env `AZURE_LOCATION`}}",
+    "vm_size": "{{env `AZURE_VM_SIZE`}}",
+    "build_definition_name": "{{env `BUILD_DEFINITION_NAME`}}",
+    "build_number": "{{env `BUILD_NUMBER`}}",
+    "build_id": "{{env `BUILD_ID`}}",
+    "commit": "{{env `GIT_VERSION`}}",
+    "feature_flags": "{{env `FEATURE_FLAGS`}}",
+    "image_version": "{{env `IMAGE_VERSION`}}",
+    "os_version": "{{env `OS_VERSION`}}",
+    "sku_name": "{{env `SKU_NAME`}}",
+    "hyperv_generation": "{{env `HYPERV_GENERATION`}}",
+    "sig_gallery_name": "{{env `SIG_GALLERY_NAME`}}",
+    "sig_image_name": "{{env `SIG_IMAGE_NAME`}}",
+    "sig_image_version": "{{env `SIG_IMAGE_VERSION`}}",
+    "container_runtime": "{{env `CONTAINER_RUNTIME`}}",
+    "teleportd_plugin_download_url": "{{env `TELEPORTD_PLUGIN_DOWNLOAD_URL`}}",
+    "captured_sig_version": "{{env `${CAPTURED_SIG_VERSION`}}",
+    "enable_fips": "{{env `ENABLE_FIPS`}}",
+    "img_publisher": "{{env `IMG_PUBLISHER`}}",
+    "img_offer": "{{env `IMG_OFFER`}}",
+    "img_sku": "{{env `IMG_SKU`}}",
+    "img_version": "{{env `IMG_VERSION`}}",
+    "sgx_install": "{{env `SGX_INSTALL`}}",
+    "vnet_name": "{{env `VNET_NAME`}}",
+    "subnet_name": "{{env `SUBNET_NAME`}}",
+    "private_packages_url": "{{env `PRIVATE_PACKAGES_URL`}}",
+    "linux_msi_resource_id": "{{env `LINUX_MSI_RESOURCE_ID`}}"
+  },
+  "builders": [
+    {
+      "type": "azure-arm",
+      "virtual_network_name": "{{user `vnet_name`}}",
+      "virtual_network_subnet_name": "{{user `subnet_name`}}",
+      "ssh_read_write_timeout": "5m",
+      "client_id": "{{user `client_id`}}",
+      "client_secret": "{{user `client_secret`}}",
+      "tenant_id": "{{user `tenant_id`}}",
+      "subscription_id": "{{user `subscription_id`}}",
+      "os_type": "Linux",
+      "os_disk_size_gb": 30,
+      "image_publisher": "{{user `img_publisher`}}",
+      "image_offer": "{{user `img_offer`}}",
+      "image_sku": "{{user `img_sku`}}",
+      "image_version": "{{user `img_version`}}",
+      "azure_tags": {
+        "buildDefinitionName": "{{user `build_definition_name`}}",
+        "buildNumber": "{{user `build_number`}}",
+        "buildId": "{{user `build_id`}}",
+        "SkipLinuxAzSecPack": "true",
+        "os": "Linux",
+        "now": "{{user `create_time`}}",
+        "createdBy": "aks-vhd-pipeline",
+        "image_sku": "{{user `img_sku`}}"
+      },
+      "location": "{{user `location`}}",
+      "vm_size": "{{user `vm_size`}}",
+      "managed_image_storage_account_type": "Premium_LRS",
+      "managed_image_resource_group_name": "{{user `resource_group_name`}}",
+      "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
+      "polling_duration_timeout": "1h",
+      "shared_image_gallery_destination": {
+        "resource_group": "{{user `resource_group_name`}}",
+        "gallery_name": "{{user `sig_gallery_name`}}",
+        "image_name": "{{user `sig_image_name`}}",
+        "image_version": "{{user `captured_sig_version`}}",
+        "replication_regions": [
+          "{{user `location`}}"
+        ]
+      },
+      "user_assigned_managed_identities": "{{user `linux_msi_resource_ids`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "sudo mkdir -p /opt/azure/containers",
+        "sudo chown -R $USER /opt/azure/containers"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sudo mkdir -p /opt/scripts",
+        "sudo chown -R $USER /opt/scripts",
+        "sudo mkdir -p /opt/certs",
+        "sudo chown -R $USER /opt/certs"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "vhdbuilder/packer/prefetch.sh",
+      "destination": "/home/packer/prefetch.sh"
+    },
+    {
+      "type": "file",
+      "source": "vhdbuilder/packer/cleanup-vhd.sh",
+      "destination": "/home/packer/cleanup-vhd.sh"
+    },
+    {
+      "type": "file",
+      "source": "vhdbuilder/packer/packer_source.sh",
+      "destination": "/home/packer/packer_source.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/cse_install.sh",
+      "destination": "/home/packer/provision_installs.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh",
+      "destination": "/home/packer/provision_installs_distro.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/cse_helpers.sh",
+      "destination": "/home/packer/provision_source.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh",
+      "destination": "/home/packer/provision_source_distro.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/cse_config.sh",
+      "destination": "/home/packer/provision_configs.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/cse_main.sh",
+      "destination": "/home/packer/provision.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/cse_start.sh",
+      "destination": "/home/packer/provision_start.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/containerd_exec_start.conf",
+      "destination": "/home/packer/containerd_exec_start.conf"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/kubelet.service",
+      "destination": "/home/packer/kubelet.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/reconcile-private-hosts.sh",
+      "destination": "/home/packer/reconcile-private-hosts.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/block_wireserver.sh",
+      "destination": "/home/packer/block_wireserver.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/cse_redact_cloud_config.py",
+      "destination": "/home/packer/cse_redact_cloud_config.py"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/cse_send_logs.py",
+      "destination": "/home/packer/cse_send_logs.py"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud.sh",
+      "destination": "/home/packer/init-aks-custom-cloud.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/reconcile-private-hosts.service",
+      "destination": "/home/packer/reconcile-private-hosts.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/mig-partition.service",
+      "destination": "/home/packer/mig-partition.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/bind-mount.sh",
+      "destination": "/home/packer/bind-mount.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/bind-mount.service",
+      "destination": "/home/packer/bind-mount.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/enable-dhcpv6.sh",
+      "destination": "/home/packer/enable-dhcpv6.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/dhcpv6.service",
+      "destination": "/home/packer/dhcpv6.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/sync-container-logs.sh",
+      "destination": "/home/packer/sync-container-logs.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/sync-container-logs.service",
+      "destination": "/home/packer/sync-container-logs.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/crictl.yaml",
+      "destination": "/home/packer/crictl.yaml"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/ensure-no-dup.sh",
+      "destination": "/home/packer/ensure-no-dup.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/ensure-no-dup.service",
+      "destination": "/home/packer/ensure-no-dup.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/teleportd.service",
+      "destination": "/home/packer/teleportd.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/setup-custom-search-domains.sh",
+      "destination": "/home/packer/setup-custom-search-domains.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/ubuntu/ubuntu-snapshot-update.sh",
+      "destination": "/home/packer/ubuntu-snapshot-update.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/ubuntu/snapshot-update.service",
+      "destination": "/home/packer/snapshot-update.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/ubuntu/snapshot-update.timer",
+      "destination": "/home/packer/snapshot-update.timer"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/cis.sh",
+      "destination": "/home/packer/cis.sh"
+    },
+    {
+      "type": "file",
+      "source": "vhdbuilder/scripts/linux/tool_installs.sh",
+      "destination": "/home/packer/tool_installs.sh"
+    },
+    {
+      "type": "file",
+      "source": "vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh",
+      "destination": "/home/packer/tool_installs_distro.sh"
+    },
+    {
+      "type": "file",
+      "source": "vhdbuilder/packer/asc-baseline-1.1.0-268.amd64.deb",
+      "destination": "/home/packer/asc-baseline.deb"
+    },
+    {
+      "type": "file",
+      "source": "vhdbuilder/packer/pre-install-dependencies.sh",
+      "destination": "/home/packer/pre-install-dependencies.sh"
+    },
+    {
+      "type": "file",
+      "source": "vhdbuilder/packer/install-dependencies.sh",
+      "destination": "/home/packer/install-dependencies.sh"
+    },
+    {
+      "type": "file",
+      "source": "vhdbuilder/packer/post-install-dependencies.sh",
+      "destination": "/home/packer/post-install-dependencies.sh"
+    },
+    {
+      "type": "file",
+      "source": "vhdbuilder/packer/components.json",
+      "destination": "/home/packer/components.json"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/manifest.json",
+      "destination": "/home/packer/manifest.json"
+    },
+    {
+      "type": "file",
+      "source": "vhdbuilder/packer/kube-proxy-images.json",
+      "destination": "/home/packer/kube-proxy-images.json"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/sysctl-d-60-CIS.conf",
+      "destination": "/home/packer/sysctl-d-60-CIS.conf"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/sshd_config",
+      "destination": "/home/packer/sshd_config"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/sshd_config_1604",
+      "destination": "/home/packer/sshd_config_1604"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/sshd_config_1804_fips",
+      "destination": "/home/packer/sshd_config_1804_fips"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/rsyslog-d-60-CIS.conf",
+      "destination": "/home/packer/rsyslog-d-60-CIS.conf"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/etc-issue",
+      "destination": "/home/packer/etc-issue"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/etc-issue.net",
+      "destination": "/home/packer/etc-issue.net"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/modprobe-CIS.conf",
+      "destination": "/home/packer/modprobe-CIS.conf"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/pwquality-CIS.conf",
+      "destination": "/home/packer/pwquality-CIS.conf"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/pam-d-su",
+      "destination": "/home/packer/pam-d-su"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/pam-d-common-auth",
+      "destination": "/home/packer/pam-d-common-auth"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/pam-d-common-auth-2204",
+      "destination": "/home/packer/pam-d-common-auth-2204"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/pam-d-common-password",
+      "destination": "/home/packer/pam-d-common-password"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/profile-d-cis.sh",
+      "destination": "/home/packer/profile-d-cis.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/disk_queue.service",
+      "destination": "/home/packer/disk_queue.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/cgroup-memory-telemetry.sh",
+      "destination": "/home/packer/cgroup-memory-telemetry.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/cgroup-memory-telemetry.service",
+      "destination": "/home/packer/cgroup-memory-telemetry.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/cgroup-memory-telemetry.timer",
+      "destination": "/home/packer/cgroup-memory-telemetry.timer"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/cgroup-pressure-telemetry.sh",
+      "destination": "/home/packer/cgroup-pressure-telemetry.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/cgroup-pressure-telemetry.service",
+      "destination": "/home/packer/cgroup-pressure-telemetry.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/cgroup-pressure-telemetry.timer",
+      "destination": "/home/packer/cgroup-pressure-telemetry.timer"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/update_certs.service",
+      "destination": "/home/packer/update_certs.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/update_certs.path",
+      "destination": "/home/packer/update_certs.path"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/update_certs.sh",
+      "destination": "/home/packer/update_certs.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/ci-syslog-watcher.path",
+      "destination": "/home/packer/ci-syslog-watcher.path"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/ci-syslog-watcher.service",
+      "destination": "/home/packer/ci-syslog-watcher.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/ci-syslog-watcher.sh",
+      "destination": "/home/packer/ci-syslog-watcher.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/aks-log-collector.sh",
+      "destination": "/home/packer/aks-log-collector.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/aks-log-collector-send.py",
+      "destination": "/home/packer/aks-log-collector-send.py"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/aks-log-collector.service",
+      "destination": "/home/packer/aks-log-collector.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/aks-log-collector.slice",
+      "destination": "/home/packer/aks-log-collector.slice"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/aks-log-collector.timer",
+      "destination": "/home/packer/aks-log-collector.timer"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/aks-check-network.sh",
+      "destination": "/home/packer/aks-check-network.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/aks-check-network.service",
+      "destination": "/home/packer/aks-check-network.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/aks-logrotate.sh",
+      "destination": "/home/packer/logrotate.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/aks-logrotate.service",
+      "destination": "/home/packer/logrotate.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/aks-logrotate.timer",
+      "destination": "/home/packer/logrotate.timer"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/aks-logrotate-override.conf",
+      "destination": "/home/packer/override.conf"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/aks-rsyslog",
+      "destination": "/home/packer/rsyslog"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/ipv6_nftables",
+      "destination": "/home/packer/ipv6_nftables"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/ipv6_nftables.service",
+      "destination": "/home/packer/ipv6_nftables.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/ipv6_nftables.sh",
+      "destination": "/home/packer/ipv6_nftables.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/apt-preferences",
+      "destination": "/home/packer/apt-preferences"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/kms.service",
+      "destination": "/home/packer/kms.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/mig-partition.sh",
+      "destination": "/home/packer/mig-partition.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/docker_clear_mount_propagation_flags.conf",
+      "destination": "/home/packer/docker_clear_mount_propagation_flags.conf"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/nvidia-modprobe.service",
+      "destination": "/home/packer/nvidia-modprobe.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/nvidia-docker-daemon.json",
+      "destination": "/home/packer/nvidia-docker-daemon.json"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/nvidia-device-plugin.service",
+      "destination": "/home/packer/nvidia-device-plugin.service"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/pam-d-common-auth",
+      "destination": "/home/packer/pam-d-common-auth"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/pam-d-common-password",
+      "destination": "/home/packer/pam-d-common-password"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/pam-d-su",
+      "destination": "/home/packer/pam-d-su"
+    },
+    {
+      "type": "file",
+      "source": "vhdbuilder/notice.txt",
+      "destination": "/home/packer/NOTICE.txt"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} HYPERV_GENERATION={{user `hyperv_generation`}} CONTAINER_RUNTIME={{user `container_runtime`}} TELEPORTD_PLUGIN_DOWNLOAD_URL={{user `teleportd_plugin_download_url`}} ENABLE_FIPS={{user `enable_fips`}} SGX_INSTALL={{user `sgx_install`}} IMG_SKU={{user `img_sku`}} /bin/bash -ux /home/packer/pre-install-dependencies.sh"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": "sudo reboot",
+      "expect_disconnect": true,
+      "skip_clean": true,
+      "pause_after": "60s"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} HYPERV_GENERATION={{user `hyperv_generation`}} CONTAINER_RUNTIME={{user `container_runtime`}} TELEPORTD_PLUGIN_DOWNLOAD_URL={{user `teleportd_plugin_download_url`}} ENABLE_FIPS={{user `enable_fips`}} SGX_INSTALL={{user `sgx_install`}} IMG_SKU={{user `img_sku`}} PRIVATE_PACKAGES_URL={{user `private_packages_url`}} LINUX_MSI_RESOURCE_IDS={{user `linux_msi_resource_ids`}} /bin/bash -ux /home/packer/install-dependencies.sh"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": "sudo reboot",
+      "expect_disconnect": true,
+      "skip_clean": true,
+      "pause_after": "60s"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} HYPERV_GENERATION={{user `hyperv_generation`}} CONTAINER_RUNTIME={{user `container_runtime`}} TELEPORTD_PLUGIN_DOWNLOAD_URL={{user `teleportd_plugin_download_url`}} ENABLE_FIPS={{user `enable_fips`}} SGX_INSTALL={{user `sgx_install`}} IMG_SKU={{user `img_sku`}} /bin/bash -ux /home/packer/post-install-dependencies.sh"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "vhdbuilder/packer/list-images.sh",
+      "destination": "/home/packer/list-images.sh"
+    },
+    {
+      "type": "file",
+      "source": "vhdbuilder/packer/trivy-scan.sh",
+      "destination": "/home/packer/trivy-scan.sh"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sudo SKU_NAME={{user `sku_name`}} IMAGE_VERSION={{user `image_version`}} CONTAINER_RUNTIME={{user `container_runtime`}} /bin/bash -ux /home/packer/list-images.sh"
+      ]
+    },
+    {
+      "type": "file",
+      "direction": "download",
+      "source": "/opt/azure/containers/image-bom.json",
+      "destination": "image-bom.json"
+    },
+    {
+      "type": "file",
+      "direction": "download",
+      "source": "/opt/azure/vhd-install.complete",
+      "destination": "release-notes.txt"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sudo /bin/bash -eux /home/packer/cis.sh",
+        "sudo /bin/bash -eux /opt/azure/containers/cleanup-vhd.sh",
+        "sudo /usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync || exit 125"
+      ]
+    }
+  ]
+}

--- a/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
@@ -16,7 +16,7 @@
     "sig_image_name": "{{env `SIG_IMAGE_NAME`}}",
     "container_runtime": "{{env `CONTAINER_RUNTIME`}}",
     "teleportd_plugin_download_url": "{{env `TELEPORTD_PLUGIN_DOWNLOAD_URL`}}",
-    "arm64_os_disk_snapshot_name": "{{env `${ARM64_OS_DISK_SNAPSHOT_NAME`}}",
+    "os_disk_snapshot_name": "{{env `${OS_DISK_SNAPSHOT_NAME`}}",
     "captured_sig_version": "{{env `${CAPTURED_SIG_VERSION`}}",
     "enable_fips": "{{env `ENABLE_FIPS`}}",
     "img_publisher": "{{env `IMG_PUBLISHER`}}",

--- a/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
@@ -56,10 +56,10 @@
       "location": "{{user `location`}}",
       "vm_size": "{{user `vm_size`}}",
       "managed_image_storage_account_type": "Premium_LRS",
-      "managed_image_os_disk_snapshot_name": "{{user `arm64_os_disk_snapshot_name`}}",
+      "managed_image_os_disk_snapshot_name": "{{user `os_disk_snapshot_name`}}",
+      "skip_create_image": "true",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
-      "skip_create_image": "true",
       "user_assigned_managed_identities": "{{user `linux_msi_resource_ids`}}"
     }
   ],

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -16,6 +16,7 @@
     "sig_image_name": "{{env `SIG_IMAGE_NAME`}}",
     "container_runtime": "{{env `CONTAINER_RUNTIME`}}",
     "teleportd_plugin_download_url": "{{env `TELEPORTD_PLUGIN_DOWNLOAD_URL`}}",
+    "os_disk_snapshot_name": "{{env `${OS_DISK_SNAPSHOT_NAME`}}",
     "captured_sig_version": "{{env `${CAPTURED_SIG_VERSION`}}",
     "enable_fips": "{{env `ENABLE_FIPS`}}",
     "img_publisher": "{{env `IMG_PUBLISHER`}}",

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -55,18 +55,10 @@
       "location": "{{user `location`}}",
       "vm_size": "{{user `vm_size`}}",
       "managed_image_storage_account_type": "Premium_LRS",
+      "managed_image_os_disk_snapshot_name": "{{user `os_disk_snapshot_name`}}",
+      "skip_create_image": "true",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
-      "polling_duration_timeout": "1h",
-      "shared_image_gallery_destination": {
-        "resource_group": "{{user `resource_group_name`}}",
-        "gallery_name": "{{user `sig_gallery_name`}}",
-        "image_name": "{{user `sig_image_name`}}",
-        "image_version": "{{user `captured_sig_version`}}",
-        "replication_regions": [
-          "{{user `location`}}"
-        ]
-      },
       "user_assigned_managed_identities": "{{user `linux_msi_resource_ids`}}"
     }
   ],


### PR DESCRIPTION
**What type of PR is this?**

/kind performance

**What this PR does / why we need it**:

This PR changes the replication method for VHDs from full replication with the packer tool to shallow replication with a direct SIG API call. Currently, we are using the packer tool to fully replicate all non-arm64 VHDs to the SIG. For arm64 builds, a snapshot is created at the beginning of the build, updated at the end of the build, and then converted to the SIG. 

This PR uses the arm64 publishing logic that is already in place to publish all VHDs to the SIG using shallow replication, with the exception of the confidential VM because it cannot be made into a snapshot.

In order to accomplish this, all references to arm64_os_disk* were changed to encompass all VHDs, all existing packer templates were modified to remove the `shared_image_gallery_destination` block, a new packer template was created to publish the confidential VM using the `shared_image_gallery_destination` block, and the convert-os-disk-snapshot-to-sig.sh file was modified to be used with all VHDs by assigning the architecture property dynamically and enabling shallow replication. Additionally, the deis/go-dev container needed to be reverted to v1.38.0.

Further details regarding these changes can be found in the project presentation.

**Which issue(s) this PR fixes**:

Unsatisfactory VHD Build Times.

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
