### PR TITLE
fix e2e

### DIFF
--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 )
@@ -109,11 +109,6 @@ func extractClusterParameters(ctx context.Context, t *testing.T, kube *Kubeclien
 	require.NoError(t, err)
 
 	bootstrapConfig := execResult.stdout.Bytes()
-	bootstrapToken, err := extractKeyValuePair("token", string(bootstrapConfig))
-	require.NoError(t, err)
-
-	bootstrapToken, err = strconv.Unquote(bootstrapToken)
-	require.NoError(t, err)
 
 	server, err := extractKeyValuePair("server", string(bootstrapConfig))
 	require.NoError(t, err)
@@ -128,9 +123,26 @@ func extractClusterParameters(ctx context.Context, t *testing.T, kube *Kubeclien
 
 	return ClusterParams{
 		CACert:         caCert.stdout.Bytes(),
-		BootstrapToken: bootstrapToken,
+		BootstrapToken: getBootstrapToken(ctx, t, kube),
 		FQDN:           fqdn,
 	}
+}
+
+func getBootstrapToken(ctx context.Context, t *testing.T, kube *Kubeclient) string {
+	secrets, err := kube.Typed.CoreV1().Secrets("kube-system").List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	secret := func() *corev1.Secret {
+		for _, secret := range secrets.Items {
+			if strings.HasPrefix(secret.Name, "bootstrap-token-") {
+				return &secret
+			}
+		}
+		t.Fatal("could not find secret with bootstrap-token- prefix")
+		return nil
+	}()
+	id := secret.Data["token-id"]
+	token := secret.Data["token-secret"]
+	return fmt.Sprintf("%s.%s", id, token)
 }
 
 func execOnVM(ctx context.Context, kube *Kubeclient, vmPrivateIP, jumpboxPodName, sshPrivateKey, command string, isShellBuiltIn bool) (*podExecResult, error) {


### PR DESCRIPTION
/kind test

Fetch node bootstrap token from secrets instead of from a VM in system nodepool. 

We caught an edge case where the bootstrap token has been changed due to node upgrade. But the existing VM still contains the old token.

It failed e2e in a hard to debug way.
