### PR TITLE
Remove nbcparser from VHD

### DIFF
--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -112,10 +112,6 @@ steps:
       echo "##vso[task.setvariable variable=SKU_NAME]$SKU_NAME"
       echo "Set SKU_NAME to $SKU_NAME"
     displayName: Set SKU Name
-  - bash: |
-      ./build.sh
-    displayName: Build node-bootstrapper
-    workingDirectory: node-bootstrapper
   - bash: make -f packer.mk run-packer
     displayName: Build VHD
     retryCountOnTaskFailure: 3

--- a/node-bootstrapper/.gitignore
+++ b/node-bootstrapper/.gitignore
@@ -1,3 +1,2 @@
 node-bootstrapper.log
 node-bootstrapper
-dist

--- a/node-bootstrapper/build.sh
+++ b/node-bootstrapper/build.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -x
-set -e
-go test ./...
-GOOS=linux GOARCH=amd64 go build -o ./dist/node-bootstrapper-linux-amd64
-GOOS=linux GOARCH=arm64 go build -o ./dist/node-bootstrapper-linux-arm64
-GOOS=windows GOARCH=amd64 go build -o ./dist/node-bootstrapper-windows-amd64.exe
-GOOS=windows GOARCH=arm64 go build -o ./dist/node-bootstrapper-windows-arm64.exe

--- a/packer.mk
+++ b/packer.mk
@@ -5,7 +5,7 @@ ifeq (${ARCHITECTURE},ARM64)
 	GOARCH=arm64
 endif
 
-build-packer: generate-prefetch-scripts build-lister-binary
+build-packer: generate-prefetch-scripts build-lister-binary build-node-bootstrapper
 ifeq (${ARCHITECTURE},ARM64)
 	@echo "${MODE}: Building with Hyper-v generation 2 ARM64 VM"
 ifeq (${OS_SKU},Ubuntu)

--- a/packer.mk
+++ b/packer.mk
@@ -113,7 +113,7 @@ ifeq (${MODE},linuxVhdMode)
 endif
 
 build-node-bootstrapper:
-	@echo "Building node bootstrapper binary for $(GOARCH)"
+	@echo "Building node bootstrapper binaries"
 	@bash -c "pushd node-bootstrapper && \
 	go test ./... && \
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/node-bootstrapper-linux-amd64 && \

--- a/packer.mk
+++ b/packer.mk
@@ -5,7 +5,7 @@ ifeq (${ARCHITECTURE},ARM64)
 	GOARCH=arm64
 endif
 
-build-packer: generate-prefetch-scripts build-nbcparser-all build-lister-binary
+build-packer: generate-prefetch-scripts build-lister-binary
 ifeq (${ARCHITECTURE},ARM64)
 	@echo "${MODE}: Building with Hyper-v generation 2 ARM64 VM"
 ifeq (${OS_SKU},Ubuntu)
@@ -112,13 +112,15 @@ ifeq (${MODE},linuxVhdMode)
 	@bash -c "pushd vhdbuilder/prefetch; go run cmd/main.go --components-path=../../parts/linux/cloud-init/artifacts/components.json --output-path=../packer/prefetch.sh || exit 1; popd"
 endif
 
-build-nbcparser-all:
-	@$(MAKE) -f packer.mk build-nbcparser-binary ARCH=amd64
-	@$(MAKE) -f packer.mk build-nbcparser-binary ARCH=arm64
-
-build-nbcparser-binary:
-	@echo "Building nbcparser binary"
-	@bash -c "pushd nbcparser && CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -o bin/nbcparser-$(ARCH) main.go && popd"
+build-node-bootstrapper:
+	@echo "Building node bootstrapper binary for $(GOARCH)"
+	@bash -c "pushd node-bootstrapper && \
+    go test ./... && \
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/node-bootstrapper-linux-amd64 && \
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/node-bootstrapper-linux-arm64 && \
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o bin/node-bootstrapper-windows-amd64.exe && \
+	CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -o bin/node-bootstrapper-windows-arm64.exe && \
+	popd"
 
 build-lister-binary:
 	@echo "Building lister binary for $(GOARCH)"

--- a/packer.mk
+++ b/packer.mk
@@ -115,7 +115,7 @@ endif
 build-node-bootstrapper:
 	@echo "Building node bootstrapper binary for $(GOARCH)"
 	@bash -c "pushd node-bootstrapper && \
-    go test ./... && \
+	go test ./... && \
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/node-bootstrapper-linux-amd64 && \
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/node-bootstrapper-linux-arm64 && \
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o bin/node-bootstrapper-windows-amd64.exe && \

