### PR TITLE
perf: enable shallow replication

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -3,7 +3,7 @@ trigger: none
 
 variables:
   - name: CONTAINER_IMAGE
-    value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.1'
+    value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.0'
 
 pool:
   name: $(POOL_NAME)

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -13,7 +13,8 @@ parameters:
     displayName: Use Shallow Replication
     type: boolean
     default: true
-    description: Uncheck this box if you want to run an E2E test in a different Azure region after this build.
+    metadata:
+      description: Uncheck this box if you want to run an E2E test in a different Azure region after this build.
   - name: useOverrides
     displayName: Use component overrides
     type: boolean

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -169,7 +169,7 @@ parameters:
 
 variables:
 - name: CONTAINER_IMAGE
-  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.1'
+  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.39.1'
   
 pool:
   name: $(POOL_NAME)

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -169,7 +169,7 @@ parameters:
 
 variables:
 - name: CONTAINER_IMAGE
-  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.39.1'
+  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.1'
   
 pool:
   name: $(POOL_NAME)

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -169,7 +169,7 @@ parameters:
 
 variables:
 - name: CONTAINER_IMAGE
-  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.0'
+  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.1'
   
 pool:
   name: $(POOL_NAME)

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -167,13 +167,6 @@ parameters:
     type: boolean
     default: False
 
-variables:
-- name: CONTAINER_IMAGE
-  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.0'
-  
-pool:
-  name: $(POOL_NAME)
-
 stages:
   - stage: build
     jobs:

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -9,6 +9,10 @@ pool:
   name: $(POOL_NAME)
 
 parameters:
+  - name: useShallowReplication
+    displayName: Use Shallow Replication
+    type: boolean
+    default: true
   - name: useOverrides
     displayName: Use component overrides
     type: boolean
@@ -17,10 +21,6 @@ parameters:
     displayName: Branch in aks-rp to use for overrides
     type: string
     default: master
-  - name: useShallowReplication
-    displayName: Use Shallow Replication
-    type: boolean
-    default: true
   - name: build1804containerd
     displayName: Build 1804 containerd
     type: boolean

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -169,7 +169,7 @@ parameters:
 
 variables:
 - name: CONTAINER_IMAGE
-  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.1'
+  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.0'
   
 pool:
   name: $(POOL_NAME)

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -4,7 +4,6 @@ trigger: none
 variables:
   - name: CONTAINER_IMAGE
     value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.1'
-  - group: aks-vuln-to-kusto
 
 pool:
   name: $(POOL_NAME)

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -13,7 +13,7 @@ parameters:
     displayName: Use Shallow Replication
     type: boolean
     default: true
-    helpMarkDown: Uncheck this box if you want to run an E2E test in a different Azure region after this build.
+    description: Uncheck this box if you want to run an E2E test in a different Azure region after this build.
   - name: useOverrides
     displayName: Use component overrides
     type: boolean

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -13,6 +13,7 @@ parameters:
     displayName: Use Shallow Replication
     type: boolean
     default: true
+    helpMarkDown: Uncheck this box if you want to run an E2E test in a different Azure region after this build.
   - name: useOverrides
     displayName: Use component overrides
     type: boolean

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -17,6 +17,10 @@ parameters:
     displayName: Branch in aks-rp to use for overrides
     type: string
     default: master
+  - name: useShallowReplication
+    displayName: Use Shallow Replication
+    type: boolean
+    default: true
   - name: build1804containerd
     displayName: Build 1804 containerd
     type: boolean

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -196,6 +196,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 1804-containerd
@@ -222,6 +223,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 1804-gen2-containerd
@@ -248,6 +250,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 1804-gpu-containerd
@@ -274,6 +277,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 1804-gen2-gpu-containerd
@@ -302,6 +306,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: marinerv2-gen1
@@ -330,6 +335,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: azurelinuxv2-gen1
@@ -358,6 +364,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: marinerv2-gen2
@@ -386,6 +393,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: azurelinuxv2-gen2
@@ -414,6 +422,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: marinerv2-gen1-fips
@@ -442,6 +451,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: azurelinuxv2-gen1-fips
@@ -470,6 +480,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: marinerv2-gen2-fips
@@ -498,6 +509,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: azurelinuxv2-gen2-fips
@@ -526,6 +538,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: marinerv2-gen2-arm64
@@ -554,6 +567,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: azurelinuxv2-gen2-arm64
@@ -582,6 +596,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: marinerv2-gen2-kata
@@ -610,6 +625,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: azurelinuxv2-gen2-kata
@@ -638,6 +654,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: marinerv2-gen2-trustedlaunch
@@ -666,6 +683,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: azurelinuxv2-gen2-trustedlaunch
@@ -694,6 +712,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: marinerv2-gen2-kata-trustedlaunch
@@ -722,6 +741,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: azurelinuxv2-gen2-kata-trustedlaunch
@@ -749,6 +769,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 1804-fips-containerd
@@ -776,6 +797,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 1804-fips-gen2-containerd
@@ -803,6 +825,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 2004-fips-containerd
@@ -830,6 +853,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 2004-fips-gen2-containerd
@@ -858,6 +882,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 2204-fips-containerd
@@ -886,6 +911,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 2204-fips-gen2-containerd
@@ -913,6 +939,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 2204-arm64-gen2-containerd
@@ -940,6 +967,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 2404-arm64-gen2-containerd
@@ -966,6 +994,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 2204-containerd
@@ -992,6 +1021,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 2204-gen2-containerd
@@ -1018,6 +1048,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 2404-containerd
@@ -1044,6 +1075,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 2404-gen2-containerd
@@ -1070,6 +1102,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 2004-cvm-gen2-containerd
@@ -1096,6 +1129,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 2204-tl-gen2-containerd
@@ -1122,6 +1156,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 2204-minimal-gen1-containerd
@@ -1148,6 +1183,7 @@ stages:
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
+              useShallowReplication: ${{ parameters.useShallowReplication }}
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: 2204-minimal-gen2-containerd

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -10,11 +10,9 @@ pool:
 
 parameters:
   - name: useShallowReplication
-    displayName: Use Shallow Replication
+    displayName: Use Shallow Replication (Only check this box if you will be running E2E in the same region as the build)
     type: boolean
     default: true
-    metadata:
-      description: Uncheck this box if you want to run an E2E test in a different Azure region after this build.
   - name: useOverrides
     displayName: Use component overrides
     type: boolean

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -24,7 +24,7 @@ pool:
 
 variables:
 - name: CONTAINER_IMAGE
-  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.1'
+  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.0'
 
 stages:
   - stage: build

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -24,7 +24,7 @@ pool:
 
 variables:
 - name: CONTAINER_IMAGE
-  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.0'
+  value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.1'
 
 stages:
   - stage: build

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -19,12 +19,12 @@ pr:
     - vhdbuilder/packer/*windows*
     - vhdbuilder/packer/**/*windows*
 
-pool:
-  name: $(POOL_NAME)
-
 variables:
 - name: CONTAINER_IMAGE
   value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.0'
+
+pool:
+  name: $(POOL_NAME)
 
 stages:
   - stage: build

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -22,6 +22,7 @@ pr:
 variables:
 - name: CONTAINER_IMAGE
   value: 'mcr.microsoft.com/oss/azcu/go-dev:v1.38.0'
