### PR TITLE
Add coredns image v1.9.4-hotfix.20240520

### DIFF
--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -25,7 +25,8 @@
       "downloadURL": "mcr.microsoft.com/oss/kubernetes/coredns:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.9.4-hotfix.20240327"
+        "v1.9.4-hotfix.20240327",
+        "v1.9.4-hotfix.20240520"
       ]
     },
     {


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
To add coreDNS hotfix image (coredns:v1.9.4-hotfix.20240520) to cache that contains fix for CVE - CVE-2023-45288, CVE-2024-24788.

Requirements:

 uses [conventional commit messages](https://www.conventionalcommits.org/)
 includes documentation
 adds unit tests
 tested upgrade from previous version

Special notes for your reviewer:
https://mcr.microsoft.com/en-us/product/oss/kubernetes/coredns/tags
docker pull mcr.microsoft.com/oss/kubernetes/coredns:v1.9.4-hotfix.20240520

**Release note**:
```
none
```
