### PR TITLE
cleanup: Use k8s 1.29 in AgentBaker E2E tests

### DIFF
--- a/e2e/template.go
+++ b/e2e/template.go
@@ -28,7 +28,7 @@ func baseTemplate(location string) *datamodel.NodeBootstrappingConfiguration {
 				ProvisioningState: "",
 				OrchestratorProfile: &datamodel.OrchestratorProfile{
 					OrchestratorType:    "Kubernetes",
-					OrchestratorVersion: "1.26.0",
+					OrchestratorVersion: "1.29.6",
 					KubernetesConfig: &datamodel.KubernetesConfig{
 						KubernetesImageBase:               "",
 						MCRKubernetesImageBase:            "",
@@ -100,6 +100,7 @@ func baseTemplate(location string) *datamodel.NodeBootstrappingConfiguration {
 						VnetSubnetID:        "",
 						Distro:              "aks-ubuntu-containerd-18.04-gen2",
 						CustomNodeLabels: map[string]string{
+							"kubernetes.azure.com/cluster":            "test-cluster", // Some AKS daemonsets require that this exists, but the value doesn't matter.
 							"kubernetes.azure.com/mode":               "system",
 							"kubernetes.azure.com/node-image-version": "AKSUbuntu-1804gen2containerd-2022.01.19",
 						},
@@ -272,6 +273,7 @@ func baseTemplate(location string) *datamodel.NodeBootstrappingConfiguration {
 			VnetSubnetID:        "",
 			Distro:              "aks-ubuntu-containerd-18.04-gen2",
 			CustomNodeLabels: map[string]string{
+				"kubernetes.azure.com/cluster":            "test-cluster", // Some AKS daemonsets require that this exists, but the value doesn't matter.
 				"kubernetes.azure.com/mode":               "system",
 				"kubernetes.azure.com/node-image-version": "AKSUbuntu-1804gen2containerd-2022.01.19",
 			},
@@ -379,8 +381,8 @@ func baseTemplate(location string) *datamodel.NodeBootstrappingConfiguration {
 			"--azure-container-registry-config":   "/etc/kubernetes/azure.json",
 			"--cgroups-per-qos":                   "true",
 			"--client-ca-file":                    "/etc/kubernetes/certs/ca.crt",
-			"--cloud-config":                      "/etc/kubernetes/azure.json",
-			"--cloud-provider":                    "azure",
+			"--cloud-config":                      "",
+			"--cloud-provider":                    "external",
 			"--cluster-dns":                       "10.0.0.10",
 			"--cluster-domain":                    "cluster.local",
 			"--dynamic-config-dir":                "/var/lib/kubelet",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

AgentBaker E2E tests were using k8s 1.26, which is past EOL. Update to use k8s 1.29 which is the current default in AKS. This required two other changes to node bootstrapping config:

1. Switch from in-tree to external cloud-provider (`--cloud-config=""` and `--cloud-provider=external`). Otherwise kubelet exits with an error that in-tree cloud-provider is no longer supported ("built-in cloud providers are disabled").
2. Add kubernetes.azure.com/cluster node label. Otherwise, cloud-node-manager and other daemonsets won't schedule on the node, so the node gets stuck with "uninitialized" taint

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
