### PR TITLE
feat: add datamodel field for Windows next-gen networking

### DIFF
--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -800,6 +800,13 @@ func (a *AgentPoolProfile) GetCustomLinuxOSConfig() *CustomLinuxOSConfig {
 	return a.CustomLinuxOSConfig
 }
 
+func (a *AgentPoolProfile) GetAgentPoolWindowsProfile() *AgentPoolWindowsProfile {
+	if a == nil {
+		return nil
+	}
+	return a.AgentPoolWindowsProfile
+}
+
 // Properties represents the AKS cluster definition.
 type Properties struct {
 	ClusterID               string
@@ -2189,6 +2196,9 @@ func (err *CSEStatusParsingError) Error() string {
 
 type AgentPoolWindowsProfile struct {
 	DisableOutboundNat *bool `json:"disableOutboundNat,omitempty"`
+
+	// Windows next-gen networking uses Windows eBPF for the networking dataplane.
+	NextGenNetworkingURL *string `json:"nextGenNetworkingURL,omitempty"`
 }
 
 // IsDisableWindowsOutboundNat returns true if the Windows agent pool disable OutboundNAT.
@@ -2196,6 +2206,17 @@ func (a *AgentPoolProfile) IsDisableWindowsOutboundNat() bool {
 	return a.AgentPoolWindowsProfile != nil &&
 		a.AgentPoolWindowsProfile.DisableOutboundNat != nil &&
 		*a.AgentPoolWindowsProfile.DisableOutboundNat
+}
+
+func (a *AgentPoolWindowsProfile) IsNextGenNetworkingEnabled() bool {
+	return a != nil && a.NextGenNetworkingURL != nil
+}
+
+func (a *AgentPoolWindowsProfile) GetNextGenNetworkingURL() string {
+	if a == nil || a.NextGenNetworkingURL == nil {
+		return ""
+	}
+	return *a.NextGenNetworkingURL
 }
 
 // SecurityProfile begin.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

NextGenNetworkingURL is the per-cloud URL for downloading Windows eBPF assets.
Next-gen networking is enabled only when NextGenNetworkingURL is non-nil.

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
