### PR TITLE
using discard_unpacked_layers with CRI to reduce the size on disk of the cached images

### DIFF
--- a/nbcparser/pkg/parser/templates/cse_cmd.sh.gtpl
+++ b/nbcparser/pkg/parser/templates/cse_cmd.sh.gtpl
@@ -51,7 +51,6 @@ LOAD_BALANCER_SKU={{getStringFromLoadBalancerSkuType .ClusterConfig.GetLoadBalan
 EXCLUDE_MASTER_FROM_STANDARD_LB={{getExcludeMasterFromStandardLB .ClusterConfig.GetLoadBalancerConfig}}
 MAXIMUM_LOADBALANCER_RULE_COUNT={{getMaxLBRuleCount .ClusterConfig.GetLoadBalancerConfig}}
 CONTAINER_RUNTIME=containerd
-CLI_TOOL=ctr
 CONTAINERD_DOWNLOAD_URL_BASE={{.ContainerdConfig.GetContainerdDownloadUrlBase}} 
 NETWORK_MODE="transparent"
 KUBE_BINARY_URL={{.KubeBinaryConfig.GetKubeBinaryUrl}}

--- a/parts/linux/cloud-init/artifacts/cse_cmd.sh
+++ b/parts/linux/cloud-init/artifacts/cse_cmd.sh
@@ -52,7 +52,6 @@ LOAD_BALANCER_SKU={{GetVariable "loadBalancerSku"}}
 EXCLUDE_MASTER_FROM_STANDARD_LB={{GetVariable "excludeMasterFromStandardLB"}}
 MAXIMUM_LOADBALANCER_RULE_COUNT={{GetVariable "maximumLoadBalancerRuleCount"}}
 CONTAINER_RUNTIME={{GetParameter "containerRuntime"}}
-CLI_TOOL={{GetParameter "cliTool"}}
 CONTAINERD_DOWNLOAD_URL_BASE={{GetParameter "containerdDownloadURLBase"}}
 NETWORK_MODE={{GetParameter "networkMode"}}
 KUBE_BINARY_URL={{GetParameter "kubeBinaryURL"}}

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -744,7 +744,7 @@ configGPUDrivers() {
     if [[ $OS == $UBUNTU_OS_NAME ]]; then
         mkdir -p /opt/{actions,gpu}
         if [[ "${CONTAINER_RUNTIME}" == "containerd" ]]; then
-            ctr image pull $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG
+            pullContainerImage "crictl" $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG
             retrycmd_if_failure 5 10 600 bash -c "$CTR_GPU_INSTALL_CMD $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG gpuinstall /entrypoint.sh install"
             ret=$?
             if [[ "$ret" != "0" ]]; then

--- a/parts/linux/cloud-init/artifacts/cse_install.sh
+++ b/parts/linux/cloud-init/artifacts/cse_install.sh
@@ -388,7 +388,7 @@ installCrictl() {
     CPU_ARCH=$(getCPUArch)
     currentVersion=$(crictl --version 2>/dev/null | sed 's/crictl version //g')
     if [[ "${currentVersion}" != "" ]]; then
-        echo "version ${currentVersion} of crictl already installed. skipping installCrictl of target version ${KUBERNETES_VERSION%.*}.0"
+        echo "version ${currentVersion} of crictl already installed. skipping installCrictl of target version ${1%.*}.0"
     else
         # this is only called during cse. VHDs should have crictl binaries pre-cached so no need to download.
         # if the vhd does not have crictl pre-baked, return early
@@ -399,7 +399,7 @@ installCrictl() {
             return 1
         fi
         echo "Unpacking crictl into ${CRICTL_BIN_DIR}"
-        tar zxvf "$CRICTL_DOWNLOAD_DIR/${CRICTL_TGZ_TEMP}" -C ${CRICTL_BIN_DIR}
+        tar zxvf "$CRICTL_DOWNLOAD_DIR/${CRICTL_TGZ_TEMP}" -C ${CRICTL_BIN_DIR} || exit $ERR_CRICTL_OPERATION_ERROR
         chown root:root $CRICTL_BIN_DIR/crictl
         chmod 755 $CRICTL_BIN_DIR/crictl
     fi
@@ -626,29 +626,29 @@ installKubeletKubectlAndKubeProxy() {
 }
 
 pullContainerImage() {
-    CLI_TOOL=$1
-    CONTAINER_IMAGE_URL=$2
-    echo "pulling the image ${CONTAINER_IMAGE_URL} using ${CLI_TOOL}"
-    if [[ ${CLI_TOOL} == "ctr" ]]; then
-        logs_to_events "AKS.CSE.imagepullctr.${CONTAINER_IMAGE_URL}" "retrycmd_if_failure 2 1 120 ctr --namespace k8s.io image pull $CONTAINER_IMAGE_URL" || (echo "timed out pulling image ${CONTAINER_IMAGE_URL} via ctr" && exit $ERR_CONTAINERD_CTR_IMG_PULL_TIMEOUT)
-    elif [[ ${CLI_TOOL} == "crictl" ]]; then
-        logs_to_events "AKS.CSE.imagepullcrictl.${CONTAINER_IMAGE_URL}" "retrycmd_if_failure 2 1 120 crictl pull $CONTAINER_IMAGE_URL" || (echo "timed out pulling image ${CONTAINER_IMAGE_URL} via crictl" && exit $ERR_CONTAINERD_CRICTL_IMG_PULL_TIMEOUT)
+    local cliTool=$1
+    local containerImageURL=$2
+    echo "pulling the image ${containerImageURL} using ${cliTool}"
+    if [[ ${cliTool} == "ctr" ]]; then
+        logs_to_events "AKS.CSE.imagepullctr.${containerImageURL}" "retrycmd_if_failure 2 1 120 ctr --namespace k8s.io image pull $containerImageURL" || (echo "timed out pulling image ${containerImageURL} via ctr" && exit $ERR_CONTAINERD_CTR_IMG_PULL_TIMEOUT)
+    elif [[ ${cliTool} == "crictl" ]]; then
+        logs_to_events "AKS.CSE.imagepullcrictl.${containerImageURL}" "retrycmd_if_failure 2 1 120 crictl pull $containerImageURL" || (echo "timed out pulling image ${containerImageURL} via crictl" && exit $ERR_CONTAINERD_CRICTL_IMG_PULL_TIMEOUT)
     else
-        logs_to_events "AKS.CSE.imagepull.${CONTAINER_IMAGE_URL}" "retrycmd_if_failure 2 1 120 docker pull $CONTAINER_IMAGE_URL" || (echo "timed out pulling image ${CONTAINER_IMAGE_URL} via docker" && exit $ERR_DOCKER_IMG_PULL_TIMEOUT)
+        logs_to_events "AKS.CSE.imagepull.${containerImageURL}" "retrycmd_if_failure 2 1 120 docker pull $containerImageURL" || (echo "timed out pulling image ${containerImageURL} via docker" && exit $ERR_DOCKER_IMG_PULL_TIMEOUT)
     fi
 }
 
 retagContainerImage() {
-    CLI_TOOL=$1
-    CONTAINER_IMAGE_URL=$2
-    RETAG_IMAGE_URL=$3
-    echo "retagging from ${CONTAINER_IMAGE_URL} to ${RETAG_IMAGE_URL} using ${CLI_TOOL}"
-    if [[ ${CLI_TOOL} == "ctr" ]]; then
-        ctr --namespace k8s.io image tag $CONTAINER_IMAGE_URL $RETAG_IMAGE_URL
-    elif [[ ${CLI_TOOL} == "crictl" ]]; then
-        crictl image tag $CONTAINER_IMAGE_URL $RETAG_IMAGE_URL
+    local cliTool=$1
+    local containerImageURL=$2
+    local retagImageURL=$3
+    echo "retagging from ${containerImageURL} to ${retagImageURL} using ${cliTool}"
+    if [[ ${cliTool} == "ctr" ]]; then
+        ctr --namespace k8s.io image tag $containerImageURL $retagImageURL
+    elif [[ ${cliTool} == "crictl" ]]; then
+        crictl image tag $containerImageURL $retagImageURL
     else
-        docker image tag $CONTAINER_IMAGE_URL $RETAG_IMAGE_URL
+        docker image tag $containerImageURL $retagImageURL
     fi
 }
 
@@ -668,7 +668,6 @@ retagMCRImagesForChina() {
         # in mooncake, the mcr endpoint is: mcr.azk8s.cn
         # shellcheck disable=SC2001
         retagMCRImage=$(echo ${mcrImage} | sed -e 's/^mcr.microsoft.com/mcr.azk8s.cn/g')
-        # can't use CLI_TOOL because crictl doesn't support retagging.
         if [[ "${CONTAINER_RUNTIME}" == "containerd" ]]; then
             retagContainerImage "ctr" ${mcrImage} ${retagMCRImage}
         else
@@ -678,22 +677,22 @@ retagMCRImagesForChina() {
 }
 
 removeContainerImage() {
-    CLI_TOOL=$1
-    CONTAINER_IMAGE_URL=$2
-    if [[ "${CLI_TOOL}" == "docker" ]]; then
-        docker image rm $CONTAINER_IMAGE_URL
+   local cliTool=$1
+   local containerImageURL=$2
+    if [[ "${cliTool}" == "docker" ]]; then
+        docker image rm $containerImageURL
     else
         # crictl should always be present
-        crictl rmi $CONTAINER_IMAGE_URL
+        crictl rmi $containerImageURL
     fi
 }
 
 cleanUpImages() {
-    local targetImage=$1
-    export targetImage
     function cleanupImagesRun() {
+        local cliTool=$1
+        local targetImage=$2
         if [ "${NEEDS_CONTAINERD}" == "true" ]; then
-            if [[ "${CLI_TOOL}" == "crictl" ]]; then
+            if [[ "${cliTool}" == "crictl" ]]; then
                 images_to_delete=$(crictl images | awk '{print $1":"$2}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}.[0-9]+$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep ${targetImage} | tr ' ' '\n')
             else
                 images_to_delete=$(ctr --namespace k8s.io images list | awk '{print $1}' | grep -vE "${KUBERNETES_VERSION}$|${KUBERNETES_VERSION}.[0-9]+$|${KUBERNETES_VERSION}-|${KUBERNETES_VERSION}_" | grep ${targetImage} | tr ' ' '\n')
@@ -707,52 +706,26 @@ cleanUpImages() {
         elif [[ "${images_to_delete}" != "" ]]; then
             echo "${images_to_delete}" | while read image; do
                 if [ "${NEEDS_CONTAINERD}" == "true" ]; then
-                    removeContainerImage ${CLI_TOOL} ${image}
+                    removeContainerImage ${cliTool} ${image}
                 else
                     removeContainerImage "docker" ${image}
                 fi
             done
         fi
     }
+
     export -f cleanupImagesRun
-    retrycmd_if_failure 10 5 120 bash -c cleanupImagesRun
+    retrycmd_if_failure 10 5 120 bash -c cleanupImagesRun ${1} ${2}
 }
 
 cleanUpKubeProxyImages() {
     echo $(date),$(hostname), startCleanUpKubeProxyImages
-    cleanUpImages "kube-proxy"
+    cleanUpImages "ctr" "kube-proxy"
     echo $(date),$(hostname), endCleanUpKubeProxyImages
-}
-
-cleanupRetaggedImages() {
-    if [[ "${TARGET_CLOUD}" != "AzureChinaCloud" ]]; then
-        if [ "${NEEDS_CONTAINERD}" == "true" ]; then
-            if [[ "${CLI_TOOL}" == "crictl" ]]; then
-                images_to_delete=$(crictl images | awk '{print $1":"$2}' | grep '^mcr.azk8s.cn/' | tr ' ' '\n')
-            else
-                images_to_delete=$(ctr --namespace k8s.io images list | awk '{print $1}' | grep '^mcr.azk8s.cn/' | tr ' ' '\n')
-            fi
-        else
-            images_to_delete=$(docker images --format '{{OpenBraces}}.Repository{{CloseBraces}}:{{OpenBraces}}.Tag{{CloseBraces}}' | grep '^mcr.azk8s.cn/' | tr ' ' '\n')
-        fi
-        if [[ "${images_to_delete}" != "" ]]; then
-            echo "${images_to_delete}" | while read image; do
-                if [ "${NEEDS_CONTAINERD}" == "true" ]; then
-                    # crictl will remove *ALL* references to a given imageID (SHA), which removes too much, so always use ctr
-                    removeContainerImage "ctr" ${image}
-                else
-                    removeContainerImage "docker" ${image}
-                fi
-            done
-        fi
-    else
-        echo "skipping container cleanup for AzureChinaCloud"
-    fi
 }
 
 cleanUpContainerImages() {
     export KUBERNETES_VERSION
-    export CLI_TOOL
     export -f retrycmd_if_failure
     export -f removeContainerImage
     export -f cleanUpImages

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -451,7 +451,6 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 			}
 			config.ContainerdPackageURL = "containerd-package-url"
 		}, func(o *nodeBootstrappingOutput) {
-			Expect(o.vars["CLI_TOOL"]).To(Equal("ctr"))
 			Expect(o.vars["CONTAINERD_PACKAGE_URL"]).To(Equal("containerd-package-url"))
 		}),
 
@@ -461,7 +460,6 @@ var _ = Describe("Assert generated customData and cseCmd", func() {
 			}
 			config.ContainerdPackageURL = "containerd-package-url"
 		}, func(o *nodeBootstrappingOutput) {
-			Expect(o.vars["CLI_TOOL"]).To(Equal("docker"))
 			Expect(o.vars["CONTAINERD_PACKAGE_URL"]).To(Equal(""))
 		}),
 		Entry("AKSUbuntu1604 with temp disk (api field)", "AKSUbuntu1604+TempDiskExplicit", "1.15.7",

--- a/pkg/agent/params.go
+++ b/pkg/agent/params.go
@@ -89,7 +89,6 @@ func assignKubernetesParametersFromAgentProfile(profile *datamodel.AgentPoolProf
 	// this allows for heteregenous clusters
 	addValue(parametersMap, "containerRuntime", profile.KubernetesConfig.ContainerRuntime)
 	if profile.KubernetesConfig.ContainerRuntime == "containerd" {
-		addValue(parametersMap, "cliTool", "ctr")
 		if config.ContainerdVersion != "" {
 			addValue(parametersMap, "containerdVersion", config.ContainerdVersion)
 		}
@@ -97,8 +96,6 @@ func assignKubernetesParametersFromAgentProfile(profile *datamodel.AgentPoolProf
 			addValue(parametersMap, "teleportdPluginURL", config.TeleportdPluginURL)
 		}
 		addValue(parametersMap, "containerdPackageURL", config.ContainerdPackageURL)
-	} else {
-		addValue(parametersMap, "cliTool", "docker")
 	}
 }
 

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -226,6 +226,7 @@ while IFS= read -r p; do
       for version in ${PACKAGE_VERSIONS[@]}; do
         evaluatedURL=$(evalPackageDownloadURL ${PACKAGE_DOWNLOAD_URL})
         downloadCrictl "${downloadDir}" "${evaluatedURL}"
+        installCrictl "${version}"
         echo "  - crictl version ${version}" >> ${VHD_LOGS_FILEPATH}
         # other steps are dependent on CRICTL_VERSION and CRICTL_VERSIONS
         # since we only have 1 entry in CRICTL_VERSIONS, we simply set both to the same value
@@ -265,6 +266,8 @@ while IFS= read -r p; do
           installStandaloneContainerd "${version}"
         fi
         echo "  - containerd version ${version}" >> ${VHD_LOGS_FILEPATH}
+        # k8s will use images in the k8s.io namespaces - create it
+        ctr namespace create k8s.io
       done
       ;;
     "oras")
@@ -339,17 +342,10 @@ fi
 if [ $OS == $MARINER_OS_NAME ]  && [ $OS_VERSION == "2.0" ] && [ $(isARM64)  != 1 ]; then
   installAndConfigureArtifactStreaming acr-mirror-mariner rpm
 fi
-
-KUBERNETES_VERSION=$CRICTL_VERSIONS installCrictl || exit $ERR_CRICTL_DOWNLOAD_TIMEOUT
-
-# k8s will use images in the k8s.io namespaces - create it
-ctr namespace create k8s.io
-cliTool="ctr"
-
-
-INSTALLED_RUNC_VERSION=$(runc --version | head -n1 | sed 's/runc version //')
-echo "  - runc version ${INSTALLED_RUNC_VERSION}" >> ${VHD_LOGS_FILEPATH}
 capture_benchmark "${SCRIPT_NAME}_artifact_streaming_download"
+
+
+
 
 if [[ $OS == $UBUNTU_OS_NAME && $(isARM64) != 1 ]]; then  # no ARM64 SKU with GPU now
   gpu_action="copy"
@@ -357,7 +353,7 @@ if [[ $OS == $UBUNTU_OS_NAME && $(isARM64) != 1 ]]; then  # no ARM64 SKU with GP
   export NVIDIA_DRIVER_IMAGE_TAG="cuda-550.90.12-${NVIDIA_DRIVER_IMAGE_SHA}"
 
   mkdir -p /opt/{actions,gpu}
-  ctr image pull $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG
+  pullContainerImage "crictl" $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG
   if grep -q "fullgpu" <<< "$FEATURE_FLAGS"; then
     bash -c "$CTR_GPU_INSTALL_CMD $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG gpuinstall /entrypoint.sh install"
     ret=$?
@@ -370,13 +366,12 @@ if [[ $OS == $UBUNTU_OS_NAME && $(isARM64) != 1 ]]; then  # no ARM64 SKU with GP
   cat << EOF >> ${VHD_LOGS_FILEPATH}
   - nvidia-driver=${NVIDIA_DRIVER_IMAGE_TAG}
 EOF
-fi
-
 ls -ltr /opt/gpu/* >> ${VHD_LOGS_FILEPATH}
+capture_benchmark "${SCRIPT_NAME}_pull_and_install_nvidia_driver_image"
+fi
 
 installBpftrace
 echo "  - $(bpftrace --version)" >> ${VHD_LOGS_FILEPATH}
-
 PRESENT_DIR=$(pwd)
 # run installBcc in a subshell and continue on with container image pull in order to decrease total build time
 (
@@ -384,16 +379,12 @@ PRESENT_DIR=$(pwd)
   installBcc
   exit $?
 ) > /var/log/bcc_installation.log 2>&1 &
-
 BCC_PID=$!
-
-echo "${CONTAINER_RUNTIME} images pre-pulled:" >> ${VHD_LOGS_FILEPATH}
-capture_benchmark "${SCRIPT_NAME}_pull_nvidia_driver_image_and_run_installBcc_in_subshell"
+capture_benchmark "${SCRIPT_NAME}_run_installBcc_in_subshell"
 
 string_replace() {
   echo ${1//\*/$2}
 }
-
 # Limit number of parallel pulls to 2 less than number of processor cores in order to prevent issues with network, CPU, and disk resources
 # Account for possibility that number of cores is 3 or less
 num_proc=$(nproc)
@@ -405,7 +396,7 @@ fi
 echo "Limit for parallel container image pulls set to $parallel_container_image_pull_limit"
 
 declare -a image_pids=()
-
+echo "${CONTAINER_RUNTIME} images pre-pulled:" >> ${VHD_LOGS_FILEPATH}
 ContainerImages=$(jq ".ContainerImages" $COMPONENTS_FILEPATH | jq .[] --monochrome-output --compact-output)
 while IFS= read -r imageToBePulled; do
   downloadURL=$(echo "${imageToBePulled}" | jq .downloadURL -r)
@@ -425,7 +416,7 @@ while IFS= read -r imageToBePulled; do
 
   for version in ${versions}; do
     CONTAINER_IMAGE=$(string_replace $downloadURL $version)
-    pullContainerImage "${cliTool}" "${CONTAINER_IMAGE}" &
+    pullContainerImage "crictl" "${CONTAINER_IMAGE}" &
     image_pids+=($!)
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
     while [[ $(jobs -p | wc -l) -ge $parallel_container_image_pull_limit ]]; do
@@ -434,6 +425,7 @@ while IFS= read -r imageToBePulled; do
   done
 done <<< "$ContainerImages"
 wait ${image_pids[@]}
+capture_benchmark "${SCRIPT_NAME}_pulled_images_in_parallel"
 
 watcher=$(jq '.ContainerImages[] | select(.downloadURL | contains("aks-node-ca-watcher"))' $COMPONENTS_FILEPATH)
 watcherBaseImg=$(echo $watcher | jq -r .downloadURL)
@@ -446,41 +438,42 @@ watcherFullImg=${watcherBaseImg//\*/$watcherVersion}
 # may be intercepted by an untrusted TLS MITM firewall.
 watcherStaticImg=${watcherBaseImg//\*/static}
 
-# can't use cliTool because crictl doesn't support retagging.
+# can't use crictl since it doesn't support retagging.
 retagContainerImage "ctr" ${watcherFullImg} ${watcherStaticImg}
-capture_benchmark "${SCRIPT_NAME}_pull_and_retag_container_images"
+capture_benchmark "${SCRIPT_NAME}_retag_aks_node_ca_watcher_image"
+
+if [[ $OS == $UBUNTU_OS_NAME && $(isARM64) != 1 ]]; then  # no ARM64 SKU with GPU now
+NVIDIA_DEVICE_PLUGIN_VERSION="v0.14.5"
+
+DEVICE_PLUGIN_CONTAINER_IMAGE="mcr.microsoft.com/oss/nvidia/k8s-device-plugin:${NVIDIA_DEVICE_PLUGIN_VERSION}"
+pullContainerImage "crictl" ${DEVICE_PLUGIN_CONTAINER_IMAGE}
+
+  # GPU device plugin
+  if grep -q "fullgpu" <<< "$FEATURE_FLAGS" && grep -q "gpudaemon" <<< "$FEATURE_FLAGS"; then
+    kubeletDevicePluginPath="/var/lib/kubelet/device-plugins"
+    mkdir -p $kubeletDevicePluginPath
+    echo "  - $kubeletDevicePluginPath" >> ${VHD_LOGS_FILEPATH}
+
+    DEST="/usr/local/nvidia/bin"
+    mkdir -p $DEST
+    ctr --namespace k8s.io run --rm --mount type=bind,src=${DEST},dst=${DEST},options=bind:rw --cwd ${DEST} $DEVICE_PLUGIN_CONTAINER_IMAGE plugingextract /bin/sh -c "cp /usr/bin/nvidia-device-plugin $DEST" || exit 1
+    chmod a+x $DEST/nvidia-device-plugin
+    echo "  - extracted nvidia-device-plugin..." >> ${VHD_LOGS_FILEPATH}
+    ls -ltr $DEST >> ${VHD_LOGS_FILEPATH}
+
+    systemctlEnableAndStart nvidia-device-plugin || exit 1
+    ctr --namespace k8s.io images rm $DEVICE_PLUGIN_CONTAINER_IMAGE || exit 1
+  fi
+fi
+capture_benchmark "${SCRIPT_NAME}_download_gpu_device_plugin"
+
+
 
 # IPv6 nftables rules are only available on Ubuntu or Mariner/AzureLinux
 if [[ $OS == $UBUNTU_OS_NAME ]] || isMarinerOrAzureLinux "$OS"; then
   systemctlEnableAndStart ipv6_nftables || exit 1
 fi
 capture_benchmark "${SCRIPT_NAME}_configure_networking_and_interface"
-
-if [[ $OS == $UBUNTU_OS_NAME && $(isARM64) != 1 ]]; then  # no ARM64 SKU with GPU now
-NVIDIA_DEVICE_PLUGIN_VERSION="v0.14.5"
-
-DEVICE_PLUGIN_CONTAINER_IMAGE="mcr.microsoft.com/oss/nvidia/k8s-device-plugin:${NVIDIA_DEVICE_PLUGIN_VERSION}"
-pullContainerImage ${cliTool} ${DEVICE_PLUGIN_CONTAINER_IMAGE}
-
-# GPU device plugin
-if grep -q "fullgpu" <<< "$FEATURE_FLAGS" && grep -q "gpudaemon" <<< "$FEATURE_FLAGS"; then
-  kubeletDevicePluginPath="/var/lib/kubelet/device-plugins"
-  mkdir -p $kubeletDevicePluginPath
-  echo "  - $kubeletDevicePluginPath" >> ${VHD_LOGS_FILEPATH}
-
-  DEST="/usr/local/nvidia/bin"
-  mkdir -p $DEST
-  ctr --namespace k8s.io run --rm --mount type=bind,src=${DEST},dst=${DEST},options=bind:rw --cwd ${DEST} $DEVICE_PLUGIN_CONTAINER_IMAGE plugingextract /bin/sh -c "cp /usr/bin/nvidia-device-plugin $DEST" || exit 1
-  chmod a+x $DEST/nvidia-device-plugin
-  echo "  - extracted nvidia-device-plugin..." >> ${VHD_LOGS_FILEPATH}
-  ls -ltr $DEST >> ${VHD_LOGS_FILEPATH}
-
-  systemctlEnableAndStart nvidia-device-plugin || exit 1
-  ctr --namespace k8s.io images rm $DEVICE_PLUGIN_CONTAINER_IMAGE || exit 1
-fi
-fi
-
-capture_benchmark "download_gpu_device_plugin"
 
 mkdir -p /var/log/azure/Microsoft.Azure.Extensions.CustomScript/events
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Reducing the Packed Image layers (content) under /var/lib/containerd folder, this data is not used normally for creating container, it's used for republishing.  CRICTL allows for this storage to be dleeted post unpacking, using the CRI flag  
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
