### PR TITLE
test: don't trigger e2e test on non e2e file changes

### DIFF
--- a/.pipelines/e2e.yaml
+++ b/.pipelines/e2e.yaml
@@ -13,12 +13,7 @@ pr:
       - .pipelines/e2e.yaml
       - .pipelines/templates/e2e-template.yaml
       - e2e
-      - parts/linux
-      - pkg/agent
     exclude:
       - e2e/windows
-      - pkg/agent/datamodel/sig_config*.go # SIG config changes
-      - pkg/agent/datamodel/*.json # SIG version changes
-      - pkg/agent/testdata/AKSWindows* # Windows test data
 jobs:
   - template: ./templates/e2e-template.yaml


### PR DESCRIPTION
The pipeline doesn't build new VHD. So, triggering it on VHD changes is pointless.

There is another pipeline that run e2e after VHD build.