### PR TITLE
[Draft] Publish new AMDv6 Image to temporary Image Definition

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -154,6 +154,10 @@ parameters:
     displayName: Build 2204 Minimal Gen2 Containerd
     type: boolean
     default: false
+  - name: build2204gen2containerdamdv6test
+    displayName: Build 2204 Gen2 Containerd - AMDv6 Test
+    type: boolean
+    default: false
   - name: dryrun
     displayName: Dry run
     type: boolean
@@ -1069,6 +1073,31 @@ stages:
           - template: ./templates/.builder-release-template.yaml
             parameters:
               artifactName: 2204-minimal-gen2-containerd
+      - job: build2204gen2containerdamdv6test
+        condition: eq('${{ parameters.build2204gen2containerdamdv6test }}', true)
+        dependsOn: [ ]
+        timeoutInMinutes: 180
+        steps:
+          - bash: |
+              echo '##vso[task.setvariable variable=DRY_RUN]${{parameters.dryrun}}'
+              echo '##vso[task.setvariable variable=OS_SKU]Ubuntu'
+              echo '##vso[task.setvariable variable=OS_VERSION]22.04'
+              echo '##vso[task.setvariable variable=IMG_PUBLISHER]Canonical'
+              echo '##vso[task.setvariable variable=IMG_OFFER]0001-com-ubuntu-server-jammy'
+              echo '##vso[task.setvariable variable=IMG_SKU]22_04-lts-gen2'
+              echo '##vso[task.setvariable variable=IMG_VERSION]latest'
+              echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
+              echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ds_v5'
+              echo '##vso[task.setvariable variable=FEATURE_FLAGS]None'
+              echo '##vso[task.setvariable variable=CONTAINER_RUNTIME]containerd'
+              echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
+              echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]False'
+              echo '##vso[task.setvariable variable=SGX_INSTALL]True'
+              echo '##vso[task.setvariable variable=AMDV6TEST]True'
+            displayName: Setup Build Variables
+          - template: ./templates/.builder-release-template.yaml
+            parameters:
+              artifactName: 2204-gen2-containerd-amdv6-test
   - stage: Run_E2E_Tests
     condition: and(ne(variables.SKIP_E2E_TESTS, 'true'), eq('${{ parameters.dryrun }}', false))
     variables:

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -63,6 +63,7 @@ steps:
       if [[ "${IMG_SKU}" == *"minimal"* ]]; then SKU_NAME="${SKU_NAME}minimal"; fi && \
       if [[ "${ENABLE_TRUSTED_LAUNCH}" == "True" ]]; then SKU_NAME="${SKU_NAME}TL"; fi && \
       if [[ ${OS_SKU} != "CBLMariner" && ${OS_SKU} != "AzureLinux" && "${CONTAINER_RUNTIME}" == "containerd" ]]; then SKU_NAME="${SKU_NAME}containerd"; fi && \
+      if [[ "${AMDV6TEST}" == "True" ]]; then SKU_NAME="${SKU_NAME}amdv6test"; fi && \
       SKU_NAME=$(echo ${SKU_NAME} | tr -d '.') && \
       echo "##vso[task.setvariable variable=SKU_NAME]$SKU_NAME"
       echo "Set SKU_NAME to $SKU_NAME"

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -534,7 +534,7 @@ var (
 	SIGUbuntuContainerd2204Gen2ImageConfigTemplate = SigImageConfigTemplate{
 		ResourceGroup: AKSUbuntuResourceGroup,
 		Gallery:       AKSUbuntuGalleryName,
-		Definition:    "2204gen2containerd",
+		Definition:    "2204gen2containerdamdv6test", // Where does this get set in AME build pipeline??  I set this in builder-release-template.yaml SetSKU for now
 		Version:       LinuxSIGImageVersion,
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
Test

**What this PR does / why we need it**:
This PR creates and builds a new "temporary" image definition for the AMD v6 SKUs.  This is needed to test upgrade paths with standalone environments with the new DiskControllerTypes=SCSI,NVMe features.

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
