### PR TITLE
Update GRID driver to 535.161.08 for kernel compat issue

### DIFF
--- a/pkg/agent/common/gpu.go
+++ b/pkg/agent/common/gpu.go
@@ -26,13 +26,13 @@ const (
 	nvidia470CudaDriverVersion = "cuda-470.82.01"
 	nvidia535CudaDriverVersion = "cuda-535.54.03"
 	nvidia550CudaDriverVersion = "cuda-550.54.15"
-	nvidia535GridDriverVersion = "grid-535.154.05"
+	nvidia535GridDriverVersion = "grid-535.161.08"
 )
 
 // These SHAs will change once we update aks-gpu images in aks-gpu repository. We do that fairly rarely at this time.
 // So for now these will be kept here like this.
 const (
-	aksGPUGridSHA = "sha-13f51b"
+	aksGPUGridSHA = "sha-d1f0ca"
 	aksGPUCudaSHA = "sha-2d4c96"
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR updates the GRID driver container to fix this issue affecting Linux kernels 5.15.1063+ versions.

It's a new driver based on vGPU 16.5.

Modpost issue tracking:
https://forums.developer.nvidia.com/t/linux-6-7-3-545-29-06-550-40-07-error-modpost-gpl-incompatible-module-nvidia-ko-uses-gpl-only-symbol-rcu-read-lock/280908/4

Update based on: https://github.com/Azure/aks-gpu/pull/40

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
GRID driver updated to 535.161.08.
```
