### PR TITLE
feat: add the container registry as a registry mirror for mcr.microsoft.com when bootstrap container registry is enabled

### DIFF
--- a/parts/linux/cloud-init/nodecustomdata.yml
+++ b/parts/linux/cloud-init/nodecustomdata.yml
@@ -415,3 +415,13 @@ write_files:
   owner: root
   content: !!binary |
     {{GetVariableProperty "cloudInitData" "customSearchDomainsScript"}}
+
+{{- if (ne GetBootstrapProfileContainerRegistryServer "") }}
+# TODO(binxi): need to update for sovereign cloud.
+- path: /etc/containerd/certs.d/mcr.microsoft.com/hosts.toml
+  permissions: "0644"
+  owner: root
+  content: |
+    [host."https://{{GetBootstrapProfileContainerRegistryServer}}"]
+      capabilities = ["pull", "resolve"]
+{{- end}}

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -964,6 +964,9 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 		"GetPrivateEgressProxyAddress": func() string {
 			return config.ContainerService.Properties.SecurityProfile.GetProxyAddress()
 		},
+		"GetBootstrapProfileContainerRegistryServer": func() string {
+			return config.ContainerService.Properties.SecurityProfile.GetPrivateEgressContainerRegistryServer()
+		},
 		"IsArtifactStreamingEnabled": func() bool {
 			return config.EnableArtifactStreaming
 		},

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -1354,11 +1354,16 @@ oom_score = 0
 			func(config *datamodel.NodeBootstrappingConfiguration) {
 				config.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
-						Enabled:      true,
-						ProxyAddress: "https://test-pe-proxy",
+						Enabled:                 true,
+						ProxyAddress:            "https://test-pe-proxy",
+						ContainerRegistryServer: "testserver.azurecr.io",
 					},
 				}
-			}, nil),
+			}, func(o *nodeBootstrappingOutput) {
+				containerdConfigFileContent := o.files["/etc/containerd/certs.d/mcr.microsoft.com/hosts.toml"].value
+				Expect(strings.Contains(containerdConfigFileContent, "[host.\"https://testserver.azurecr.io\"]")).To(BeTrue())
+				Expect(strings.Contains(containerdConfigFileContent, "capabilities = [\"pull\", \"resolve\"]")).To(BeTrue())
+			}),
 		Entry("AKSUbuntu2204 IMDSRestriction with enable restriction and insert to mangle table", "AKSUbuntu2204+IMDSRestrictionOnWithMangleTable", "1.24.2",
 			func(config *datamodel.NodeBootstrappingConfiguration) {
 				config.EnableIMDSRestriction = true

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -2242,4 +2242,11 @@ func (s *SecurityProfile) GetProxyAddress() string {
 	return ""
 }
 
+func (s *SecurityProfile) GetPrivateEgressContainerRegistryServer() string {
+	if s != nil && s.PrivateEgress != nil && s.PrivateEgress.Enabled {
+		return s.PrivateEgress.ContainerRegistryServer
+	}
+	return ""
+}
+
 // SecurityProfile end.

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -2702,3 +2702,44 @@ func TestSecurityProfileGetProxyAddress(t *testing.T) {
 		})
 	}
 }
+
+func TestSecurityProfileGetPrivateEgressContainerRegistryServer(t *testing.T) {
+	testContainerRegistryServer := "https://testserver.azurecr.io"
+	cases := []struct {
+		name            string
+		securityProfile *SecurityProfile
+		expected        string
+	}{
+		{
+			name:            "SecurityProfile nil",
+			securityProfile: nil,
+			expected:        "",
+		},
+		{
+			name:            "PrivateEgress nil",
+			securityProfile: &SecurityProfile{},
+			expected:        "",
+		},
+		{
+			name:            "PrivateEgress disabled",
+			securityProfile: &SecurityProfile{PrivateEgress: &PrivateEgress{Enabled: false}},
+			expected:        "",
+		},
+		{
+			name:            "PrivateEgress enabled",
+			securityProfile: &SecurityProfile{PrivateEgress: &PrivateEgress{Enabled: true, ContainerRegistryServer: testContainerRegistryServer}},
+			expected:        testContainerRegistryServer,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			actual := c.securityProfile.GetPrivateEgressContainerRegistryServer()
+			if c.expected != actual {
+				t.Fatalf("test case: %s, expected: %s. Got: %s.", c.name, c.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/agent/testdata/AKSUbuntu2204+SecurityProfile/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+SecurityProfile/CustomData
@@ -312,3 +312,9 @@ write_files:
   owner: root
   content: !!binary |
     H4sIAAAAAAAA/5yQQYsaQRCF7/MrKsZDcmjbFSTXDDpBQVeZUQK5NGVPjXbs6Zauko3Z+N/D7uwlq6dcCurx3uPxffygdy7oHfIhYxJQvzKO52QJev3nSVWYWbFYF2Vlvs0XxTrfzK69d4bpvNqUq3u+jOwhQg+gDqyYMNkD9J8n22qzWpqqyMvJzExXy3z+aB7zZXHtwR8QIlAImsTqQPIU01G7IJQatMSDWo+Hyvp4rpULTga22Wd8YaHWijeJWDAJjIYwhochvBW4sM+e0IlpYjJ4EuOjPXKWSNLFtrVxjWnQ+XOil9AYHkZDwJOo/QuPC7jAgt5DIvRtDczcHSUxegbGdofKxraNoXv+lU4XOcQwGnx5k73bMZzQHnFPRyf3lnXc3qMqi3yxNOu8qr6vyukrrddJ8DO6AGp7w7YLbKuivH7tf7pfesM/gUb1W4PO1Q/9Gf4zl/0NAAD///uJhCVYAgAA
+- path: /etc/containerd/certs.d/mcr.microsoft.com/hosts.toml
+  permissions: "0644"
+  owner: root
+  content: |
+    [host."https://testserver.azurecr.io"]
+      capabilities = ["pull", "resolve"]


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

**What this PR does / why we need it**:

If bootstrap container registry is enabled, we need to pull the image from the bootstrap container registry instead of MCR. This PR is to add a containerd config to use the container registry as a registry mirror.

For example, when pulling `mcr.microsoft.com/mcr/hello-world`, the containerd will pull `{{GetBootstrapProfileContainerRegistryServer}}/mcr/hello-world`.

If bootstrap container registry is not enabled, nothing is changed.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
Add the container registry as a registry mirror for mcr.microsoft.com when bootstrap container registry is enabled
```
