### PR TITLE
fix: exit when bcc install fails

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -552,6 +552,7 @@ if [ $BCC_EXIT_CODE -eq 0 ]; then
 EOF
 else
   echo "Error: installBcc subshell failed with exit code $BCC_EXIT_CODE" >&2
+  exit $BCC_EXIT_CODE
 fi
 chmod 755 /var/log/bcc_installation.log
 capture_benchmark "${SCRIPT_NAME}_finish_installing_bcc_tools"

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -543,6 +543,7 @@ fi
 
 wait $BCC_PID
 BCC_EXIT_CODE=$?
+chmod 755 /var/log/bcc_installation.log
 
 if [ $BCC_EXIT_CODE -eq 0 ]; then
   echo "Bcc tools successfully installed."
@@ -554,7 +555,6 @@ else
   echo "Error: installBcc subshell failed with exit code $BCC_EXIT_CODE" >&2
   exit $BCC_EXIT_CODE
 fi
-chmod 755 /var/log/bcc_installation.log
 capture_benchmark "${SCRIPT_NAME}_finish_installing_bcc_tools"
 
 # use the private_packages_url to download and cache packages


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR will fail the build if BCC tools installation fails in order to address errors quicker.

**Which issue(s) this PR fixes**:

BCC install failures were only caught during the testing phase of the VHD build. 

**Requirements**:

- [x ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version