### PR TITLE
chore: add Force when the windowsnodereset task stopping services

### DIFF
--- a/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
+++ b/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
@@ -82,19 +82,19 @@ Unregister-HNSRemediatorScriptTask
 # Stop services
 #
 Write-Log "Stopping kubeproxy service"
-Stop-Service kubeproxy
+Stop-Service kubeproxy -Force
 
 Write-Log "Stopping kubelet service"
-Stop-Service kubelet
+Stop-Service kubelet -Force
 
 if ($global:CsiProxyEnabled) {
     Write-Log "Stopping csi-proxy service"
-    Stop-Service csi-proxy
+    Stop-Service csi-proxy -Force
 }
 
 if ($global:EnableHostsConfigAgent) {
     Write-Log "Stopping hosts-config-agent service"
-    Stop-Service hosts-config-agent
+    Stop-Service hosts-config-agent -Force
 }
 
 # Due to a bug in hns there is a race where it picks up the incorrect IPv6 address from the node in some cases.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Add the -Force parameter when stopping services in the windowsnodereset task to ensure they stop completely, e.g., If the service is depended on by other running services, it cannot be reliably stopped without using the -Force parameter.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
