### PR TITLE
test: use same node SKU famility for test and build

### DIFF
--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -78,16 +78,6 @@ else
     IMG_DEF=${MANAGED_SIG_ID}
   fi
 
-  # In SIG mode, Windows VM requires admin-username and admin-password to be set,
-  # otherwise 'root' is used by default but not allowed by the Windows Image. See the error image below:
-  # ERROR: This user name 'root' meets the general requirements, but is specifically disallowed for this image. Please try a different value.
-  TARGET_COMMAND_STRING=""
-  if [[ "${ARCHITECTURE,,}" == "arm64" ]]; then
-    TARGET_COMMAND_STRING+="--size Standard_D2pds_v5"
-  elif [[ "${FEATURE_FLAGS,,}" == "kata" ]]; then
-    TARGET_COMMAND_STRING="--size Standard_D4ds_v5"
-  fi
-
   if [[ "${OS_TYPE}" == "Linux" && "${ENABLE_TRUSTED_LAUNCH}" == "True" ]]; then
     if [[ -n "$TARGET_COMMAND_STRING" ]]; then
       # To take care of Mariner Kata TL images
@@ -96,6 +86,10 @@ else
     TARGET_COMMAND_STRING+="--security-type TrustedLaunch --enable-secure-boot true --enable-vtpm true"
   fi
 
+
+# In SIG mode, Windows VM requires admin-username and admin-password to be set,
+# otherwise 'root' is used by default but not allowed by the Windows Image. See the error image below:
+# ERROR: This user name 'root' meets the general requirements, but is specifically disallowed for this image. Please try a different value.
   az vm create \
       --resource-group $RESOURCE_GROUP_NAME \
       --name $VM_NAME \
@@ -103,7 +97,7 @@ else
       --admin-username $TEST_VM_ADMIN_USERNAME \
       --admin-password $TEST_VM_ADMIN_PASSWORD \
       --public-ip-address "" \
-      ${TARGET_COMMAND_STRING}
+      --size Standard_D4ds_v5
       
   echo "VHD test VM username: $TEST_VM_ADMIN_USERNAME, password: $TEST_VM_ADMIN_PASSWORD"
 fi


### PR DESCRIPTION
We use `Standard_D16ds_v5` for VM build.


`az vm create` uses `--size=Standard_DS1_v2` by default. It led to a situation where we 4 different families for the build to succeed.

Reducing variety in node SKUs should reduce likelihood of encountering capacity constraints.