### PR TITLE
chore: add 2404 sig config

### DIFF
--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -113,6 +113,12 @@ var AvailableUbuntu2204Distros = []Distro{
 }
 
 //nolint:gochecknoglobals
+var AvailableUbuntu2404Distros = []Distro{
+	AKSUbuntuContainerd2404,
+	AKSUbuntuContainerd2404Gen2,
+}
+
+//nolint:gochecknoglobals
 var AvailableContainerdDistros = []Distro{
 	AKSUbuntuContainerd1804,
 	AKSUbuntuContainerd1804Gen2,
@@ -347,6 +353,8 @@ const (
 	//  of support and image builds have stopped.
 	FrozenCBLMarinerV1SIGImageVersionForDeprecation string = "202308.28.0"
 
+	// This is currently for testing only, we do not build 2404 images regularly.
+	// Once 2404 is preview in AKS, we will refer to the images using regular LinuxSIGImageVersion and remove this
 	Ubuntu2404SIGImageVersionForTest string = "202405.20.0"
 
 	// We do not use AKS Windows image versions in AgentBaker. These fake values are only used for unit tests.

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -151,6 +151,8 @@ var AvailableContainerdDistros = []Distro{
 	AKSUbuntuEdgeZoneContainerd2204Gen2,
 	AKSUbuntuMinimalContainerd2204,
 	AKSUbuntuMinimalContainerd2204Gen2,
+	AKSUbuntuContainerd2404,
+	AKSUbuntuContainerd2404Gen2,
 }
 
 //nolint:gochecknoglobals
@@ -177,6 +179,7 @@ var AvailableGen2Distros = []Distro{
 	AKSUbuntuContainerd2204TLGen2,
 	AKSUbuntuEdgeZoneContainerd2204Gen2,
 	AKSUbuntuMinimalContainerd2204Gen2,
+	AKSUbuntuContainerd2404Gen2,
 	AKSCBLMarinerV2Gen2,
 	AKSAzureLinuxV2Gen2,
 	AKSCBLMarinerV2Gen2FIPS,
@@ -343,6 +346,8 @@ const (
 	// CBLMarinerV1 pinned to the last image build as Mariner 1.0 is out
 	//  of support and image builds have stopped.
 	FrozenCBLMarinerV1SIGImageVersionForDeprecation string = "202308.28.0"
+
+	Ubuntu2404SIGImageVersionForTest string = "202405.20.0"
 
 	// We do not use AKS Windows image versions in AgentBaker. These fake values are only used for unit tests.
 	Windows2019SIGImageVersion string = "17763.2019.221114"
@@ -550,6 +555,20 @@ var (
 		Version:       FrozenLinuxSIGImageVersionForEgressTest,
 	}
 
+	SIGUbuntuContainerd2404ImageConfigTemplate = SigImageConfigTemplate{
+		ResourceGroup: AKSUbuntuResourceGroup,
+		Gallery:       AKSUbuntuGalleryName,
+		Definition:    "2404containerd",
+		Version:       Ubuntu2404SIGImageVersionForTest,
+	}
+
+	SIGUbuntuContainerd2404Gen2ImageConfigTemplate = SigImageConfigTemplate{
+		ResourceGroup: AKSUbuntuResourceGroup,
+		Gallery:       AKSUbuntuGalleryName,
+		Definition:    "2404gen2containerd",
+		Version:       Ubuntu2404SIGImageVersionForTest,
+	}
+
 	SIGCBLMarinerV1ImageConfigTemplate = SigImageConfigTemplate{
 		ResourceGroup: AKSCBLMarinerResourceGroup,
 		Gallery:       AKSCBLMarinerGalleryName,
@@ -730,6 +749,8 @@ func getSigUbuntuImageConfigMapWithOpts(opts ...SigImageConfigOpt) map[Distro]Si
 		AKSUbuntuMinimalContainerd2204:     SIGUbuntuMinimalContainerd2204ImageConfigTemplate.WithOptions(opts...),
 		AKSUbuntuMinimalContainerd2204Gen2: SIGUbuntuMinimalContainerd2204Gen2ImageConfigTemplate.WithOptions(opts...),
 		AKSUbuntuEgressContainerd2204Gen2:  SIGUbuntuEgressContainerd2204Gen2ImageConfigTemplate.WithOptions(opts...),
+		AKSUbuntuContainerd2404:            SIGUbuntuContainerd2404ImageConfigTemplate.WithOptions(opts...),
+		AKSUbuntuContainerd2404Gen2:        SIGUbuntuContainerd2404Gen2ImageConfigTemplate.WithOptions(opts...),
 	}
 }
 

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -353,8 +353,8 @@ const (
 	//  of support and image builds have stopped.
 	FrozenCBLMarinerV1SIGImageVersionForDeprecation string = "202308.28.0"
 
-	// This is currently for testing only, we do not build 2404 images regularly.
-	// Once 2404 is preview in AKS, we will refer to the images using regular LinuxSIGImageVersion and remove this
+	// This is currently for testing only, we do not build 2404 images regularly
+	// Once 2404 is preview in AKS, we will refer to the images using regular LinuxSIGImageVersion and remove this.
 	Ubuntu2404SIGImageVersionForTest string = "202405.20.0"
 
 	// We do not use AKS Windows image versions in AgentBaker. These fake values are only used for unit tests.

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(sigConfig.SigTenantID).To(Equal("sometenantid"))
 		Expect(sigConfig.SubscriptionID).To(Equal("somesubid"))
 
-		Expect(len(sigConfig.SigUbuntuImageConfig)).To(Equal(23))
+		Expect(len(sigConfig.SigUbuntuImageConfig)).To(Equal(25))
 
 		aksUbuntuGPU1804Gen2 := sigConfig.SigUbuntuImageConfig[AKSUbuntuGPU1804Gen2]
 		Expect(aksUbuntuGPU1804Gen2.ResourceGroup).To(Equal("resourcegroup"))
@@ -236,5 +236,17 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(aksUbuntuEgressContainerd2204Gen2.Gallery).To(Equal("aksubuntu"))
 		Expect(aksUbuntuEgressContainerd2204Gen2.Definition).To(Equal("2204gen2containerd"))
 		Expect(aksUbuntuEgressContainerd2204Gen2.Version).To(Equal("2022.10.03"))
+
+		aksUbuntu2404Containerd := sigConfig.SigUbuntuImageConfig[AKSUbuntuContainerd2404]
+		Expect(aksUbuntu2404Containerd.ResourceGroup).To(Equal("resourcegroup"))
+		Expect(aksUbuntu2404Containerd.Gallery).To(Equal("aksubuntu"))
+		Expect(aksUbuntu2404Containerd.Definition).To(Equal("2404containerd"))
+		Expect(aksUbuntu2404Containerd.Version).To(Equal("202405.20.0"))
+
+		aksUbuntu2404Gen2Containerd := sigConfig.SigUbuntuImageConfig[AKSUbuntuContainerd2404Gen2]
+		Expect(aksUbuntu2404Gen2Containerd.ResourceGroup).To(Equal("resourcegroup"))
+		Expect(aksUbuntu2404Gen2Containerd.Gallery).To(Equal("aksubuntu"))
+		Expect(aksUbuntu2404Gen2Containerd.Definition).To(Equal("2404gen2containerd"))
+		Expect(aksUbuntu2404Gen2Containerd.Version).To(Equal("202405.20.0"))
 	})
 })

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -294,7 +294,7 @@ func (d Distro) Is2204VHDDistro() bool {
 	return false
 }
 