+- group: aks-vuln-to-kusto
 
 pool:
   name: $(POOL_NAME)

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -151,16 +151,6 @@ steps:
     retryCountOnTaskFailure: 3
     displayName: Building VHD
   - bash: |
-        echo MODE=$(MODE) && \
-        captured_sig_version="$(cat vhdbuilder/packer/settings.json | grep "captured_sig_version" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
-        SIG_GALLERY_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_gallery_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
-        SIG_IMAGE_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_image_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
-        echo "##vso[task.setvariable variable=CAPTURED_SIG_VERSION]$captured_sig_version"
-        echo "##vso[task.setvariable variable=SIG_IMAGE_NAME]$SIG_IMAGE_NAME"
-        echo "##vso[task.setvariable variable=SIG_GALLERY_NAME]$SIG_GALLERY_NAME"
-    retryCountOnTaskFailure: 1
-    displayName: Set Stage Variables
-  - bash: |
       OS_DISK_URI="$(cat packer-output | grep "OSDiskUri:" | cut -d " " -f 2)" && \
       MANAGED_SIG_ID="$(cat packer-output | grep "ManagedImageSharedImageGalleryId:" | cut -d " " -f 2)" && \
       PKR_RG_NAME="$(cat packer-output | grep "ResourceGroupName" | cut -d "'" -f 2 | head -1)" && \

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -284,7 +284,7 @@ steps:
         -e SIG_IMAGE_NAME=${SIG_IMAGE_NAME} \
         -e CAPTURED_SIG_VERSION=${captured_sig_version} \
         -e ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH} \
-        -e AZURE_MSI_RESOURCE_STRING=$(AZURE_MSI_RESOURCE_ID) \
+        -e AZURE_MSI_RESOURCE_STRING=$(AZURE_MSI_RESOURCE_STRING) \
         ${CONTAINER_IMAGE} make -f packer.mk convert-sig-to-classic-storage-account-blob
     displayName: Convert Shared Image Gallery To VHD Blob In Classic Storage Account
     condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -81,7 +81,6 @@ steps:
       ls -R
     displayName: show Directory
   - bash: |
-      lsb_release -a
       set -x
       GOPATH="$(go env GOPATH)"
       echo "GOPATH is currently set to $GOPATH"
@@ -109,12 +108,6 @@ steps:
     displayName: Set SKU Name
   - bash: |
         echo MODE=$(MODE) && \
-        captured_sig_version="$(cat vhdbuilder/packer/settings.json | grep "captured_sig_version" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
-        SIG_GALLERY_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_gallery_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
-        SIG_IMAGE_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_image_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
-        echo "##vso[task.setvariable variable=CAPTURED_SIG_VERSION]$captured_sig_version"
-        echo "##vso[task.setvariable variable=SIG_IMAGE_NAME]$SIG_IMAGE_NAME"
-        echo "##vso[task.setvariable variable=SIG_GALLERY_NAME]$SIG_GALLERY_NAME"
         docker run --rm \
         -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
         -v /usr/local/bin/packer:/usr/local/bin/packer \
@@ -157,6 +150,19 @@ steps:
         ${CONTAINER_IMAGE} make -f packer.mk run-packer
     retryCountOnTaskFailure: 3
     displayName: Building VHD
+  - bash: |
+        echo MODE=$(MODE) && \
+        captured_sig_version="$(cat vhdbuilder/packer/settings.json | grep "captured_sig_version" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
+        SIG_GALLERY_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_gallery_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
+        SIG_IMAGE_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_image_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
+        echo "##vso[task.setvariable variable=CAPTURED_SIG_VERSION]$captured_sig_version"
+        echo "##vso[task.setvariable variable=SIG_IMAGE_NAME]$SIG_IMAGE_NAME"
+        echo "##vso[task.setvariable variable=SIG_GALLERY_NAME]$SIG_GALLERY_NAME"
+        echo "CAPTURED_SIG_VERSION is $CAPTURED_SIG_VERSION"
+        echo "SIG_IMAGE_NAME is $SIG_IMAGE_NAME"
+        echo "SIG_GALLERY_NAME is $SIG_GALLERY_NAME"
+  retryCountOnTaskFailure: 1
+  displayName: Set Stage Variables
   - bash: |
       OS_DISK_URI="$(cat packer-output | grep "OSDiskUri:" | cut -d " " -f 2)" && \
       MANAGED_SIG_ID="$(cat packer-output | grep "ManagedImageSharedImageGalleryId:" | cut -d " " -f 2)" && \
@@ -277,6 +283,7 @@ steps:
     displayName: Copy image bom
   - bash: |
         echo MODE=$(MODE) && \
+        thisVar="5" && \
         make -f packer.mk convert-sig-to-classic-storage-account-blob
     env:
       SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -110,7 +110,6 @@ steps:
         echo MODE=$(MODE) && \
         docker run --rm \
         -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
-        -v /usr/local/bin/packer:/usr/local/bin/packer \
         -w /go/src/github.com/Azure/AgentBaker \
         -e POOL_NAME=$(POOL_NAME) \
         -e SUBSCRIPTION_ID="${SUBSCRIPTION_ID}" \

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -110,7 +110,9 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
-        azcopy login --login-type=MSI
+        export AZCOPY_AUTO_LOGIN_TYPE="MSI" && \
+        export AZCOPY_MSI_RESOURCE_STRING="$AZURE_MSI_RESOURCE_STRING" && \
+        azcopy doc -h
     displayName: 'Check AZCopy login'
   - bash: |
         echo MODE=$(MODE) && \

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -44,9 +44,9 @@ steps:
     displayName: Apply Overrides
     condition: eq('${{ parameters.useOverrides }}', true)
   - bash: |
-        m="linuxVhdMode" && \
-        echo "Set build mode to $m" && \
-        echo "##vso[task.setvariable variable=MODE]$m"
+      m="linuxVhdMode" && \
+      echo "Set build mode to $m" && \
+      echo "##vso[task.setvariable variable=MODE]$m"
     displayName: Get Build Mode
   - task: UniversalPackages@0
     displayName: Download Asc Baseline

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -106,6 +106,12 @@ steps:
       echo "##vso[task.setvariable variable=SKU_NAME]$SKU_NAME"
       echo "Set SKU_NAME to $SKU_NAME"
     displayName: Set SKU Name
+  - task: Bash@3
+    inputs:
+      targetType: 'inline'
+      script: |
+        azcopy login --login-type=MSI
+    displayName: 'Check AZCopy login'
   - bash: |
         echo MODE=$(MODE) && \
         docker run --rm \

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -283,7 +283,6 @@ steps:
     displayName: Copy image bom
   - bash: |
         echo MODE=$(MODE) && \
-        thisVar="5" && \
         make -f packer.mk convert-sig-to-classic-storage-account-blob
     env:
       SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -284,7 +284,7 @@ steps:
         -e SIG_IMAGE_NAME=${SIG_IMAGE_NAME} \
         -e CAPTURED_SIG_VERSION=${captured_sig_version} \
         -e ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH} \
-        -e AZURE_MSI_RESOURCE_STRING=$(AZURE_MSI_RESOURCE_STRING) \
+        -e AZURE_MSI_RESOURCE_STRING=$(AZURE_MSI_RESOURCE_ID) \
         ${CONTAINER_IMAGE} make -f packer.mk convert-sig-to-classic-storage-account-blob
     displayName: Convert Shared Image Gallery To VHD Blob In Classic Storage Account
     condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -106,14 +106,6 @@ steps:
       echo "##vso[task.setvariable variable=SKU_NAME]$SKU_NAME"
       echo "Set SKU_NAME to $SKU_NAME"
     displayName: Set SKU Name
