### PR TITLE
test: publish bcc installation logs

### DIFF
--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -164,6 +164,21 @@ steps:
     condition: always()
     displayName: Check Build Performance
 
+  - task: PublishPipelineArtifact@0
+    condition: always()
+    displayName: Publish BCC Tools Installation Log
+    inputs:
+      artifactName: 'bcc-tools-installation-log-${{ parameters.artifactName }}'
+      targetPath: 'bcc-tools-installation.log'
+
+  - task: CopyFiles@2
+    condition: always()
+    displayName: Copy BCC Tools Installation Log
+    inputs:
+      SourceFolder: '$(System.DefaultWorkingDirectory)'
+      Contents: 'bcc-tools-installation.log'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
   - task: CopyFiles@2
     condition: eq(variables['IS_NOT_1804'], 'true')
     displayName: Copy Trivy Report
@@ -178,14 +193,6 @@ steps:
     inputs:
       SourceFolder: '$(System.DefaultWorkingDirectory)'
       Contents: 'trivy-images-table.txt'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
-
-  - task: CopyFiles@2
-    condition: always()
-    displayName: Copy BCC Tools Logs
-    inputs:
-      SourceFolder: '$(System.DefaultWorkingDirectory)'
-      Contents: 'bcc-tools-installation.log'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
   - task: PublishPipelineArtifact@0

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -180,6 +180,14 @@ steps:
       Contents: 'trivy-images-table.txt'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
+  - task: CopyFiles@2
+    condition: always()
+    displayName: Copy BCC Tools Logs
+    inputs:
+      SourceFolder: '$(System.DefaultWorkingDirectory)'
+      Contents: 'bcc-tools-installation.log'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
   - task: PublishPipelineArtifact@0
     displayName: Publish Release Notes
     inputs:
@@ -205,14 +213,6 @@ steps:
     inputs:
       SourceFolder: '$(System.DefaultWorkingDirectory)'
       Contents: 'image-bom.json'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
-
-  - task: CopyFiles@2
-    condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))
-    displayName: Copy BCC Tools Logs
-    inputs:
-      SourceFolder: '$(System.DefaultWorkingDirectory)'
-      Contents: 'bcc-tools-installation.log'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
   - bash: make -f packer.mk convert-sig-to-classic-storage-account-blob

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -207,6 +207,14 @@ steps:
       Contents: 'image-bom.json'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
+  - task: CopyFiles@2
+    condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))
+    displayName: Copy BCC Tools Logs
+    inputs:
+      SourceFolder: '$(System.DefaultWorkingDirectory)'
+      Contents: 'bcc-tools-installation.log'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
   - bash: make -f packer.mk convert-sig-to-classic-storage-account-blob
     condition: and(succeeded(), eq(variables.DRY_RUN, 'False'))
     displayName: Convert Shared Image Gallery To VHD Blob In Classic Storage Account

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -562,6 +562,7 @@ EOF
 else
   echo "Error: installBcc subshell failed with exit code $BCC_EXIT_CODE" >&2
 fi
+chmod 755 /var/log/bcc_installation.log
 capture_benchmark "finish_installing_bcc_tools"
 
 # use the private_packages_url to download and cache packages

--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -599,6 +599,12 @@
       ]
     },
     {
+      "type": "file",
+      "direction": "download",
+      "source": "/var/log/bcc_installation.log",
+      "destination": "bcc-tools-installation.log"
+    },
+    {
       "type": "shell",
       "inline": "sudo reboot",
       "expect_disconnect": true,

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -611,6 +611,12 @@
       ]
     },
     {
+      "type": "file",
+      "direction": "download",
+      "source": "/var/log/bcc_installation.log",
+      "destination": "bcc-tools-installation.log"
+    },
+    {
       "type": "shell",
       "inline": "sudo reboot",
       "expect_disconnect": true,

--- a/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
@@ -568,6 +568,12 @@
       ]
     },
     {
+      "type": "file",
+      "direction": "download",
+      "source": "/var/log/bcc_installation.log",
+      "destination": "bcc-tools-installation.log"
+    },
+    {
       "type": "shell",
       "inline": "sudo reboot",
       "expect_disconnect": true,

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -590,6 +590,12 @@
       ]
     },
     {
+      "type": "file",
+      "direction": "download",
+      "source": "/var/log/bcc_installation.log",
+      "destination": "bcc-tools-installation.log"
+    },
+    {
       "type": "shell",
       "inline": "sudo reboot",
       "expect_disconnect": true,


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

This PR publishes bcc install logs after the completion of the VHD build in order to gain visibility into the installation process after failed downloads.

**Which issue(s) this PR fixes**:

Lack of visibility into bcc tools installation process. 


**Requirements**:

- [x ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version