### PR TITLE
fix: install upgrades for CVM images in pre-install dependencies

### DIFF
--- a/vhdbuilder/packer/pre-install-dependencies.sh
+++ b/vhdbuilder/packer/pre-install-dependencies.sh
@@ -99,23 +99,9 @@ else
   # Run apt get update to refresh repo list
   # Run apt dist get upgrade to install packages/kernels
 
-  # CVM breaks on kernel image updates due to nullboot package post-install.
-  # it relies on boot measurements from real tpm hardware.
-  # building on a real CVM would solve this, but packer doesn't support it.
-  # we could make upstream changes but that takes time, and we are broken now.
-  # so we just hold the kernel image packages for now on CVM.
-  # this still allows us base image and package updates on a weekly cadence.
-#  if [[ "$IMG_SKU" != "20_04-lts-cvm" ]]; then
-#    # Canonical snapshot is only implemented for 20.04 LTS, 22.04 LTS and 23.10 and above
-#    # For 20.04, the only SKUs we support are FIPS, and it reaches out to ESM to get the packages, ESM does not have canonical snapshot support
-#    # Therefore keeping this to 22.04 only for now
-#    if [[ -n "${VHD_BUILD_TIMESTAMP}" && "${OS_VERSION}" == "22.04" ]]; then
-#      sed -i "s#http://azure.archive.ubuntu.com/ubuntu/#https://snapshot.ubuntu.com/ubuntu/${VHD_BUILD_TIMESTAMP}#g" /etc/apt/sources.list
-#    fi
-#    apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT
-#    apt_get_dist_upgrade || exit $ERR_APT_DIST_UPGRADE_TIMEOUT
-#  fi
-
+  # Canonical snapshot is only implemented for 20.04 LTS, 22.04 LTS and 23.10 and above
+  # For 20.04, the only SKUs we support are FIPS, and it reaches out to ESM to get the packages, ESM does not have canonical snapshot support
+  # Therefore keeping this to 22.04 only for now
   if [[ -n "${VHD_BUILD_TIMESTAMP}" && "${OS_VERSION}" == "22.04" ]]; then
     sed -i "s#http://azure.archive.ubuntu.com/ubuntu/#https://snapshot.ubuntu.com/ubuntu/${VHD_BUILD_TIMESTAMP}#g" /etc/apt/sources.list
   fi

--- a/vhdbuilder/packer/pre-install-dependencies.sh
+++ b/vhdbuilder/packer/pre-install-dependencies.sh
@@ -105,16 +105,22 @@ else
   # we could make upstream changes but that takes time, and we are broken now.
   # so we just hold the kernel image packages for now on CVM.
   # this still allows us base image and package updates on a weekly cadence.
-  if [[ "$IMG_SKU" != "20_04-lts-cvm" ]]; then
-    # Canonical snapshot is only implemented for 20.04 LTS, 22.04 LTS and 23.10 and above
-    # For 20.04, the only SKUs we support are FIPS, and it reaches out to ESM to get the packages, ESM does not have canonical snapshot support
-    # Therefore keeping this to 22.04 only for now
-    if [[ -n "${VHD_BUILD_TIMESTAMP}" && "${OS_VERSION}" == "22.04" ]]; then
-      sed -i "s#http://azure.archive.ubuntu.com/ubuntu/#https://snapshot.ubuntu.com/ubuntu/${VHD_BUILD_TIMESTAMP}#g" /etc/apt/sources.list
-    fi
-    apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT
-    apt_get_dist_upgrade || exit $ERR_APT_DIST_UPGRADE_TIMEOUT
+#  if [[ "$IMG_SKU" != "20_04-lts-cvm" ]]; then
+#    # Canonical snapshot is only implemented for 20.04 LTS, 22.04 LTS and 23.10 and above
+#    # For 20.04, the only SKUs we support are FIPS, and it reaches out to ESM to get the packages, ESM does not have canonical snapshot support
+#    # Therefore keeping this to 22.04 only for now
+#    if [[ -n "${VHD_BUILD_TIMESTAMP}" && "${OS_VERSION}" == "22.04" ]]; then
+#      sed -i "s#http://azure.archive.ubuntu.com/ubuntu/#https://snapshot.ubuntu.com/ubuntu/${VHD_BUILD_TIMESTAMP}#g" /etc/apt/sources.list
+#    fi
+#    apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT
+#    apt_get_dist_upgrade || exit $ERR_APT_DIST_UPGRADE_TIMEOUT
+#  fi
+
+  if [[ -n "${VHD_BUILD_TIMESTAMP}" && "${OS_VERSION}" == "22.04" ]]; then
+    sed -i "s#http://azure.archive.ubuntu.com/ubuntu/#https://snapshot.ubuntu.com/ubuntu/${VHD_BUILD_TIMESTAMP}#g" /etc/apt/sources.list
   fi
+  apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT
+  apt_get_dist_upgrade || exit $ERR_APT_DIST_UPGRADE_TIMEOUT
 
   if [[ "${ENABLE_FIPS,,}" == "true" ]]; then
     # This is FIPS Install for Ubuntu, it purges non FIPS Kernel and attaches UA FIPS Updates


### PR DESCRIPTION
**What type of PR is this?**
We had originally skipped apt updates to CVM base image because the newer kernels were incompatible with the nullboot package, which relied on boot measurements from TPM hardware.

This seems to have been fixed upstream, therefore removing the conditional to skip updates for CVM.

Successful build: https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=99290941&view=results

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
