### PR TITLE
test: allow filtering tests by a tag

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -3,19 +3,17 @@ package config
 import (
 	"os"
 	"strings"
-
-	"github.com/Azure/agentbakere2e/toolkit"
 )
 
 var (
-	BuildID            = getEnvWithDefaultIfEmpty(os.Getenv("BUILD_ID"), "local")
-	SubscriptionID     = getEnvWithDefaultIfEmpty("SUBSCRIPTION_ID", "8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8")
-	Location           = getEnvWithDefaultIfEmpty("LOCATION", "eastus")
-	ResourceGroupName  = "abe2e-" + Location
-	ScenariosToRun     = envmap("SCENARIOS_TO_RUN")
-	ScenariosToExclude = envmap("SCENARIOS_TO_EXCLUDE")
-	KeepVMSS           = strings.EqualFold(os.Getenv("KEEP_VMSS"), "true")
-	Azure              = MustNewAzureClient(SubscriptionID)
+	BuildID           = getEnvWithDefaultIfEmpty(os.Getenv("BUILD_ID"), "local")
+	SubscriptionID    = getEnvWithDefaultIfEmpty("SUBSCRIPTION_ID", "8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8")
+	Location          = getEnvWithDefaultIfEmpty("LOCATION", "eastus")
+	ResourceGroupName = "abe2e-" + Location
+	TagsToRun         = os.Getenv("TAGS_TO_RUN")
+	TagsToSkip        = os.Getenv("TAGS_TO_SKIP")
+	KeepVMSS          = strings.EqualFold(os.Getenv("KEEP_VMSS"), "true")
+	Azure             = MustNewAzureClient(SubscriptionID)
 	// ADO tags every SIG image version with `branch` tag. By specifying `branch=refs/heads/master` we load latest image version from the master branch.
 	SIGVersionTagName             = getEnvWithDefaultIfEmpty("SIG_VERSION_TAG_NAME", "branch")
 	SIGVersionTagValue            = getEnvWithDefaultIfEmpty("SIG_VERSION_TAG_VALUE", "refs/heads/master")
@@ -28,12 +26,4 @@ func getEnvWithDefaultIfEmpty(env string, defaultValue string) string {
 		return defaultValue
 	}
 	return val
-}
-
-func envmap(env string) map[string]bool {
-	envVal := os.Getenv(env)
-	if envVal == "" {
-		return nil
-	}
-	return toolkit.StrToBoolMap(envVal)
 }

--- a/e2e/scenario/scenario.go
+++ b/e2e/scenario/scenario.go
@@ -54,5 +54,6 @@ func AllScenarios() []*Scenario {
 		ubuntu2204gpu("ubuntu2204-gpu-ncv3", "Standard_NC6s_v3"),
 		ubuntu2204gpu("ubuntu2204-gpu-a100", "Standard_NC24ads_A100_v4"),
 		ubuntu2204gpu("ubuntu2204-gpu-a10", "Standard_NV6ads_A10_v5"),
+		ubuntu2204GPUGridDriver(),
 	}
 }

