### PR TITLE
fix: containerd/runc versions in mariner/azlinux release notes

### DIFF
--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -114,7 +114,7 @@ installStandaloneContainerd() {
         echo "installing containerd version ${CONTAINERD_VERSION}"
         removeContainerd
         # TODO: tie runc to r92 once that's possible on Mariner's pkg repo and if we're still using v1.linux shim
-        # right now we just takes the latest version from PMC without specifying anything specifically
+        # right now we just take the latest version from PMC without specifying anything specifically
         # TODO: factor out desired version to components.json
         if ! dnf_install 30 1 600 moby-containerd; then
           exit $ERR_CONTAINERD_INSTALL_TIMEOUT

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -114,6 +114,8 @@ installStandaloneContainerd() {
         echo "installing containerd version ${CONTAINERD_VERSION}"
         removeContainerd
         # TODO: tie runc to r92 once that's possible on Mariner's pkg repo and if we're still using v1.linux shim
+        # right now we just takes the latest version from PMC without specifying anything specifically
+        # TODO: factor out desired version to components.json
         if ! dnf_install 30 1 600 moby-containerd; then
           exit $ERR_CONTAINERD_INSTALL_TIMEOUT
         fi

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -236,7 +236,8 @@ for p in ${packages[*]}; do
         if [[ "${OS}" == "${UBUNTU_OS_NAME}" ]]; then
           installContainerd "${downloadDir}" "${evaluatedURL}" "${version}"
         fi
-        echo "  - containerd version $(containerd -version | cut -d " " -f 3 | sed 's|v||' | cut -d "+" -f 1)" >> ${VHD_LOGS_FILEPATH}
+        installed_version=$(containerd -version | cut -d " " -f 3 | sed 's|v||' | cut -d "+" -f 1 | tr '.' '\n' | head -n 2 | paste -sd.)
+        echo "  - containerd version ${installed_version}" >> ${VHD_LOGS_FILEPATH}
       done
       ;;
     *)

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -228,7 +228,7 @@ for p in ${packages[*]}; do
     "containerd")
       for version in $PackageVersions; do
         evaluatedURL=$(evalPackageDownloadURL ${packageDownloadURL})
-        if [[ "${OS}" == "${MARINER_HOST_NAME}" ]]; then
+        if [[ "${OS}" == "${MARINER_OS_NAME}" ]]; then
           # runc is bundled with the moby-containerd package on Mariner/AzureLinux
           installStandaloneContainerd "${version}"
           echo "  - runc version $(runc --version | grep "runc version" | sed 's/runc version//')" >> ${VHD_LOGS_FILEPATH}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

fixes a bug we've had for a while where the reported containerd/runc versions weren't correct within azurelinux/mariner release notes

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
