### PR TITLE
chore: remove unused dropgz versions

### DIFF
--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -165,31 +165,11 @@
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/cni-dropgz",
           "latestVersion": "v0.0.20"
-        },
-        {
-          "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/cni-dropgz",
-          "latestVersion": "v0.1.4"
-        },
-        {
-          "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/cni-dropgz",
-          "latestVersion": "v0.2.0"
         }
       ],
       "prefetchOptimizations": [
         {
           "version": "v0.0.20",
-          "binaries": [
-            "dropgz"
-          ]
-        },
-        {
-          "version": "v0.1.4",
-          "binaries": [
-            "dropgz"
-          ]
-        },
-        {
-          "version": "v0.2.0",
           "binaries": [
             "dropgz"
           ]

--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -117,8 +117,6 @@ $global:imagesToPull += @(
     "mcr.microsoft.com/containernetworking/azure-cns:v1.6.5",
     "mcr.microsoft.com/containernetworking/azure-cns:v1.6.7",
     # CNI installer for azure-vnet. Owner: evanbaker
-    "mcr.microsoft.com/containernetworking/cni-dropgz:v0.1.4",
-    "mcr.microsoft.com/containernetworking/cni-dropgz:v0.2.0",
     "mcr.microsoft.com/containernetworking/azure-cni:v1.5.35",
     "mcr.microsoft.com/containernetworking/azure-cni:v1.6.5",
     "mcr.microsoft.com/containernetworking/azure-cni:v1.6.7"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Removes unused cni-dropgz images to free up space on the VHD
Dropgz v0.1.4 and v0.2.0 target k8 v1.28 and v1.30+ respectively, but for those k8 versions we already use azure-cni to install cni, not dropgz. So, we no longer need these dropgz images. k8s 1.27- still uses dropgz v0.0.x which is why it stays.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
