### PR TITLE
Add metrics-server and addon-resizer images from MCR oss/v2

### DIFF
--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -6,7 +6,8 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/kubernetes/autoscaler/addon-resizer",
-          "latestVersion": "1.8.22"
+          "latestVersion": "1.8.22",
+          "previousLatestVersion": "1.8.20"
         }
       ]
     },

--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -6,8 +6,17 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/kubernetes/autoscaler/addon-resizer",
-          "latestVersion": "1.8.22",
-          "previousLatestVersion": "1.8.20"
+          "latestVersion": "1.8.22"
+        }
+      ]
+    },
+    {
+      "downloadURL": "mcr.microsoft.com/oss/v2/kubernetes/addon-resizer:*",
+      "amd64OnlyVersions": [],
+      "multiArchVersionsV2": [
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/addon-resizer",
+          "latestVersion": "v1.8.22-2"
         }
       ]
     },
@@ -42,6 +51,20 @@
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/coredns",
           "latestVersion": "v1.9.4-2"
+        }
+      ]
+    },
+    {
+      "downloadURL": "mcr.microsoft.com/oss/v2/kubernetes/metrics-server:*",
+      "amd64OnlyVersions": [],
+      "multiArchVersionsV2": [
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/metrics-server",
+          "latestVersion": "v0.7.2-3"
+        },
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/metrics-server",
+          "latestVersion": "v0.6.3-2"
         }
       ]
     },


### PR DESCRIPTION
**What type of PR is this?**

I have created, tested and published metrics-server images v0.7.2-3 and v0.6.3-2 to MCR using the new Dalec framework. The new Dalec framework publish the images to MCR under oss/v2 path. We plan to use  v0.7.2-3 on all AKS clusters with 1.31 versions and existing clusters will use v0.6.3-2. All AKS clusters will use v1.8.22-2 version or Addon-Resizer. 

mcr.microsoft.com/oss/v2/kubernetes/metrics-server:v0.7.2-3
mcr.microsoft.com/oss/v2/kubernetes/metrics-server:v0.6.3-2
mcr.microsoft.com/oss/v2/kubernetes/autoscaler/addon-resizer:v1.8.22-2


**What this PR does / why we need it**:
These image have fixes for all the CVEs. I plan to rollout these images to AKS cluster and need to cache the images on VHD. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
https://mcr.microsoft.com/en-us/artifact/mar/oss/v2/kubernetes/autoscaler/addon-resizer/tags
https://mcr.microsoft.com/en-us/artifact/mar/oss/v2/kubernetes/metrics-server/tags

**Release note**:

```
none
```
