### PR TITLE
fix: do not use return in updating kubelet node labels

### DIFF
--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -147,3 +147,21 @@ Describe 'Validate Exit Codes' {
     }
   }
 }
+
+# When using return to return values in a function with using Write-Log, the logs will be returned as well.
+Describe "Mock Write-Log" {
+  It 'should never exist in ut' {
+    # Path to the PowerShell script you want to test
+    $scriptPaths = @()
+    $cseScripts = Get-ChildItem -Path "$PSScriptRoot\..\..\staging\cse\windows\" -Filter "*tests.ps1"
+    foreach($script in $cseScripts) {
+      $scriptPaths += $script.FullName
+    }
+    
+    foreach($scriptPath in $scriptPaths) {
+      Write-Host "Validating $scriptPath"
+      $scriptContent = Get-Content -Path $scriptPath
+      $scriptContent -join "`n" | Should -Not -Match "Mock Write-Log"
+    }
+  }
+}

--- a/staging/cse/windows/kubeletfunc.ps1
+++ b/staging/cse/windows/kubeletfunc.ps1
@@ -212,34 +212,30 @@ function Get-KubePackage {
 function Add-KubeletNodeLabel {
     Param(
         [Parameter(Mandatory=$true)][string]
-        $KubeletNodeLabels,
-        [Parameter(Mandatory=$true)][string]
         $Label
     )
 
-    $labelList = $KubeletNodeLabels -split ","
+    $labelList = $global:KubeletNodeLabels -split ","
     foreach ($existingLabel in $labelList) {
         if ($existingLabel -eq $Label) {
             Write-Log "found existing kubelet node label $existingLabel, will continue without adding anything"
-            return $KubeletNodeLabels
+            return
         }
     }
     Write-Log "adding label $Label to kubelet node labels..."
     $labelList += $Label
-    return $labelList -join ","
+    $global:KubeletNodeLabels = $labelList -join ","
 }
 
 function Remove-KubeletNodeLabel {
     Param(
         [Parameter(Mandatory=$true)][string]
-        $KubeletNodeLabels,
-        [Parameter(Mandatory=$true)][string]
         $Label
     )
 
-    $labelList = $KubeletNodeLabels -split ","
+    $labelList = $global:KubeletNodeLabels -split ","
     $filtered = $labelList | Where-Object { $_ -ne $Label }
-    return $filtered -join ","
+    $global:KubeletNodeLabels = $filtered -join ","
 }
 
 function Get-TagValue {
@@ -285,12 +281,12 @@ function Configure-KubeletServingCertificateRotation {
     if ($disabled -eq "true") {
         Write-Log "Kubelet serving certificate rotation is disabled by nodepool tags, will reconfigure kubelet flags and node labels"
         $global:KubeletConfigArgs = $global:KubeletConfigArgs -replace "--rotate-server-certificates=true", "--rotate-server-certificates=false"
-        $global:KubeletNodeLabels = Remove-KubeletNodeLabel -KubeletNodeLabels $global:KubeletNodeLabels -Label $nodeLabel
+        Remove-KubeletNodeLabel -Label $nodeLabel
         return
     }
 
     Write-Log "Kubelet serving certificate rotation is enabled, will add node label if needed"
-    $global:KubeletNodeLabels = Add-KubeletNodeLabel -KubeletNodeLabels $global:KubeletNodeLabels -Label $nodeLabel
+    Add-KubeletNodeLabel -Label $nodeLabel
 }
 
 # DEPRECATED - TODO(cameissner): remove once k8s setup script has been updated
@@ -316,7 +312,7 @@ function Disable-KubeletServingCertificateRotationForTags {
     Write-Log "Kubelet serving certificate rotation is disabled by nodepool tags, will reconfigure kubelet flags and node labels"
 
     $global:KubeletConfigArgs = $global:KubeletConfigArgs -replace "--rotate-server-certificates=true", "--rotate-server-certificates=false"
-    $global:KubeletNodeLabels = Remove-KubeletNodeLabel -KubeletNodeLabels $global:KubeletNodeLabels -Label "kubernetes.azure.com/kubelet-serving-ca=cluster"
+    Remove-KubeletNodeLabel -Label "kubernetes.azure.com/kubelet-serving-ca=cluster"
 }
 
 # TODO: replace KubeletStartFile with a Kubelet config, remove NSSM, and use built-in service integration

--- a/staging/cse/windows/kubeletfunc.tests.ps1
+++ b/staging/cse/windows/kubeletfunc.tests.ps1
@@ -67,7 +67,6 @@ Describe 'Get-KubePackage' {
 Describe 'Configure-KubeletServingCertificateRotation' {
     BeforeEach {
         Mock Logs-To-Event
-        Mock Write-Log
     }
 
     It "Should no-op when EnableKubeletServingCertificateRotation is false" {
@@ -233,64 +232,67 @@ Describe 'Get-TagValue' {
 
 Describe 'Add-KubeletNodeLabel' {
     BeforeEach {
-        Mock Write-Log
+        $global:KubeletNodeLabels = ""
     }
 
     It "Should perform a no-op when the specified label already exists within the label string" {
-        $labelString = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/kubelet-serving-ca=cluster,kubernetes.azure.com/agentpool=wp0"
+        $global:KubeletNodeLabels = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/kubelet-serving-ca=cluster,kubernetes.azure.com/agentpool=wp0"
         $label = "kubernetes.azure.com/kubelet-serving-ca=cluster"
         $expected = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/kubelet-serving-ca=cluster,kubernetes.azure.com/agentpool=wp0"
-        $result = Add-KubeletNodeLabel -KubeletNodeLabels $labelString -Label $label
-        Compare-Object $result $expected | Should -Be $null
+        Add-KubeletNodeLabel -Label $label
+        Compare-Object $global:KubeletNodeLabels $expected | Should -Be $null
     }
 
     It "Should append the label when it does not already exist within the label string" {
-        $labelString = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/agentpool=wp0"
+        $global:KubeletNodeLabels = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/agentpool=wp0"
         $label = "kubernetes.azure.com/kubelet-serving-ca=cluster"
         $expected = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/agentpool=wp0,kubernetes.azure.com/kubelet-serving-ca=cluster"
-        $result = Add-KubeletNodeLabel -KubeletNodeLabels $labelString -Label $label
-        Compare-Object $result $expected | Should -Be $null
+        Add-KubeletNodeLabel -Label $label
+        Compare-Object $global:KubeletNodeLabels $expected | Should -Be $null
     }
 }
 
 Describe 'Remove-KubeletNodeLabel' {
+    BeforeEach {
+        $global:KubeletNodeLabels = ""
+    }
     It "Should remove the specified label when it exists within the label string" {
-        $labelString = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/kubelet-serving-ca=cluster,kubernetes.azure.com/agentpool=wp0"
+        $global:KubeletNodeLabels = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/kubelet-serving-ca=cluster,kubernetes.azure.com/agentpool=wp0"
         $label = "kubernetes.azure.com/kubelet-serving-ca=cluster"
         $expected = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/agentpool=wp0"
-        $result = Remove-KubeletNodeLabel -KubeletNodeLabels $labelString -Label $label
-        Compare-Object $result $expected | Should -Be $null
+        Remove-KubeletNodeLabel -Label $label
+        Compare-Object $global:KubeletNodeLabels $expected | Should -Be $null
     }
 
     It "Should remove the specified label when it is the first label within the label string" {
-        $labelString = "kubernetes.azure.com/kubelet-serving-ca=cluster,kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/agentpool=wp0"
+        $global:KubeletNodeLabels = "kubernetes.azure.com/kubelet-serving-ca=cluster,kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/agentpool=wp0"
         $label = "kubernetes.azure.com/kubelet-serving-ca=cluster"
         $expected = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/agentpool=wp0"
-        $result = Remove-KubeletNodeLabel -KubeletNodeLabels $labelString -Label $label
-        Compare-Object $result $expected | Should -Be $null
+        Remove-KubeletNodeLabel -Label $label
+        Compare-Object $global:KubeletNodeLabels $expected | Should -Be $null
     }
 
     It "Should remove the specified label when it is the last label within the label string" {
-        $labelString = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/agentpool=wp0,kubernetes.azure.com/kubelet-serving-ca=cluster"
+        $global:KubeletNodeLabels = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/agentpool=wp0,kubernetes.azure.com/kubelet-serving-ca=cluster"
         $label = "kubernetes.azure.com/kubelet-serving-ca=cluster"
         $expected = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/agentpool=wp0"
-        $result = Remove-KubeletNodeLabel -KubeletNodeLabels $labelString -Label $label
-        Compare-Object $result $expected | Should -Be $null
+        Remove-KubeletNodeLabel -Label $label
+        Compare-Object $global:KubeletNodeLabels $expected | Should -Be $null
     }
 
     It "Should not alter the specified label string if the target label does not exist" {
-        $labelString = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/agentpool=wp0"
+        $global:KubeletNodeLabels = "kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/agentpool=wp0"
         $label = "kubernetes.azure.com/kubelet-serving-ca=cluster"
-        $expected = $labelString
-        $result = Remove-KubeletNodeLabel -KubeletNodeLabels $labelString -Label $label
-        Compare-Object $result $expected | Should -Be $null
+        $expected = $global:KubeletNodeLabels
+        Remove-KubeletNodeLabel -Label $label
+        Compare-Object $global:KubeletNodeLabels $expected | Should -Be $null
     }
 
     It "Should return an empty string if the only label within the label string is the target" {
-        $labelString = "kubernetes.azure.com/kubelet-serving-ca=cluster"
+        $global:KubeletNodeLabels = "kubernetes.azure.com/kubelet-serving-ca=cluster"
         $label = "kubernetes.azure.com/kubelet-serving-ca=cluster"
         $expected = ""
-        $result = Remove-KubeletNodeLabel -KubeletNodeLabels $labelString -Label $label
-        Compare-Object $result $expected | Should -Be $null
+        Remove-KubeletNodeLabel -Label $label
+        Compare-Object $global:KubeletNodeLabels $expected | Should -Be $null
     }
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

fixes a bug in Add-KubeletNodeLabel where the log content is added to the return value by Write-Log, causing KubeletNodeLabels to contain unexpected content which ends preventing kubelet from starting:


```
                                       "NodeLabels":  [
                                                          "2024-10-23T18:24:39.6797661+00:00: adding label kubernetes.azure.com/kubelet-serving-ca=cluster to kubelet node labels...",
                                                          "agentpool=npwin,kubernetes.azure.com/agentpool=npwin,agentpool=npwin,kubernetes.azure.com/agentpool=npwin,kubernetes.azure.com/cluster=MC_cameissebld106479871_wintester_eastus2,kubernetes.azure.com/consolidated-additional-properties=a3253cd6-916b-11ef-a610-6643c19b51dd,kubernetes.azure.com/kubelet-identity-client-id=78f4691a-f952-4bd3-83c0-0869e2821eed,kubernetes.azure.com/mode=user,kubernetes.azure.com/node-image-version=AKSWindows-2022-containerd-20348.2762.241009,kubernetes.azure.com/nodepool-type=VirtualMachineScaleSets,kubernetes.azure.com/os-sku=Windows2022,kubernetes.azure.com/role=agent,kubernetes.azure.com/storageprofile=managed,kubernetes.azure.com/storagetier=Premium_LRS,storageprofile=managed,storagetier=Premium_LRS,kubernetes.azure.com/kubelet-serving-ca=cluster"

...

Exception calling "RunProcess" with "3" argument(s): "Cannot process request because the process (992) has exited."
At C:\k\kubeletstart.ps1:106 char:1
+ [RunProcess.exec]::RunProcess($exe, $args, [System.Diagnostics.Proces ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : InvalidOperationException
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
