### PR TITLE
GPU container images in components.json, add new schema for GPU images

### DIFF
--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -562,21 +562,17 @@
   "GPUContainerImages": [
     {
       "downloadURL": "mcr.microsoft.com/aks/aks-gpu-cuda:*",
-      "multiArchVersionsV2": [
-        {
+      "gpuVersion": {
           "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-cuda",
           "latestVersion": "550.90.12-20241021233454"
         }
-      ]
     },
     {
       "downloadURL": "mcr.microsoft.com/aks/aks-gpu-grid:*",
-      "multiArchVersionsV2": [
-      { 
+      "gpuVersion": { 
         "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-grid",
         "latestVersion": "535.161.08-20241021235607"
       }
-      ]
     }
   ],
 

--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -566,20 +566,12 @@
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-cuda",
           "latestVersion": "550.90.12-20241021233454"
-        },
-        {
-          "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-cuda",
-          "latestVersion": "550.90.12-20241021233454"
         }
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/aks/aks-gpu-grid:*",
       "multiArchVersionsV2": [
-      { 
-        "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-grid",
-        "latestVersion": "535.161.08-20241021235607"
-      },
       { 
         "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-grid",
         "latestVersion": "535.161.08-20241021235607"

--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -566,12 +566,20 @@
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-cuda",
           "latestVersion": "550.90.12-20241021233454"
+        },
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-cuda",
+          "latestVersion": "550.90.12-20241021233454"
         }
       ]
     },
     {
       "downloadURL": "mcr.microsoft.com/aks/aks-gpu-grid:*",
       "multiArchVersionsV2": [
+      { 
+        "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-grid",
+        "latestVersion": "535.161.08-20241021235607"
+      },
       { 
         "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-grid",
         "latestVersion": "535.161.08-20241021235607"

--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -561,7 +561,7 @@
 
   "GPUContainerImages": [
     {
-      "downloadURL": "mcr.microsoft.com/aks/aks-gpu-grid",
+      "downloadURL": "mcr.microsoft.com/aks/aks-gpu-cuda:*",
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-cuda",
@@ -570,7 +570,7 @@
       ]
     },
     {
-      "downloadURL": "mcr.microsoft.com/aks/aks-gpu-grid",
+      "downloadURL": "mcr.microsoft.com/aks/aks-gpu-grid:*",
       "multiArchVersionsV2": [
       { 
         "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-grid",

--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -558,6 +558,28 @@
       ]
     }
   ],
+
+  "GPUContainerImages": [
+    {
+      "downloadURL": "mcr.microsoft.com/aks/aks-gpu-grid",
+      "multiArchVersionsV2": [
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-cuda",
+          "latestVersion": "550.90.12-20241021233454"
+        }
+      ]
+    },
+    {
+      "downloadURL": "mcr.microsoft.com/aks/aks-gpu-grid",
+      "multiArchVersionsV2": [
+      { 
+        "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-grid",
+        "latestVersion": "535.161.08-20241021235607"
+      }
+      ]
+    }
+  ],
+
   "Packages": [
     {
       "name": "oras",

--- a/schemas/components.cue
+++ b/schemas/components.cue
@@ -15,7 +15,13 @@ package components
 	multiArchVersionsV2:   [...#VersionV2]
 }
 
+#GPUContainerImage: {
+	downloadURL: string
+	multiArchVersionsV2:   [...#VersionV2]
+}
+
 #Images: [...#ContainerImage]
+#GPUContainerImage: [...#GPUContainerImage]
 #Packages: [...#Package]
 #VersionV2: {
 	k8sVersion?:             string
@@ -67,7 +73,8 @@ package components
 
 #Components: {
 	ContainerImages: #Images
-	Packages:        #Packages    
+	Packages:        #Packages
+	GPUContainerImages: #GPUContainerImage
 }
 
 #Components

--- a/schemas/components.cue
+++ b/schemas/components.cue
@@ -21,7 +21,7 @@ package components
 }
 
 #Images: [...#ContainerImage]
-#GPUContainerImage: [...#GPUContainerImage]
+#GPUContainerImages: [...#GPUContainerImage]
 #Packages: [...#Package]
 #VersionV2: {
 	k8sVersion?:             string

--- a/schemas/components.cue
+++ b/schemas/components.cue
@@ -21,7 +21,7 @@ package components
 }
 
 #Images: [...#ContainerImage]
-#GPUContainerImages: [...#GPUContainerImage]
+#GPUImages: [...#GPUContainerImage]
 #Packages: [...#Package]
 #VersionV2: {
 	k8sVersion?:             string
@@ -74,7 +74,7 @@ package components
 #Components: {
 	ContainerImages: #Images
 	Packages:        #Packages
-	GPUContainerImages: #GPUContainerImage
+	GPUContainerImages?: #GPUImages
 }
 
 #Components

