### PR TITLE
chore: remove components.json symlink from vhdbuilder/packer

### DIFF
--- a/.github/workflows/validate-components.yml
+++ b/.github/workflows/validate-components.yml
@@ -32,6 +32,6 @@ jobs:
         run: |
           GOPATH="$(go env | grep GOPATH | cut -d= -f2 | tr -d '"')"
           export PATH="$PATH:$GOPATH/bin"
-          cue vet -c ./schemas/components.cue ./vhdbuilder/packer/components.json
-          cue eval ./schemas/components.cue ./vhdbuilder/packer/components.json
+          cue vet -c ./schemas/components.cue ./parts/linux/cloud-init/artifacts/components.json
+          cue eval ./schemas/components.cue ./parts/linux/cloud-init/artifacts/components.json
 

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,6 @@ unit-tests:
 
 .PHONY: validate-components
 validate-components:
-	@./hack/tools/bin/cue vet -c ./schemas/components.cue ./vhdbuilder/packer/components.json
+	@./hack/tools/bin/cue vet -c ./schemas/components.cue ./parts/linux/cloud-init/artifacts/components.json
 
 include versioning.mk

--- a/e2e/scenario_helpers_test.go
+++ b/e2e/scenario_helpers_test.go
@@ -144,7 +144,7 @@ func executeScenario(ctx context.Context, t *testing.T, opts *scenarioRunOpts) {
 func getExpectedPackageVersions(packageName, distro, release string) []string {
 	var expectedVersions []string
 	// since we control this json, we assume its going to be properly formatted here
-	jsonBytes, _ := os.ReadFile("../vhdbuilder/packer/components.json")
+	jsonBytes, _ := os.ReadFile("../parts/linux/cloud-init/artifacts/components.json")
 	packages := gjson.GetBytes(jsonBytes, fmt.Sprintf("Packages.#(name=%s).downloadURIs", packageName))
 
 	for _, packageItem := range packages.Array() {

--- a/packer.mk
+++ b/packer.mk
@@ -5,11 +5,7 @@ ifeq (${ARCHITECTURE},ARM64)
 	GOARCH=arm64
 endif
 
-build-packer: build-nbcparser-all build-lister-binary
-ifeq (${MODE},linuxVhdMode)
-	@echo "${MODE}: Generating prefetch scripts"
-	@bash -c "pushd vhdbuilder/prefetch; go run main.go --components=../packer/components.json --container-image-prefetch-script=../packer/prefetch.sh; popd"
-endif
+build-packer: generate-prefetch-scripts build-nbcparser-all build-lister-binary
 ifeq (${ARCHITECTURE},ARM64)
 	@echo "${MODE}: Building with Hyper-v generation 2 ARM64 VM"
 ifeq (${OS_SKU},Ubuntu)
@@ -103,6 +99,12 @@ test-building-vhd: az-login
 
 scanning-vhd: az-login
 	@./vhdbuilder/packer/vhd-scanning.sh
+
+generate-prefetch-scripts:
+ifeq (${MODE},linuxVhdMode)
+	@echo "${MODE}: Generating prefetch scripts"
+	@bash -c "pushd vhdbuilder/prefetch; go run main.go --components-path=../parts/linux/cloud-init/artifacts/components.json --output-path=../packer/prefetch.sh || exit 1; popd"
+endif
 
 build-nbcparser-all:
 	@$(MAKE) -f packer.mk build-nbcparser-binary ARCH=amd64

--- a/packer.mk
+++ b/packer.mk
@@ -103,7 +103,7 @@ scanning-vhd: az-login
 generate-prefetch-scripts:
 ifeq (${MODE},linuxVhdMode)
 	@echo "${MODE}: Generating prefetch scripts"
-	@bash -c "pushd vhdbuilder/prefetch; go run main.go --components-path=../parts/linux/cloud-init/artifacts/components.json --output-path=../packer/prefetch.sh || exit 1; popd"
+	@bash -c "pushd vhdbuilder/prefetch; go run main.go --components-path=../../parts/linux/cloud-init/artifacts/components.json --output-path=../packer/prefetch.sh || exit 1; popd"
 endif
 
 build-nbcparser-all:

--- a/pkg/vhdbuilder/datamodel/component_configs.go
+++ b/pkg/vhdbuilder/datamodel/component_configs.go
@@ -8,8 +8,8 @@ import (
 )
 
 // Components is the data model for the component config.
-// The component config is a JSON file, for example, vhdbuilder/packer/components.json.
-// for example, vhdbuilder/packer/components.json.
+// The component config is a JSON file, for example, parts/linux/cloud-init/artifacts/components.json.
+// for example, parts/linux/cloud-init/artifacts/components.json.
 type Components struct {
 	ContainerImages []*ContainerImage `json:"ContainerImages"`
 	DownloadFiles   []DownloadFile    `json:"DownloadFiles"`

--- a/vhdbuilder/packer/components.json
+++ b/vhdbuilder/packer/components.json
@@ -1,1 +1,0 @@
-../../parts/linux/cloud-init/artifacts/components.json

--- a/vhdbuilder/packer/test/run-pretest.sh
+++ b/vhdbuilder/packer/test/run-pretest.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-components=$(jq .ContainerImages[] --monochrome-output --compact-output < vhdbuilder/packer/components.json)
+components=$(jq .ContainerImages[] --monochrome-output --compact-output < parts/linux/cloud-init/artifacts/components.json)
 for component in ${components[*]}; do
 	downloadURL=$(echo ${component} | jq .downloadURL)
 	downloadURL=$(echo ${downloadURL//\*/} | jq 'sub(".com/" ; ".com/v2/") | sub(":" ; "/tags/list")' -r)

--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -301,7 +301,7 @@
     },
     {
       "type": "file",
-      "source": "vhdbuilder/packer/components.json",
+      "source": "parts/linux/cloud-init/artifacts/components.json",
       "destination": "/home/packer/components.json"
     },
     {

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -303,7 +303,7 @@
     },
     {
       "type": "file",
-      "source": "vhdbuilder/packer/components.json",
+      "source": "parts/linux/cloud-init/artifacts/components.json",
       "destination": "/home/packer/components.json"
     },
     {

--- a/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
@@ -280,7 +280,7 @@
     },
     {
       "type": "file",
-      "source": "vhdbuilder/packer/components.json",
+      "source": "parts/linux/cloud-init/artifacts/components.json",
       "destination": "/home/packer/components.json"
     },
     {

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -297,7 +297,7 @@
     },
     {
       "type": "file",
-      "source": "vhdbuilder/packer/components.json",
+      "source": "parts/linux/cloud-init/artifacts/components.json",
       "destination": "/home/packer/components.json"
     },
     {

--- a/vhdbuilder/prefetch/main.go
+++ b/vhdbuilder/prefetch/main.go
@@ -11,29 +11,29 @@ import (
 func main() {
 	var (
 		// program args
-		componentListPath                string
-		containerImagePrefetchScriptPath string
+		componentsPath string
+		outputPath     string
 	)
-	flag.StringVar(&componentListPath, "components", "", "path to the component list JSON file.")
-	flag.StringVar(&containerImagePrefetchScriptPath, "container-image-prefetch-script", "", "where to place the newly generated container image prefetch script.")
+	flag.StringVar(&componentsPath, "components-path", "", "path to the component list JSON file.")
+	flag.StringVar(&outputPath, "output-path", "", "where to place the newly generated container image prefetch script.")
 	flag.Parse()
 
-	if componentListPath == "" {
+	if componentsPath == "" {
 		fmt.Println("path to the component list must be specified")
 		os.Exit(1)
 	}
-	if containerImagePrefetchScriptPath == "" {
+	if outputPath == "" {
 		fmt.Println("CNI prefetch script destination path must be specified")
 		os.Exit(1)
 	}
 
-	components, err := container.ParseComponents(componentListPath)
+	components, err := container.ParseComponents(componentsPath)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	if err = container.Generate(components, containerImagePrefetchScriptPath); err != nil {
+	if err = container.Generate(components, outputPath); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/vhdbuilder/prefetch/pkg/container/types.go
+++ b/vhdbuilder/prefetch/pkg/container/types.go
@@ -1,6 +1,6 @@
 package container
 
-// List represents a component list (e.g. vhdbuilder/packer/components.json).
+// List represents a component list (e.g. parts/linux/cloud-init/artifacts/components.json).
 type ComponentList struct {
 	Images []Image `json:"ContainerImages,omitempty"`
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

removes a dangling symlink for components.json located at vhdbuilder/packer/components.json - this was originally created to reduce the size of a previous PR's change-set

having a symlink to the actual components.json located at parts/linux/cloud-init/artifafts/components.json creates confusion for component owners and overall reduces maintainability, this PR aims to mitigate this by removing the symlink and all references to it altogether

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
