### PR TITLE
chore: upload test results in pipeline

### DIFF
--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -36,8 +36,9 @@ jobs:
           fi
           
           cd e2e
-          GOBIN=/usr/local/go/bin/ go install github.com/jstemmer/go-junit-report/v2@latest
-          go test -v -parallel 100 -timeout 90m -v ./... 2>&1 | go-junit-report -iocopy -set-exit-code -out "$(Build.SourcesDirectory)/e2e/report.xml"
+          mkdir -p bin
+          GOBIN=./bin/ go install github.com/jstemmer/go-junit-report/v2@latest
+          go test -v -parallel 100 -timeout 90m -v ./... 2>&1 | ./bin/go-junit-report -iocopy -set-exit-code -out "$(Build.SourcesDirectory)/e2e/report.xml"
         displayName: Run AgentBaker E2E
         env:
           VHD_BUILD_ID: $(VHD_BUILD_ID)

--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -8,17 +8,20 @@ jobs:
       - group: ab-e2e
     steps:
       - bash: |
+          set -ex
           az login --identity
           az account set -s $(AZURE_SUBSCRIPTION_ID)
         displayName: Azure login
       - bash: bash .pipelines/scripts/setup_go.sh
         displayName: Setup go
       - bash: |
+          set -ex
           LOGGING_DIR="scenario-logs-$(date +%s)"
           echo "setting logging dir to $LOGGING_DIR"
           echo "##vso[task.setvariable variable=LOGGING_DIR]$LOGGING_DIR"
         displayName: Set logging directory
       - bash: |
+          set -ex
           export PATH="/usr/local/go/bin:$PATH"
           go version
           

--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -22,7 +22,7 @@ jobs:
         displayName: Set logging directory
       - bash: |
           set -ex
-          export PATH="/usr/local/go/bin:$PATH"
+          export PATH="/usr/local/go/bin:$GOPATH/bin:$PATH"
           go version
           
           echo "VHD_BUILD_ID=$VHD_BUILD_ID"

--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -33,7 +33,8 @@ jobs:
           fi
           
           cd e2e
-          go test -parallel 100 -timeout 90m -v ./...
+          go install github.com/jstemmer/go-junit-report/v2@latest
+          go test -v -parallel 100 -timeout 90m -v ./... 2>&1 | go-junit-report -iocopy -set-exit-code -out "$(Build.SourcesDirectory)/e2e/report.xml"
         displayName: Run AgentBaker E2E
         env:
           VHD_BUILD_ID: $(VHD_BUILD_ID)
@@ -43,6 +44,12 @@ jobs:
       - bash: mkdir -p $(System.DefaultWorkingDirectory)/e2e/$(LOGGING_DIR)
         condition: always()
         displayName: Create folder for scenario logs
+      - task: PublishTestResults@2
+        displayName: Upload test results
+        condition: succeededOrFailed()
+        inputs:
+          testRunner: JUnit
+          testResultsFiles: "$(Build.SourcesDirectory)/e2e/report.xml"
       - publish: $(System.DefaultWorkingDirectory)/e2e/$(LOGGING_DIR)
         artifact: $(LOGGING_DIR)
         condition: always()

--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -22,7 +22,7 @@ jobs:
         displayName: Set logging directory
       - bash: |
           set -ex
-          export PATH="/usr/local/go/bin:$GOPATH/bin:$PATH"
+          export PATH="/usr/local/go/bin:$PATH"
           go version
           
           echo "VHD_BUILD_ID=$VHD_BUILD_ID"
@@ -36,7 +36,7 @@ jobs:
           fi
           
           cd e2e
-          go install github.com/jstemmer/go-junit-report/v2@latest
+          GOBIN=/usr/local/go/bin/ go install github.com/jstemmer/go-junit-report/v2@latest
           go test -v -parallel 100 -timeout 90m -v ./... 2>&1 | go-junit-report -iocopy -set-exit-code -out "$(Build.SourcesDirectory)/e2e/report.xml"
         displayName: Run AgentBaker E2E
         env:

--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -37,7 +37,7 @@ jobs:
           
           cd e2e
           mkdir -p bin
-          GOBIN=./bin/ go install github.com/jstemmer/go-junit-report/v2@latest
+          GOBIN=`pwd`/bin/ go install github.com/jstemmer/go-junit-report/v2@latest
           go test -v -parallel 100 -timeout 90m -v ./... 2>&1 | ./bin/go-junit-report -iocopy -set-exit-code -out "$(Build.SourcesDirectory)/e2e/report.xml"
         displayName: Run AgentBaker E2E
         env:


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What this PR does / why we need it**:

Uploads test results to DevOps so we get a cleaner view of what failed. These appear in the ADO pipeline page under the "Tests" tab. This tab is only visible after the results are uploaded. Because that's ADO for you.

![image](https://github.com/user-attachments/assets/2d26956b-3ed0-49d3-a613-031e3ec6148a)


**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```

