### PR TITLE
feat: placeholder for windows next-gen networking func

### DIFF
--- a/staging/cse/windows/nextgennetworking.ps1
+++ b/staging/cse/windows/nextgennetworking.ps1
@@ -1,0 +1,10 @@
+function Start-InstallWindowsNextGenNetworking {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$NextGenNetworkingURL
+    )
+
+    Logs-To-Event -TaskName "AKS.WindowsCSE.InstallWindowsNextGenNetworking" -TaskMessage "Start to install Windows next-gen networking eBPF using URL $NextGenNetworkingURL"
+
+    # TODO: this is a placeholder for the installation script.
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

This function is a placeholder that we plan to override in testing to verify the installation process (dynamically override Windows CSE package). Once the install script is fully tested, this function will be updated.

A follow-on PR will update kuberneteswindowssetup.ps1 to source nextgennetworking.ps1 and invoke `Start-InstallWindowsNextGenNetworking`

**Release note**:

```
none
```
