### PR TITLE
kata: Use image for AzL3 Kata UVM

### DIFF
--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -38,7 +38,7 @@ steps:
         exit 1
       fi
       echo "Found source components.json to use for overrides: ${COMPONENT_JSON_SRC}"
-      
+
       echo "Overwriting component.json from ${COMPONENT_JSON_SRC} -> ${COMPONENT_JSON_DEST}"
       cp -af "${COMPONENT_JSON_SRC}" "${COMPONENT_JSON_DEST}"
     displayName: Apply Overrides
@@ -71,6 +71,7 @@ steps:
         **/kata-containers-igvm-debug.img**
         **/igvm-measurement**
         **/kata-containers-igvm.img**
+        **/kata-containers-cc.img**
         **/kata-containers.img**
         **/kata-containers-initrd-base.img**
         **/reference-info-base64**

--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -144,8 +144,32 @@ copyPackerFiles() {
 
   if grep -q "kata" <<< "$FEATURE_FLAGS"; then
     # KataCC SPEC file assumes kata config points to the files exactly under this path
-    KATA_CONFIG_DIR=/var/cache/kata-containers/osbuilder-images/kernel-uvm/
+    if [[ $OS_VERSION == "2.0" ]]; then
+      KATA_CONFIG_DIR=/var/cache/kata-containers/osbuilder-images/kernel-uvm
+    elif [[ $OS_VERSION == "3.0" ]]; then
+      KATA_CONFIG_DIR=/usr/share/kata-containers
+    else
+      exit 1
+    fi
     KATACC_CONFIG_DIR=/opt/confidential-containers/share/kata-containers
+
+    if [[ $OS_VERSION == "2.0" ]]; then
+      KATA_INITRD_SRC=/home/packer/kata-containers-initrd-base.img
+      KATA_INITRD_DEST=$KATA_CONFIG_DIR/kata-containers-initrd.img
+      cpAndMode $KATA_INITRD_SRC $KATA_INITRD_DEST 0755
+
+      KATACC_IMAGE_SRC=/home/packer/kata-containers.img
+      KATACC_IMAGE_DEST=$KATACC_CONFIG_DIR/kata-containers.img
+      cpAndMode $KATACC_IMAGE_SRC $KATACC_IMAGE_DEST 0755
+    elif [[ $OS_VERSION == "3.0" ]]; then
+      KATA_IMAGE_SRC=/home/packer/kata-containers.img
+      KATA_IMAGE_DEST=$KATA_CONFIG_DIR/kata-containers.img
+      cpAndMode $KATA_IMAGE_SRC $KATA_IMAGE_DEST 0755
+
+      KATACC_IMAGE_SRC=/home/packer/kata-containers-cc.img
+      KATACC_IMAGE_DEST=$KATACC_CONFIG_DIR/kata-containers.img
+      cpAndMode $KATACC_IMAGE_SRC $KATACC_IMAGE_DEST 0755
+    fi
 
     IGVM_DEBUG_BIN_SRC=/home/packer/kata-containers-igvm-debug.img
     IGVM_DEBUG_BIN_DEST=$KATACC_CONFIG_DIR/kata-containers-igvm-debug.img
@@ -154,14 +178,6 @@ copyPackerFiles() {
     IGVM_BIN_SRC=/home/packer/kata-containers-igvm.img
     IGVM_BIN_DEST=$KATACC_CONFIG_DIR/kata-containers-igvm.img
     cpAndMode $IGVM_BIN_SRC $IGVM_BIN_DEST 0755
-
-    KATA_INITRD_SRC=/home/packer/kata-containers-initrd-base.img
-    KATA_INITRD_DEST=$KATA_CONFIG_DIR/kata-containers-initrd.img
-    cpAndMode $KATA_INITRD_SRC $KATA_INITRD_DEST 0755
-
-    KATACC_IMAGE_SRC=/home/packer/kata-containers.img
-    KATACC_IMAGE_DEST=$KATACC_CONFIG_DIR/kata-containers.img
-    cpAndMode $KATACC_IMAGE_SRC $KATACC_IMAGE_DEST 0755
 
     REF_INFO_SRC=/home/packer/reference-info-base64
     REF_INFO_DEST=$KATACC_CONFIG_DIR/reference-info-base64

--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -149,6 +149,7 @@ copyPackerFiles() {
     elif [[ $OS_VERSION == "3.0" ]]; then
       KATA_CONFIG_DIR=/usr/share/kata-containers
     else
+      echo "Unexpected OS version '${OS_VERSION}' in kata feature flag code path"
       exit 1
     fi
     KATACC_CONFIG_DIR=/opt/confidential-containers/share/kata-containers

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -562,6 +562,11 @@
     },
     {
       "type": "file",
+      "source": "kata-containers-cc.img",
+      "destination": "/home/packer/kata-containers-cc.img"
+    },
+    {
+      "type": "file",
       "source": "reference-info-base64",
       "destination": "/home/packer/reference-info-base64"
     },


### PR DESCRIPTION
While AzL2 uses an initrd file for the Kata UVM, AzL3 will use an image file aligned with Kata CoCo where an image file is being used.