### PR TITLE
chore: update npm linux to v1.5.29

### DIFF
--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -115,7 +115,7 @@
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-npm:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.5.23"
+        "v1.5.29"
       ]
     },
     {


### PR DESCRIPTION
**What type of PR is this?** NPM Version Update

**What this PR does / why we need it**: Updates the NPM Linux image version from v1.5.23 to v1.5.29 to address Ubuntu repo CVEs. Merging both rp and ab simultaneously to address the customer CVE.

**Release note**: https://github.com/Azure/azure-container-networking/releases/tag/v1.5.29