### PR TITLE
fix: Ensure nvidia modprobe is run before kubelet

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -885,6 +885,7 @@ func runScenarioUbuntu2204GPU(t *testing.T, vmSize string) {
 			},
 			LiveVMValidators: []*LiveVMValidator{
 				NvidiaModProbeInstalledValidator(),
+				// Ensure nvidia-modprobe install does not restart kubelet and temporarily cause node to be unschedulable
 				KubeletHasNotStoppedValidator(),
 			},
 		},

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -909,6 +909,9 @@ func Test_ubuntu2204GPUGridDriver(t *testing.T) {
 			},
 			LiveVMValidators: []*LiveVMValidator{
 				NvidiaSMIInstalledValidator(),
+				// ensure kubelet is not restarted
+				FileHasContentsValidator("/var/log/messages", "Starting Kubelet"),
+				FileExcludesContentsValidator("/var/log/messages", "Stopping Kubelet", "Stopping Kubelet"),
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -883,6 +883,10 @@ func runScenarioUbuntu2204GPU(t *testing.T, vmSize string) {
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				vmss.SKU.Name = to.Ptr(vmSize)
 			},
+			LiveVMValidators: []*LiveVMValidator{
+				NvidiaModProbeInstalledValidator(),
+				KubeletHasNotStoppedValidator(),
+			},
 		},
 	})
 }
@@ -909,9 +913,8 @@ func Test_ubuntu2204GPUGridDriver(t *testing.T) {
 			},
 			LiveVMValidators: []*LiveVMValidator{
 				NvidiaSMIInstalledValidator(),
-				// ensure kubelet is not restarted
-				FileHasContentsValidator("/var/log/messages", "Starting Kubelet"),
-				FileExcludesContentsValidator("/var/log/messages", "Stopping Kubelet", "Stopping Kubelet"),
+				NvidiaModProbeInstalledValidator(),
+				KubeletHasNotStoppedValidator(),
 			},
 		},
 	})

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -387,6 +387,8 @@ func containerdWasmShimsValidator() *LiveVMValidator {
 	}
 }
 
+// Ensure kubelet does not restart which can result in delays deploying pods and unnecessary nodepool scaling while the node is incapacitated.
+// This is intended to stop services (e.g. nvidia-modprobe), restarting kubelet rather than specifying the dependency order to run before kubelet.service
 func KubeletHasNotStoppedValidator() *LiveVMValidator {
 	return &LiveVMValidator{
 		Description: "assert that kubelet has not stopped or restarted",

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -92,6 +92,24 @@ func NvidiaSMIInstalledValidator() *LiveVMValidator {
 	}
 }
 
+func NvidiaModProbeInstalledValidator() *LiveVMValidator {
+	return &LiveVMValidator{
+		Description: "assert nvidia-modprobe is installed",
+		Command:     "nvidia-modprobe",
+		Asserter: func(code, stdout, stderr string) error {
+			if code != "0" {
+				return fmt.Errorf(
+					"nvidia-modprobe installed should trigger exit 0 actual was: %q, stdout: %q, stderr: %q",
+					code,
+					stdout,
+					stderr,
+				)
+			}
+			return nil
+		},
+	}
+}
+
 func NonEmptyDirectoryValidator(dirName string) *LiveVMValidator {
 	return &LiveVMValidator{
 		Description: fmt.Sprintf("assert that there are files in %s", dirName),
@@ -363,6 +381,26 @@ func containerdWasmShimsValidator() *LiveVMValidator {
 				if !strings.Contains(stdout, section) || !strings.Contains(stdout, runtimeType) {
 					return fmt.Errorf("expected to find section %q with runtime type %q in containerd config.toml, but it was not found. Full config.toml content:\n%s", section, runtimeType, stdout)
 				}
+			}
+			return nil
+		},
+	}
+}
+
+func KubeletHasNotStoppedValidator() *LiveVMValidator {
+	return &LiveVMValidator{
+		Description: "assert that kubelet has not stopped or restarted",
+		Command:     "journalctl -u kubelet",
+		Asserter: func(code, stdout, stderr string) error {
+			startedText := "Started Kubelet"
+			stoppedText := "Stopped Kubelet"
+			stoppedCount := strings.Count(stdout, stoppedText)
+			startedCount := strings.Count(stdout, startedText)
+			if stoppedCount > 0 {
+				return fmt.Errorf("expected no occurences of '%s' in kubelet log, but found %d", stoppedText, stoppedCount)
+			}
+			if startedCount == 0 {
+				return fmt.Errorf("expected at least one occurence of '%s' in kubelet log, but found 0", startedText)
 			}
 			return nil
 		},

--- a/parts/linux/cloud-init/artifacts/nvidia-modprobe.service
+++ b/parts/linux/cloud-init/artifacts/nvidia-modprobe.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=Installs and loads Nvidia GPU kernel module
+Before=kubelet.service
 [Service]
 Type=oneshot
 RemainAfterExit=true
 ExecStartPre=/bin/sh -c "dkms autoinstall --verbose"
 ExecStart=/bin/sh -c "nvidia-modprobe -u -c0"
-ExecStartPost=/bin/sh -c "sleep 10 && systemctl restart kubelet"
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target kubelet.service


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Removes the  `kubelet restart` from nvidia-modprobe service and ensures nvidia-modprobe is run before kubelet.
**Which issue(s) this PR fixes**:
Incident 487929399, 552859186


**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