-  - task: Bash@3
-    inputs:
-      targetType: 'inline'
-      script: |
-        export AZCOPY_AUTO_LOGIN_TYPE="MSI" && \
-        export AZCOPY_MSI_RESOURCE_STRING="$AZURE_MSI_RESOURCE_STRING" && \
-        azcopy doc -h
-    displayName: 'Check AZCopy login'
   - bash: |
         echo MODE=$(MODE) && \
         docker run --rm \
@@ -283,9 +275,6 @@ steps:
         SIG_IMAGE_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_image_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
         docker run --rm \
         -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
-        -v /usr/local/bin/azcopy:/usr/local/bin/azcopy \
-        -v /usr/bin/az:/usr/bin/az \
-        -v /usr/bin/go:/usr/bin/go \
         -w /go/src/github.com/Azure/AgentBaker \
         -e SUBSCRIPTION_ID="${SUBSCRIPTION_ID}" \
         -e RESOURCE_GROUP_NAME="${AZURE_RESOURCE_GROUP_NAME}" \

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -284,7 +284,7 @@ steps:
         -e SIG_IMAGE_NAME=${SIG_IMAGE_NAME} \
         -e CAPTURED_SIG_VERSION=${captured_sig_version} \
         -e ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH} \
-        -e AZURE_MSI_RESOURCE_STRING=$(AZURE_MSI_RESOURCE_ID) \
+        -e AZURE_MSI_RESOURCE_STRING=${AZURE_MSI_RESOURCE_STRING} \
         ${CONTAINER_IMAGE} make -f packer.mk convert-sig-to-classic-storage-account-blob
     displayName: Convert Shared Image Gallery To VHD Blob In Classic Storage Account
     condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -275,6 +275,8 @@ steps:
         captured_sig_version="$(cat vhdbuilder/packer/settings.json | grep "captured_sig_version" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
         SIG_GALLERY_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_gallery_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
         SIG_IMAGE_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_image_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
+        echo "${captured_sig_version}" && \
+        echo "${SIG_IMAGE_NAME}" && \
         make -f packer.mk convert-sig-to-classic-storage-account-blob
     env:
       SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -110,6 +110,7 @@ steps:
         echo MODE=$(MODE) && \
         docker run --rm \
         -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
+        -v /usr/local/bin/packer:/usr/local/bin/packer \
         -w /go/src/github.com/Azure/AgentBaker \
         -e POOL_NAME=$(POOL_NAME) \
         -e SUBSCRIPTION_ID="${SUBSCRIPTION_ID}" \

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -284,7 +284,7 @@ steps:
         -e SIG_IMAGE_NAME=${SIG_IMAGE_NAME} \
         -e CAPTURED_SIG_VERSION=${captured_sig_version} \
         -e ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH} \
-        -e AZURE_MSI_RESOURCE_STRING=${AZURE_MSI_RESOURCE_STRING} \
+        -e AZURE_MSI_RESOURCE_STRING=$(AZURE_MSI_RESOURCE_STRING) \
         ${CONTAINER_IMAGE} make -f packer.mk convert-sig-to-classic-storage-account-blob
     displayName: Convert Shared Image Gallery To VHD Blob In Classic Storage Account
     condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -8,6 +8,9 @@ parameters:
   - name: overrideBranch
     type: string
     default: master
+  - name: useShallowReplication
+    type: boolean
+    default: true
 steps:
   - checkout: self
     # s is the default path for repositories - if we don't set this when using multiple repsositories, then it is the repo name

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -287,6 +287,7 @@ steps:
         -e AZURE_MSI_RESOURCE_STRING=$(AZURE_MSI_RESOURCE_ID) \
         ${CONTAINER_IMAGE} make -f packer.mk convert-sig-to-classic-storage-account-blob
     displayName: Convert Shared Image Gallery To VHD Blob In Classic Storage Account
+    condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))
   - bash: |
       echo MODE=$(MODE) && \
       captured_sig_version="$(cat vhdbuilder/packer/settings.json | grep "captured_sig_version" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -147,7 +147,7 @@ steps:
       -e IMAGE_VERSION=${IMAGE_VERSION} \
       -e PRIVATE_PACKAGES_URL="${PRIVATE_PACKAGES_URL}" \
       -e AZURE_MSI_RESOURCE_STRING=${AZURE_MSI_RESOURCE_STRING} \
-        ${CONTAINER_IMAGE} make -f packer.mk run-packer
+      ${CONTAINER_IMAGE} make -f packer.mk run-packer
     retryCountOnTaskFailure: 3
     displayName: Building VHD
   - bash: |

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -270,23 +270,22 @@ steps:
     displayName: Copy image bom
   - bash: |
         echo MODE=$(MODE) && \
+        pwd && \
         captured_sig_version="$(cat vhdbuilder/packer/settings.json | grep "captured_sig_version" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
         SIG_GALLERY_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_gallery_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
         SIG_IMAGE_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_image_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
-        docker run --rm \
-        -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
-        -w /go/src/github.com/Azure/AgentBaker \
-        -e SUBSCRIPTION_ID="${SUBSCRIPTION_ID}" \
-        -e RESOURCE_GROUP_NAME="${AZURE_RESOURCE_GROUP_NAME}" \
-        -e PACKER_BUILD_LOCATION="${PACKER_BUILD_LOCATION}" \
-        -e OS_TYPE="Linux" \
-        -e CLASSIC_BLOB=${CLASSIC_BLOB} \
-        -e SIG_GALLERY_NAME=${SIG_GALLERY_NAME} \
-        -e SIG_IMAGE_NAME=${SIG_IMAGE_NAME} \
-        -e CAPTURED_SIG_VERSION=${captured_sig_version} \
-        -e ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH} \
-        -e AZURE_MSI_RESOURCE_STRING=$(AZURE_MSI_RESOURCE_STRING) \
-        ${CONTAINER_IMAGE} make -f packer.mk convert-sig-to-classic-storage-account-blob
+        make -f packer.mk convert-sig-to-classic-storage-account-blob
+    env:
+      SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
+      RESOURCE_GROUP_NAME: $(AZURE_RESOURCE_GROUP_NAME)
+      PACKER_BUILD_LOCATION: $(PACKER_BUILD_LOCATION)
+      OS_TYPE: Linux
+      CLASSIC_BLOB: $(CLASSIC_BLOB)
+      SIG_GALLERY_NAME: $(SIG_GALLERY_NAME)
+      SIG_IMAGE_NAME: $(SIG_IMAGE_NAME)
+      CAPTURED_SIG_VERSION: $(captured_sig_version)
+      ENABLE_TRUSTED_LAUNCH: $(ENABLE_TRUSTED_LAUNCH)
+      AZURE_MSI_RESOURCE_STRING: $(AZURE_MSI_RESOURCE_STRING)
     displayName: Convert Shared Image Gallery To VHD Blob In Classic Storage Account
     condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))
   - bash: |

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -107,46 +107,46 @@ steps:
       echo "Set SKU_NAME to $SKU_NAME"
     displayName: Set SKU Name
   - bash: |
