### PR TITLE
chore: add NVMe disk controller type to new gen2 image defs

### DIFF
--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -250,6 +250,10 @@ if [[ "$MODE" == "linuxVhdMode" || "$MODE" == "windowsVhdMode" ]]; then
 			TARGET_COMMAND_STRING+="--features SecurityType=ConfidentialVMSupported"
 		elif [[ ${ENABLE_TRUSTED_LAUNCH} == "True" ]]; then
 			TARGET_COMMAND_STRING+="--features SecurityType=TrustedLaunch"
+		elif [[ ${HYPERV_GENERATION} == "V2" ]]; then
+		  # NVMe SKUs are only enabled for Gen2 VM sizes, and Arm64 doesnt need special tagging + CVM sizes are not v6
+		  # TODO(amaheshwari): add a check for TL + Gen2 combo, currently fine since the only TL SKU is updated already
+		  TARGET_COMMAND_STRING+="--features DiskControllerTypes=SCSI,NVMe"
 		fi
 
 		az sig image-definition create \


### PR DESCRIPTION
**What type of PR is this?**
This PR enables tagging any new Gen2 Image Definition with diskControllerTypes=SCSI,NVMe to work with v6 SKUs

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
