### PR TITLE
feat(abe2e): move kubelet node IP validator to common validators

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -25,7 +25,6 @@ func Test_azurelinuxv2(t *testing.T) {
 			LiveVMValidators: []*LiveVMValidator{
 				containerdVersionValidator("1.6.26"),
 				runcVersionValidator("1.1.9"),
-				kubeletNodeIPValidator(),
 			},
 		},
 	})
@@ -120,9 +119,6 @@ func Test_azurelinuxv2_azurecni(t *testing.T) {
 				nbc.AgentPoolProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
 				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-azurelinux-v2-gen2"
 				nbc.AgentPoolProfile.Distro = "aks-azurelinux-v2-gen2"
-			},
-			LiveVMValidators: []*LiveVMValidator{
-				kubeletNodeIPValidator(),
 			},
 		},
 	})
@@ -371,9 +367,6 @@ func Test_marinerv2_azurecni(t *testing.T) {
 				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-cblmariner-v2-gen2"
 				nbc.AgentPoolProfile.Distro = "aks-cblmariner-v2-gen2"
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				kubeletNodeIPValidator(),
-			},
 		},
 	})
 }
@@ -522,7 +515,6 @@ func Test_ubuntu1804(t *testing.T) {
 			LiveVMValidators: []*LiveVMValidator{
 				containerdVersionValidator("1.7.1+azure-1"),
 				runcVersionValidator("1.1.14-1"),
-				kubeletNodeIPValidator(),
 			},
 		},
 	})
@@ -537,9 +529,6 @@ func Test_ubuntu1804_azurecni(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
 				nbc.AgentPoolProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
-			},
-			LiveVMValidators: []*LiveVMValidator{
-				kubeletNodeIPValidator(),
 			},
 		},
 	})
@@ -634,7 +623,6 @@ func Test_ubuntu2204(t *testing.T) {
 			LiveVMValidators: []*LiveVMValidator{
 				containerdVersionValidator("1.7.20-1"),
 				runcVersionValidator("1.1.14-1"),
-				kubeletNodeIPValidator(),
 			},
 		},
 	})

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/agentbakere2e/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -148,6 +149,12 @@ func commonLiveVMValidators(opts *scenarioRunOpts) []*LiveVMValidator {
 		},
 	}
 	validators = append(validators, leakedSecretsValidators(opts)...)
+
+	// kubeletNodeIPValidator cannot be run on older VHDs with kubelet < 1.29
+	if opts.scenario.VHD != config.VHDUbuntu2204Gen2ContainerdPrivateKubePkg {
+		validators = append(validators, kubeletNodeIPValidator())
+	}
+
 	return validators
 }
 

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -151,7 +151,7 @@ func commonLiveVMValidators(opts *scenarioRunOpts) []*LiveVMValidator {
 	validators = append(validators, leakedSecretsValidators(opts)...)
 
 	// kubeletNodeIPValidator cannot be run on older VHDs with kubelet < 1.29
-	if opts.scenario.VHD != config.VHDUbuntu2204Gen2ContainerdPrivateKubePkg {
+	if opts.scenario.VHD.Version != config.VHDUbuntu2204Gen2ContainerdPrivateKubePkg.Version {
 		validators = append(validators, kubeletNodeIPValidator())
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

makes the kubelet node ip validator a common validator, though still excludes it from scenarios (privatepkg) that utilize older VHDs that aren't at least on k8s 1.29

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
