### PR TITLE
fix: correctly return error in testBccTools test if the test fails

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -367,7 +367,7 @@ installBpftrace
 echo "  - $(bpftrace --version)" >> ${VHD_LOGS_FILEPATH}
 
 PRESENT_DIR=$(pwd)
-#run installBcc in a subshell and continue on with container image pull in order to decrease total build time
+# Run installBcc in a subshell and continue on with container image pull in order to decrease total build time
 (
   cd $PRESENT_DIR || { echo "Subshell in the wrong directory" >&2; exit 1; }
 

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -367,7 +367,7 @@ installBpftrace
 echo "  - $(bpftrace --version)" >> ${VHD_LOGS_FILEPATH}
 
 PRESENT_DIR=$(pwd)
-# Run installBcc in a subshell and continue on with container image pull in order to decrease total build time
+# run installBcc in a subshell and continue on with container image pull in order to decrease total build time
 (
   cd $PRESENT_DIR || { echo "Subshell in the wrong directory" >&2; exit 1; }
 

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -367,7 +367,7 @@ installBpftrace
 echo "  - $(bpftrace --version)" >> ${VHD_LOGS_FILEPATH}
 
 PRESENT_DIR=$(pwd)
- run installBcc in a subshell and continue on with container image pull in order to decrease total build time
+#run installBcc in a subshell and continue on with container image pull in order to decrease total build time
 (
   cd $PRESENT_DIR || { echo "Subshell in the wrong directory" >&2; exit 1; }
 

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -370,9 +370,7 @@ PRESENT_DIR=$(pwd)
 # run installBcc in a subshell and continue on with container image pull in order to decrease total build time
 (
   cd $PRESENT_DIR || { echo "Subshell in the wrong directory" >&2; exit 1; }
-
   installBcc
-
   exit $?
 ) > /var/log/bcc_installation.log 2>&1 &
 

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -371,7 +371,7 @@ PRESENT_DIR=$(pwd)
 (
   cd $PRESENT_DIR || { echo "Subshell in the wrong directory" >&2; exit 1; }
   installBcc
-  exit 1
+  exit $?
 ) > /var/log/bcc_installation.log 2>&1 &
 
 BCC_PID=$!

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -373,7 +373,7 @@ PRESENT_DIR=$(pwd)
 
   installBcc
 
-  exit 1
+  exit $?
 ) > /var/log/bcc_installation.log 2>&1 &
 
 BCC_PID=$!

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -363,20 +363,20 @@ fi
 
 ls -ltr /opt/gpu/* >> ${VHD_LOGS_FILEPATH}
 
-installBpftrace
-echo "  - $(bpftrace --version)" >> ${VHD_LOGS_FILEPATH}
+#installBpftrace
+#echo "  - $(bpftrace --version)" >> ${VHD_LOGS_FILEPATH}
 
-PRESENT_DIR=$(pwd)
+#PRESENT_DIR=$(pwd)
 # run installBcc in a subshell and continue on with container image pull in order to decrease total build time
-(
-  cd $PRESENT_DIR || { echo "Subshell in the wrong directory" >&2; exit 1; }
+#(
+  #cd $PRESENT_DIR || { echo "Subshell in the wrong directory" >&2; exit 1; }
 
-  installBcc
+  #installBcc
 
-  exit $?
-) > /var/log/bcc_installation.log 2>&1 &
+  #exit $?
+#) > /var/log/bcc_installation.log 2>&1 &
 
-BCC_PID=$!
+#BCC_PID=$!
 
 echo "${CONTAINER_RUNTIME} images pre-pulled:" >> ${VHD_LOGS_FILEPATH}
 capture_benchmark "pull_nvidia_driver_image_and_run_installBcc_in_subshell"
@@ -547,18 +547,18 @@ if [[ $OS == $UBUNTU_OS_NAME ]]; then
   sed -i 's/After=network-online.target/After=multi-user.target/g' /lib/systemd/system/motd-news.service
 fi
 
-wait $BCC_PID
-BCC_EXIT_CODE=$?
+#wait $BCC_PID
+#BCC_EXIT_CODE=$?
 
-if [ $BCC_EXIT_CODE -eq 0 ]; then
-  echo "Bcc tools successfully installed."
-  cat << EOF >> ${VHD_LOGS_FILEPATH}
-  - bcc-tools
-  - libbcc-examples
-EOF
-else
-  echo "Error: installBcc subshell failed with exit code $BCC_EXIT_CODE" >&2
-fi
+#if [ $BCC_EXIT_CODE -eq 0 ]; then
+  #echo "Bcc tools successfully installed."
+  #cat << EOF >> ${VHD_LOGS_FILEPATH}
+  #- bcc-tools
+  #- libbcc-examples
+#EOF
+#else
+  #echo "Error: installBcc subshell failed with exit code $BCC_EXIT_CODE" >&2
+#fi
 capture_benchmark "finish_installing_bcc_tools"
 
 # use the private_packages_url to download and cache packages

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -363,20 +363,20 @@ fi
 
 ls -ltr /opt/gpu/* >> ${VHD_LOGS_FILEPATH}
 
-#installBpftrace
-#echo "  - $(bpftrace --version)" >> ${VHD_LOGS_FILEPATH}
+installBpftrace
+echo "  - $(bpftrace --version)" >> ${VHD_LOGS_FILEPATH}
 
-#PRESENT_DIR=$(pwd)
-# run installBcc in a subshell and continue on with container image pull in order to decrease total build time
-#(
-  #cd $PRESENT_DIR || { echo "Subshell in the wrong directory" >&2; exit 1; }
+PRESENT_DIR=$(pwd)
+ run installBcc in a subshell and continue on with container image pull in order to decrease total build time
+(
+  cd $PRESENT_DIR || { echo "Subshell in the wrong directory" >&2; exit 1; }
 
-  #installBcc
+  installBcc
 
-  #exit $?
-#) > /var/log/bcc_installation.log 2>&1 &
+  exit 1
+) > /var/log/bcc_installation.log 2>&1 &
 
-#BCC_PID=$!
+BCC_PID=$!
 
 echo "${CONTAINER_RUNTIME} images pre-pulled:" >> ${VHD_LOGS_FILEPATH}
 capture_benchmark "pull_nvidia_driver_image_and_run_installBcc_in_subshell"
@@ -547,18 +547,18 @@ if [[ $OS == $UBUNTU_OS_NAME ]]; then
   sed -i 's/After=network-online.target/After=multi-user.target/g' /lib/systemd/system/motd-news.service
 fi
 
-#wait $BCC_PID
-#BCC_EXIT_CODE=$?
+wait $BCC_PID
+BCC_EXIT_CODE=$?
 
-#if [ $BCC_EXIT_CODE -eq 0 ]; then
-  #echo "Bcc tools successfully installed."
-  #cat << EOF >> ${VHD_LOGS_FILEPATH}
-  #- bcc-tools
-  #- libbcc-examples
-#EOF
-#else
-  #echo "Error: installBcc subshell failed with exit code $BCC_EXIT_CODE" >&2
-#fi
+if [ $BCC_EXIT_CODE -eq 0 ]; then
+  echo "Bcc tools successfully installed."
+  cat << EOF >> ${VHD_LOGS_FILEPATH}
+  - bcc-tools
+  - libbcc-examples
+EOF
+else
+  echo "Error: installBcc subshell failed with exit code $BCC_EXIT_CODE" >&2
+fi
 capture_benchmark "finish_installing_bcc_tools"
 
 # use the private_packages_url to download and cache packages

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -371,7 +371,7 @@ PRESENT_DIR=$(pwd)
 (
   cd $PRESENT_DIR || { echo "Subshell in the wrong directory" >&2; exit 1; }
   installBcc
-  exit $?
+  exit 1
 ) > /var/log/bcc_installation.log 2>&1 &
 
 BCC_PID=$!

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -373,7 +373,7 @@ PRESENT_DIR=$(pwd)
 
   installBcc
 
-  exit $?
+  exit 1
 ) > /var/log/bcc_installation.log 2>&1 &
 
 BCC_PID=$!

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -932,14 +932,14 @@ testContainerImagePrefetchScript() {
 
 testBccTools () {
   local test="BCCInstallTest"
-  echo "$test: checking if BCC tools were successfully downloaded"
-  for line in '- bcc-tools' '- libbcc-examples'; do
-    if ! grep -F -x -e "$line" /opt/azure/vhd-install.complete; then
-      err "BCC tools were not successfully downloaded."
+  echo "$test: checking if BCC tools were successfully installed"
+  for line in '  - bcc-tools' '  - libbcc-examples'; do
+    if ! grep -F -x -e "$line" $VHD_LOGS_FILEPATH; then
+      err "BCC tools were not successfully installed"
       return 1
     fi
   done
-  echo "BCC tools were successfully downloaded."
+  echo "$test: BCC tools were successfully installed"
   return 0
 }
 

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -931,6 +931,8 @@ testContainerImagePrefetchScript() {
 }
 
 testBccTools () {
+  local test="BCCInstallTest"
+  echo "$test: checking if BCC tools were successfully downloaded"
   for line in '- bcc-tools' '- libbcc-examples'; do
     if ! grep -F -x -e "$line" /opt/azure/vhd-install.complete; then
       err "BCC tools were not successfully downloaded."

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -933,7 +933,7 @@ testContainerImagePrefetchScript() {
 testBccTools () {
   for line in '- bcc-tools' '- libbcc-examples'; do
     if ! grep -F -x -e "$line" /opt/azure/vhd-install.complete; then
-      echo "BCC tools were not successfully downloaded."
+      err "BCC tools were not successfully downloaded."
       return 1
     fi
   done


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

If the BCC install test fails it does not return "err", it just returns 1. This results in the az vm run command failing to recognize that the test failed. 

**Which issue(s) this PR fixes**:

testBccTools test in linux-vhd-content-test.sh is failing to correctly return an error.

**Requirements**:

- [ x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version