### PR TITLE
fix: linux VHD build check-in pipeline trigger + prefetch script generation

### DIFF
--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -11,6 +11,7 @@ pr:
     - vhdbuilder/scripts/linux
     - .pipelines/.vsts-vhd-builder.yaml
     - parts/linux/cloud-init/artifacts/manifest.json
+    - parts/linux/cloud-init/artifacts/components.json
     - parts/linux/cloud-init/artifacts/cse_install.sh
     - parts/linux/cloud-init/artifacts/cse_helpers.sh
     - parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh

--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -60,12 +60,6 @@
       ],
       "prefetchOptimizations": [
         {
-          "version": "v1.5.23",
-          "binaries": [
-            "usr/local/bin/azure-cns"
-          ]
-        },
-        {
           "version": "v1.5.26",
           "binaries": [
             "usr/local/bin/azure-cns"


### PR DESCRIPTION
…ration

**What type of PR is this?**
fixes an issue just introduced which attempts to prefetch an azure-cns version on the VHD which is not being cached - this issue should've been caught by the linux VHD check-in build pipeline, thus this PR also fixes the path triggers to make sure that doesn't happen again

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
