### PR TITLE
fix: ensure /mnt is mounted before bind-mount.service (#5297)

### DIFF
--- a/parts/linux/cloud-init/artifacts/bind-mount.service
+++ b/parts/linux/cloud-init/artifacts/bind-mount.service
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+Containerd/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+Containerd/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+Containerd/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+Containerd/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+CustomLinuxOSConfig/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+CustomLinuxOSConfig/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+CustomLinuxOSConfig/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+CustomLinuxOSConfig/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+DynamicKubeletConfig/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+DynamicKubeletConfig/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+DynamicKubeletConfig/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+CustomKubeletConfig+DynamicKubeletConfig/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+Disable1804SystemdResolved=false/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+Disable1804SystemdResolved=false/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+Disable1804SystemdResolved=false/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+Disable1804SystemdResolved=false/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+Disable1804SystemdResolved=true/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+Disable1804SystemdResolved=true/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+Disable1804SystemdResolved=true/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+Disable1804SystemdResolved=true/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+Docker/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+Docker/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+Docker/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+Docker/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+DynamicKubeletConfig/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+DynamicKubeletConfig/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+DynamicKubeletConfig/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+DynamicKubeletConfig/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+EnablePrivateClusterHostsConfigAgent/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+EnablePrivateClusterHostsConfigAgent/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+EnablePrivateClusterHostsConfigAgent/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+EnablePrivateClusterHostsConfigAgent/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+GPUDedicatedVHD/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+GPUDedicatedVHD/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+GPUDedicatedVHD/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+GPUDedicatedVHD/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+K8S115/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+K8S115/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+K8S115/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+K8S115/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+K8S117/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+K8S117/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+K8S117/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+K8S117/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+K8S118/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+K8S118/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+K8S118/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+K8S118/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+KubeletConfigFile/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+KubeletConfigFile/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+KubeletConfigFile/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+KubeletConfigFile/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+OSKubeletDisk/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+OSKubeletDisk/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+OSKubeletDisk/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+OSKubeletDisk/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+TempDisk+Containerd/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+TempDiskExplicit/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+TempDiskExplicit/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+TempDiskExplicit/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+TempDiskExplicit/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1604+TempDiskToggle/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1604+TempDiskToggle/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1604+TempDiskToggle/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1604+TempDiskToggle/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+ArtifactStreaming/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+ArtifactStreaming/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+ArtifactStreaming/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+ArtifactStreaming/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd++GPU+runcshimv2/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd++GPU+runcshimv2/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd++GPU+runcshimv2/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd++GPU+runcshimv2/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Certsd/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Certsd/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Certsd/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Certsd/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+ContainerdVersion/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+ContainerdVersion/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+ContainerdVersion/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+ContainerdVersion/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPAddress+FQDN/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPAddress+FQDN/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPAddress+FQDN/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPAddress+FQDN/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPMasqAgent/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPMasqAgent/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPMasqAgent/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+IPMasqAgent/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+Calico/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+Calico/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+Calico/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+Calico/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+FIPSEnabled/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+FIPSEnabled/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+FIPSEnabled/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet+FIPSEnabled/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Kubenet/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG+NoFabricManager/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG+NoFabricManager/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG+NoFabricManager/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG+NoFabricManager/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+MIG/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+MotD/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+MotD/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+MotD/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+MotD/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+NSeriesSku/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+PrivateACR/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+PrivateACR/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+PrivateACR/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+PrivateACR/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Teleport/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Teleport/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+Teleport/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+Teleport/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+runcshimv2/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+runcshimv2/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Containerd+runcshimv2/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Containerd+runcshimv2/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+CustomCATrust/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+CustomCATrust/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+CustomCATrust/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+CustomCATrust/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=false/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=false/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=false/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=false/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=true/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=true/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=true/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+Disable1804SystemdResolved=true/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+DisableCustomData/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+DisableCustomData/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+DisableCustomData/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+DisableCustomData/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+HTTPProxy/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+HTTPProxy/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+HTTPProxy/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+HTTPProxy/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+KubeletClientTLSBootstrapping/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+KubeletClientTLSBootstrapping/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+KubeletClientTLSBootstrapping/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+KubeletClientTLSBootstrapping/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+NoArtifactStreaming/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+NoArtifactStreaming/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+NoArtifactStreaming/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+NoArtifactStreaming/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+NoneCNI/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+NoneCNI/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+NoneCNI/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+NoneCNI/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804+krustlet/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804+krustlet/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804+krustlet/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804+krustlet/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+CustomKubeImageandBinaries/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+CustomKubeImageandBinaries/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+CustomKubeImageandBinaries/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+CustomKubeImageandBinaries/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+NoCustomKubeImageandBinaries/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+NoCustomKubeImageandBinaries/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+NoCustomKubeImageandBinaries/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804ARM64Containerd+NoCustomKubeImageandBinaries/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu1804Containerd+RuncVersion/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu1804Containerd+RuncVersion/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu1804Containerd+RuncVersion/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu1804Containerd+RuncVersion/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+China/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+China/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+China/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+China/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+Containerd+MIG+ArtifactStreaming/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+Containerd+MIG+ArtifactStreaming/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+Containerd+MIG+ArtifactStreaming/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+Containerd+MIG+ArtifactStreaming/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+Containerd+MIG/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+Containerd+MIG/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+Containerd+MIG/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+Containerd+MIG/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+CustomCloud+ootcredentialprovider/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+CustomCloud+ootcredentialprovider/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+CustomCloud+ootcredentialprovider/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+CustomCloud+ootcredentialprovider/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+CustomCloud/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+CustomCloud/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+CustomCloud/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+CustomCloud/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+CustomKubeletConfig+CustomLinuxOSConfig/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+CustomKubeletConfig+CustomLinuxOSConfig/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+CustomKubeletConfig+CustomLinuxOSConfig/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+CustomKubeletConfig+CustomLinuxOSConfig/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+CustomKubeletConfig+SerializeImagePulls/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+CustomKubeletConfig+SerializeImagePulls/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+CustomKubeletConfig+SerializeImagePulls/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+CustomKubeletConfig+SerializeImagePulls/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+DisableKubeletServingCertificateRotation+CustomKubeletConfig/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+DisableKubeletServingCertificateRotation+CustomKubeletConfig/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+DisableKubeletServingCertificateRotation+CustomKubeletConfig/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+DisableKubeletServingCertificateRotation+CustomKubeletConfig/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+DisableKubeletServingCertificateRotation/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+DisableKubeletServingCertificateRotation/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+DisableKubeletServingCertificateRotation/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+DisableKubeletServingCertificateRotation/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+IMDSRestrictionOff/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+IMDSRestrictionOff/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+IMDSRestrictionOff/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+IMDSRestrictionOff/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+IMDSRestrictionOnWithFilterTable/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+IMDSRestrictionOnWithFilterTable/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+IMDSRestrictionOnWithFilterTable/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+IMDSRestrictionOnWithFilterTable/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+IMDSRestrictionOnWithMangleTable/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+IMDSRestrictionOnWithMangleTable/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+IMDSRestrictionOnWithMangleTable/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+IMDSRestrictionOnWithMangleTable/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+ImplicitlyDisableKubeletServingCertificateRotation/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+ImplicitlyDisableKubeletServingCertificateRotation/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+ImplicitlyDisableKubeletServingCertificateRotation/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+ImplicitlyDisableKubeletServingCertificateRotation/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+KubeletServingCertificateRotation+CustomKubeletConfig/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+KubeletServingCertificateRotation+CustomKubeletConfig/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+KubeletServingCertificateRotation+CustomKubeletConfig/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+KubeletServingCertificateRotation+CustomKubeletConfig/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+KubeletServingCertificateRotation/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+KubeletServingCertificateRotation/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+KubeletServingCertificateRotation/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+KubeletServingCertificateRotation/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+OutboundTypeBlocked/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+OutboundTypeBlocked/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+OutboundTypeBlocked/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+OutboundTypeBlocked/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+OutboundTypeNil/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+OutboundTypeNil/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+OutboundTypeNil/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+OutboundTypeNil/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+OutboundTypeNone/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+OutboundTypeNone/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+OutboundTypeNone/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+OutboundTypeNone/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+SSHStatusOff/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+SSHStatusOff/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+SSHStatusOff/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+SSHStatusOff/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+SSHStatusOn/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+SSHStatusOn/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+SSHStatusOn/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+SSHStatusOn/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+SecureTLSBoostrapping/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+SecureTLSBoostrapping/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+SecureTLSBoostrapping/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+SecureTLSBoostrapping/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+SecureTLSBootstrapping+CustomAADResource/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+SecureTLSBootstrapping+CustomAADResource/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+SecureTLSBootstrapping+CustomAADResource/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+SecureTLSBootstrapping+CustomAADResource/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+SecurityProfile/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+SecurityProfile/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+SecurityProfile/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+SecurityProfile/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+SerializeImagePulls/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+SerializeImagePulls/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+SerializeImagePulls/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+SerializeImagePulls/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+cgroupv2/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+cgroupv2/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+cgroupv2/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+cgroupv2/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AKSUbuntu2204+ootcredentialprovider/CustomData
+++ b/pkg/agent/testdata/AKSUbuntu2204+ootcredentialprovider/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AKSUbuntu2204+ootcredentialprovider/line156.sh
+++ b/pkg/agent/testdata/AKSUbuntu2204+ootcredentialprovider/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AzureLinuxV2+Kata/CustomData
+++ b/pkg/agent/testdata/AzureLinuxV2+Kata/CustomData
@@ -150,7 +150,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AzureLinuxV2+Kata/line153.sh
+++ b/pkg/agent/testdata/AzureLinuxV2+Kata/line153.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AzureLinuxv2+DisableUnattendedUpgrades=false/CustomData
+++ b/pkg/agent/testdata/AzureLinuxv2+DisableUnattendedUpgrades=false/CustomData
@@ -150,7 +150,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AzureLinuxv2+DisableUnattendedUpgrades=false/line153.sh
+++ b/pkg/agent/testdata/AzureLinuxv2+DisableUnattendedUpgrades=false/line153.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AzureLinuxv2+DisableUnattendedUpgrades=true/CustomData
+++ b/pkg/agent/testdata/AzureLinuxv2+DisableUnattendedUpgrades=true/CustomData
@@ -150,7 +150,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AzureLinuxv2+DisableUnattendedUpgrades=true/line153.sh
+++ b/pkg/agent/testdata/AzureLinuxv2+DisableUnattendedUpgrades=true/line153.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AzureLinuxv2+Kata+DisableUnattendedUpgrades=false/CustomData
+++ b/pkg/agent/testdata/AzureLinuxv2+Kata+DisableUnattendedUpgrades=false/CustomData
@@ -150,7 +150,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AzureLinuxv2+Kata+DisableUnattendedUpgrades=false/line153.sh
+++ b/pkg/agent/testdata/AzureLinuxv2+Kata+DisableUnattendedUpgrades=false/line153.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/AzureLinuxv2+Kata+DisableUnattendedUpgrades=true/CustomData
+++ b/pkg/agent/testdata/AzureLinuxv2+Kata+DisableUnattendedUpgrades=true/CustomData
@@ -150,7 +150,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/AzureLinuxv2+Kata+DisableUnattendedUpgrades=true/line153.sh
+++ b/pkg/agent/testdata/AzureLinuxv2+Kata+DisableUnattendedUpgrades=true/line153.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/CustomizedImage/CustomData
+++ b/pkg/agent/testdata/CustomizedImage/CustomData
@@ -148,7 +148,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/CustomizedImage/line151.sh
+++ b/pkg/agent/testdata/CustomizedImage/line151.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/CustomizedImageKata/CustomData
+++ b/pkg/agent/testdata/CustomizedImageKata/CustomData
@@ -148,7 +148,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/CustomizedImageKata/line151.sh
+++ b/pkg/agent/testdata/CustomizedImageKata/line151.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/MarinerV2+CustomCloud/CustomData
+++ b/pkg/agent/testdata/MarinerV2+CustomCloud/CustomData
@@ -150,7 +150,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/MarinerV2+CustomCloud/line153.sh
+++ b/pkg/agent/testdata/MarinerV2+CustomCloud/line153.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/MarinerV2+Kata/CustomData
+++ b/pkg/agent/testdata/MarinerV2+Kata/CustomData
@@ -150,7 +150,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/MarinerV2+Kata/line153.sh
+++ b/pkg/agent/testdata/MarinerV2+Kata/line153.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/Marinerv2+DisableUnattendedUpgrades=false/CustomData
+++ b/pkg/agent/testdata/Marinerv2+DisableUnattendedUpgrades=false/CustomData
@@ -150,7 +150,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/Marinerv2+DisableUnattendedUpgrades=false/line153.sh
+++ b/pkg/agent/testdata/Marinerv2+DisableUnattendedUpgrades=false/line153.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/Marinerv2+DisableUnattendedUpgrades=true/CustomData
+++ b/pkg/agent/testdata/Marinerv2+DisableUnattendedUpgrades=true/CustomData
@@ -150,7 +150,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/Marinerv2+DisableUnattendedUpgrades=true/line153.sh
+++ b/pkg/agent/testdata/Marinerv2+DisableUnattendedUpgrades=true/line153.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/Marinerv2+Kata+DisableUnattendedUpgrades=false/CustomData
+++ b/pkg/agent/testdata/Marinerv2+Kata+DisableUnattendedUpgrades=false/CustomData
@@ -150,7 +150,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/Marinerv2+Kata+DisableUnattendedUpgrades=false/line153.sh
+++ b/pkg/agent/testdata/Marinerv2+Kata+DisableUnattendedUpgrades=false/line153.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/Marinerv2+Kata+DisableUnattendedUpgrades=true/CustomData
+++ b/pkg/agent/testdata/Marinerv2+Kata+DisableUnattendedUpgrades=true/CustomData
@@ -150,7 +150,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/Marinerv2+Kata+DisableUnattendedUpgrades=true/line153.sh
+++ b/pkg/agent/testdata/Marinerv2+Kata+DisableUnattendedUpgrades=true/line153.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/RawUbuntu/CustomData
+++ b/pkg/agent/testdata/RawUbuntu/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/RawUbuntu/line156.sh
+++ b/pkg/agent/testdata/RawUbuntu/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes

--- a/pkg/agent/testdata/RawUbuntuContainerd/CustomData
+++ b/pkg/agent/testdata/RawUbuntuContainerd/CustomData
@@ -153,7 +153,7 @@ write_files:
   encoding: gzip
   owner: root
   content: !!binary |
-    H4sIAAAAAAAC/xzNMU7DQBBG4X5O4Qs4e4ItiEhBm4AoLBdj+w8esZ61ZmZRzOkRqZ+evuFDJUZ6hc8me0jVfBZduq02je67TSiIbuFgGm6wH5kx0hUebJGr9neW0gx0xcaiL/eAXR4S+YDT+7EjV4WvNejywHx7XmkSTRP72qW6R+LfZkhz1WBRmP/npX/6J1+Jhjf14FJG+mQNLOcjb62E9M1hp2D7QtBfAAAA//8tGsoCxwAAAA==
+    H4sIAAAAAAAC/0zNsU6EUBCF4X6eghcAnuAWbtzCltVYEIoBzspEmIszc83i0xupLE/+fDn9m0oM9AyfTPaQrOkiOldbLhrVZxmxIqqZg6nDVxGDp02jOTs93QP2b1N/g33LhIE6eLBFylrfWdZioA4bi57m+pBIB5xejx0pK3zJQdcHptup2lG0HdmXqs17tPxTDO2UNVgU5n95rs/Pxhei/kU9eF0HemcNzJcjbWUNqYvDmmD7QNBvAAAA///RbR0T6wAAAA==
 
 - path: /etc/systemd/system/dhcpv6.service
   permissions: "0644"

--- a/pkg/agent/testdata/RawUbuntuContainerd/line156.sh
+++ b/pkg/agent/testdata/RawUbuntuContainerd/line156.sh
@@ -1,5 +1,8 @@
 [Unit]
 Description=Bind mount kubelet data
+Requires=mnt.mount
+After=mnt.mount
+
 [Service]
 Restart=on-failure
 RemainAfterExit=yes


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Fixes a bug where bind-mount,service tries to run before /mnt is mounted upon reboot.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
