### PR TITLE
fix: use Write-Host in Add-KubeletNodeLabel within kubeletfunc.ps1

### DIFF
--- a/staging/cse/windows/kubeletfunc.ps1
+++ b/staging/cse/windows/kubeletfunc.ps1
@@ -220,11 +220,12 @@ function Add-KubeletNodeLabel {
     $labelList = $KubeletNodeLabels -split ","
     foreach ($existingLabel in $labelList) {
         if ($existingLabel -eq $Label) {
-            Write-Host "found existing kubelet node label $existingLabel, will continue without adding anything"
+            # we need to use Write-Host since Write-Log will add content to the return value, which we don't want
+            Write-Host("found existing kubelet node label $existingLabel, will continue without adding anything" | Timestamp)
             return $KubeletNodeLabels
         }
     }
-    Write-Host "adding label $Label to kubelet node labels..."
+    Write-Host("adding label $Label to kubelet node labels..." | Timestamp)
     $labelList += $Label
     return $labelList -join ","
 }

--- a/staging/cse/windows/kubeletfunc.ps1
+++ b/staging/cse/windows/kubeletfunc.ps1
@@ -220,11 +220,11 @@ function Add-KubeletNodeLabel {
     $labelList = $KubeletNodeLabels -split ","
     foreach ($existingLabel in $labelList) {
         if ($existingLabel -eq $Label) {
-            Write-Log "found existing kubelet node label $existingLabel, will continue without adding anything"
+            Write-Host "found existing kubelet node label $existingLabel, will continue without adding anything"
             return $KubeletNodeLabels
         }
     }
-    Write-Log "adding label $Label to kubelet node labels..."
+    Write-Host "adding label $Label to kubelet node labels..."
     $labelList += $Label
     return $labelList -join ","
 }

--- a/staging/cse/windows/kubeletfunc.tests.ps1
+++ b/staging/cse/windows/kubeletfunc.tests.ps1
@@ -232,10 +232,6 @@ Describe 'Get-TagValue' {
 }
 
 Describe 'Add-KubeletNodeLabel' {
-    BeforeEach {
-        Mock Write-Log
-    }
-
     It "Should perform a no-op when the specified label already exists within the label string" {
         $labelString = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/kubelet-serving-ca=cluster,kubernetes.azure.com/agentpool=wp0"
         $label = "kubernetes.azure.com/kubelet-serving-ca=cluster"


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

fixes a bug in Add-KubeletNodeLabel where the log content is added to the return value by Write-Log, causing KubeletNodeLabels to contain unexpected content which ends preventing kubelet from starting:


```
                                       "NodeLabels":  [
                                                          "2024-10-23T18:24:39.6797661+00:00: adding label kubernetes.azure.com/kubelet-serving-ca=cluster to kubelet node labels...",
                                                          "agentpool=npwin,kubernetes.azure.com/agentpool=npwin,agentpool=npwin,kubernetes.azure.com/agentpool=npwin,kubernetes.azure.com/cluster=MC_cameissebld106479871_wintester_eastus2,kubernetes.azure.com/consolidated-additional-properties=a3253cd6-916b-11ef-a610-6643c19b51dd,kubernetes.azure.com/kubelet-identity-client-id=78f4691a-f952-4bd3-83c0-0869e2821eed,kubernetes.azure.com/mode=user,kubernetes.azure.com/node-image-version=AKSWindows-2022-containerd-20348.2762.241009,kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/os-sku=Windows2022,kubernetes.azure.com/role=agent,kubernetes.azure.com/storageprofile=managed,kubernetes.azure.com/storagetier=Premium_LRS,storageprofile=managed,storagetier=Premium_LRS,kubernetes.azure.com/kubelet-serving-ca=cluster"

...

Exception calling "RunProcess" with "3" argument(s): "Cannot process request because the process (992) has exited."
At C:\k\kubeletstart.ps1:106 char:1
+ [RunProcess.exec]::RunProcess($exe, $args, [System.Diagnostics.Proces ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : InvalidOperationException
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
