### PR TITLE
bug: Add artifacts back to root in staging dir

### DIFF
--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -181,12 +181,22 @@ steps:
       Contents: 'trivy-images-table.txt'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
     displayName: Copy trivy table
+  - task: PublishPipelineArtifact@0
+    inputs:
+        artifactName: 'vhd-release-notes-${{ parameters.artifactName }}'
+        targetPath: 'release-notes.txt'
+    displayName: publish release notes
   - task: CopyFiles@2
     inputs:
       SourceFolder: '$(System.DefaultWorkingDirectory)'
       Contents: 'release-notes.txt'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
     displayName: Copy release notes
+  - task: PublishPipelineArtifact@0
+    inputs:
+        artifactName: 'vhd-image-bom-${{ parameters.artifactName }}'
+        targetPath: 'image-bom.json'
+    displayName: publish container image list
   - task: CopyFiles@2
     condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))
     inputs:
@@ -267,6 +277,12 @@ steps:
         -e IMAGE_VERSION=${IMAGE_VERSION} \
         ${CONTAINER_IMAGE} make -f packer.mk generate-sas
     displayName: Getting Shared Access Signature URI
+    condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))
+  - task: PublishPipelineArtifact@1
+    displayName: Publish publishing-info 
+    inputs:
+      artifactName: 'publishing-info-${{ parameters.artifactName }}'
+      targetPath: 'vhd-publishing-info.json'
     condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))
   - task: CopyFiles@2
     condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))


### PR DESCRIPTION
**What type of PR is this?** The placement of files was necessary for release pipelines. Adding back to unblock release
https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=95238523&view=results - running
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
