### PR TITLE
feat: Add option to configure --seccompDefault property on kubelet

### DIFF
--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -710,6 +710,7 @@ type CustomKubeletConfig struct {
 	ContainerLogMaxSizeMB *int32    `json:"containerLogMaxSizeMB,omitempty"`
 	ContainerLogMaxFiles  *int32    `json:"containerLogMaxFiles,omitempty"`
 	PodMaxPids            *int32    `json:"podMaxPids,omitempty"`
+	SeccompDefault        *bool     `json:"seccompDefault,omitempty"`
 }
 
 // CustomLinuxOSConfig represents custom os configurations for agent pool nodes.
@@ -2113,6 +2114,10 @@ type AKSKubeletConfiguration struct {
 	// Default: true
 	// +optional
 	SerializeImagePulls *bool `json:"serializeImagePulls,omitempty"`
+	// SeccompDefault enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
+	// Default: false
+	// +optional
+	SeccompDefault *bool `json:"seccompDefault,omitempty"`
 }
 
 type Duration string

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -543,6 +543,9 @@ func setCustomKubeletConfig(customKc *datamodel.CustomKubeletConfig,
 		if customKc.PodMaxPids != nil {
 			kubeletConfig.PodPidsLimit = to.Int64Ptr(int64(*customKc.PodMaxPids))
 		}
+		if customKc.SeccompDefault != nil {
+			kubeletConfig.SeccompDefault = customKc.SeccompDefault
+		}
 	}
 }
 

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -60,6 +60,7 @@ func TestGetKubeletConfigFileFromFlags(t *testing.T) {
 		ContainerLogMaxSizeMB: to.Int32Ptr(1000),
 		ContainerLogMaxFiles:  to.Int32Ptr(99),
 		PodMaxPids:            to.Int32Ptr(12345),
+		SeccompDefault:        to.BoolPtr(true),
 	}
 	configFileStr := GetKubeletConfigFileContent(kc, customKc)
 	diff := cmp.Diff(expectedKubeletJSON, configFileStr)
@@ -217,7 +218,8 @@ var expectedKubeletJSON = `{
     "allowedUnsafeSysctls": [
         "kernel.msg*",
         "net.ipv4.route.min_pmtu"
-    ]
+    ],
+    "seccompDefault": true
 }`
 
 var expectedKubeletJSONWithNodeStatusReportFrequency = `{
@@ -603,6 +605,7 @@ func TestGetKubeletConfigFileCustomKCShouldOverrideValuesPassedInKc(t *testing.T
 		ContainerLogMaxFiles:  to.Int32Ptr(99),
 		ContainerLogMaxSizeMB: to.Int32Ptr(1000),
 		PodMaxPids:            to.Int32Ptr(12345),
+		SeccompDefault:        to.BoolPtr(true),
 	}
 	configFileStr := GetKubeletConfigFileContent(kc, customKc)
 	diff := cmp.Diff(expectedKubeletJSON, configFileStr)


### PR DESCRIPTION
https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration

Allow user to configure extra kubelet parameter.

Test it manualy:

I created a new nodepool using e2e test. And created next DaemonSet:
```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: violating-daemonset
  labels:
    app: violating-app
spec:
  selector:
    matchLabels:
      app: violating-app
  template:
    metadata:
      labels:
        app: violating-app
    spec:
      containers:
        - name: seccomp-test
          image: alpine:latest
          command: ["/bin/sh", "-c"]
          args:
            - |
              echo "Attempting to use unshare..."
              unshare -r echo "This should fail"
              echo "Exit code: $?"
#          securityContext:
#            seccompProfile:
#              type: RuntimeDefault
```

I received different log message on seccomp-enabled node.

But I don't think it's something worth adding a new test to e2e suite.