-        echo MODE=$(MODE) && \
-        docker run --rm \
-        -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
-        -v /usr/local/bin/packer:/usr/local/bin/packer \
-        -w /go/src/github.com/Azure/AgentBaker \
-        -e POOL_NAME=$(POOL_NAME) \
-        -e SUBSCRIPTION_ID="${SUBSCRIPTION_ID}" \
-        -e AZURE_VM_SIZE=$(AZURE_VM_SIZE) \
-        -e AZURE_RESOURCE_GROUP_NAME=${AZURE_RESOURCE_GROUP_NAME} \
-        -e ENVIRONMENT=${ENVIRONMENT} \
-        -e PACKER_BUILD_LOCATION=${PACKER_BUILD_LOCATION} \
-        -e FEATURE_FLAGS=$(FEATURE_FLAGS) \
-        -e GIT_VERSION=$(Build.SourceVersion) \
-        -e BUILD_DEFINITION_NAME="$(Build.DefinitionName)" \
-        -e BUILD_ID=$(Build.BuildId) \
-        -e BUILD_NUMBER=$(Build.BuildNumber) \
-        -e OS_VERSION=$(OS_VERSION) \
-        -e OS_SKU=${OS_SKU} \
-        -e SKU_NAME=$(SKU_NAME) \
-        -e HYPERV_GENERATION=${HYPERV_GENERATION} \
-        -e OS_TYPE="Linux" \
-        -e IMG_PUBLISHER=${IMG_PUBLISHER} \
-        -e IMG_OFFER=${IMG_OFFER} \
-        -e IMG_SKU=${IMG_SKU} \
-        -e IMG_VERSION=${IMG_VERSION} \
-        -e MODE=$(MODE) \
-        -e SIG_GALLERY_NAME=${SIG_GALLERY_NAME} \
-        -e SIG_IMAGE_NAME=${SIG_IMAGE_NAME} \
-        -e BRANCH=$(Build.SourceBranch) \
-        -e SIG_IMAGE_VERSION=${SIG_IMAGE_VERSION} \
-        -e CONTAINER_RUNTIME=${CONTAINER_RUNTIME} \
-        -e TELEPORTD_PLUGIN_DOWNLOAD_URL=${TELEPORTD_PLUGIN_DOWNLOAD_URL} \
-        -e ENABLE_FIPS=${ENABLE_FIPS} \
-        -e ARCHITECTURE=${ARCHITECTURE} \
-        -e ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH} \
-        -e SGX_INSTALL=${SGX_INSTALL} \
-        -e ENABLE_CGROUPV2=${ENABLE_CGROUPV2} \
-        -e IMAGE_VERSION=${IMAGE_VERSION} \
-        -e PRIVATE_PACKAGES_URL="${PRIVATE_PACKAGES_URL}" \
-        -e AZURE_MSI_RESOURCE_STRING=${AZURE_MSI_RESOURCE_STRING} \
+      echo MODE=$(MODE) && \
+      docker run --rm \
+      -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
+      -v /usr/local/bin/packer:/usr/local/bin/packer \
+      -w /go/src/github.com/Azure/AgentBaker \
+      -e POOL_NAME=$(POOL_NAME) \
+      -e SUBSCRIPTION_ID="${SUBSCRIPTION_ID}" \
+      -e AZURE_VM_SIZE=$(AZURE_VM_SIZE) \
+      -e AZURE_RESOURCE_GROUP_NAME=${AZURE_RESOURCE_GROUP_NAME} \
+      -e ENVIRONMENT=${ENVIRONMENT} \
+      -e PACKER_BUILD_LOCATION=${PACKER_BUILD_LOCATION} \
+      -e FEATURE_FLAGS=$(FEATURE_FLAGS) \
+      -e GIT_VERSION=$(Build.SourceVersion) \
+      -e BUILD_DEFINITION_NAME="$(Build.DefinitionName)" \
+      -e BUILD_ID=$(Build.BuildId) \
+      -e BUILD_NUMBER=$(Build.BuildNumber) \
+      -e OS_VERSION=$(OS_VERSION) \
+      -e OS_SKU=${OS_SKU} \
+      -e SKU_NAME=$(SKU_NAME) \
+      -e HYPERV_GENERATION=${HYPERV_GENERATION} \
+      -e OS_TYPE="Linux" \
+      -e IMG_PUBLISHER=${IMG_PUBLISHER} \
+      -e IMG_OFFER=${IMG_OFFER} \
+      -e IMG_SKU=${IMG_SKU} \
+      -e IMG_VERSION=${IMG_VERSION} \
+      -e MODE=$(MODE) \
+      -e SIG_GALLERY_NAME=${SIG_GALLERY_NAME} \
+      -e SIG_IMAGE_NAME=${SIG_IMAGE_NAME} \
+      -e BRANCH=$(Build.SourceBranch) \
+      -e SIG_IMAGE_VERSION=${SIG_IMAGE_VERSION} \
+      -e CONTAINER_RUNTIME=${CONTAINER_RUNTIME} \
+      -e TELEPORTD_PLUGIN_DOWNLOAD_URL=${TELEPORTD_PLUGIN_DOWNLOAD_URL} \
+      -e ENABLE_FIPS=${ENABLE_FIPS} \
+      -e ARCHITECTURE=${ARCHITECTURE} \
+      -e ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH} \
+      -e SGX_INSTALL=${SGX_INSTALL} \
+      -e ENABLE_CGROUPV2=${ENABLE_CGROUPV2} \
+      -e IMAGE_VERSION=${IMAGE_VERSION} \
+      -e PRIVATE_PACKAGES_URL="${PRIVATE_PACKAGES_URL}" \
+      -e AZURE_MSI_RESOURCE_STRING=${AZURE_MSI_RESOURCE_STRING} \
         ${CONTAINER_IMAGE} make -f packer.mk run-packer
     retryCountOnTaskFailure: 3
     displayName: Building VHD

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -108,6 +108,7 @@ steps:
     displayName: Set SKU Name
   - bash: |
         echo MODE=$(MODE) && \
+        az --version && \
         docker run --rm \
         -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
         -v /usr/local/bin/packer:/usr/local/bin/packer \

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -158,9 +158,6 @@ steps:
         echo "##vso[task.setvariable variable=CAPTURED_SIG_VERSION]$captured_sig_version"
         echo "##vso[task.setvariable variable=SIG_IMAGE_NAME]$SIG_IMAGE_NAME"
         echo "##vso[task.setvariable variable=SIG_GALLERY_NAME]$SIG_GALLERY_NAME"
-        echo "CAPTURED_SIG_VERSION is $CAPTURED_SIG_VERSION"
-        echo "SIG_IMAGE_NAME is $SIG_IMAGE_NAME"
-        echo "SIG_GALLERY_NAME is $SIG_GALLERY_NAME"
     retryCountOnTaskFailure: 1
     displayName: Set Stage Variables
   - bash: |

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -280,20 +280,24 @@ steps:
     displayName: Copy image bom
   - bash: |
         echo MODE=$(MODE) && \
