### PR TITLE
bug: add systemd dropon for chrony so it will restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bin/
 .env
 .coverprofile
 coverage.txt
+e2e/scenario-logs
 **/vhd-publishing-info.json
 
 test/junit/

--- a/e2e/artifact/download.go
+++ b/e2e/artifact/download.go
@@ -82,8 +82,7 @@ func (d *Downloader) downloadPublishingInfo(ctx context.Context, tempDir, artifa
 	if err != nil {
 		log.Printf(err.Error())
 		if isMissingArtifactError(err) {
-			log.Printf("unable to download publishing info %q, not found for build ID: %d", artifactName, opts.BuildID)
-			panic(err)
+			log.Fatalf("unable to download publishing info %q, not found for build ID: %d", artifactName, opts.BuildID)
 		} else {
 			d.errChan <- fmt.Errorf("unable get artifact info for %q: %w", artifactName, err)
 		}
@@ -96,14 +95,14 @@ func (d *Downloader) downloadPublishingInfo(ctx context.Context, tempDir, artifa
 	zipOut, err := os.Create(zipName)
 	if err != nil {
 		d.errChan <- fmt.Errorf("unable to create zip archive %s: %w", zipName, err)
-		panic(err)
+		log.Fatalf("unable to create zip archive %s: %w", zipName, err)
 	}
 
 	client := &http.Client{}
 	req, err := http.NewRequest(http.MethodGet, downloadURL, nil)
 	if err != nil {
 		d.errChan <- fmt.Errorf("unable to create new HTTP request: %w", err)
-		panic(err)
+		log.Fatalf("unable to create new HTTP request: %w", err)
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", d.basicAuth))
@@ -111,22 +110,22 @@ func (d *Downloader) downloadPublishingInfo(ctx context.Context, tempDir, artifa
 	resp, err := client.Do(req)
 	if err != nil {
 		d.errChan <- fmt.Errorf("unable to perform HTTP request to download artifact: %w", err)
-		panic(err)
+		log.Fatalf("unable to perform HTTP request to download artifact: %w", err)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		d.errChan <- fmt.Errorf("unable to download artifact from %s, received HTTP status code: %d", downloadURL, resp.StatusCode)
-		panic(err)
+		log.Fatalf("unable to download artifact from %s, received HTTP status code: %d", downloadURL, resp.StatusCode)
 	}
 
 	if _, err = io.Copy(zipOut, resp.Body); err != nil {
 		d.errChan <- fmt.Errorf("unable to copy artifact data to zip archive: %w", err)
-		panic(err)
+		log.Fatalf("unable to copy artifact data to zip archive: %w", err)
 	}
 
 	if err = extractPublishingInfoFromZip(artifactName, zipName, opts.TargetDir); err != nil {
 		d.errChan <- fmt.Errorf("unable to extract publishing info from zip archive %s: %w", zipName, err)
-		panic(err)
+		log.Fatalf("unable to extract publishing info from zip archive %s: %w", zipName, err)
 	}
 }
 

--- a/e2e/pollers.go
+++ b/e2e/pollers.go
@@ -121,20 +121,20 @@ func pollExtractClusterParameters(ctx context.Context, kube *kubeclient) (map[st
 	return clusterParams, nil
 }
 
-// Wraps exctracLogsFromVM and dumpFileMapToDir in a poller with a 15-second wait interval and 5-minute timeout
+// Wraps extractLogsFromVM and dumpFileMapToDir in a poller with a 15-second wait interval and 5-minute timeout
 func pollExtractVMLogs(ctx context.Context, vmssName, privateIP string, privateKeyBytes []byte, opts *scenarioRunOpts) error {
 	err := wait.PollImmediateWithContext(ctx, extractVMLogsPollInterval, extractVMLogsPollingTimeout, func(ctx context.Context) (bool, error) {
-		log.Println("attempting to extract VM logs")
+		log.Printf("on %s attempting to extract VM logs", vmssName)
 
 		logFiles, err := extractLogsFromVM(ctx, vmssName, privateIP, string(privateKeyBytes), opts)
 		if err != nil {
-			log.Printf("error extracting VM logs: %q", err)
+			log.Printf("on %s error extracting VM logs: %q", vmssName, err)
 			return false, nil
 		}
 
-		log.Printf("dumping VM logs to local directory: %s", opts.loggingDir)
+		log.Printf("on %s dumping VM logs to local directory: %s", vmssName, opts.loggingDir)
 		if err = dumpFileMapToDir(opts.loggingDir, logFiles); err != nil {
-			log.Printf("error extracting VM logs: %q", err)
+			log.Printf("on %s error extracting VM logs: %q", vmssName, err)
 			return false, nil
 		}
 

--- a/e2e/scenario/base_vhd_catalog.json
+++ b/e2e/scenario/base_vhd_catalog.json
@@ -2,7 +2,7 @@
     "ubuntu1804": {
         "gen2containerd": {
             "artifactName": "1804-gen2-containerd",
-            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/1804Gen2/versions/1.1716223055.6413"
+            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/1804Gen2/versions/1.1717624749.32253"
         }
     },
     "ubuntu2204": {
@@ -12,7 +12,7 @@
         },
         "gen2containerd": {
             "artifactName": "2204-gen2-containerd",
-            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/2204Gen2/versions/1.1716223047.9966"
+            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/2204Gen2/versions/1.1717624764.5915"
         },
         "gen2containerdprivatekubepkg": {
             "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/2204Gen2/versions/1.1704411049.2812"
@@ -25,7 +25,7 @@
         },
         "gen2": {
             "artifactName": "azurelinuxv2-gen2",
-            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/AzureLinuxV2Gen2/versions/1.1717454216.7199"
+            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/AzureLinuxV2Gen2/versions/1.1717624767.6375"
         }
     },
     "cblmarinerv2": {
@@ -35,7 +35,7 @@
         },
         "gen2": {
             "artifactName": "marinerv2-gen2",
-            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/CBLMarinerV2Gen2/versions/1.1717454171.27526"
+            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/CBLMarinerV2Gen2/versions/1.1717624754.4093"
         }
     }
 }

--- a/e2e/scenario/base_vhd_catalog.json
+++ b/e2e/scenario/base_vhd_catalog.json
@@ -8,7 +8,7 @@
     "ubuntu2204": {
         "gen2arm64containerd": {
             "artifactName": "2204-arm64-gen2-containerd",
-            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/2204Gen2Arm64/versions/1.1716223050.23568"
+            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/2204Gen2Arm64/versions/1.1717624758.8105"
         },
         "gen2containerd": {
             "artifactName": "2204-gen2-containerd",

--- a/e2e/scenario/base_vhd_catalog.json
+++ b/e2e/scenario/base_vhd_catalog.json
@@ -2,7 +2,7 @@
     "ubuntu1804": {
         "gen2containerd": {
             "artifactName": "1804-gen2-containerd",
-            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/1804Gen2/versions/1.1717624749.32253"
+            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/1804Gen2/versions/1.1717624756.7706"
         }
     },
     "ubuntu2204": {

--- a/e2e/scenario/base_vhd_catalog.json
+++ b/e2e/scenario/base_vhd_catalog.json
@@ -2,7 +2,7 @@
     "ubuntu1804": {
         "gen2containerd": {
             "artifactName": "1804-gen2-containerd",
-            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/1804Gen2/versions/1.1717624756.7706"
+            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/1804Gen2/versions/1.1717717999.18756"
         }
     },
     "ubuntu2204": {
@@ -12,7 +12,7 @@
         },
         "gen2containerd": {
             "artifactName": "2204-gen2-containerd",
-            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/2204Gen2/versions/1.1717624764.5915"
+            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/2204Gen2/versions/1.1717717937.32392"
         },
         "gen2containerdprivatekubepkg": {
             "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/2204Gen2/versions/1.1704411049.2812"
@@ -25,7 +25,7 @@
         },
         "gen2": {
             "artifactName": "azurelinuxv2-gen2",
-            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/AzureLinuxV2Gen2/versions/1.1717624767.6375"
+            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/AzureLinuxV2Gen2/versions/1.1717717867.8926"
         }
     },
     "cblmarinerv2": {
@@ -35,7 +35,7 @@
         },
         "gen2": {
             "artifactName": "marinerv2-gen2",
-            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/CBLMarinerV2Gen2/versions/1.1717624754.4093"
+            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/CBLMarinerV2Gen2/versions/1.1717717874.25655"
         }
     }
 }

--- a/e2e/scenario/base_vhd_catalog.json
+++ b/e2e/scenario/base_vhd_catalog.json
@@ -31,7 +31,7 @@
     "cblmarinerv2": {
         "gen2arm64": {
             "artifactName": "marinerv2-gen2-arm64",
-            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/CBLMarinerV2Gen2Arm64/versions/1.1717454213.4440"
+            "resourceId": "/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/CBLMarinerV2Gen2Arm64/versions/1.1717624762.21825"
         },
         "gen2": {
             "artifactName": "marinerv2-gen2",

--- a/e2e/scenario/scenario.go
+++ b/e2e/scenario/scenario.go
@@ -44,28 +44,19 @@ func GetScenariosForSuite(ctx context.Context, suiteConfig *suite.Config) (Table
 // its return value to the slice returned by this function.
 func (t *Template) scenarios() []*Scenario {
 	return []*Scenario{
+		// block for ubuntu 1804
 		t.ubuntu1804(),
-		t.ubuntu2204(),
-		t.marinerv2(),
-		t.azurelinuxv2(),
-		t.ubuntu2204ARM64(),
-		t.marinerv2ARM64(),
-		t.azurelinuxv2ARM64(),
 		t.ubuntu1804gpu(),
-		t.marinerv2gpu(),
-		t.azurelinuxv2gpu(),
-		t.ubuntu2204CustomSysctls(),
-		t.marinerv2CustomSysctls(),
-		t.azurelinuxv2CustomSysctls(),
-		t.ubuntu2204Wasm(),
-		t.marinerv2Wasm(),
-		t.azurelinuxv2Wasm(),
 		t.ubuntu1804_azurecni(),
-		t.marinerv2_azurecni(),
-		t.azurelinuxv2_azurecni(),
 		t.ubuntu1804gpu_azurecni(),
-		t.marinerv2gpu_azurecni(),
-		t.azurelinuxv2gpu_azurecni(),
+		t.ubuntu1804SystemdChronyDropin(),
+		t.ubuntu1804ChronyRestarts(),
+
+		// block for ubuntu 2204
+		t.ubuntu2204(),
+		t.ubuntu2204ARM64(),
+		t.ubuntu2204CustomSysctls(),
+		t.ubuntu2204Wasm(),
 		t.ubuntu2204gpuNoDriver(),
 		t.ubuntu2204CustomCATrust(),
 		t.ubuntu2204ArtifactStreaming(),
@@ -73,10 +64,34 @@ func (t *Template) scenarios() []*Scenario {
 		t.ubuntu2204AirGap(),
 		t.ubuntu2204ContainerdURL(),
 		t.ubuntu2204ContainerdVersion(),
-		t.azurelinuxv2ARM64AirGap(),
+		t.ubuntu2204SystemdChronyDropin(),
+		t.ubuntu2204ChronyRestarts(),
+
+		// block for mariner v2
+		t.marinerv2(),
+		t.marinerv2ARM64(),
+		t.marinerv2gpu(),
+		t.marinerv2CustomSysctls(),
+		t.marinerv2Wasm(),
+		t.marinerv2_azurecni(),
+		t.marinerv2gpu_azurecni(),
 		t.marinerv2AirGap(),
-		t.azurelinuxv2AirGap(),
 		t.marinerv2ARM64AirGap(),
+		t.marinerv2SystemdChronyDropin(),
+		t.marinerv2ChronyRestarts(),
+
+		// block for azurelinux v2
+		t.azurelinuxv2(),
+		t.azurelinuxv2ARM64(),
+		t.azurelinuxv2gpu(),
+		t.azurelinuxv2CustomSysctls(),
+		t.azurelinuxv2Wasm(),
+		t.azurelinuxv2_azurecni(),
+		t.azurelinuxv2gpu_azurecni(),
+		t.azurelinuxv2ARM64AirGap(),
+		t.azurelinuxv2AirGap(),
+		t.azurelinuxv2SystemdChronyDropin(),
+		t.azurelinuxv2ChronyRestarts(),
 	}
 }
 

--- a/e2e/scenario/scenario.go
+++ b/e2e/scenario/scenario.go
@@ -49,7 +49,6 @@ func (t *Template) scenarios() []*Scenario {
 		t.ubuntu1804gpu(),
 		t.ubuntu1804_azurecni(),
 		t.ubuntu1804gpu_azurecni(),
-		t.ubuntu1804SystemdChronyDropin(),
 		t.ubuntu1804ChronyRestarts(),
 
 		// block for ubuntu 2204
@@ -64,7 +63,6 @@ func (t *Template) scenarios() []*Scenario {
 		t.ubuntu2204AirGap(),
 		t.ubuntu2204ContainerdURL(),
 		t.ubuntu2204ContainerdVersion(),
-		t.ubuntu2204SystemdChronyDropin(),
 		t.ubuntu2204ChronyRestarts(),
 
 		// block for mariner v2
@@ -77,7 +75,6 @@ func (t *Template) scenarios() []*Scenario {
 		t.marinerv2gpu_azurecni(),
 		t.marinerv2AirGap(),
 		t.marinerv2ARM64AirGap(),
-		t.marinerv2SystemdChronyDropin(),
 		t.marinerv2ChronyRestarts(),
 
 		// block for azurelinux v2
@@ -90,7 +87,6 @@ func (t *Template) scenarios() []*Scenario {
 		t.azurelinuxv2gpu_azurecni(),
 		t.azurelinuxv2ARM64AirGap(),
 		t.azurelinuxv2AirGap(),
-		t.azurelinuxv2SystemdChronyDropin(),
 		t.azurelinuxv2ChronyRestarts(),
 	}
 }

--- a/e2e/scenario/scenario_azurelinuxv2-chrony-restarts.go
+++ b/e2e/scenario/scenario_azurelinuxv2-chrony-restarts.go
@@ -4,26 +4,6 @@ import (
 	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 )
 
-func (t *Template) azurelinuxv2SystemdChronyDropin() *Scenario {
-	return &Scenario{
-		Name:        "azurelinuxv2-systemd-dropin-for-chrony",
-		Description: "Tests that the systemd drop-in file for chrony is placed in the right place",
-		Config: Config{
-			ClusterSelector: NetworkPluginKubenetSelector,
-			ClusterMutator:  NetworkPluginKubenetMutator,
-			VHDSelector:     t.AzureLinuxV2Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-azurelinux-v2-gen2"
-				nbc.AgentPoolProfile.Distro = "aks-azurelinux-v2-gen2"
-			},
-			LiveVMValidators: []*LiveVMValidator{
-				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
-				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
-			},
-		},
-	}
-}
-
 func (t *Template) azurelinuxv2ChronyRestarts() *Scenario {
 	return &Scenario{
 		Name:        "azurelinuxv2-chrony-restarts",
@@ -37,6 +17,8 @@ func (t *Template) azurelinuxv2ChronyRestarts() *Scenario {
 				nbc.AgentPoolProfile.Distro = "aks-azurelinux-v2-gen2"
 			},
 			LiveVMValidators: []*LiveVMValidator{
+				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
+				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
 				serviceCanRestartValidator("chronyd", 10),
 			},
 		},

--- a/e2e/scenario/scenario_azurelinuxv2-chrony-restarts.go
+++ b/e2e/scenario/scenario_azurelinuxv2-chrony-restarts.go
@@ -1,0 +1,44 @@
+package scenario
+
+import (
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
+)
+
+func (t *Template) azurelinuxv2SystemdChronyDropin() *Scenario {
+	return &Scenario{
+		Name:        "azurelinuxv2-systemd-dropin-for-chrony",
+		Description: "Tests that the systemd drop-in file for chrony is placed in the right place",
+		Config: Config{
+			ClusterSelector: NetworkPluginKubenetSelector,
+			ClusterMutator:  NetworkPluginKubenetMutator,
+			VHDSelector:     t.AzureLinuxV2Gen2,
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-azurelinux-v2-gen2"
+				nbc.AgentPoolProfile.Distro = "aks-azurelinux-v2-gen2"
+			},
+			LiveVMValidators: []*LiveVMValidator{
+				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
+				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
+			},
+		},
+	}
+}
+
+func (t *Template) azurelinuxv2ChronyRestarts() *Scenario {
+	return &Scenario{
+		Name:        "azurelinuxv2-chrony-restarts",
+		Description: "Tests that the chrony service restarts if it is killed",
+		Config: Config{
+			ClusterSelector: NetworkPluginKubenetSelector,
+			ClusterMutator:  NetworkPluginKubenetMutator,
+			VHDSelector:     t.AzureLinuxV2Gen2,
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-azurelinux-v2-gen2"
+				nbc.AgentPoolProfile.Distro = "aks-azurelinux-v2-gen2"
+			},
+			LiveVMValidators: []*LiveVMValidator{
+				serviceCanRestartValidator("chronyd", 10),
+			},
+		},
+	}
+}

--- a/e2e/scenario/scenario_azurelinuxv2-chrony-restarts.go
+++ b/e2e/scenario/scenario_azurelinuxv2-chrony-restarts.go
@@ -17,9 +17,9 @@ func (t *Template) azurelinuxv2ChronyRestarts() *Scenario {
 				nbc.AgentPoolProfile.Distro = "aks-azurelinux-v2-gen2"
 			},
 			LiveVMValidators: []*LiveVMValidator{
+				serviceCanRestartValidator("chronyd", 10),
 				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
 				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
-				serviceCanRestartValidator("chronyd", 10),
 			},
 		},
 	}

--- a/e2e/scenario/scenario_marinerv2-chrony-restarts.go
+++ b/e2e/scenario/scenario_marinerv2-chrony-restarts.go
@@ -17,9 +17,9 @@ func (t *Template) marinerv2ChronyRestarts() *Scenario {
 				nbc.AgentPoolProfile.Distro = "aks-cblmariner-v2-gen2"
 			},
 			LiveVMValidators: []*LiveVMValidator{
+				serviceCanRestartValidator("chronyd", 10),
 				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
 				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
-				serviceCanRestartValidator("chronyd", 10),
 			},
 		},
 	}

--- a/e2e/scenario/scenario_marinerv2-chrony-restarts.go
+++ b/e2e/scenario/scenario_marinerv2-chrony-restarts.go
@@ -1,0 +1,44 @@
+package scenario
+
+import (
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
+)
+
+func (t *Template) marinerv2SystemdChronyDropin() *Scenario {
+	return &Scenario{
+		Name:        "marinerv2-systemd-dropin-for-chrony",
+		Description: "Tests that the systemd drop-in file for chrony is placed in the right place",
+		Config: Config{
+			ClusterSelector: NetworkPluginKubenetSelector,
+			ClusterMutator:  NetworkPluginKubenetMutator,
+			VHDSelector:     t.CBLMarinerV2Gen2,
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-cblmariner-v2-gen2"
+				nbc.AgentPoolProfile.Distro = "aks-cblmariner-v2-gen2"
+			},
+			LiveVMValidators: []*LiveVMValidator{
+				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
+				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
+			},
+		},
+	}
+}
+
+func (t *Template) marinerv2ChronyRestarts() *Scenario {
+	return &Scenario{
+		Name:        "marinerv2-chrony-restarts",
+		Description: "Tests that the chrony service restarts if it is killed",
+		Config: Config{
+			ClusterSelector: NetworkPluginKubenetSelector,
+			ClusterMutator:  NetworkPluginKubenetMutator,
+			VHDSelector:     t.CBLMarinerV2Gen2,
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-cblmariner-v2-gen2"
+				nbc.AgentPoolProfile.Distro = "aks-cblmariner-v2-gen2"
+			},
+			LiveVMValidators: []*LiveVMValidator{
+				serviceCanRestartValidator("chronyd", 10),
+			},
+		},
+	}
+}

--- a/e2e/scenario/scenario_marinerv2-chrony-restarts.go
+++ b/e2e/scenario/scenario_marinerv2-chrony-restarts.go
@@ -4,26 +4,6 @@ import (
 	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 )
 
-func (t *Template) marinerv2SystemdChronyDropin() *Scenario {
-	return &Scenario{
-		Name:        "marinerv2-systemd-dropin-for-chrony",
-		Description: "Tests that the systemd drop-in file for chrony is placed in the right place",
-		Config: Config{
-			ClusterSelector: NetworkPluginKubenetSelector,
-			ClusterMutator:  NetworkPluginKubenetMutator,
-			VHDSelector:     t.CBLMarinerV2Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-cblmariner-v2-gen2"
-				nbc.AgentPoolProfile.Distro = "aks-cblmariner-v2-gen2"
-			},
-			LiveVMValidators: []*LiveVMValidator{
-				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
-				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
-			},
-		},
-	}
-}
-
 func (t *Template) marinerv2ChronyRestarts() *Scenario {
 	return &Scenario{
 		Name:        "marinerv2-chrony-restarts",
@@ -37,6 +17,8 @@ func (t *Template) marinerv2ChronyRestarts() *Scenario {
 				nbc.AgentPoolProfile.Distro = "aks-cblmariner-v2-gen2"
 			},
 			LiveVMValidators: []*LiveVMValidator{
+				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
+				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
 				serviceCanRestartValidator("chronyd", 10),
 			},
 		},

--- a/e2e/scenario/scenario_ubuntu1804-chrony-restarts.go
+++ b/e2e/scenario/scenario_ubuntu1804-chrony-restarts.go
@@ -4,26 +4,6 @@ import (
 	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 )
 
-func (t *Template) ubuntu1804SystemdChronyDropin() *Scenario {
-	return &Scenario{
-		Name:        "ubuntu1804-systemd-dropin-for-chrony",
-		Description: "Tests that the systemd drop-in file for chrony is placed in the right place",
-		Config: Config{
-			ClusterSelector: NetworkPluginKubenetSelector,
-			ClusterMutator:  NetworkPluginKubenetMutator,
-			VHDSelector:     t.Ubuntu1804Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-ubuntu-containerd-18.04-gen2"
-				nbc.AgentPoolProfile.Distro = "aks-ubuntu-containerd-18.04-gen2"
-			},
-			LiveVMValidators: []*LiveVMValidator{
-				FileHasContentsValidator("/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "Restart=always"),
-				FileHasContentsValidator("/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "RestartSec=5"),
-			},
-		},
-	}
-}
-
 func (t *Template) ubuntu1804ChronyRestarts() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu1804-chrony-restarts",
@@ -37,6 +17,8 @@ func (t *Template) ubuntu1804ChronyRestarts() *Scenario {
 				nbc.AgentPoolProfile.Distro = "aks-ubuntu-containerd-18.04-gen2"
 			},
 			LiveVMValidators: []*LiveVMValidator{
+				FileHasContentsValidator("/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "Restart=always"),
+				FileHasContentsValidator("/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "RestartSec=5"),
 				serviceCanRestartValidator("chronyd", 10),
 			},
 		},

--- a/e2e/scenario/scenario_ubuntu1804-chrony-restarts.go
+++ b/e2e/scenario/scenario_ubuntu1804-chrony-restarts.go
@@ -1,0 +1,44 @@
+package scenario
+
+import (
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
+)
+
+func (t *Template) ubuntu1804SystemdChronyDropin() *Scenario {
+	return &Scenario{
+		Name:        "ubuntu1804-systemd-dropin-for-chrony",
+		Description: "Tests that the systemd drop-in file for chrony is placed in the right place",
+		Config: Config{
+			ClusterSelector: NetworkPluginKubenetSelector,
+			ClusterMutator:  NetworkPluginKubenetMutator,
+			VHDSelector:     t.Ubuntu1804Gen2Containerd,
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-ubuntu-containerd-18.04-gen2"
+				nbc.AgentPoolProfile.Distro = "aks-ubuntu-containerd-18.04-gen2"
+			},
+			LiveVMValidators: []*LiveVMValidator{
+				FileHasContentsValidator("/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "Restart=always"),
+				FileHasContentsValidator("/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "RestartSec=5"),
+			},
+		},
+	}
+}
+
+func (t *Template) ubuntu1804ChronyRestarts() *Scenario {
+	return &Scenario{
+		Name:        "ubuntu1804-chrony-restarts",
+		Description: "Tests that the chrony service restarts if it is killed",
+		Config: Config{
+			ClusterSelector: NetworkPluginKubenetSelector,
+			ClusterMutator:  NetworkPluginKubenetMutator,
+			VHDSelector:     t.Ubuntu1804Gen2Containerd,
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-ubuntu-containerd-18.04-gen2"
+				nbc.AgentPoolProfile.Distro = "aks-ubuntu-containerd-18.04-gen2"
+			},
+			LiveVMValidators: []*LiveVMValidator{
+				serviceCanRestartValidator("chronyd", 10),
+			},
+		},
+	}
+}

--- a/e2e/scenario/scenario_ubuntu1804-chrony-restarts.go
+++ b/e2e/scenario/scenario_ubuntu1804-chrony-restarts.go
@@ -17,9 +17,9 @@ func (t *Template) ubuntu1804ChronyRestarts() *Scenario {
 				nbc.AgentPoolProfile.Distro = "aks-ubuntu-containerd-18.04-gen2"
 			},
 			LiveVMValidators: []*LiveVMValidator{
+				serviceCanRestartValidator("chronyd", 10),
 				FileHasContentsValidator("/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "Restart=always"),
 				FileHasContentsValidator("/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "RestartSec=5"),
-				serviceCanRestartValidator("chronyd", 10),
 			},
 		},
 	}

--- a/e2e/scenario/scenario_ubuntu2204-chrony-restarts.go
+++ b/e2e/scenario/scenario_ubuntu2204-chrony-restarts.go
@@ -1,0 +1,44 @@
+package scenario
+
+import (
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
+)
+
+func (t *Template) ubuntu2204SystemdChronyDropin() *Scenario {
+	return &Scenario{
+		Name:        "ubuntu2204-systemd-dropin-for-chrony",
+		Description: "Tests that the systemd drop-in file for chrony is placed in the right place",
+		Config: Config{
+			ClusterSelector: NetworkPluginKubenetSelector,
+			ClusterMutator:  NetworkPluginKubenetMutator,
+			VHDSelector:     t.Ubuntu2204Gen2Containerd,
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-ubuntu-containerd-22.04-gen2"
+				nbc.AgentPoolProfile.Distro = "aks-ubuntu-containerd-22.04-gen2"
+			},
+			LiveVMValidators: []*LiveVMValidator{
+				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
+				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
+			},
+		},
+	}
+}
+
+func (t *Template) ubuntu2204ChronyRestarts() *Scenario {
+	return &Scenario{
+		Name:        "ubuntu2204-chrony-restarts",
+		Description: "Tests that the chrony service restarts if it is killed",
+		Config: Config{
+			ClusterSelector: NetworkPluginKubenetSelector,
+			ClusterMutator:  NetworkPluginKubenetMutator,
+			VHDSelector:     t.Ubuntu2204Gen2Containerd,
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-ubuntu-containerd-22.04-gen2"
+				nbc.AgentPoolProfile.Distro = "aks-ubuntu-containerd-22.04-gen2"
+			},
+			LiveVMValidators: []*LiveVMValidator{
+				serviceCanRestartValidator("chronyd", 10),
+			},
+		},
+	}
+}

--- a/e2e/scenario/scenario_ubuntu2204-chrony-restarts.go
+++ b/e2e/scenario/scenario_ubuntu2204-chrony-restarts.go
@@ -4,26 +4,6 @@ import (
 	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 )
 
-func (t *Template) ubuntu2204SystemdChronyDropin() *Scenario {
-	return &Scenario{
-		Name:        "ubuntu2204-systemd-dropin-for-chrony",
-		Description: "Tests that the systemd drop-in file for chrony is placed in the right place",
-		Config: Config{
-			ClusterSelector: NetworkPluginKubenetSelector,
-			ClusterMutator:  NetworkPluginKubenetMutator,
-			VHDSelector:     t.Ubuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-ubuntu-containerd-22.04-gen2"
-				nbc.AgentPoolProfile.Distro = "aks-ubuntu-containerd-22.04-gen2"
-			},
-			LiveVMValidators: []*LiveVMValidator{
-				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
-				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
-			},
-		},
-	}
-}
-
 func (t *Template) ubuntu2204ChronyRestarts() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu2204-chrony-restarts",
@@ -37,6 +17,8 @@ func (t *Template) ubuntu2204ChronyRestarts() *Scenario {
 				nbc.AgentPoolProfile.Distro = "aks-ubuntu-containerd-22.04-gen2"
 			},
 			LiveVMValidators: []*LiveVMValidator{
+				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
+				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
 				serviceCanRestartValidator("chronyd", 10),
 			},
 		},

--- a/e2e/scenario/scenario_ubuntu2204-chrony-restarts.go
+++ b/e2e/scenario/scenario_ubuntu2204-chrony-restarts.go
@@ -17,9 +17,9 @@ func (t *Template) ubuntu2204ChronyRestarts() *Scenario {
 				nbc.AgentPoolProfile.Distro = "aks-ubuntu-containerd-22.04-gen2"
 			},
 			LiveVMValidators: []*LiveVMValidator{
+				serviceCanRestartValidator("chronyd", 10),
 				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
 				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
-				serviceCanRestartValidator("chronyd", 10),
 			},
 		},
 	}

