### PR TITLE
perf: use premium SSDs

### DIFF
--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -59,8 +59,6 @@
       "location": "{{user `location`}}",
       "vm_size": "{{user `vm_size`}}",
       "polling_duration_timeout": "1h",
-      "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
-      "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
         "resource_group": "{{user `resource_group_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -59,6 +59,9 @@
       "location": "{{user `location`}}",
       "vm_size": "{{user `vm_size`}}",
       "polling_duration_timeout": "1h",
+      "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
+      "managed_image_resource_group_name": "{{user `resource_group_name`}}",
+      "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
         "resource_group": "{{user `resource_group_name`}}",
         "gallery_name": "{{user `sig_gallery_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -61,6 +61,7 @@
       "polling_duration_timeout": "1h",
       "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
+      "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
         "resource_group": "{{user `resource_group_name`}}",
         "gallery_name": "{{user `sig_gallery_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
@@ -58,6 +58,9 @@
       "location": "{{user `location`}}",
       "vm_size": "{{user `vm_size`}}",
       "polling_duration_timeout": "1h",
+      "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
+      "managed_image_resource_group_name": "{{user `resource_group_name`}}",
+      "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
         "resource_group": "{{user `resource_group_name`}}",
         "gallery_name": "{{user `sig_gallery_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
@@ -58,8 +58,6 @@
       "location": "{{user `location`}}",
       "vm_size": "{{user `vm_size`}}",
       "polling_duration_timeout": "1h",
-      "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
-      "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
         "resource_group": "{{user `resource_group_name`}}",

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -60,6 +60,7 @@
       "polling_duration_timeout": "1h",
       "managed_image_name": "{{user `sig_image_name`}}-{{user `captured_sig_version`}}",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
+      "managed_image_storage_account_type": "Premium_LRS",
       "shared_image_gallery_destination": {
         "resource_group": "{{user `resource_group_name`}}",
         "gallery_name": "{{user `sig_gallery_name`}}",


### PR DESCRIPTION
**What type of PR is this?**

/kind perf

**What this PR does / why we need it**:

This PR instructs packer to use premium SSDs when building our custom images. This greatly reduces VHD build time given the faster IOPS/Mbps of the Premium SSDs over Standard HDD. The average build time reduction across all SKUs is 00:07:10.

**Which issue(s) this PR fixes**:

Unsatisfactory VHD Build times.

**Requirements**:

- [ x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version