### PR TITLE
chore: use devinfra assistant PAT in VHD automation + abe2e pipelines

### DIFF
--- a/.pipelines/.vsts-vhd-automation.yaml
+++ b/.pipelines/.vsts-vhd-automation.yaml
@@ -17,6 +17,9 @@ parameters:
   type: boolean
   default: true
 
+variables:
+  - group: "AKS Dev Assistant (KV)"
+
 steps:
 - bash: |
         set -x
@@ -38,7 +41,7 @@ steps:
         echo $MAPPED_ADO_PAT | az devops login --organization=https://dev.azure.com/msazure
         az devops configure --defaults organization=https://dev.azure.com/msazure project=CloudNativeCompute
   env:
-        MAPPED_ADO_PAT: $(ADO_PAT)
+        MAPPED_ADO_PAT: $(PAT-aksdevassistant)
   displayName: 'az devops login'
 - bash: |
         echo "PR for Image Bumping, Official Branch Cutting"

--- a/.pipelines/.vsts-vhd-windows-automation.yaml
+++ b/.pipelines/.vsts-vhd-windows-automation.yaml
@@ -16,13 +16,16 @@ parameters:
   type: boolean
   default: false
 
+variables:
+  - group: "AKS Dev Assistant (KV)"
+
 steps:
 - bash: |
         az extension add -n azure-devops
         echo $MAPPED_ADO_PAT | az devops login --organization=https://dev.azure.com/msazure
         az devops configure --defaults organization=https://dev.azure.com/msazure project=CloudNativeCompute
   env:
-        MAPPED_ADO_PAT: $(ADO_PAT)
+        MAPPED_ADO_PAT: $(PAT-aksdevassistant)
   displayName: 'az devops login'
 - bash: |
         echo "Bumping windows VHD base image version"
@@ -47,7 +50,7 @@ steps:
         /bin/bash vhdbuilder/scripts/windows/automate_release_notes.sh $BUILD_ID $MAPPED_GITHUB_PAT '${{ parameters.GithubUserName }}'
   env:
         MAPPED_GITHUB_PAT: $(GITHUB_PAT)
-        MAPPED_ADO_PAT: $(ADO_PAT)
+        MAPPED_ADO_PAT: $(PAT-aksdevassistant)
   displayName: 'Release Notes'
   condition: eq('${{ parameters.ReleaseNotes }}', true)
   

--- a/.pipelines/.vsts-vhd-windows-automation.yaml
+++ b/.pipelines/.vsts-vhd-windows-automation.yaml
@@ -16,16 +16,13 @@ parameters:
   type: boolean
   default: false
 
-variables:
-  - group: "AKS Dev Assistant (KV)"
-
 steps:
 - bash: |
         az extension add -n azure-devops
         echo $MAPPED_ADO_PAT | az devops login --organization=https://dev.azure.com/msazure
         az devops configure --defaults organization=https://dev.azure.com/msazure project=CloudNativeCompute
   env:
-        MAPPED_ADO_PAT: $(PAT-aksdevassistant)
+        MAPPED_ADO_PAT: $(ADO_PAT)
   displayName: 'az devops login'
 - bash: |
         echo "Bumping windows VHD base image version"
@@ -50,7 +47,7 @@ steps:
         /bin/bash vhdbuilder/scripts/windows/automate_release_notes.sh $BUILD_ID $MAPPED_GITHUB_PAT '${{ parameters.GithubUserName }}'
   env:
         MAPPED_GITHUB_PAT: $(GITHUB_PAT)
-        MAPPED_ADO_PAT: $(PAT-aksdevassistant)
+        MAPPED_ADO_PAT: $(ADO_PAT)
   displayName: 'Release Notes'
   condition: eq('${{ parameters.ReleaseNotes }}', true)
   

--- a/.pipelines/e2e.yaml
+++ b/.pipelines/e2e.yaml
@@ -18,6 +18,7 @@ pr:
     - pkg/agent/testdata/AKSWindows* # Windows test data
     
 variables:
+- group: "AKS Dev Assistant (KV)"
 - group: ab-e2e
 - name: defaultTimeout
   value: 90
@@ -46,7 +47,7 @@ jobs:
     displayName: Run AgentBaker E2E
     env:
       VHD_BUILD_ID: $(VHD_BUILD_ID)
-      ADO_PAT: $(ADO_PAT)
+      ADO_PAT: $(PAT-aksdevassistant)
   - publish: $(System.DefaultWorkingDirectory)/e2e/scenario-logs
     artifact: scenario-logs
     condition: always()


### PR DESCRIPTION
**What type of PR is this?**
updates VHD automation pipeline to use dev infra's "devinfraassistant" service account for downloading artifacts from ADO, instead of personal accounts

TODO: investigate how to do the same for github PATs?

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
