### PR TITLE
fix: return error first before accessing fields that might be nil in extractLogsFromVM

### DIFF
--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -72,7 +72,8 @@ func extractLogsFromVM(ctx context.Context, t *testing.T, vmssName, privateIP, s
 
 		execResult, err := execOnVM(ctx, opts.clusterConfig.Kube, privateIP, podName, sshPrivateKey, sourceCmd, false)
 		if err != nil {
-			t.Fatalf("error executing command on remote VM at %s of VMSS %s: %s", privateIP, vmssName, err)
+			t.Logf("error executing command on remote VM at %s of VMSS %s: %s", privateIP, vmssName, err)
+			return nil, err
 		}
 
 		if execResult.stdout != nil {

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -71,7 +71,6 @@ func extractLogsFromVM(ctx context.Context, t *testing.T, vmssName, privateIP, s
 		t.Logf("executing command on remote VM at %s of VMSS %s: %q", privateIP, vmssName, sourceCmd)
 
 		execResult, err := execOnVM(ctx, opts.clusterConfig.Kube, privateIP, podName, sshPrivateKey, sourceCmd, false)
-
 		if err != nil {
 			t.Logf("error executing command on remote VM at %s of VMSS %s: %s", privateIP, vmssName, err)
 		}

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -71,6 +71,11 @@ func extractLogsFromVM(ctx context.Context, t *testing.T, vmssName, privateIP, s
 		t.Logf("executing command on remote VM at %s of VMSS %s: %q", privateIP, vmssName, sourceCmd)
 
 		execResult, err := execOnVM(ctx, opts.clusterConfig.Kube, privateIP, podName, sshPrivateKey, sourceCmd, false)
+
+		if err != nil {
+			t.Logf("error executing command on remote VM at %s of VMSS %s: %s", privateIP, vmssName, err)
+		}
+
 		if execResult.stdout != nil {
 			out := execResult.stdout.String()
 			if out != "" {
@@ -83,10 +88,6 @@ func extractLogsFromVM(ctx context.Context, t *testing.T, vmssName, privateIP, s
 			if out != "" {
 				result[file+".stderr.txt"] = out
 			}
-		}
-
-		if err != nil {
-			t.Logf("error executing command on remote VM at %s of VMSS %s: %s", privateIP, vmssName, err)
 		}
 	}
 	return result, nil

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -72,7 +72,7 @@ func extractLogsFromVM(ctx context.Context, t *testing.T, vmssName, privateIP, s
 
 		execResult, err := execOnVM(ctx, opts.clusterConfig.Kube, privateIP, podName, sshPrivateKey, sourceCmd, false)
 		if err != nil {
-			t.Logf("error executing command on remote VM at %s of VMSS %s: %s", privateIP, vmssName, err)
+			t.Fatalf("error executing command on remote VM at %s of VMSS %s: %s", privateIP, vmssName, err)
 		}
 
 		if execResult.stdout != nil {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
