### PR TITLE
feat: bump Windows 2022 image versions to 2024.6OOB

### DIFF
--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -60,8 +60,8 @@ switch -Regex ($windowsSku) {
         )
     }
     "2022-containerd*" {
-        $global:patchUrls = @("https://catalog.s.download.windowsupdate.com/d/msdownload/update/software/secu/2024/06/windows10.0-kb5039227-x64_136403ab41a524bb82063bc097e9cafbf0039630.msu")
-        $global:patchIDs = @("KB5039227")
+        $global:patchUrls = @("https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2024/06/windows10.0-kb5041054-x64_0a6d6b4af8a6f87cf01cab2e42fb07e326974f3b.msu")
+        $global:patchIDs = @("KB5041054")
 
         $global:imagesToPull = @(
             "mcr.microsoft.com/windows/servercore:ltsc2022",

--- a/vhdbuilder/packer/windows-image.env
+++ b/vhdbuilder/packer/windows-image.env
@@ -9,14 +9,14 @@ WINDOWS_2019_BASE_IMAGE_VERSION=17763.5936.240607
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:2022-Datacenter-Core-smalldisk:latest
 WINDOWS_2022_BASE_IMAGE_SKU=2022-Datacenter-Core-smalldisk
-WINDOWS_2022_BASE_IMAGE_VERSION=20348.2527.240607
+WINDOWS_2022_BASE_IMAGE_VERSION=20348.2529.240619
 
 # CLI example to get all available image version under a SKU (suffix g2 for Gen 2):
 #   az vm image list --all --publisher MicrosoftWindowsServer --offer WindowsServer --output table -s 2022-datacenter-core-smalldisk-g2
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:2022-datacenter-core-smalldisk-g2:latest
 WINDOWS_2022_GEN2_BASE_IMAGE_SKU=2022-datacenter-core-smalldisk-g2
-WINDOWS_2022_GEN2_BASE_IMAGE_VERSION=20348.2527.240607
+WINDOWS_2022_GEN2_BASE_IMAGE_VERSION=20348.2529.240619
 
 # CLI example to get the latest image version:
 #   az vm image show --urn MicrosoftWindowsServer:WindowsServer:23h2-datacenter-core:latest


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
bump Windows 2022 image versions to 2024.6OOB
- Windows 2022: [June 20, 2024—KB5041054 (OS Build 20348.2529) Out-of-band](https://support.microsoft.com/en-us/topic/june-20-2024-kb5041054-os-build-20348-2529-out-of-band-b746ffbd-934e-42ac-9c66-ed0636edf7f1)

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
