### PR TITLE
fix: allow abe2e retries with multiple pipeline artifacts

### DIFF
--- a/e2e/log.go
+++ b/e2e/log.go
@@ -2,12 +2,14 @@ package e2e
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 )
 
-const (
-	e2eLogsDir = "scenario-logs"
+var (
+	e2eLogsDir = fmt.Sprintf("scenario-logs-%d", time.Now().Unix())
 )
 
 func createDirIfNeeded(dir string) error {
@@ -23,8 +25,8 @@ func createE2ELoggingDir() error {
 	return createDirIfNeeded(e2eLogsDir)
 }
 
-func createVMLogsDir(caseName string) (string, error) {
-	logDir := filepath.Join(e2eLogsDir, caseName)
+func createScenarioLogsDir(name string) (string, error) {
+	logDir := filepath.Join(e2eLogsDir, name)
 	return logDir, createDirIfNeeded(logDir)
 }
 

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -87,7 +87,7 @@ func setupAndRunScenario(ctx context.Context, t *testing.T, e2eScenario *scenari
 
 	e2eScenario.PrepareNodeBootstrappingConfiguration(nbc)
 
-	loggingDir, err := createVMLogsDir(e2eScenario.Name)
+	loggingDir, err := createScenarioLogsDir(e2eScenario.Name)
 	require.NoError(t, err)
 
 	executeScenario(ctx, t, &scenarioRunOpts{


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

allows users to manually retry abe2e runs by randomizing the name of the pipeline artifact containing scenario logs

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
