### PR TITLE
Add coredns image v1.9.4-hotfix.20240627

### DIFF
--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -25,8 +25,8 @@
       "downloadURL": "mcr.microsoft.com/oss/kubernetes/coredns:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.9.4-hotfix.20240327",
-        "v1.9.4-hotfix.20240520"
+        "v1.9.4-hotfix.20240520",
+        "v1.9.4-hotfix.20240627"
       ]
     },
     {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
To add coreDNS hotfix image (coredns:v1.9.4-hotfix.20240627) to cache that contains fixes for - CVE-2024-24790, CVE-2024-24789. Removing old image - v1.9.4-hotfix.20240327

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # CVE-2024-24790, CVE-2024-24789

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
https://mcr.microsoft.com/en-us/product/oss/kubernetes/coredns/tags 
docker pull mcr.microsoft.com/oss/kubernetes/coredns:v1.9.4-hotfix.20240627

**Release note**:
```
none
```