--- a/e2e/scenario/validators.go
+++ b/e2e/scenario/validators.go
@@ -2,7 +2,6 @@ package scenario
 
 import (
 	"fmt"
-	"log"
 	"strings"
 )
 
@@ -147,7 +146,6 @@ func makeExecutableCommand(steps []string) string {
 
 	command := fmt.Sprintf("bash -c '%s'", quotedCommand)
 
-	log.Printf("command: %s", command)
 	return command
 }
 

--- a/e2e/scenario/validators.go
+++ b/e2e/scenario/validators.go
@@ -135,16 +135,11 @@ func cleanse(str string) string {
 func makeExecutableCommand(steps []string) string {
 	stepsWithEchos := make([]string, len(steps)*2)
 
-	for i, s := range steps {
-		stepsWithEchos[i*2] = fmt.Sprintf("echo '%s'", cleanse(s))
-		stepsWithEchos[i*2+1] = s
-	}
-
 	// quote " quotes and $ vars
 	joinedCommand := strings.Join(stepsWithEchos, " && ")
 	quotedCommand := strings.Replace(joinedCommand, "'", "'\"'\"'", -1)
 
-	command := fmt.Sprintf("bash -c '%s'", quotedCommand)
+	command := fmt.Sprintf("bash -x -c '%s'", quotedCommand)
 
 	return command
 }

--- a/e2e/scenario/validators.go
+++ b/e2e/scenario/validators.go
@@ -133,10 +133,8 @@ func cleanse(str string) string {
 }
 
 func makeExecutableCommand(steps []string) string {
-	stepsWithEchos := make([]string, len(steps)*2)
-
 	// quote " quotes and $ vars
-	joinedCommand := strings.Join(stepsWithEchos, " && ")
+	joinedCommand := strings.Join(steps, " && ")
 	quotedCommand := strings.Replace(joinedCommand, "'", "'\"'\"'", -1)
 
 	command := fmt.Sprintf("bash -x -c '%s'", quotedCommand)

--- a/e2e/scenario/validators.go
+++ b/e2e/scenario/validators.go
@@ -174,7 +174,7 @@ func serviceCanRestartValidator(serviceName string, restartTimeoutInSeconds int)
 		"echo POST_PID: $POST_PID",
 
 		// verify the PID has changed.
-		"if [[ \"$INITIAL_PID\" == \"$POST_PID\" ]]; then exit 1; fi",
+		"if [[ \"$INITIAL_PID\" == \"$POST_PID\" ]]; then echo 'PID didn't change after restart, failing validator.'; exit 1; fi",
 	}
 
 	command := makeExecutableCommand(steps)

--- a/e2e/scenario/validators.go
+++ b/e2e/scenario/validators.go
@@ -92,11 +92,77 @@ func NvidiaSMIInstalledValidator() *LiveVMValidator {
 
 func NonEmptyDirectoryValidator(dirName string) *LiveVMValidator {
 	return &LiveVMValidator{
-		Description: "assert that there are files in directory",
+		Description: fmt.Sprintf("assert that there are files in %s", dirName),
 		Command:     fmt.Sprintf("ls -1q %s | grep -q '^.*$' && true || false", dirName),
 		Asserter: func(code, stdout, stderr string) error {
 			if code != "0" {
 				return fmt.Errorf("expected to find a file in directory %s, but did not", dirName)
+			}
+			return nil
+		},
+	}
+}
+
+func FileHasContentsValidator(fileName string, contents string) *LiveVMValidator {
+	return &LiveVMValidator{
+		Description: fmt.Sprintf("Assert that %s has defined contents", fileName),
+		Command:     fmt.Sprintf("ls -la %[1]s && cat %[1]s | grep -q '%[2]s'", fileName, contents),
+		Asserter: func(code, stdout, stderr string) error {
+			if code != "0" {
+				return fmt.Errorf("expected to find a file '%s' with contents '%s' but did not", fileName, contents)
+			}
+			return nil
+		},
+	}
+}
+
+// this function is just used to remove some bash specific tokens so we can echo the command to stdout.
+func cleanse(str string) string {
+	str = strings.Replace(str, "'", "", -1)
+	str = strings.Replace(str, "\"", "", -1)
+	str = strings.Replace(str, "(", "OB", -1)
+	str = strings.Replace(str, ")", "CB", -1)
+	str = strings.Replace(str, "||", "OR", -1)
+	str = strings.Replace(str, "&&", "AND", -1)
+
+	return str
+}
+
+func serviceCanRestartValidator(serviceName string, restartTimeoutInSeconds int) *LiveVMValidator {
+	steps := []string{
+		fmt.Sprintf("systemctl start %s", serviceName),
+		fmt.Sprintf("sleep %d", restartTimeoutInSeconds),
+
+		// Verify the service is active - print the state then verify so we have logs
+		fmt.Sprintf("(systemctl -n 5 status %s || true)", serviceName),
+		fmt.Sprintf("systemctl is-active %s", serviceName),
+
+		// we use systemctl kill rather than kill -9 because container restrictions stop us sending a kill sig to a process
+		fmt.Sprintf("echo Killing %s", serviceName),
+		fmt.Sprintf("systemctl kill %s", serviceName),
+
+		// sleep for restartTimeoutInSeconds seconds to give the service time tor restart
+		fmt.Sprintf("sleep %d", restartTimeoutInSeconds),
+
+		// print the status of the service and then verify it is active.
+		fmt.Sprintf("(systemctl -n 5 status %s || true)", serviceName),
+		fmt.Sprintf("systemctl is-active %s", serviceName),
+	}
+	stepsWithEchos := make([]string, len(steps)*2)
+
+	for i, s := range steps {
+		stepsWithEchos[i*2] = fmt.Sprintf("echo '%s'", cleanse(s))
+		stepsWithEchos[i*2+1] = s
+	}
+
+	command := strings.Join(stepsWithEchos, " && ")
+
+	return &LiveVMValidator{
+		Description: fmt.Sprintf("asserts that %s restarts after it is killed", serviceName),
+		Command:     command,
+		Asserter: func(code, stdout, stderr string) error {
+			if code != "0" {
+				return fmt.Errorf("service kill and check terminated with exit code %q (expected 0).\nCommand: %s\n\nStdout:\n%s\n\n Stderr:\n%s\n", code, command, stdout, stderr)
 			}
 			return nil
 		},

--- a/e2e/scenario/validators.go
+++ b/e2e/scenario/validators.go
@@ -106,7 +106,8 @@ func NonEmptyDirectoryValidator(dirName string) *LiveVMValidator {
 func FileHasContentsValidator(fileName string, contents string) *LiveVMValidator {
 	return &LiveVMValidator{
 		Description: fmt.Sprintf("Assert that %s has defined contents", fileName),
-		Command:     fmt.Sprintf("bash -s \"ls -la %[1]s && cat %[1]s | grep -q '%[2]s'\"", fileName, contents),
+		// on mariner and ubuntu, the chronyd drop-in file is not readable by the default user, so we run as root.
+		Command: fmt.Sprintf("sudo bash -s \"ls -la %[1]s && cat %[1]s | grep -q '%[2]s'\"", fileName, contents),
 		Asserter: func(code, stdout, stderr string) error {
 			if code != "0" {
 				return fmt.Errorf("expected to find a file '%s' with contents '%s' but did not", fileName, contents)

--- a/e2e/scenario/validators.go
+++ b/e2e/scenario/validators.go
@@ -174,7 +174,7 @@ func serviceCanRestartValidator(serviceName string, restartTimeoutInSeconds int)
 		"echo POST_PID: $POST_PID",
 
 		// verify the PID has changed.
-		"if [[ \"$INITIAL_PID\" == \"$POST_PID\" ]]; then echo 'PID didn't change after restart, failing validator.'; exit 1; fi",
+		"if [[ \"$INITIAL_PID\" == \"$POST_PID\" ]]; then echo PID did not change after restart, failing validator. ; exit 1; fi",
 	}
 
 	command := makeExecutableCommand(steps)

--- a/e2e/scenario/vhd.go
+++ b/e2e/scenario/vhd.go
@@ -241,7 +241,7 @@ func (c *VHDCatalog) addEntryFromPublishingInfo(info artifact.VHDPublishingInfo)
 		case vhdNameCBLMarinerV2Gen2:
 			c.CBLMarinerV2.Gen2.ResourceID = id
 		default:
-			panic(fmt.Sprintf("cannot assign VHD resource IDto VHD name \"%s\" as name not known.", name))
+			panic(fmt.Sprintf("cannot assign VHD resource ID to VHD name \"%s\" as name not known.", name))
 		}
 	}
 }

--- a/e2e/scenario/vhd.go
+++ b/e2e/scenario/vhd.go
@@ -55,6 +55,8 @@ func getVHDsFromBuild(ctx context.Context, suiteConfig *suite.Config, tmpl *Temp
 		}
 	}
 
+	log.Printf("using artifact from build %d with name: %s", suiteConfig.VHDBuildID, fmt.Sprint(artifactNames))
+
 	err = downloader.DownloadVHDBuildPublishingInfo(ctx, artifact.PublishingInfoDownloadOpts{
 		BuildID:       suiteConfig.VHDBuildID,
 		TargetDir:     artifact.DefaultPublishingInfoDir,
@@ -221,7 +223,9 @@ func (c *VHDCatalog) CBLMarinerV2Gen2() VHD {
 func (c *VHDCatalog) addEntryFromPublishingInfo(info artifact.VHDPublishingInfo) {
 	if resourceID := info.CapturedImageVersionResourceID; resourceID != "" {
 		id := VHDResourceID(resourceID)
-		switch getVHDNameFromPublishingInfo(info) {
+		name := getVHDNameFromPublishingInfo(info)
+		log.Printf("Assigning name %s to use id %s ", name, id)
+		switch name {
 		case vhdName1804Gen2:
 			c.Ubuntu1804.Gen2Containerd.ResourceID = id
 		case vhdName2204Gen2ARM64Containerd:
@@ -236,6 +240,8 @@ func (c *VHDCatalog) addEntryFromPublishingInfo(info artifact.VHDPublishingInfo)
 			c.CBLMarinerV2.Gen2Arm64.ResourceID = id
 		case vhdNameCBLMarinerV2Gen2:
 			c.CBLMarinerV2.Gen2.ResourceID = id
+		default:
+			panic(fmt.Sprintf("cannot assign VHD resource IDto VHD name \"%s\" as name not known.", name))
 		}
 	}
 }

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -146,6 +146,8 @@ func runScenario(ctx context.Context, t *testing.T, r *mrand.Rand, opts *scenari
 		}
 	}
 
+	log.Println("Waiting for vmss creation...")
+
 	vmPrivateIP, err := pollGetVMPrivateIP(ctx, vmssName, opts)
 	if err != nil {
 		t.Fatalf("failed to get VM private IP: %s", err)
@@ -161,7 +163,7 @@ func runScenario(ctx context.Context, t *testing.T, r *mrand.Rand, opts *scenari
 
 	// Only perform node readiness/pod-related checks when VMSS creation succeeded
 	if vmssSucceeded {
-		log.Println("vmss creation succeded, proceeding with node readiness and pod checks...")
+		log.Println("vmss creation succeeded, proceeding with node readiness and pod checks...")
 		nodeName, err := validateNodeHealth(ctx, opts.clusterConfig.kube, vmssName)
 		if err != nil {
 			t.Fatal(err)

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -77,12 +77,27 @@ else
   done
 fi
 
+CHRONYD_DIR=/etc/systemd/system/chronyd.service.d
+if [[ "$OS" == "$UBUNTU_OS_NAME" ]]; then
+  if [ "${OS_VERSION}" == "18.04" ]; then
+    CHRONYD_DIR=/etc/systemd/system/chrony.service.d
+  fi
+fi
+
+mkdir -p "${CHRONYD_DIR}"
+cat >> "${CHRONYD_DIR}"/10-chrony-restarts.conf <<EOF
+[Service]
+Restart=always
+RestartSec=5
+EOF
+
 tee -a /etc/systemd/journald.conf > /dev/null <<'EOF'
 Storage=persistent
 SystemMaxUse=1G
 RuntimeMaxUse=1G
 ForwardToSyslog=yes
 EOF
+
 stop_watch $capture_time "Install Dependencies" false
 start_watch
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #27616556

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

* Have manually tested by creating VMs with the VHDs for mariner2, azurelinux2, ubuntu1804, and ubuntu2204, ssh'd to it, checked chrony was running, killed it, and checked it restarted.
* Have e2e tests verifying the contents of the systemd drop-in for those 3 distros
* have e2e tests replicating the automated tests.

**Release note**:
```
Add drop-in for systemd so Chrony will restart if it crashes
```