--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -246,10 +246,6 @@ copyPackerFiles() {
   CSE_HELPERS_DISTRO_DEST=/opt/azure/containers/provision_source_distro.sh
   cpAndMode $CSE_HELPERS_DISTRO_SRC $CSE_HELPERS_DISTRO_DEST 0744
 
-  NBC_PARSER_SRC=/home/packer/nbcparser
-  NBC_PARSER_DEST=/opt/azure/containers/nbcparser
-  cpAndMode $NBC_PARSER_SRC $NBC_PARSER_DEST 0755
-
   NOTICE_SRC=/home/packer/NOTICE.txt
   NOTICE_DEST=/NOTICE.txt
 

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -961,26 +961,6 @@ testBccTools () {
   return 0
 }
 
-testNBCParserBinary () {
-  local test="testNBCParserBinary"
-  local go_binary_path="/opt/azure/containers/nbcparser"
-
-  echo "$test: checking existence of nbcparser go binary at $go_binary_path"
-  if [ ! -f "$go_binary_path" ]; then
-    err "$test: nbcparser go binary does not exist at $go_binary_path"
-    return 1
-  fi
-  echo "$test: nbcparser go binary exists at $go_binary_path"
-  errs=$($go_binary_path 2>/dev/null)
-  code=$?
-  if [ $code -ne 0 ]; then
-    err "$test: nbcparser go binary exited with code $code, stderr:\n$errs"
-    return 1
-  fi
-  echo "$test: nbcparser go binary ran successfully"
-
-}
-
 testWasmRuntimesInstalled() {
   local test="testWasmRuntimesInstalled"
   local wasm_runtimes_path=${1}
@@ -1082,4 +1062,3 @@ testPamDSettings $OS_SKU $OS_VERSION
 testPam $OS_SKU $OS_VERSION
 testUmaskSettings
 testContainerImagePrefetchScript
-testNBCParserBinary

--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -91,18 +91,13 @@
     },
     {
       "type": "file",
-      "source": "node-bootstrapper/dist/node-bootstrapper-linux-arm64",
+      "source": "node-bootstrapper/bin/node-bootstrapper-linux-arm64",
       "destination": "/home/packer/node-bootstrapper"
     },
     {
       "type": "file",
       "source": "vhdbuilder/lister/bin/lister",
       "destination": "/home/packer/lister"
-    },
-    {
-      "type": "file",
-      "source": "nbcparser/bin/nbcparser-arm64",
-      "destination": "/home/packer/nbcparser"
     },
     {
       "type": "file",

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -93,18 +93,13 @@
     },
     {
       "type": "file",
-      "source": "node-bootstrapper/dist/node-bootstrapper-linux-amd64",
+      "source": "node-bootstrapper/bin/node-bootstrapper-linux-amd64",
       "destination": "/home/packer/node-bootstrapper"
     },
     {
       "type": "file",
       "source": "vhdbuilder/lister/bin/lister",
       "destination": "/home/packer/lister"
-    },
-    {
-      "type": "file",
-      "source": "nbcparser/bin/nbcparser-amd64",
-      "destination": "/home/packer/nbcparser"
     },
     {
       "type": "file",

--- a/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
@@ -90,18 +90,13 @@
     },
     {
       "type": "file",
-      "source": "node-bootstrapper/dist/node-bootstrapper-linux-arm64",
+      "source": "node-bootstrapper/bin/node-bootstrapper-linux-arm64",
       "destination": "/home/packer/node-bootstrapper"
     },
     {
       "type": "file",
       "source": "vhdbuilder/lister/bin/lister",
       "destination": "/home/packer/lister"
-    },
-    {
-      "type": "file",
-      "source": "nbcparser/bin/nbcparser-arm64",
-      "destination": "/home/packer/nbcparser"
     },
     {
       "type": "file",

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -92,18 +92,13 @@
     },
     {
       "type": "file",
-      "source": "node-bootstrapper/dist/node-bootstrapper-linux-amd64",
+      "source": "node-bootstrapper/bin/node-bootstrapper-linux-amd64",
       "destination": "/home/packer/node-bootstrapper"
     },
     {
       "type": "file",
       "source": "vhdbuilder/lister/bin/lister",
       "destination": "/home/packer/lister"
-    },
-    {
-      "type": "file",
-      "source": "nbcparser/bin/nbcparser-amd64",
-      "destination": "/home/packer/nbcparser"
     },
     {
       "type": "file",


### PR DESCRIPTION
/kind cleanup

Remove nbcparser binary from VHD. It's not utilized currently. 

node-bootstrapper will be a new entry point to provision a node with a "scriptless" approach.
At the later stage a new contract will be moved from nbcparser to node-bootstrapper.

In the meantime, bash scripts can be replaced with golang code without altering the existing contract.