### PR TITLE
chore: bump Linux NPM to v1.5.36

### DIFF
--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -145,7 +145,7 @@
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-npm:*",
       "amd64OnlyVersions": [],
       "multiArchVersions": [
-        "v1.5.34"
+        "v1.5.36"
       ]
     },
     {


### PR DESCRIPTION
**What type of PR is this?**

NPM version update.

**What this PR does / why we need it**:

We are rolling out a fix for a race condition in NPM (see release notes).

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Release note**:

https://github.com/Azure/azure-container-networking/releases/tag/v1.5.36