-// This function will later be consumed by CSE to determine cgroupv2 usage
+// This function will later be consumed by CSE to determine cgroupv2 usage.
 func (d Distro) Is2404VHDDistro() bool {
 	for _, distro := range AvailableUbuntu2404Distros {
 		if d == distro {

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -188,6 +188,8 @@ const (
 	AKSUbuntuMinimalContainerd2204      Distro = "aks-ubuntu-minimal-containerd-22.04"
 	AKSUbuntuMinimalContainerd2204Gen2  Distro = "aks-ubuntu-minimal-containerd-22.04-gen2"
 	AKSUbuntuEgressContainerd2204Gen2   Distro = "aks-ubuntu-egress-containerd-22.04-gen2"
+	AKSUbuntuContainerd2404             Distro = "aks-ubuntu-containerd-24.04"
+	AKSUbuntuContainerd2404Gen2         Distro = "aks-ubuntu-containerd-24.04-gen2"
 
 	RHEL              Distro = "rhel"
 	CoreOS            Distro = "coreos"
@@ -263,6 +265,8 @@ var AKSDistrosAvailableOnVHD = []Distro{
 	AKSUbuntuContainerd2204TLGen2,
 	AKSUbuntuMinimalContainerd2204,
 	AKSUbuntuMinimalContainerd2204Gen2,
+	AKSUbuntuContainerd2404,
+	AKSUbuntuContainerd2404Gen2,
 }
 
 type CustomConfigurationComponent string

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -294,6 +294,16 @@ func (d Distro) Is2204VHDDistro() bool {
 	return false
 }
 
+// This function will later be consumed by CSE to determine cgroupv2 usage
+func (d Distro) Is2404VHDDistro() bool {
+	for _, distro := range AvailableUbuntu2404Distros {
+		if d == distro {
+			return true
+		}
+	}
+	return false
+}
+
 func (d Distro) IsAzureLinuxCgroupV2VHDDistro() bool {
 	for _, distro := range AvailableAzureLinuxCgroupV2Distros {
 		if d == distro {


### PR DESCRIPTION
**What type of PR is this?**
This PR adds 2404 SIG config for AMD64 images. These images are one-off test images published to AME to test with aks-rp node image selection logic, these wont be consumed until 24.04 hit preview in AKS.

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