--- a/e2e/scenario/scenario_azurelinuxv2-airgap.go
+++ b/e2e/scenario/scenario_azurelinuxv2-airgap.go
@@ -9,6 +9,12 @@ func azurelinuxv2AirGap() *Scenario {
 	return &Scenario{
 		Name:        "azurelinuxv2-airgap",
 		Description: "Tests that a node using a AzureLinuxV2 (CgroupV2) VHD can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "azurelinuxv2-airgap",
+			OS:       "azurelinuxv2",
+			Platform: "x64",
+			Airgap:   true,
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_azurelinuxv2-arm64-airgap.go
+++ b/e2e/scenario/scenario_azurelinuxv2-arm64-airgap.go
@@ -11,6 +11,12 @@ func azurelinuxv2ARM64AirGap() *Scenario {
 	return &Scenario{
 		Name:        "azurelinuxv2-arm64-airgap",
 		Description: "Tests that a node using a AzureLinuxV2 (CgroupV2) VHD on ARM64 architecture can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "azurelinuxv2-arm64-airgap",
+			OS:       "azurelinuxv2",
+			Platform: "arm64",
+			Airgap:   true,
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_azurelinuxv2-arm64.go
+++ b/e2e/scenario/scenario_azurelinuxv2-arm64.go
@@ -11,6 +11,11 @@ func azurelinuxv2ARM64() *Scenario {
 	return &Scenario{
 		Name:        "azurelinuxv2-arm64",
 		Description: "Tests that a node using a AzureLinuxV2 (CgroupV2) VHD on ARM64 architecture can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "azurelinuxv2-arm64",
+			OS:       "azurelinuxv2",
+			Platform: "arm64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_azurelinuxv2-azurecni.go
+++ b/e2e/scenario/scenario_azurelinuxv2-azurecni.go
@@ -10,6 +10,11 @@ func azurelinuxv2_azurecni() *Scenario {
 	return &Scenario{
 		Name:        "azurelinuxv2-azurecni",
 		Description: "azurelinuxv2 scenario on a cluster configured with Azure CNI",
+		Tags: Tags{
+			Name:     "azurelinuxv2-azurecni",
+			OS:       "azurelinuxv2",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginAzureSelector,
 			ClusterMutator:  NetworkPluginAzureMutator,

--- a/e2e/scenario/scenario_azurelinuxv2-chrony-restarts.go
+++ b/e2e/scenario/scenario_azurelinuxv2-chrony-restarts.go
@@ -9,6 +9,11 @@ func azurelinuxv2ChronyRestarts() *Scenario {
 	return &Scenario{
 		Name:        "azurelinuxv2-chrony-restarts",
 		Description: "Tests that the chrony service restarts if it is killed",
+		Tags: Tags{
+			Name:     "azurelinuxv2-chrony-restarts",
+			OS:       "azurelinuxv2",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_azurelinuxv2-custom-sysctls.go
+++ b/e2e/scenario/scenario_azurelinuxv2-custom-sysctls.go
@@ -22,6 +22,11 @@ func azurelinuxv2CustomSysctls() *Scenario {
 	return &Scenario{
 		Name:        "azurelinuxv2-custom-sysctls",
 		Description: "tests that a AzureLinuxV2 (CgroupV2) VHD can be properly bootstrapped when supplied custom node config that contains custom sysctl settings",
+		Tags: Tags{
+			Name:     "azurelinuxv2-custom-sysctls",
+			OS:       "azurelinuxv2",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_azurelinuxv2-gpu-azurecni.go
+++ b/e2e/scenario/scenario_azurelinuxv2-gpu-azurecni.go
@@ -12,6 +12,7 @@ func azurelinuxv2gpu_azurecni() *Scenario {
 	return &Scenario{
 		Name:        "azurelinuxv2-gpu-azurecni",
 		Description: "AzureLinux V2 (CgroupV2) gpu scenario on cluster configured with Azure CNI",
+		Tags:        Tags{Name: "azurelinuxv2-gpu-azurecni", OS: "azurelinuxv2", Platform: "x64", GPU: true},
 		Config: Config{
 			ClusterSelector: NetworkPluginAzureSelector,
 			ClusterMutator:  NetworkPluginAzureMutator,

--- a/e2e/scenario/scenario_azurelinuxv2-gpu.go
+++ b/e2e/scenario/scenario_azurelinuxv2-gpu.go
@@ -12,6 +12,12 @@ func azurelinuxv2gpu() *Scenario {
 	return &Scenario{
 		Name:        "azurelinuxv2-gpu",
 		Description: "Tests that a GPU-enabled node using a AzureLinuxV2 (CgroupV2) VHD can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "azurelinuxv2-gpu",
+			OS:       "azurelinuxv2",
+			Platform: "x64",
+			GPU:      true,
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_azurelinuxv2-wasm.go
+++ b/e2e/scenario/scenario_azurelinuxv2-wasm.go
@@ -9,6 +9,12 @@ func azurelinuxv2Wasm() *Scenario {
 	return &Scenario{
 		Name:        "azurelinuxv2-wasm",
 		Description: "tests that a new AzureLinuxV2 (CgroupV2) node using krustlet can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "azurelinuxv2-wasm",
+			OS:       "azurelinuxv2",
+			Platform: "x64",
+			WASM:     true,
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_azurelinuxv2.go
+++ b/e2e/scenario/scenario_azurelinuxv2.go
@@ -9,6 +9,11 @@ func azurelinuxv2() *Scenario {
 	return &Scenario{
 		Name:        "azurelinuxv2",
 		Description: "Tests that a node using a AzureLinuxV2 (CgroupV2) VHD can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "azurelinuxv2",
+			OS:       "azurelinuxv2",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_marinerv2-airgap.go
+++ b/e2e/scenario/scenario_marinerv2-airgap.go
@@ -9,6 +9,12 @@ func marinerv2AirGap() *Scenario {
 	return &Scenario{
 		Name:        "marinerv2-airgap",
 		Description: "Tests that a node using a MarinerV2 VHD can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "marinerv2-airgap",
+			OS:       "marinerv2",
+			Platform: "x64",
+			Airgap:   true,
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_marinerv2-arm64-airgap.go
+++ b/e2e/scenario/scenario_marinerv2-arm64-airgap.go
@@ -11,6 +11,12 @@ func marinerv2ARM64AirGap() *Scenario {
 	return &Scenario{
 		Name:        "marinerv2-arm64-airgap",
 		Description: "Tests that a node using a MarinerV2 VHD on ARM64 architecture can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "marinerv2-arm64-airgap",
+			OS:       "marinerv2",
+			Platform: "arm64",
+			Airgap:   true,
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_marinerv2-arm64.go
+++ b/e2e/scenario/scenario_marinerv2-arm64.go
@@ -11,6 +11,11 @@ func marinerv2ARM64() *Scenario {
 	return &Scenario{
 		Name:        "marinerv2-arm64",
 		Description: "Tests that a node using a MarinerV2 VHD on ARM64 architecture can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "marinerv2-arm64",
+			OS:       "marinerv2",
+			Platform: "arm64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_marinerv2-azurecni.go
+++ b/e2e/scenario/scenario_marinerv2-azurecni.go
@@ -10,6 +10,11 @@ func marinerv2_azurecni() *Scenario {
 	return &Scenario{
 		Name:        "marinerv2-azurecni",
 		Description: "marinerv2 scenario on a cluster configured with Azure CNI",
+		Tags: Tags{
+			Name:     "marinerv2-azurecni",
+			OS:       "marinerv2",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginAzureSelector,
 			ClusterMutator:  NetworkPluginAzureMutator,

--- a/e2e/scenario/scenario_marinerv2-chrony-restarts.go
+++ b/e2e/scenario/scenario_marinerv2-chrony-restarts.go
@@ -9,6 +9,11 @@ func marinerv2ChronyRestarts() *Scenario {
 	return &Scenario{
 		Name:        "marinerv2-chrony-restarts",
 		Description: "Tests that the chrony service restarts if it is killed",
+		Tags: Tags{
+			Name:     "marinerv2-chrony-restarts",
+			OS:       "marinerv2",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_marinerv2-custom-sysctls.go
+++ b/e2e/scenario/scenario_marinerv2-custom-sysctls.go
@@ -22,6 +22,11 @@ func marinerv2CustomSysctls() *Scenario {
 	return &Scenario{
 		Name:        "marinerv2-custom-sysctls",
 		Description: "tests that a MarinerV2 VHD can be properly bootstrapped when supplied custom node config that contains custom sysctl settings",
+		Tags: Tags{
+			Name:     "marinerv2-custom-sysctls",
+			OS:       "marinerv2",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_marinerv2-gpu-azurecni.go
+++ b/e2e/scenario/scenario_marinerv2-gpu-azurecni.go
@@ -12,6 +12,12 @@ func marinerv2gpu_azurecni() *Scenario {
 	return &Scenario{
 		Name:        "marinerv2-gpu-azurecni",
 		Description: "MarinerV2 gpu scenario on cluster configured with Azure CNI",
+		Tags: Tags{
+			Name:     "marinerv2-gpu-azurecni",
+			OS:       "marinerv2",
+			Platform: "x64",
+			GPU:      true,
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginAzureSelector,
 			ClusterMutator:  NetworkPluginAzureMutator,

--- a/e2e/scenario/scenario_marinerv2-gpu.go
+++ b/e2e/scenario/scenario_marinerv2-gpu.go
@@ -12,6 +12,12 @@ func marinerv2gpu() *Scenario {
 	return &Scenario{
 		Name:        "marinerv2-gpu",
 		Description: "Tests that a GPU-enabled node using a MarinerV2 VHD can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "marinerv2-gpu",
+			OS:       "marinerv2",
+			Platform: "x64",
+			GPU:      true,
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_marinerv2-wasm.go
+++ b/e2e/scenario/scenario_marinerv2-wasm.go
@@ -9,6 +9,12 @@ func marinerv2Wasm() *Scenario {
 	return &Scenario{
 		Name:        "marinerv2-wasm",
 		Description: "tests that a new marinerv2 node using krustlet can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "marinerv2-wasm",
+			OS:       "marinerv2",
+			Platform: "x64",
+			WASM:     true,
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_marinerv2.go
+++ b/e2e/scenario/scenario_marinerv2.go
@@ -9,6 +9,11 @@ func marinerv2() *Scenario {
 	return &Scenario{
 		Name:        "marinerv2",
 		Description: "Tests that a node using a MarinerV2 VHD can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "marinerv2",
+			OS:       "marinerv2",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu1804-azurecni.go
+++ b/e2e/scenario/scenario_ubuntu1804-azurecni.go
@@ -10,6 +10,11 @@ func ubuntu1804_azurecni() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu1804-azurecni",
 		Description: "ubuntu1804 scenario on cluster configured with Azure CNI",
+		Tags: Tags{
+			Name:     "ubuntu1804-azurecni",
+			OS:       "ubuntu1804",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginAzureSelector,
 			ClusterMutator:  NetworkPluginAzureMutator,

--- a/e2e/scenario/scenario_ubuntu1804-chrony-restarts.go
+++ b/e2e/scenario/scenario_ubuntu1804-chrony-restarts.go
@@ -9,6 +9,11 @@ func ubuntu1804ChronyRestarts() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu1804-chrony-restarts",
 		Description: "Tests that the chrony service restarts if it is killed",
+		Tags: Tags{
+			Name:     "ubuntu1804-chrony-restarts",
+			OS:       "ubuntu1804",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu1804-gpu-azurecni.go
+++ b/e2e/scenario/scenario_ubuntu1804-gpu-azurecni.go
@@ -12,6 +12,12 @@ func ubuntu1804gpu_azurecni() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu1804-gpu-azurecni",
 		Description: "Ubuntu1804 gpu scenario on cluster configured with Azure CNI",
+		Tags: Tags{
+			Name:     "ubuntu1804-gpu-azurecni",
+			OS:       "ubuntu1804",
+			Platform: "x64",
+			GPU:      true,
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginAzureSelector,
 			ClusterMutator:  NetworkPluginAzureMutator,

--- a/e2e/scenario/scenario_ubuntu1804-gpu.go
+++ b/e2e/scenario/scenario_ubuntu1804-gpu.go
@@ -12,6 +12,12 @@ func ubuntu1804gpu() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu1804-gpu",
 		Description: "Tests that a GPU-enabled node using an Ubuntu 1804 VHD can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "ubuntu1804-gpu",
+			OS:       "ubuntu1804",
+			Platform: "x64",
+			GPU:      true,
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu1804.go
+++ b/e2e/scenario/scenario_ubuntu1804.go
@@ -7,6 +7,11 @@ func ubuntu1804() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu1804",
 		Description: "Tests that a node using an Ubuntu 1804 VHD can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "ubuntu1804",
+			OS:       "ubuntu1804",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu2204-airgap.go
+++ b/e2e/scenario/scenario_ubuntu2204-airgap.go
@@ -9,6 +9,12 @@ func ubuntu2204AirGap() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu2204-airgap",
 		Description: "Tests that a node using the Ubuntu 2204 VHD and is airgap can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "ubuntu2204-airgap",
+			OS:       "ubuntu2204",
+			Platform: "x64",
+			Airgap:   true,
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu2204-arm64.go
+++ b/e2e/scenario/scenario_ubuntu2204-arm64.go
@@ -11,6 +11,11 @@ func ubuntu2204ARM64() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu2204-arm64",
 		Description: "Tests that an Ubuntu 2204 Node using ARM64 architecture can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "ubuntu2204-arm64",
+			OS:       "ubuntu2204",
+			Platform: "arm64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu2204-artifact-streaming.go
+++ b/e2e/scenario/scenario_ubuntu2204-artifact-streaming.go
@@ -9,6 +9,11 @@ func ubuntu2204ArtifactStreaming() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu2204-artifact-streaming",
 		Description: "tests that a new ubuntu 2204 node using artifact streaming can be properly bootstrapepd",
+		Tags: Tags{
+			Name:     "ubuntu2204-artifact-streaming",
+			OS:       "ubuntu2204",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu2204-chrony-restarts.go
+++ b/e2e/scenario/scenario_ubuntu2204-chrony-restarts.go
@@ -9,6 +9,11 @@ func ubuntu2204ChronyRestarts() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu2204-chrony-restarts",
 		Description: "Tests that the chrony service restarts if it is killed",
+		Tags: Tags{
+			Name:     "ubuntu2204-chrony-restarts",
+			OS:       "ubuntu2204",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu2204-custom-ca-trust.go
+++ b/e2e/scenario/scenario_ubuntu2204-custom-ca-trust.go
@@ -11,6 +11,11 @@ func ubuntu2204CustomCATrust() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu2204-custom-ca-trust",
 		Description: "Tests that a node using the Ubuntu 2204 VHD can be properly bootstrapped and custom CA was correctly added",
+		Tags: Tags{
+			Name:     "ubuntu2204-custom-ca-trust",
+			OS:       "ubuntu2204",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu2204-custom-sysctls.go
+++ b/e2e/scenario/scenario_ubuntu2204-custom-sysctls.go
@@ -22,6 +22,11 @@ func ubuntu2204CustomSysctls() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu2204-custom-sysctls",
 		Description: "tests that an ubuntu 2204 VHD can be properly bootstrapped when supplied custom node config that contains custom sysctl settings",
+		Tags: Tags{
+			Name:     "ubuntu2204-custom-sysctls",
+			OS:       "ubuntu2204",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu2204-gpu-grid.go
+++ b/e2e/scenario/scenario_ubuntu2204-gpu-grid.go
@@ -11,6 +11,12 @@ func ubuntu2204GPUGridDriver() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu2204-gpu-grid",
 		Description: "Tests that a GPU-enabled node using the Ubuntu 2204 VHD with grid driver can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "ubuntu2204-gpu-grid",
+			OS:       "ubuntu2204",
+			Platform: "x64",
+			GPU:      true,
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu2204-gpu-nodriver.go
+++ b/e2e/scenario/scenario_ubuntu2204-gpu-nodriver.go
@@ -11,6 +11,12 @@ func ubuntu2204gpuNoDriver() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu2204-gpu-nodriver",
 		Description: "Tests that a GPU-enabled node using the Ubuntu 2204 VHD opting for skipping gpu driver installation can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "ubuntu2204-gpu-nodriver",
+			OS:       "ubuntu2204",
+			Platform: "x64",
+			GPU:      true,
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu2204-gpu.go
+++ b/e2e/scenario/scenario_ubuntu2204-gpu.go
@@ -14,6 +14,7 @@ func ubuntu2204gpu(name string, vmSize string) *Scenario {
 	return &Scenario{
 		Name:        name,
 		Description: fmt.Sprintf("Tests that a GPU-enabled node with VM size %s using an Ubuntu 2204 VHD can be properly bootstrapped", vmSize),
+		Tags:        Tags{Name: name, OS: "ubuntu2204", Platform: "x64", GPU: true},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu2204-private-kube-pkg.go
+++ b/e2e/scenario/scenario_ubuntu2204-private-kube-pkg.go
@@ -9,6 +9,11 @@ func ubuntu2204privatekubepkg() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu2204privatekubepkg",
 		Description: "Tests that a node using the Ubuntu 2204 VHD that was built with private kube packages can be properly bootstrapped with the specified kube version",
+		Tags: Tags{
+			Name:     "ubuntu2204privatekubepkg",
+			OS:       "ubuntu2204",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu2204-standalone-containerd.go
+++ b/e2e/scenario/scenario_ubuntu2204-standalone-containerd.go
@@ -13,6 +13,11 @@ func ubuntu2204ContainerdURL() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu2204ContainerdURL",
 		Description: "tests that a node using the Ubuntu 2204 VHD with the ContainerdPackageURL override bootstraps with the provided URL and not the maifest contianerd version",
+		Tags: Tags{
+			Name:     "ubuntu2204ContainerdURL",
+			OS:       "ubuntu2204",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu2204-wasm.go
+++ b/e2e/scenario/scenario_ubuntu2204-wasm.go
@@ -9,6 +9,11 @@ func ubuntu2204Wasm() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu2204-wasm",
 		Description: "tests that a new ubuntu 2204 node using krustlet can be properly bootstrapepd",
+		Tags: Tags{
+			Name:     "ubuntu2204-wasm",
+			OS:       "ubuntu2204",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/scenario_ubuntu2204.go
+++ b/e2e/scenario/scenario_ubuntu2204.go
@@ -9,6 +9,11 @@ func ubuntu2204() *Scenario {
 	return &Scenario{
 		Name:        "ubuntu2204",
 		Description: "Tests that a node using the Ubuntu 2204 VHD can be properly bootstrapped",
+		Tags: Tags{
+			Name:     "ubuntu2204",
+			OS:       "ubuntu2204",
+			Platform: "x64",
+		},
 		Config: Config{
 			ClusterSelector: NetworkPluginKubenetSelector,
 			ClusterMutator:  NetworkPluginKubenetMutator,

--- a/e2e/scenario/types.go
+++ b/e2e/scenario/types.go
@@ -2,6 +2,9 @@ package scenario
 
 import (
 	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
 
 	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/Azure/agentbakere2e/config"
@@ -10,6 +13,86 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice"
 )
 
+type Tags struct {
+	Name     string
+	OS       string
+	Platform string
+	Airgap   bool
+	GPU      bool
+	WASM     bool
+}
+
+// MatchesFilters checks if the Tags struct matches all given filters.
+// Filters are comma-separated "key=value" pairs (e.g., "gpu=true,os=x64").
+// Returns true if all filters match, false otherwise. Errors on invalid input.
+func (t Tags) MatchesFilters(filters string) (bool, error) {
+	return t.matchFilters(filters, true)
+}
+
+// MatchesAnyFilter checks if the Tags struct matches at least one of the given filters.
+// Filters are comma-separated "key=value" pairs (e.g., "gpu=true,os=x64").
+// Returns true if any filter matches, false if none match. Errors on invalid input.
+func (t Tags) MatchesAnyFilter(filters string) (bool, error) {
+	return t.matchFilters(filters, false)
+}
+
+// matchFilters is a helper function used by both MatchesFilters and MatchesAnyFilter.
+// The 'all' parameter determines whether all filters must match (true) or just any filter (false).
+func (t Tags) matchFilters(filters string, all bool) (bool, error) {
+	if filters == "" {
+		return true, nil
+	}
+
+	v := reflect.ValueOf(t)
+	filterPairs := strings.Split(filters, ",")
+
+	for _, pair := range filterPairs {
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) != 2 {
+			return false, fmt.Errorf("invalid filter format: %s", pair)
+		}
+
+		key := strings.TrimSpace(kv[0])
+		value := strings.TrimSpace(kv[1])
+
+		// Case-insensitive field lookup
+		field := reflect.Value{}
+		for i := 0; i < v.NumField(); i++ {
+			if strings.EqualFold(v.Type().Field(i).Name, key) {
+				field = v.Field(i)
+				break
+			}
+		}
+
+		if !field.IsValid() {
+			return false, fmt.Errorf("unknown filter key: %s", key)
+		}
+
+		match := false
+		switch field.Kind() {
+		case reflect.String:
+			match = strings.EqualFold(field.String(), value)
+		case reflect.Bool:
+			boolValue, err := strconv.ParseBool(value)
+			if err != nil {
+				return false, fmt.Errorf("invalid boolean value for %s: %s", key, value)
+			}
+			match = field.Bool() == boolValue
+		default:
+			return false, fmt.Errorf("unsupported field type for %s", key)
+		}
+
+		if all && !match {
+			return false, nil
+		}
+		if !all && match {
+			return true, nil
+		}
+	}
+
+	return all, nil
+}
+
 // Scenario represents an AgentBaker E2E scenario
 type Scenario struct {
 	// Name is the name of the scenario
@@ -17,6 +100,9 @@ type Scenario struct {
 
 	// Description is a short description of what the scenario does and tests for
 	Description string
+
+	// Tags are used for filtering scenarios to run based on the tags provided
+	Tags Tags
 
 	// Config contains the configuration of the scenario
 	Config


### PR DESCRIPTION
With this change it should be easier to temporary disable some of the tests.

For example, in a case of GPU capacity constraint all gpu scenarios can be disabled by setting `TAGS_TO_SKIP="gpu=true"`

I also noticed that I didn't update the README.md. Updated with an assumption #4590 is merged.