-        make -f packer.mk convert-sig-to-classic-storage-account-blob
-    env:
-      SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
-      RESOURCE_GROUP_NAME: $(AZURE_RESOURCE_GROUP_NAME)
-      PACKER_BUILD_LOCATION: $(PACKER_BUILD_LOCATION)
-      OS_TYPE: Linux
-      CLASSIC_BLOB: $(CLASSIC_BLOB)
-      SIG_GALLERY_NAME: $(SIG_GALLERY_NAME)
-      SIG_IMAGE_NAME: $(SIG_IMAGE_NAME)
-      CAPTURED_SIG_VERSION: $(CAPTURED_SIG_VERSION)
-      ENABLE_TRUSTED_LAUNCH: $(ENABLE_TRUSTED_LAUNCH)
-      AZURE_MSI_RESOURCE_STRING: $(AZURE_MSI_RESOURCE_STRING)
+        captured_sig_version="$(cat vhdbuilder/packer/settings.json | grep "captured_sig_version" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
+        SIG_GALLERY_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_gallery_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
+        SIG_IMAGE_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_image_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
+        docker run --rm \
+        -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
+        -w /go/src/github.com/Azure/AgentBaker \
+        -e SUBSCRIPTION_ID="${SUBSCRIPTION_ID}" \
+        -e RESOURCE_GROUP_NAME="${AZURE_RESOURCE_GROUP_NAME}" \
+        -e PACKER_BUILD_LOCATION="${PACKER_BUILD_LOCATION}" \
+        -e OS_TYPE="Linux" \
+        -e CLASSIC_BLOB=${CLASSIC_BLOB} \
+        -e SIG_GALLERY_NAME=${SIG_GALLERY_NAME} \
+        -e SIG_IMAGE_NAME=${SIG_IMAGE_NAME} \
+        -e CAPTURED_SIG_VERSION=${captured_sig_version} \
+        -e ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH} \
+        -e AZURE_MSI_RESOURCE_STRING=$(AZURE_MSI_RESOURCE_ID) \
+        ${CONTAINER_IMAGE} make -f packer.mk convert-sig-to-classic-storage-account-blob
     displayName: Convert Shared Image Gallery To VHD Blob In Classic Storage Account
-    condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))
   - bash: |
       echo MODE=$(MODE) && \
       captured_sig_version="$(cat vhdbuilder/packer/settings.json | grep "captured_sig_version" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -81,6 +81,7 @@ steps:
       ls -R
     displayName: show Directory
   - bash: |
+      lsb_release -a
       set -x
       GOPATH="$(go env GOPATH)"
       echo "GOPATH is currently set to $GOPATH"

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -109,6 +109,7 @@ steps:
   - bash: |
         echo MODE=$(MODE) && \
         az --version && \
+        which az && \
         docker run --rm \
         -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
         -v /usr/local/bin/packer:/usr/local/bin/packer \

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -113,7 +113,6 @@ steps:
       echo MODE=$(MODE) && \
       docker run --rm \
       -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
-      -v /usr/local/bin/packer:/usr/local/bin/packer \
       -w /go/src/github.com/Azure/AgentBaker \
       -e POOL_NAME=$(POOL_NAME) \
       -e SUBSCRIPTION_ID="${SUBSCRIPTION_ID}" \

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -44,7 +44,6 @@ steps:
     displayName: Apply Overrides
     condition: eq('${{ parameters.useOverrides }}', true)
   - bash: |
-        which go
         m="linuxVhdMode" && \
         echo "Set build mode to $m" && \
         echo "##vso[task.setvariable variable=MODE]$m"
@@ -109,8 +108,6 @@ steps:
     displayName: Set SKU Name
   - bash: |
         echo MODE=$(MODE) && \
-        az --version && \
-        which az && \
         docker run --rm \
         -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
         -v /usr/local/bin/packer:/usr/local/bin/packer \
@@ -280,6 +277,7 @@ steps:
         -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
         -v /usr/local/bin/azcopy:/usr/local/bin/azcopy \
         -v /usr/bin/az:/usr/bin/az \
+        -v /usr/bin/go:/usr/bin/go \
         -w /go/src/github.com/Azure/AgentBaker \
         -e SUBSCRIPTION_ID="${SUBSCRIPTION_ID}" \
         -e RESOURCE_GROUP_NAME="${AZURE_RESOURCE_GROUP_NAME}" \

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -44,9 +44,10 @@ steps:
     displayName: Apply Overrides
     condition: eq('${{ parameters.useOverrides }}', true)
   - bash: |
-      m="linuxVhdMode" && \
-      echo "Set build mode to $m" && \
-      echo "##vso[task.setvariable variable=MODE]$m"
+        which go
+        m="linuxVhdMode" && \
+        echo "Set build mode to $m" && \
+        echo "##vso[task.setvariable variable=MODE]$m"
     displayName: Get Build Mode
   - task: UniversalPackages@0
     displayName: Download Asc Baseline
@@ -278,6 +279,7 @@ steps:
         docker run --rm \
         -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
         -v /usr/local/bin/azcopy:/usr/local/bin/azcopy \
+        -v /usr/bin/az:/usr/bin/az \
         -w /go/src/github.com/Azure/AgentBaker \
         -e SUBSCRIPTION_ID="${SUBSCRIPTION_ID}" \
         -e RESOURCE_GROUP_NAME="${AZURE_RESOURCE_GROUP_NAME}" \

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -109,6 +109,12 @@ steps:
     displayName: Set SKU Name
   - bash: |
         echo MODE=$(MODE) && \
+        captured_sig_version="$(cat vhdbuilder/packer/settings.json | grep "captured_sig_version" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
+        SIG_GALLERY_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_gallery_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
+        SIG_IMAGE_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_image_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
+        echo "##vso[task.setvariable variable=CAPTURED_SIG_VERSION]$captured_sig_version"
+        echo "##vso[task.setvariable variable=SIG_IMAGE_NAME]$SIG_IMAGE_NAME"
+        echo "##vso[task.setvariable variable=SIG_GALLERY_NAME]$SIG_GALLERY_NAME"
         docker run --rm \
         -v ${PWD}:/go/src/github.com/Azure/AgentBaker \
         -v /usr/local/bin/packer:/usr/local/bin/packer \
@@ -271,12 +277,6 @@ steps:
     displayName: Copy image bom
   - bash: |
         echo MODE=$(MODE) && \
-        pwd && \
-        captured_sig_version="$(cat vhdbuilder/packer/settings.json | grep "captured_sig_version" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
-        SIG_GALLERY_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_gallery_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
-        SIG_IMAGE_NAME="$(cat vhdbuilder/packer/settings.json | grep "sig_image_name" | awk -F':' '{print $2}' | awk -F'"' '{print $2}')" && \
-        echo "${captured_sig_version}" && \
-        echo "${SIG_IMAGE_NAME}" && \
         make -f packer.mk convert-sig-to-classic-storage-account-blob
     env:
       SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
@@ -286,7 +286,7 @@ steps:
       CLASSIC_BLOB: $(CLASSIC_BLOB)
       SIG_GALLERY_NAME: $(SIG_GALLERY_NAME)
       SIG_IMAGE_NAME: $(SIG_IMAGE_NAME)
-      CAPTURED_SIG_VERSION: $(captured_sig_version)
+      CAPTURED_SIG_VERSION: $(CAPTURED_SIG_VERSION)
       ENABLE_TRUSTED_LAUNCH: $(ENABLE_TRUSTED_LAUNCH)
       AZURE_MSI_RESOURCE_STRING: $(AZURE_MSI_RESOURCE_STRING)
     displayName: Convert Shared Image Gallery To VHD Blob In Classic Storage Account

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -147,6 +147,7 @@ steps:
       -e IMAGE_VERSION=${IMAGE_VERSION} \
       -e PRIVATE_PACKAGES_URL="${PRIVATE_PACKAGES_URL}" \
       -e AZURE_MSI_RESOURCE_STRING=${AZURE_MSI_RESOURCE_STRING} \
