### PR TITLE
feat: allow configuring "seccompDefault" property on kubelet

### DIFF
--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -700,6 +700,7 @@ type CustomKubeletConfig struct {
 	ContainerLogMaxSizeMB *int32    `json:"containerLogMaxSizeMB,omitempty"`
 	ContainerLogMaxFiles  *int32    `json:"containerLogMaxFiles,omitempty"`
 	PodMaxPids            *int32    `json:"podMaxPids,omitempty"`
+	SeccompDefault        *bool     `json:"seccompDefault,omitempty"`
 }
 
 // CustomLinuxOSConfig represents custom os configurations for agent pool nodes.
@@ -2088,6 +2089,10 @@ type AKSKubeletConfiguration struct {
 	Default: []
 	+optional. */
 	AllowedUnsafeSysctls []string `json:"allowedUnsafeSysctls,omitempty"`
+	// SeccompDefault enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
+	// Default: false
+	// +optional
+	SeccompDefault *bool `json:"seccompDefault,omitempty"`
 }
 
 type Duration string

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -495,6 +495,9 @@ func setCustomKubeletConfig(customKc *datamodel.CustomKubeletConfig,
 		if customKc.PodMaxPids != nil {
 			kubeletConfig.PodPidsLimit = to.Int64Ptr(int64(*customKc.PodMaxPids))
 		}
+		if customKc.SeccompDefault != nil {
+			kubeletConfig.SeccompDefault = customKc.SeccompDefault
+		}
 	}
 }
 

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -58,6 +58,7 @@ func TestGetKubeletConfigFileFromFlags(t *testing.T) {
 		ContainerLogMaxSizeMB: to.Int32Ptr(1000),
 		ContainerLogMaxFiles:  to.Int32Ptr(99),
 		PodMaxPids:            to.Int32Ptr(12345),
+		SeccompDefault:        to.BoolPtr(true),
 	}
 	configFileStr := GetKubeletConfigFileContent(kc, customKc)
 	diff := cmp.Diff(expectedKubeletJSON, configFileStr)
@@ -213,7 +214,8 @@ var expectedKubeletJSON = `{
     "allowedUnsafeSysctls": [
         "kernel.msg*",
         "net.ipv4.route.min_pmtu"
-    ]
+    ],
+    "seccompDefault": true
 }`
 
 var expectedKubeletJSONWithNodeStatusReportFrequency = `{
@@ -430,6 +432,7 @@ func TestGetKubeletConfigFileCustomKCShouldOverrideValuesPassedInKc(t *testing.T
 		ContainerLogMaxFiles:  to.Int32Ptr(99),
 		ContainerLogMaxSizeMB: to.Int32Ptr(1000),
 		PodMaxPids:            to.Int32Ptr(12345),
+		SeccompDefault:        to.BoolPtr(true),
 	}
 	configFileStr := GetKubeletConfigFileContent(kc, customKc)
 	diff := cmp.Diff(expectedKubeletJSON, configFileStr)


### PR DESCRIPTION
Allow configuring "seccompDefault" property on kubelet https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/

We want to allow AKS users to be able to enable it. In the future the default will be changed to "true".
And additionally, a custom seccomps configuration can be provided.

**Release note**:

```
Add seccompDefault field to custom kubelet configuration
```
