### PR TITLE
bug: add publishing info back

### DIFF
--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -291,3 +291,9 @@ steps:
       targetPath: '$(Build.ArtifactStagingDirectory)'
     displayName: Publish artifacts
     condition: always()
+  - task: PublishPipelineArtifact@1
+    displayName: Publish publishing-info so e2e tests can be run locally
+    inputs:
+      artifactName: 'publishing-info-${{ parameters.artifactName }}'
+      targetPath: 'vhd-publishing-info.json'
+    condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
**What this PR does / why we need it**:

Adds the publishing info back so we can run e2e tests locally again.

**Requirements**:

- [x ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