+      -e USE_SHALLOW_REPLICATION=${{ parameters.useShallowReplication }} \
       ${CONTAINER_IMAGE} make -f packer.mk run-packer
     retryCountOnTaskFailure: 3
     displayName: Building VHD

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -161,8 +161,8 @@ steps:
         echo "CAPTURED_SIG_VERSION is $CAPTURED_SIG_VERSION"
         echo "SIG_IMAGE_NAME is $SIG_IMAGE_NAME"
         echo "SIG_GALLERY_NAME is $SIG_GALLERY_NAME"
-  retryCountOnTaskFailure: 1
-  displayName: Set Stage Variables
+    retryCountOnTaskFailure: 1
+    displayName: Set Stage Variables
   - bash: |
       OS_DISK_URI="$(cat packer-output | grep "OSDiskUri:" | cut -d " " -f 2)" && \
       MANAGED_SIG_ID="$(cat packer-output | grep "ManagedImageSharedImageGalleryId:" | cut -d " " -f 2)" && \

--- a/packer.mk
+++ b/packer.mk
@@ -76,7 +76,8 @@ init-packer:
 	@./vhdbuilder/packer/init-variables.sh
 
 run-packer: az-login
-	@packer init ./vhdbuilder/packer/linux-packer-plugin.pkr.hcl && packer version && ($(MAKE) -f packer.mk init-packer | tee packer-output) && ($(MAKE) -f packer.mk build-packer | tee -a packer-output)
+	@packer init ./vhdbuilder/packer/linux-packer-plugin.pkr.hcl
+	@packer version && ($(MAKE) -f packer.mk init-packer | tee packer-output) && ($(MAKE) -f packer.mk build-packer | tee -a packer-output)
 
 run-packer-windows: az-login
 	@packer init ./vhdbuilder/packer/packer-plugin.pkr.hcl && packer version && ($(MAKE) -f packer.mk init-packer | tee packer-output) && ($(MAKE) -f packer.mk build-packer-windows | tee -a packer-output)

--- a/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
+++ b/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
@@ -88,7 +88,7 @@ echo "Setting azcopy environment variables with pool identity: $AZURE_MSI_RESOUR
 
 echo "Uploading $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
 
-azcopy login --login-type="MSI"
+azcopy login --login-type=MSI
 azcopy copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?
 
 echo "Uploaded $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"

--- a/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
+++ b/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
@@ -83,7 +83,8 @@ echo "Granting access to $disk_resource_id for 1 hour"
 # shellcheck disable=SC2102
 sas=$(az disk grant-access --ids $disk_resource_id --duration-in-seconds 3600 --query [accessSas] -o tsv)
 
-azcopy login --login-type=MSI
+export AZCOPY_AUTO_LOGIN_TYPE="MSI"
+export AZCOPY_MSI_RESOURCE_STRING="$AZURE_MSI_RESOURCE_STRING"
 
 echo "Uploading $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
 azcopy copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?

