### PR TITLE
Add coredns image v1.9.4-hotfix.20240704

### DIFF
--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -27,7 +27,8 @@
       "amd64OnlyVersions": [],
       "multiArchVersions": [
         "v1.9.4-hotfix.20240520",
-        "v1.9.4-hotfix.20240627"
+        "v1.9.4-hotfix.20240627",
+        "v1.9.4-hotfix.20240704"
       ]
     },
     {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
To add coreDNS hotfix image (coredns:v1.9.4-hotfix.20240704) to cache that contains fixes for - CVE-2024-24791

**Which issue(s) this PR fixes**:
Fixes # CVE-2024-24791 

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
https://mcr.microsoft.com/en-us/product/oss/kubernetes/coredns/tags
docker pull mcr.microsoft.com/oss/kubernetes/coredns:v1.9.4-hotfix.20240704

**Release note**:

```
none
```
