### PR TITLE
fix: dns resolution for abe2e airgrap security rules

### DIFF
--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -322,7 +322,7 @@ func chooseCluster(
 		config := &clusterConfigs[i]
 		if (scenario.Airgap && !config.isAirgapCluster) || (config.isAirgapCluster && !scenario.Airgap) {
 			continue
-		} 
+		}
 
 		if scenario.Config.ClusterSelector(config.cluster) {
 			// only validate + prep the cluster for testing if we didn't just create it and it hasn't already been prepared

--- a/e2e/suite/const.go
+++ b/e2e/suite/const.go
@@ -1,5 +1,0 @@
-package suite
-
-const (
-	abe2eResourceGroupNameTemplate = "abe2e-%s"
-)

--- a/e2e/suite/suite.go
+++ b/e2e/suite/suite.go
@@ -10,8 +10,6 @@ import (
 )
 
 const (
-	publishingInfoDirName = "publishinginfo"
-
 	buildIDEnvironmentVarName            = "BUILD_ID"
 	adoPATEnvironmentVarName             = "ADO_PAT"
 	subscriptionIdEnvironmentVarName     = "SUBSCRIPTION_ID"
@@ -21,7 +19,8 @@ const (
 	scenariosToRunEnvironmentVarName     = "SCENARIOS_TO_RUN"
 	scenariosToExcludeEnvironmentVarName = "SCENARIOS_TO_EXCLUDE"
 
-	suiteConfigStringTemplate = `subscription: %[1]s,
+	abe2eResourceGroupNameTemplate = "abe2e-%s"
+	suiteConfigStringTemplate      = `subscription: %[1]s,
 location: %[2]s,
 resource group: %[3]s,
 keep vmss: %[4]t`


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

fixes incorrect security rules on airgap NSGs within agentbaker e2e's. this was caused by a change to the front-door IP address of `mcr.microsoft.com`, manifesting in provisioning failures with exit code 50.

this PR adds logic to dynamically lookup the IP address of each required DNS name so future changes of this nature no longer break anything

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