--- a/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
+++ b/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
@@ -85,10 +85,9 @@ sas=$(az disk grant-access --ids $disk_resource_id --duration-in-seconds 3600 --
 
 # TBD: Need to investigate why `azcopy-preview login --login-type=MSI` does not work
 echo "Setting azcopy environment variables with pool identity: $AZURE_MSI_RESOURCE_STRING"
-azcopy login --identity
 
 echo "Uploading $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
-azcopy copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?
+azcopy copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true --login-type=MSI || exit $?
 
 echo "Uploaded $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
 

--- a/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
+++ b/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
@@ -83,21 +83,13 @@ echo "Granting access to $disk_resource_id for 1 hour"
 # shellcheck disable=SC2102
 sas=$(az disk grant-access --ids $disk_resource_id --duration-in-seconds 3600 --query [accessSas] -o tsv)
 
+# TBD: Need to investigate why `azcopy-preview login --login-type=MSI` does not work
+echo "Setting azcopy environment variables with pool identity: $AZURE_MSI_RESOURCE_STRING"
+export AZCOPY_AUTO_LOGIN_TYPE="MSI"
+export AZCOPY_MSI_RESOURCE_STRING="$AZURE_MSI_RESOURCE_STRING"
+
 echo "Uploading $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
-
-if [ "${OS_TYPE,,}" == "linux" ]; then
-  # Use azcopy login for Linux
-  azcopy login --login-type=MSI
-  azcopy copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?
-else
-  # Use azcopy-preview for Windows
-  # TBD: Need to investigate why `azcopy-preview login --login-type=MSI` does not work
-  echo "Setting azcopy environment variables with pool identity: $AZURE_MSI_RESOURCE_STRING"
-  export AZCOPY_AUTO_LOGIN_TYPE="MSI"
-  export AZCOPY_MSI_RESOURCE_STRING="$AZURE_MSI_RESOURCE_STRING"
-
-  azcopy-preview copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?
-fi
+azcopy-preview copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?
 
 echo "Uploaded $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
 

--- a/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
+++ b/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
@@ -83,11 +83,13 @@ echo "Granting access to $disk_resource_id for 1 hour"
 # shellcheck disable=SC2102
 sas=$(az disk grant-access --ids $disk_resource_id --duration-in-seconds 3600 --query [accessSas] -o tsv)
 
+# TBD: Need to investigate why `azcopy-preview login --login-type=MSI` does not work
+echo "Setting azcopy environment variables with pool identity: $AZURE_MSI_RESOURCE_STRING"
 export AZCOPY_AUTO_LOGIN_TYPE="MSI"
 export AZCOPY_MSI_RESOURCE_STRING="$AZURE_MSI_RESOURCE_STRING"
 
 echo "Uploading $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
-azcopy copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?
+azcopy-preview copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?
 
 echo "Uploaded $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
 

--- a/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
+++ b/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
@@ -87,7 +87,9 @@ sas=$(az disk grant-access --ids $disk_resource_id --duration-in-seconds 3600 --
 echo "Setting azcopy environment variables with pool identity: $AZURE_MSI_RESOURCE_STRING"
 
 echo "Uploading $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
-azcopy copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true --login-type=MSI || exit $?
+
+azcopy login --login-type="MSI"
+azcopy copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?
 
 echo "Uploaded $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
 

--- a/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
+++ b/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
@@ -85,8 +85,7 @@ sas=$(az disk grant-access --ids $disk_resource_id --duration-in-seconds 3600 --
 
 # TBD: Need to investigate why `azcopy-preview login --login-type=MSI` does not work
 echo "Setting azcopy environment variables with pool identity: $AZURE_MSI_RESOURCE_STRING"
-export AZCOPY_AUTO_LOGIN_TYPE="MSI"
-export AZCOPY_MSI_RESOURCE_STRING="$AZURE_MSI_RESOURCE_STRING"
+azcopy login --identity
 
 echo "Uploading $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
 azcopy copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?

--- a/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
+++ b/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
@@ -83,10 +83,7 @@ echo "Granting access to $disk_resource_id for 1 hour"
 # shellcheck disable=SC2102
 sas=$(az disk grant-access --ids $disk_resource_id --duration-in-seconds 3600 --query [accessSas] -o tsv)
 
-# TBD: Need to investigate why `azcopy-preview login --login-type=MSI` does not work
-echo "Setting azcopy environment variables with pool identity: $AZURE_MSI_RESOURCE_STRING"
-export AZCOPY_AUTO_LOGIN_TYPE="MSI"
-export AZCOPY_MSI_RESOURCE_STRING="$AZURE_MSI_RESOURCE_STRING"
+azcopy login --identity
 
 echo "Uploading $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
 azcopy copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?

--- a/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
+++ b/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
@@ -89,7 +89,7 @@ export AZCOPY_AUTO_LOGIN_TYPE="MSI"
 export AZCOPY_MSI_RESOURCE_STRING="$AZURE_MSI_RESOURCE_STRING"
 
 echo "Uploading $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
-azcopy-preview copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?
+azcopy copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?
 
 echo "Uploaded $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
 

--- a/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
+++ b/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
@@ -86,7 +86,7 @@ sas=$(az disk grant-access --ids $disk_resource_id --duration-in-seconds 3600 --
 # TBD: Need to investigate why `azcopy-preview login --login-type=MSI` does not work
 echo "Setting azcopy environment variables with pool identity: $AZURE_MSI_RESOURCE_STRING"
 export AZCOPY_AUTO_LOGIN_TYPE="MSI"
-export AZCOPY_MSI_RESOURCE_STRING="$AZURE_MSI_RESOURCE_STRING"
+export AZCOPY_MSI_RESOURCE_STRING="${AZURE_MSI_RESOURCE_STRING}"
 
 echo "Uploading $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
 azcopy-preview copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?

--- a/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
+++ b/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
@@ -83,7 +83,7 @@ echo "Granting access to $disk_resource_id for 1 hour"
 # shellcheck disable=SC2102
 sas=$(az disk grant-access --ids $disk_resource_id --duration-in-seconds 3600 --query [accessSas] -o tsv)
 
-azcopy login --identity
+azcopy login --login-type=MSI
 
 echo "Uploading $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
 azcopy copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?

--- a/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
+++ b/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
@@ -86,7 +86,7 @@ sas=$(az disk grant-access --ids $disk_resource_id --duration-in-seconds 3600 --
 # TBD: Need to investigate why `azcopy-preview login --login-type=MSI` does not work
 echo "Setting azcopy environment variables with pool identity: $AZURE_MSI_RESOURCE_STRING"
 export AZCOPY_AUTO_LOGIN_TYPE="MSI"
-export AZCOPY_MSI_RESOURCE_STRING="${AZURE_MSI_RESOURCE_STRING}"
+export AZCOPY_MSI_RESOURCE_STRING="$AZURE_MSI_RESOURCE_STRING"
 
 echo "Uploading $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"
 azcopy-preview copy "${sas}" "${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true || exit $?

--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -113,13 +113,7 @@ if [ -z "${SUBNET_NAME}" ]; then
 	SUBNET_NAME="packer"
 fi
 
-USE_SHALLOW_REPLICATION="false"
-if [[ "${OS_TYPE,,}" == "linux" ]] && [[ "${ENVIRONMENT,,}" == "test" ]]; then
-  # only use shallow replication in test for now
-  USE_SHALLOW_REPLICATION="true"
-fi
-
-echo "SHALLOW_REPLICATION set to: ${USE_SHALLOW_REPLICATION}"
+echo "USE_SHALLOW_REPLICATION set to: ${USE_SHALLOW_REPLICATION}"
 
 echo "VNET_RG_NAME set to: ${VNET_RG_NAME}"
 

--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -113,7 +113,11 @@ if [ -z "${SUBNET_NAME}" ]; then
 	SUBNET_NAME="packer"
 fi
 
-SHALLOW_REPLICATION="true"
+SHALLOW_REPLICATION="false"
+if [[ "${OS_TYPE,,}" == "linux" ]] && [[ "${ENVIRONMENT,,}" == "test" ]]; then
+  # only use shallow replication in test for now
+  SHALLOW_REPLICATION="true"
+fi
 
 echo "SHALLOW_REPLICATION set to: ${SHALLOW_REPLICATION}"
 

--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -113,13 +113,9 @@ if [ -z "${SUBNET_NAME}" ]; then
 	SUBNET_NAME="packer"
 fi
 
-SHALLOW_REPLICATION_TOGGLE="false"
-if [[ "${MODE}" == "linuxVhdMode" ]] && [[ "${ENVIRONMENT,,}" == "test" ]]; then
-  # continue using full replication for prod builds for now
-  SHALLOW_REPLICATION_TOGGLE="true"
-fi
+SHALLOW_REPLICATION="true"
 
-echo "SHALLOW_REPLICATION_TOGGLE set to: ${SHALLOW_REPLICATION_TOGGLE}"
+echo "SHALLOW_REPLICATION set to: ${SHALLOW_REPLICATION}"
 
 echo "VNET_RG_NAME set to: ${VNET_RG_NAME}"
 
@@ -484,7 +480,7 @@ fi
 # aks_windows_image_version refers to the version built by AKS Windows SIG
 cat <<EOF > vhdbuilder/packer/settings.json
 { 
-  "shallow_replication_toggle": "${SHALLOW_REPLICATION_TOGGLE}",
+  "shallow_replication": "${SHALLOW_REPLICATION}",
   "subscription_id":  "${SUBSCRIPTION_ID}",
   "resource_group_name": "${AZURE_RESOURCE_GROUP_NAME}",
   "location": "${PACKER_BUILD_LOCATION}",

--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -113,13 +113,13 @@ if [ -z "${SUBNET_NAME}" ]; then
 	SUBNET_NAME="packer"
 fi
 
-SHALLOW_REPLICATION="false"
+USE_SHALLOW_REPLICATION="false"
 if [[ "${OS_TYPE,,}" == "linux" ]] && [[ "${ENVIRONMENT,,}" == "test" ]]; then
   # only use shallow replication in test for now
-  SHALLOW_REPLICATION="true"
+  USE_SHALLOW_REPLICATION="true"
 fi
 
-echo "SHALLOW_REPLICATION set to: ${SHALLOW_REPLICATION}"
+echo "SHALLOW_REPLICATION set to: ${USE_SHALLOW_REPLICATION}"
 
 echo "VNET_RG_NAME set to: ${VNET_RG_NAME}"
 
@@ -484,7 +484,7 @@ fi
 # aks_windows_image_version refers to the version built by AKS Windows SIG
 cat <<EOF > vhdbuilder/packer/settings.json
 { 
-  "shallow_replication": "${SHALLOW_REPLICATION}",
+  "use_shallow_replication": "${USE_SHALLOW_REPLICATION}",
   "subscription_id":  "${SUBSCRIPTION_ID}",
   "resource_group_name": "${AZURE_RESOURCE_GROUP_NAME}",
   "location": "${PACKER_BUILD_LOCATION}",

--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -30,7 +30,7 @@
     "private_packages_url": "{{env `PRIVATE_PACKAGES_URL`}}",
     "branch": "{{env `BRANCH`}}",
     "vhd_build_timestamp": "{{user `VHD_BUILD_TIMESTAMP`}}",
-    "shallow_replication_toggle": "{{env `SHALLOW_REPLICATION_TOGGLE`}}"
+    "shallow_replication": "{{env `SHALLOW_REPLICATION`}}"
   },
   "builders": [
     {
@@ -62,7 +62,7 @@
       "polling_duration_timeout": "1h",
       "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
-        "use_shallow_replication": "{{user `shallow_replication_toggle`}}",
+        "use_shallow_replication": "{{user `shallow_replication`}}",
         "resource_group": "{{user `resource_group_name`}}",
         "gallery_name": "{{user `sig_gallery_name`}}",
         "image_name": "{{user `sig_image_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -30,7 +30,7 @@
     "private_packages_url": "{{env `PRIVATE_PACKAGES_URL`}}",
     "branch": "{{env `BRANCH`}}",
     "vhd_build_timestamp": "{{user `VHD_BUILD_TIMESTAMP`}}",
-    "shallow_replication": "{{env `SHALLOW_REPLICATION`}}"
+    "use_shallow_replication": "{{env `USE_SHALLOW_REPLICATION`}}"
   },
   "builders": [
     {
@@ -62,7 +62,7 @@
       "polling_duration_timeout": "1h",
       "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
-        "use_shallow_replication": "{{user `shallow_replication`}}",
+        "use_shallow_replication": "{{user `use_shallow_replication`}}",
         "resource_group": "{{user `resource_group_name`}}",
         "gallery_name": "{{user `sig_gallery_name`}}",
         "image_name": "{{user `sig_image_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -62,7 +62,6 @@
       "polling_duration_timeout": "1h",
       "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
-      "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
         "use_shallow_replication": "{{user `shallow_replication_toggle`}}",
         "resource_group": "{{user `resource_group_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -30,7 +30,7 @@
     "private_packages_url": "{{env `PRIVATE_PACKAGES_URL`}}",
     "branch": "{{env `BRANCH`}}",
     "vhd_build_timestamp": "{{user `VHD_BUILD_TIMESTAMP`}}",
-    "shallow_replication_toggle": "{{env `SHALLOW_REPLICATION_TOGGLE`}}"
+    "shallow_replication": "{{env `SHALLOW_REPLICATION`}}"
   },
   "builders": [
     {
@@ -63,7 +63,7 @@
       "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "shared_image_gallery_destination": {
-        "use_shallow_replication": "{{user `shallow_replication_toggle`}}",
+        "use_shallow_replication": "{{user `shallow_replication`}}",
         "resource_group": "{{user `resource_group_name`}}",
         "gallery_name": "{{user `sig_gallery_name`}}",
         "image_name": "{{user `sig_image_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -30,7 +30,7 @@
     "private_packages_url": "{{env `PRIVATE_PACKAGES_URL`}}",
     "branch": "{{env `BRANCH`}}",
     "vhd_build_timestamp": "{{user `VHD_BUILD_TIMESTAMP`}}",
-    "shallow_replication": "{{env `SHALLOW_REPLICATION`}}"
+    "use_shallow_replication": "{{env `USE_SHALLOW_REPLICATION`}}"
   },
   "builders": [
     {
@@ -64,7 +64,7 @@
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
-        "use_shallow_replication": "{{user `shallow_replication`}}",
+        "use_shallow_replication": "{{user `use_shallow_replication`}}",
         "resource_group": "{{user `resource_group_name`}}",
         "gallery_name": "{{user `sig_gallery_name`}}",
         "image_name": "{{user `sig_image_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -62,6 +62,7 @@
       "polling_duration_timeout": "1h",
       "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
+      "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
         "use_shallow_replication": "{{user `shallow_replication`}}",
         "resource_group": "{{user `resource_group_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
@@ -29,7 +29,7 @@
     "enable_cgroupv2": "{{env `ENABLE_CGROUPV2`}}",
     "private_packages_url": "{{env `PRIVATE_PACKAGES_URL`}}",
     "branch": "{{env `BRANCH`}}",
-    "shallow_replication": "{{env `SHALLOW_REPLICATION`}}"
+    "use_shallow_replication": "{{env `USE_SHALLOW_REPLICATION`}}"
   },
   "builders": [
     {
@@ -61,7 +61,7 @@
       "polling_duration_timeout": "1h",
       "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
-        "use_shallow_replication": "{{user `shallow_replication`}}",
+        "use_shallow_replication": "{{user `use_shallow_replication`}}",
         "resource_group": "{{user `resource_group_name`}}",
         "gallery_name": "{{user `sig_gallery_name`}}",
         "image_name": "{{user `sig_image_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
@@ -29,7 +29,7 @@
     "enable_cgroupv2": "{{env `ENABLE_CGROUPV2`}}",
     "private_packages_url": "{{env `PRIVATE_PACKAGES_URL`}}",
     "branch": "{{env `BRANCH`}}",
-    "shallow_replication_toggle": "{{env `SHALLOW_REPLICATION_TOGGLE`}}"
+    "shallow_replication": "{{env `SHALLOW_REPLICATION`}}"
   },
   "builders": [
     {
@@ -61,7 +61,7 @@
       "polling_duration_timeout": "1h",
       "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
-        "use_shallow_replication": "{{user `shallow_replication_toggle`}}",
+        "use_shallow_replication": "{{user `shallow_replication`}}",
         "resource_group": "{{user `resource_group_name`}}",
         "gallery_name": "{{user `sig_gallery_name`}}",
         "image_name": "{{user `sig_image_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -29,7 +29,7 @@
     "enable_cgroupv2": "{{env `ENABLE_CGROUPV2`}}",
     "private_packages_url": "{{env `PRIVATE_PACKAGES_URL`}}",
     "branch": "{{env `BRANCH`}}",
-    "shallow_replication_toggle": "{{env `SHALLOW_REPLICATION_TOGGLE`}}"
+    "shallow_replication": "{{env `SHALLOW_REPLICATION`}}"
   },
   "builders": [
     {
@@ -63,7 +63,7 @@
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
-        "use_shallow_replication": "{{user `shallow_replication_toggle`}}",
+        "use_shallow_replication": "{{user `shallow_replication`}}",
         "resource_group": "{{user `resource_group_name`}}",
         "gallery_name": "{{user `sig_gallery_name`}}",
         "image_name": "{{user `sig_image_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -29,7 +29,7 @@
     "enable_cgroupv2": "{{env `ENABLE_CGROUPV2`}}",
     "private_packages_url": "{{env `PRIVATE_PACKAGES_URL`}}",
     "branch": "{{env `BRANCH`}}",
-    "shallow_replication": "{{env `SHALLOW_REPLICATION`}}"
+    "use_shallow_replication": "{{env `USE_SHALLOW_REPLICATION`}}"
   },
   "builders": [
     {
@@ -63,7 +63,7 @@
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
-        "use_shallow_replication": "{{user `shallow_replication`}}",
+        "use_shallow_replication": "{{user `use_shallow_replication`}}",
         "resource_group": "{{user `resource_group_name`}}",
         "gallery_name": "{{user `sig_gallery_name`}}",
         "image_name": "{{user `sig_image_name`}}",


### PR DESCRIPTION
**What type of PR is this?**

/kind perf

**What this PR does / why we need it**:

This PR enables the use of shallow replication in all VHD build pipelines in order to reduce feedback time / increase productivity. Enabling shallow replication decreases pipeline duration by 10-13 minutes depending on the run. Averages derived from 3 runs from master and 3 from this branch.

This is accomplished by installing the azure-arm plugin for packer, which enables the use of shallow replication.

**Which issue(s) this PR fixes**:

Unsatisfactory VHD Build Times.

**Requirements**:

- [x ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ x] tested upgrade from previous version
