### PR TITLE
fix: invalid variable syntax in release pipeline

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -1070,7 +1070,7 @@ stages:
             parameters:
               artifactName: 2204-minimal-gen2-containerd
   - stage: Run_E2E_Tests
-    condition: and(ne(variables.SKIP_E2E_TESTS, 'true'), eq(parameters.dryrun, false))
+    condition: and(ne(variables.SKIP_E2E_TESTS, 'true'), eq(${{parameters.dryrun}}, false))
     variables:
       VHD_BUILD_ID: $(Build.BuildId)
       LOCATION: $(PACKER_BUILD_LOCATION)

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -1070,7 +1070,7 @@ stages:
             parameters:
               artifactName: 2204-minimal-gen2-containerd
   - stage: Run_E2E_Tests
-    condition: and(ne(variables.SKIP_E2E_TESTS, 'true'), eq(${{parameters.dryrun}}, false))
+    condition: and(ne(variables.SKIP_E2E_TESTS, 'true'), eq('${{ parameters.dryrun }}', false))
     variables:
       VHD_BUILD_ID: $(Build.BuildId)
       LOCATION: $(PACKER_BUILD_LOCATION)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

dryrun parameter syntax error prevents release pipeline from executing. Error is not present in the PR check-in gate so that is probably how it got through. 

Running release pipeline now to ensure syntax works.

**Requirements**:

- [x ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version