### PR TITLE
Backport of AzCNI installer images for k8s 1.27

### DIFF
--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -38,6 +38,17 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/azure-cni",
+          "latestVersion": "v1.4.56",
+          "containerImagePrefetch": {
+            "latestVersion": {
+              "binaries": [
+                "/dropgz"
+              ]
+            }
+          }
+        },
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/azure-cni",
           "latestVersion": "v1.5.35",
           "previousLatestVersion": "v1.5.32",
           "containerImagePrefetch": {
@@ -127,6 +138,17 @@
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-ipam:*",
       "amd64OnlyVersions": [],
       "multiArchVersionsV2": [
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/azure-ipam",
+          "latestVersion": "v0.0.7",
+          "containerImagePrefetch": {
+            "latestVersion": {
+              "binaries": [
+                "/dropgz"
+              ]
+            }
+          }
+        },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/azure-ipam",
           "latestVersion": "v0.2.0",

--- a/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/generate-windows-vhd-configuration.ps1
@@ -131,6 +131,7 @@ $global:imagesToPull += @(
     "mcr.microsoft.com/containernetworking/azure-cns:v1.6.7",
     "mcr.microsoft.com/containernetworking/azure-cns:v1.6.13",
     # CNI installer for azure-vnet. Owner: evanbaker
+    "mcr.microsoft.com/containernetworking/azure-cni:v1.4.56",
     "mcr.microsoft.com/containernetworking/azure-cni:v1.5.35",
     "mcr.microsoft.com/containernetworking/azure-cni:v1.6.7",
     "mcr.microsoft.com/containernetworking/azure-cni:v1.6.13"

--- a/vhdbuilder/prefetch/internal/containerimage/testdata/prefetch.sh
+++ b/vhdbuilder/prefetch/internal/containerimage/testdata/prefetch.sh
@@ -17,6 +17,7 @@ prefetch() {
 
     ctr -n k8s.io images unmount "$mount_dir"
 }
+prefetch "mcr.microsoft.com/containernetworking/azure-cni:v1.4.56" "/dropgz"
 prefetch "mcr.microsoft.com/containernetworking/azure-cni:v1.5.35" "/dropgz"
 prefetch "mcr.microsoft.com/containernetworking/azure-cni:v1.5.32" "/dropgz"
 prefetch "mcr.microsoft.com/containernetworking/azure-cni:v1.6.13" "/dropgz"
@@ -26,5 +27,6 @@ prefetch "mcr.microsoft.com/containernetworking/azure-cns:v1.5.35" "/usr/local/b
 prefetch "mcr.microsoft.com/containernetworking/azure-cns:v1.5.32" "/usr/local/bin/azure-cns"
 prefetch "mcr.microsoft.com/containernetworking/azure-cns:v1.6.13" "/usr/local/bin/azure-cns"
 prefetch "mcr.microsoft.com/containernetworking/azure-cns:v1.6.7" "/usr/local/bin/azure-cns"
+prefetch "mcr.microsoft.com/containernetworking/azure-ipam:v0.0.7" "/dropgz"
 prefetch "mcr.microsoft.com/containernetworking/azure-ipam:v0.2.0" "/dropgz"
 prefetch "mcr.microsoft.com/containernetworking/cni-dropgz:v0.0.20" "/dropgz"


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
We have been using the `cni-dropgz` image in 1.27, this backports the `azure-ipam` and `azure-cni` images we're now building for 1.27 cluster so that we can migrate them. `cni-dropgz` image will be purged here afterwards.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
