### PR TITLE
Switch over to using the new agent pool vnet in prod

### DIFF
--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -82,10 +82,6 @@ fi
 if [ -z "${VNET_RG_NAME}" ]; then
 	if [ "$MODE" == "linuxVhdMode" ]; then
 		VNET_RG_NAME="nodesig-${ENVIRONMENT}-${PACKER_BUILD_LOCATION}-agent-pool"
-		if [ "${ENVIRONMENT,,}" == "prod" ]; then
-			# for now preserve original functionality for prod builds
-			VNET_RG_NAME="nodesigprod-agent-pool"
-		fi
 	fi
 	if [ "$MODE" == "windowsVhdMode" ]; then
 		if [[ "${POOL_NAME}" == *nodesigprod* ]]; then
@@ -99,10 +95,6 @@ fi
 if [ -z "${VNET_NAME}" ]; then
 	if [ "$MODE" == "linuxVhdMode" ]; then
 		VNET_NAME="nodesig-pool-vnet-${PACKER_BUILD_LOCATION}"
-		if [ "${ENVIRONMENT,,}" == "prod" ]; then
-			# for now preserve original functionality for prod builds
-			VNET_NAME="nodesig-pool-vnet"
-		fi
 	fi
 	if [ "$MODE" == "windowsVhdMode" ]; then
 		VNET_NAME="nodesig-pool-vnet"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This switches packer to linking the build VMs to the new nodesig-pool-vnet-<region> vnet in the new prod agent pool RG. Without this the prod build can't use the new pool - the private endpoint SSH connection fails.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