--- a/schemas/components.cue
+++ b/schemas/components.cue
@@ -17,7 +17,7 @@ package components
 
 #GPUContainerImage: {
 	downloadURL: string
-	multiArchVersionsV2:   [...#VersionV2]
+	gpuVersion:   #VersionV2
 }
 
 #Images: [...#ContainerImage]

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -351,7 +351,7 @@ INSTALLED_RUNC_VERSION=$(runc --version | head -n1 | sed 's/runc version //')
 echo "  - runc version ${INSTALLED_RUNC_VERSION}" >> ${VHD_LOGS_FILEPATH}
 capture_benchmark "${SCRIPT_NAME}_artifact_streaming_download"
 
-GPUContainerImages=$(jq ".GPUContainerImages" $COMPONENTS_FILEPATH)
+GPUContainerImages=$(jq  -c '.GPUContainerImages[]' $COMPONENTS_FILEPATH)
 
 NVIDIA_DRIVER_IMAGE=""
 NVIDIA_DRIVER_IMAGE_TAG=""

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -364,7 +364,7 @@ if [[ $OS == $UBUNTU_OS_NAME && $(isARM64) != 1 ]]; then  # No ARM64 SKU with GP
     imageName=$(echo "$downloadURL" | sed 's/:.*$//')
 
     if [[ "$imageName" == "mcr.microsoft.com/aks/aks-gpu-cuda" ]]; then
-      latestVersion=$(echo "${imageToBePulled}" | jq -r '.multiArchVersionsV2[0].latestVersion')
+      latestVersion=$(echo "${imageToBePulled}" | jq -r '.gpuVersion.latestVersion')
       NVIDIA_DRIVER_IMAGE="$imageName"
       NVIDIA_DRIVER_IMAGE_TAG="$latestVersion"
       break  # Exit the loop once we find the image

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -351,7 +351,7 @@ INSTALLED_RUNC_VERSION=$(runc --version | head -n1 | sed 's/runc version //')
 echo "  - runc version ${INSTALLED_RUNC_VERSION}" >> ${VHD_LOGS_FILEPATH}
 capture_benchmark "${SCRIPT_NAME}_artifact_streaming_download"
 
-GPUContainerImages=$(jq ".GPUContainerImages" $COMPONENTS_FILEPATH | jq -c '.[]')
+GPUContainerImages=$(jq ".GPUContainerImages" $COMPONENTS_FILEPATH)
 
 NVIDIA_DRIVER_IMAGE=""
 NVIDIA_DRIVER_IMAGE_TAG=""


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind refactor

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR moves GPU versions to a config file (components.json), so that Renovate bot can auto-update it. VHD builds will now consume the cuda version from components.json. It also adds a new schema to auto-update.

There are two new requirements: 
1) aks-gpu-cuda container image is only downloaded for particular combo of OS and arch (Ubuntu - amd64), 
2) aks-gpu-grid container image needs to be present in the config but is never downloaded in the VHD. It's only used in CSE, for certain SKUs.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
