### PR TITLE
Make E2E validation more flexible.

### DIFF
--- a/e2e/config/vhd.go
+++ b/e2e/config/vhd.go
@@ -34,52 +34,61 @@ type Gallery struct {
 	Name              string
 }
 
+type OS string
+
+var (
+	OSWindows    OS = "windows"
+	OSUbuntu     OS = "ubuntu"
+	OSMariner    OS = "mariner"
+	OSAzureLinux OS = "azurelinux"
+)
+
 var (
 	VHDUbuntu1804Gen2Containerd = &Image{
 		Name:    "1804gen2containerd",
-		OS:      "ubuntu",
+		OS:      OSUbuntu,
 		Arch:    "amd64",
 		Distro:  datamodel.AKSUbuntuContainerd1804Gen2,
 		Gallery: linuxGallery,
 	}
 	VHDUbuntu2204Gen2Arm64Containerd = &Image{
 		Name:    "2204gen2arm64containerd",
-		OS:      "ubuntu",
+		OS:      OSUbuntu,
 		Arch:    "arm64",
 		Distro:  datamodel.AKSUbuntuArm64Containerd2204Gen2,
 		Gallery: linuxGallery,
 	}
 	VHDUbuntu2204Gen2Containerd = &Image{
 		Name:    "2204gen2containerd",
-		OS:      "ubuntu",
+		OS:      OSUbuntu,
 		Arch:    "amd64",
 		Distro:  datamodel.AKSUbuntuContainerd2404Gen2,
 		Gallery: linuxGallery,
 	}
 	VHDAzureLinuxV2Gen2Arm64 = &Image{
 		Name:    "AzureLinuxV2gen2arm64",
-		OS:      "azurelinux",
+		OS:      OSAzureLinux,
 		Arch:    "arm64",
 		Distro:  datamodel.AKSAzureLinuxV2Arm64Gen2,
 		Gallery: linuxGallery,
 	}
 	VHDAzureLinuxV2Gen2 = &Image{
 		Name:    "AzureLinuxV2gen2",
-		OS:      "azurelinux",
+		OS:      OSAzureLinux,
 		Arch:    "amd64",
 		Distro:  datamodel.AKSAzureLinuxV2Gen2,
 		Gallery: linuxGallery,
 	}
 	VHDCBLMarinerV2Gen2Arm64 = &Image{
 		Name:    "CBLMarinerV2gen2arm64",
-		OS:      "mariner",
+		OS:      OSMariner,
 		Arch:    "arm64",
 		Distro:  datamodel.AKSCBLMarinerV2Arm64Gen2,
 		Gallery: linuxGallery,
 	}
 	VHDCBLMarinerV2Gen2 = &Image{
 		Name:    "CBLMarinerV2gen2",
-		OS:      "mariner",
+		OS:      OSMariner,
 		Arch:    "amd64",
 		Distro:  datamodel.AKSCBLMarinerV2Gen2,
 		Gallery: linuxGallery,
@@ -89,7 +98,7 @@ var (
 	VHDUbuntu2204Gen2ContainerdPrivateKubePkg = &Image{
 		// 2204Gen2 is a special image definition holding historical VHDs used by agentbaker e2e's.
 		Name:    "2204Gen2",
-		OS:      "ubuntu",
+		OS:      OSUbuntu,
 		Arch:    "amd64",
 		Version: "1.1704411049.2812",
 		Distro:  datamodel.AKSUbuntuContainerd2404Gen2,
@@ -99,7 +108,7 @@ var (
 	// without kubelet, kubectl, credential-provider and wasm
 	VHDUbuntu2204Gen2ContainerdAirgappedK8sNotCached = &Image{
 		Name:    "2204Gen2",
-		OS:      "ubuntu",
+		OS:      OSUbuntu,
 		Arch:    "amd64",
 		Version: "1.1725612526.29638",
 		Distro:  datamodel.AKSUbuntuContainerd2404Gen2,
@@ -126,7 +135,7 @@ var (
 
 	VHDWindows2022ContainerdGen2 = &Image{
 		Name:    "windows-2022-containerd-gen2",
-		OS:      "windows",
+		OS:      OSWindows,
 		Arch:    "amd64",
 		Distro:  datamodel.AKSWindows2022ContainerdGen2,
 		Latest:  true,
@@ -135,7 +144,7 @@ var (
 
 	VHDWindows23H2 = &Image{
 		Name:    "windows-23H2",
-		OS:      "windows",
+		OS:      OSWindows,
 		Arch:    "amd64",
 		Distro:  datamodel.AKSWindows23H2,
 		Latest:  true,
@@ -144,7 +153,7 @@ var (
 
 	VHDWindows23H2Gen2 = &Image{
 		Name:    "windows-23H2-gen2",
-		OS:      "windows",
+		OS:      OSWindows,
 		Arch:    "amd64",
 		Distro:  datamodel.AKSWindows23H2Gen2,
 		Latest:  true,
@@ -158,7 +167,7 @@ type Image struct {
 	Arch    string
 	Distro  datamodel.Distro
 	Name    string
-	OS      string
+	OS      OS
 	Version string
 	Gallery *Gallery
 	Latest  bool // a hack to get the latest version of the image for windows, currently windows images are not tagged
@@ -193,6 +202,10 @@ func (i *Image) VHDResourceID(ctx context.Context, t *testing.T) (VHDResourceID,
 
 func (i *Image) Windows() bool {
 	return i.OS == "windows"
+}
+
+func (i *Image) Ubuntu() bool {
+	return i.OS == "ubuntu"
 }
 
 // VHDResourceID represents a resource ID pointing to a VHD in Azure. This could be theoretically

--- a/e2e/config/vhd.go
+++ b/e2e/config/vhd.go
@@ -200,14 +200,6 @@ func (i *Image) VHDResourceID(ctx context.Context, t *testing.T) (VHDResourceID,
 	return i.vhd, i.vhdErr
 }
 
-func (i *Image) Windows() bool {
-	return i.OS == "windows"
-}
-
-func (i *Image) Ubuntu() bool {
-	return i.OS == "ubuntu"
-}
-
 // VHDResourceID represents a resource ID pointing to a VHD in Azure. This could be theoretically
 // be the resource ID of a managed image or SIG image version, though for now this will always be a SIG image version.
 type VHDResourceID string

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -115,11 +115,9 @@ func getBootstrapToken(ctx context.Context, t *testing.T, kube *Kubeclient) stri
 	return fmt.Sprintf("%s.%s", id, token)
 }
 
-func execOnVM(ctx context.Context, kube *Kubeclient, vmPrivateIP, jumpboxPodName, sshPrivateKey, command string, isShellBuiltIn bool) (*podExecResult, error) {
+func execOnVM(ctx context.Context, kube *Kubeclient, vmPrivateIP, jumpboxPodName, sshPrivateKey, command string) (*podExecResult, error) {
 	sshCommand := fmt.Sprintf(sshCommandTemplate, sshPrivateKey, strings.ReplaceAll(vmPrivateIP, ".", ""), vmPrivateIP)
-	if !isShellBuiltIn {
-		sshCommand = sshCommand + " sudo"
-	}
+	sshCommand = sshCommand + " sudo"
 	commandToExecute := fmt.Sprintf("%s %s", sshCommand, command)
 
 	execResult, err := execOnPrivilegedPod(ctx, kube, defaultNamespace, jumpboxPodName, commandToExecute)

--- a/e2e/scenario_helpers_test.go
+++ b/e2e/scenario_helpers_test.go
@@ -147,19 +147,19 @@ func createAndValidateVM(ctx context.Context, s *Scenario) {
 
 	s.T.Logf("node %s is ready, proceeding with validation commands...", s.Runtime.VMSSName)
 
-	vmPrivateIP, err := getVMPrivateIPAddress(ctx, s)
-
 	if s.Config.Validator != nil {
 		s.Config.Validator(ctx, s)
 	}
 
 	require.NoError(s.T, err, "get vm private IP %v", s.Runtime.VMSSName)
-	err = runLiveVMValidators(ctx, s.T, s.Runtime.VMSSName, vmPrivateIP, string(s.Runtime.SSHKeyPrivate), s)
-	require.NoError(s.T, err)
+	switch s.VHD.OS {
+	case config.OSWindows:
+		// TODO: validate something
+	default:
+		ValidateCommonLinux(ctx, s)
 
-	ValidateCommon(ctx, s)
-
-	s.T.Logf("node %s bootstrapping succeeded!", s.Runtime.VMSSName)
+	}
+	s.T.Log("validation succeeded")
 }
 
 func getExpectedPackageVersions(packageName, distro, release string) []string {

--- a/e2e/scenario_helpers_test.go
+++ b/e2e/scenario_helpers_test.go
@@ -157,6 +157,8 @@ func createAndValidateVM(ctx context.Context, s *Scenario) {
 	err = runLiveVMValidators(ctx, s.T, s.Runtime.VMSSName, vmPrivateIP, string(s.Runtime.SSHKeyPrivate), s)
 	require.NoError(s.T, err)
 
+	ValidateCommon(ctx, s)
+
 	s.T.Logf("node %s bootstrapping succeeded!", s.Runtime.VMSSName)
 }
 

--- a/e2e/scenario_node_controller_test.go
+++ b/e2e/scenario_node_controller_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -80,10 +81,10 @@ func Test_ubuntu2204AKSNodeController(t *testing.T) {
 					},
 				}
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				mobyComponentVersionValidator("containerd", getExpectedPackageVersions("containerd", "ubuntu", "r2204")[0], "apt"),
-				mobyComponentVersionValidator("runc", getExpectedPackageVersions("runc", "ubuntu", "r2204")[0], "apt"),
-				ValidateFileHasContent("/var/log/azure/aks-node-controller.log", "aks-node-controller finished successfully"),
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateInstalledPackageVersion(ctx, s, "moby-containerd", getExpectedPackageVersions("containerd", "ubuntu", "r2204")[0])
+				ValidateInstalledPackageVersion(ctx, s, "moby-runc", getExpectedPackageVersions("runc", "ubuntu", "r2204")[0])
+				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log", "aks-node-controller finished successfully")
 			},
 			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {},
 		},

--- a/e2e/scenario_node_controller_test.go
+++ b/e2e/scenario_node_controller_test.go
@@ -25,7 +25,7 @@ import (
 // the test results are unreliable, as there can be a version mismatch between the binary and the rest content of VHD image
 // it's intended to be used for quick testing without rebuilding VHD images
 // mostly executed locally
-func Test_ubuntu2204AKSNodeController(t *testing.T) {
+func Test_Ubuntu2204AKSNodeController(t *testing.T) {
 	ctx := newTestCtx(t)
 	if !config.Config.EnableAKSNodeControllerTest {
 		t.Skip("ENABLE_AKS_NODE_CONTROLLER_TEST is not set")

--- a/e2e/scenario_node_controller_test.go
+++ b/e2e/scenario_node_controller_test.go
@@ -83,7 +83,7 @@ func Test_ubuntu2204AKSNodeController(t *testing.T) {
 			LiveVMValidators: []*LiveVMValidator{
 				mobyComponentVersionValidator("containerd", getExpectedPackageVersions("containerd", "ubuntu", "r2204")[0], "apt"),
 				mobyComponentVersionValidator("runc", getExpectedPackageVersions("runc", "ubuntu", "r2204")[0], "apt"),
-				FileHasContentsValidator("/var/log/azure/aks-node-controller.log", "aks-node-controller finished successfully"),
+				ValidateFileHasContent("/var/log/azure/aks-node-controller.log", "aks-node-controller finished successfully"),
 			},
 			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {},
 		},

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -122,9 +122,11 @@ func Test_azurelinuxv2ChronyRestarts(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			LiveVMValidators: []*LiveVMValidator{
-				ServiceCanRestartValidator("chronyd", 10),
 				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
 				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				ServiceCanRestartValidator(ctx, s, "chronyd", 10)
 			},
 		},
 	})
@@ -345,9 +347,11 @@ func Test_marinerv2ChronyRestarts(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			LiveVMValidators: []*LiveVMValidator{
-				ServiceCanRestartValidator("chronyd", 10),
 				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
 				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				ServiceCanRestartValidator(ctx, s, "chronyd", 10)
 			},
 		},
 	})
@@ -501,9 +505,11 @@ func Test_ubuntu1804ChronyRestarts(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			LiveVMValidators: []*LiveVMValidator{
-				ServiceCanRestartValidator("chronyd", 10),
 				FileHasContentsValidator("/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "Restart=always"),
 				FileHasContentsValidator("/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "RestartSec=5"),
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				ServiceCanRestartValidator(ctx, s, "chronyd", 10)
 			},
 		},
 	})
@@ -679,9 +685,11 @@ func Test_ubuntu2204ChronyRestarts(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			LiveVMValidators: []*LiveVMValidator{
-				ServiceCanRestartValidator("chronyd", 10),
 				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
 				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				ServiceCanRestartValidator(ctx, s, "chronyd", 10)
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -121,11 +121,9 @@ func Test_azurelinuxv2ChronyRestarts(t *testing.T) {
 			VHD:     config.VHDAzureLinuxV2Gen2,
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
-				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
-			},
 			Validator: func(ctx context.Context, s *Scenario) {
+				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always")
+				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5")
 				ServiceCanRestartValidator(ctx, s, "chronyd", 10)
 			},
 		},
@@ -346,12 +344,10 @@ func Test_marinerv2ChronyRestarts(t *testing.T) {
 			VHD:     config.VHDCBLMarinerV2Gen2,
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
-				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
-			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ServiceCanRestartValidator(ctx, s, "chronyd", 10)
+				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always")
+				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5")
 			},
 		},
 	})
@@ -504,12 +500,10 @@ func Test_ubuntu1804ChronyRestarts(t *testing.T) {
 			VHD:     config.VHDUbuntu1804Gen2Containerd,
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				FileHasContentsValidator("/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "Restart=always"),
-				FileHasContentsValidator("/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "RestartSec=5"),
-			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ServiceCanRestartValidator(ctx, s, "chronyd", 10)
+				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "Restart=always")
+				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "RestartSec=5")
 			},
 		},
 	})
@@ -521,8 +515,8 @@ func Test_ubuntu2204ScriptlessInstaller(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			LiveVMValidators: []*LiveVMValidator{
-				FileHasContentsValidator("/var/log/azure/aks-node-controller.log", "aks-node-controller finished successfully"),
+			Validator: func(ctx context.Context, s *Scenario) {
+				FileHasContentsValidator(ctx, s, "/var/log/azure/aks-node-controller.log", "aks-node-controller finished successfully")
 			},
 			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {},
 		},
@@ -684,11 +678,9 @@ func Test_ubuntu2204ChronyRestarts(t *testing.T) {
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always"),
-				FileHasContentsValidator("/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5"),
-			},
 			Validator: func(ctx context.Context, s *Scenario) {
+				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always")
+				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5")
 				ServiceCanRestartValidator(ctx, s, "chronyd", 10)
 			},
 		},
@@ -942,7 +934,9 @@ func Test_Ubuntu2204DisableKubeletServingCertificateRotationWithTags(t *testing.
 			LiveVMValidators: []*LiveVMValidator{
 				FileExcludesContentsValidator("/etc/default/kubelet", "\\-\\-rotate-server-certificates=true", "\\-\\-rotate-server-certificates=true"),
 				FileExcludesContentsValidator("/etc/default/kubelet", "kubernetes.azure.com/kubelet-serving-ca=cluster", "kubernetes.azure.com/kubelet-serving-ca=cluster"),
-				FileHasContentsValidator("/etc/default/kubelet", "\\-\\-rotate-server-certificates=false"),
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				FileHasContentsValidator(ctx, s, "/etc/default/kubelet", "\\-\\-rotate-server-certificates=false")
 			},
 		},
 	})
@@ -981,7 +975,9 @@ func Test_Ubuntu2204DisableKubeletServingCertificateRotationWithTags_CustomKubel
 				FileExcludesContentsValidator("/etc/default/kubelet", "\\-\\-rotate-server-certificates=true", "\\-\\-rotate-server-certificates=true"),
 				FileExcludesContentsValidator("/etc/default/kubelet", "kubernetes.azure.com/kubelet-serving-ca=cluster", "kubernetes.azure.com/kubelet-serving-ca=cluster"),
 				FileExcludesContentsValidator("/etc/default/kubeletconfig.json", "\"serverTLSBootstrap\": true", "serverTLSBootstrap: true"),
-				FileHasContentsValidator("/etc/default/kubeletconfig.json", "\"serverTLSBootstrap\": false"),
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				FileHasContentsValidator(ctx, s, "/etc/default/kubeletconfig.json", "\"serverTLSBootstrap\": false")
 			},
 		},
 	})
@@ -1118,8 +1114,8 @@ func Test_Ubuntu2204MessageOfTheDay(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.MessageOfTheDay = "Zm9vYmFyDQo=" // base64 for foobar
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				FileHasContentsValidator("/etc/motd", "foobar"),
+			Validator: func(ctx context.Context, s *Scenario) {
+				FileHasContentsValidator(ctx, s, "/etc/motd", "foobar")
 			},
 		},
 	})
@@ -1134,8 +1130,8 @@ func Test_AzureLinuxV2MessageOfTheDay(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.MessageOfTheDay = "Zm9vYmFyDQo=" // base64 for foobar
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				FileHasContentsValidator("/etc/motd", "foobar"),
+			Validator: func(ctx context.Context, s *Scenario) {
+				FileHasContentsValidator(ctx, s, "/etc/motd", "foobar")
 			},
 		},
 	})
@@ -1162,7 +1158,9 @@ func Test_Ubuntu2204_KubeletCustomConfig(t *testing.T) {
 			},
 			LiveVMValidators: []*LiveVMValidator{
 				KubeletHasConfigFlagsValidator(kubeletConfigFilePath),
-				FileHasContentsValidator(kubeletConfigFilePath, "\"seccompDefault\": true"),
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				FileHasContentsValidator(ctx, s, kubeletConfigFilePath, `"seccompDefault": true`)
 			},
 		},
 	})
@@ -1189,7 +1187,9 @@ func Test_AzureLinuxV2_KubeletCustomConfig(t *testing.T) {
 			},
 			LiveVMValidators: []*LiveVMValidator{
 				KubeletHasConfigFlagsValidator(kubeletConfigFilePath),
-				FileHasContentsValidator(kubeletConfigFilePath, "\"seccompDefault\": true"),
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				FileHasContentsValidator(ctx, s, kubeletConfigFilePath, `"seccompDefault": true`)
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1138,7 +1138,6 @@ func Test_AzureLinuxV2MessageOfTheDay(t *testing.T) {
 }
 
 func Test_Ubuntu2204_KubeletCustomConfig(t *testing.T) {
-	kubeletConfigFilePath := "/etc/default/kubeletconfig.json"
 	RunScenario(t, &Scenario{
 		Tags: Tags{
 			KubeletCustomConfig: true,
@@ -1156,18 +1155,16 @@ func Test_Ubuntu2204_KubeletCustomConfig(t *testing.T) {
 				nbc.AgentPoolProfile.CustomKubeletConfig = customKubeletConfig
 				nbc.ContainerService.Properties.AgentPoolProfiles[0].CustomKubeletConfig = customKubeletConfig
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				KubeletHasConfigFlagsValidator(kubeletConfigFilePath),
-			},
 			Validator: func(ctx context.Context, s *Scenario) {
+				kubeletConfigFilePath := "/etc/default/kubeletconfig.json"
 				ValidateFileHasContent(ctx, s, kubeletConfigFilePath, `"seccompDefault": true`)
+				ValidateKubeletHasFlags(ctx, s, kubeletConfigFilePath)
 			},
 		},
 	})
 }
 
 func Test_AzureLinuxV2_KubeletCustomConfig(t *testing.T) {
-	kubeletConfigFilePath := "/etc/default/kubeletconfig.json"
 	RunScenario(t, &Scenario{
 		Tags: Tags{
 			KubeletCustomConfig: true,
@@ -1185,11 +1182,10 @@ func Test_AzureLinuxV2_KubeletCustomConfig(t *testing.T) {
 				nbc.AgentPoolProfile.CustomKubeletConfig = customKubeletConfig
 				nbc.ContainerService.Properties.AgentPoolProfiles[0].CustomKubeletConfig = customKubeletConfig
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				KubeletHasConfigFlagsValidator(kubeletConfigFilePath),
-			},
 			Validator: func(ctx context.Context, s *Scenario) {
+				kubeletConfigFilePath := "/etc/default/kubeletconfig.json"
 				ValidateFileHasContent(ctx, s, kubeletConfigFilePath, `"seccompDefault": true`)
+				ValidateKubeletHasFlags(ctx, s, kubeletConfigFilePath)
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -162,10 +162,8 @@ func Test_azurelinuxv2CustomSysctls(t *testing.T) {
 				}
 				nbc.AgentPoolProfile.CustomLinuxOSConfig = customLinuxConfig
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				UlimitValidator(customContainerdUlimits),
-			},
 			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateUlimitSettings(ctx, s, customContainerdUlimits)
 				ValidateSysctlConfig(ctx, s, customSysctls)
 			},
 		},
@@ -387,10 +385,8 @@ func Test_marinerv2CustomSysctls(t *testing.T) {
 				}
 				nbc.AgentPoolProfile.CustomLinuxOSConfig = customLinuxConfig
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				UlimitValidator(customContainerdUlimits),
-			},
 			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateUlimitSettings(ctx, s, customContainerdUlimits)
 				ValidateSysctlConfig(ctx, s, customSysctls)
 			},
 		},
@@ -744,10 +740,8 @@ func Test_ubuntu2204CustomSysctls(t *testing.T) {
 				}
 				nbc.AgentPoolProfile.CustomLinuxOSConfig = customLinuxConfig
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				UlimitValidator(customContainerdUlimits),
-			},
 			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateUlimitSettings(ctx, s, customContainerdUlimits)
 				ValidateSysctlConfig(ctx, s, customSysctls)
 			},
 		},

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -663,8 +663,8 @@ func Test_ubuntu2204ArtifactStreaming(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.EnableArtifactStreaming = true
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				NonEmptyDirectoryValidator("/etc/overlaybd"),
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateNonEmptyDirectory(ctx, s, "/etc/overlaybd")
 			},
 		},
 	})
@@ -701,8 +701,8 @@ func Test_ubuntu2204CustomCATrust(t *testing.T) {
 					},
 				}
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				NonEmptyDirectoryValidator("/usr/local/share/ca-certificates/certs"),
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateNonEmptyDirectory(ctx, s, "/usr/local/share/ca-certificates/certs")
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -229,8 +229,8 @@ func Test_azurelinuxv2Wasm(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.WorkloadRuntime = datamodel.WasmWasi
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				containerdWasmShimsValidator(),
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateContainerdWASMShims(ctx, s)
 			},
 		},
 	})
@@ -452,8 +452,8 @@ func Test_marinerv2Wasm(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.WorkloadRuntime = datamodel.WasmWasi
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				containerdWasmShimsValidator(),
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateContainerdWASMShims(ctx, s)
 			},
 		},
 	})
@@ -903,8 +903,8 @@ func Test_ubuntu2204Wasm(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.WorkloadRuntime = datamodel.WasmWasi
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				containerdWasmShimsValidator(),
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateContainerdWASMShims(ctx, s)
 			},
 		},
 	})
@@ -1062,8 +1062,8 @@ func Test_ubuntu2204WasmAirGap(t *testing.T) {
 					},
 				}
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				containerdWasmShimsValidator(),
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateContainerdWASMShims(ctx, s)
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1079,8 +1079,8 @@ func Test_ubuntu2204imdsrestriction_filtertable(t *testing.T) {
 				nbc.EnableIMDSRestriction = true
 				nbc.InsertIMDSRestrictionRuleToMangleTable = false
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				imdsRestrictionRuleValidator("filter"),
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateIMDSRestrictionRule(ctx, s, "filter")
 			},
 		},
 	})
@@ -1098,8 +1098,8 @@ func Test_ubuntu1804imdsrestriction_mangletable(t *testing.T) {
 				nbc.EnableIMDSRestriction = true
 				nbc.InsertIMDSRestrictionRuleToMangleTable = true
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				imdsRestrictionRuleValidator("mangle"),
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateIMDSRestrictionRule(ctx, s, "mangle")
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -122,8 +122,8 @@ func Test_azurelinuxv2ChronyRestarts(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always")
-				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5")
 				ServiceCanRestartValidator(ctx, s, "chronyd", 10)
 			},
 		},
@@ -346,8 +346,8 @@ func Test_marinerv2ChronyRestarts(t *testing.T) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ServiceCanRestartValidator(ctx, s, "chronyd", 10)
-				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always")
-				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5")
 			},
 		},
 	})
@@ -502,8 +502,8 @@ func Test_ubuntu1804ChronyRestarts(t *testing.T) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ServiceCanRestartValidator(ctx, s, "chronyd", 10)
-				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "Restart=always")
-				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "RestartSec=5")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "Restart=always")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/chrony.service.d/10-chrony-restarts.conf", "RestartSec=5")
 			},
 		},
 	})
@@ -516,7 +516,7 @@ func Test_ubuntu2204ScriptlessInstaller(t *testing.T) {
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
 			Validator: func(ctx context.Context, s *Scenario) {
-				FileHasContentsValidator(ctx, s, "/var/log/azure/aks-node-controller.log", "aks-node-controller finished successfully")
+				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log", "aks-node-controller finished successfully")
 			},
 			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {},
 		},
@@ -679,8 +679,8 @@ func Test_ubuntu2204ChronyRestarts(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always")
-				FileHasContentsValidator(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "Restart=always")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/chronyd.service.d/10-chrony-restarts.conf", "RestartSec=5")
 				ServiceCanRestartValidator(ctx, s, "chronyd", 10)
 			},
 		},
@@ -936,7 +936,7 @@ func Test_Ubuntu2204DisableKubeletServingCertificateRotationWithTags(t *testing.
 				FileExcludesContentsValidator("/etc/default/kubelet", "kubernetes.azure.com/kubelet-serving-ca=cluster", "kubernetes.azure.com/kubelet-serving-ca=cluster"),
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				FileHasContentsValidator(ctx, s, "/etc/default/kubelet", "\\-\\-rotate-server-certificates=false")
+				ValidateFileHasContent(ctx, s, "/etc/default/kubelet", "\\-\\-rotate-server-certificates=false")
 			},
 		},
 	})
@@ -977,7 +977,7 @@ func Test_Ubuntu2204DisableKubeletServingCertificateRotationWithTags_CustomKubel
 				FileExcludesContentsValidator("/etc/default/kubeletconfig.json", "\"serverTLSBootstrap\": true", "serverTLSBootstrap: true"),
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				FileHasContentsValidator(ctx, s, "/etc/default/kubeletconfig.json", "\"serverTLSBootstrap\": false")
+				ValidateFileHasContent(ctx, s, "/etc/default/kubeletconfig.json", "\"serverTLSBootstrap\": false")
 			},
 		},
 	})
@@ -1115,7 +1115,7 @@ func Test_Ubuntu2204MessageOfTheDay(t *testing.T) {
 				nbc.AgentPoolProfile.MessageOfTheDay = "Zm9vYmFyDQo=" // base64 for foobar
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				FileHasContentsValidator(ctx, s, "/etc/motd", "foobar")
+				ValidateFileHasContent(ctx, s, "/etc/motd", "foobar")
 			},
 		},
 	})
@@ -1131,7 +1131,7 @@ func Test_AzureLinuxV2MessageOfTheDay(t *testing.T) {
 				nbc.AgentPoolProfile.MessageOfTheDay = "Zm9vYmFyDQo=" // base64 for foobar
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				FileHasContentsValidator(ctx, s, "/etc/motd", "foobar")
+				ValidateFileHasContent(ctx, s, "/etc/motd", "foobar")
 			},
 		},
 	})
@@ -1160,7 +1160,7 @@ func Test_Ubuntu2204_KubeletCustomConfig(t *testing.T) {
 				KubeletHasConfigFlagsValidator(kubeletConfigFilePath),
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				FileHasContentsValidator(ctx, s, kubeletConfigFilePath, `"seccompDefault": true`)
+				ValidateFileHasContent(ctx, s, kubeletConfigFilePath, `"seccompDefault": true`)
 			},
 		},
 	})
@@ -1189,7 +1189,7 @@ func Test_AzureLinuxV2_KubeletCustomConfig(t *testing.T) {
 				KubeletHasConfigFlagsValidator(kubeletConfigFilePath),
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				FileHasContentsValidator(ctx, s, kubeletConfigFilePath, `"seccompDefault": true`)
+				ValidateFileHasContent(ctx, s, kubeletConfigFilePath, `"seccompDefault": true`)
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -24,7 +24,7 @@ func Test_azurelinuxv2(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				installedPackagedValidator(ctx, s, "moby-containerd", getExpectedPackageVersions("containerd", "mariner", "current")[0])
+				ValidateInstalledPackageVersion(ctx, s, "moby-containerd", getExpectedPackageVersions("containerd", "mariner", "current")[0])
 			},
 		},
 	})
@@ -163,8 +163,10 @@ func Test_azurelinuxv2CustomSysctls(t *testing.T) {
 				nbc.AgentPoolProfile.CustomLinuxOSConfig = customLinuxConfig
 			},
 			LiveVMValidators: []*LiveVMValidator{
-				SysctlConfigValidator(customSysctls),
 				UlimitValidator(customContainerdUlimits),
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateSysctlConfig(ctx, s, customSysctls)
 			},
 		},
 	})
@@ -245,7 +247,7 @@ func Test_marinerv2(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				installedPackagedValidator(ctx, s, "moby-containerd", getExpectedPackageVersions("containerd", "mariner", "current")[0])
+				ValidateInstalledPackageVersion(ctx, s, "moby-containerd", getExpectedPackageVersions("containerd", "mariner", "current")[0])
 			},
 		},
 	})
@@ -386,8 +388,10 @@ func Test_marinerv2CustomSysctls(t *testing.T) {
 				nbc.AgentPoolProfile.CustomLinuxOSConfig = customLinuxConfig
 			},
 			LiveVMValidators: []*LiveVMValidator{
-				SysctlConfigValidator(customSysctls),
 				UlimitValidator(customContainerdUlimits),
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateSysctlConfig(ctx, s, customSysctls)
 			},
 		},
 	})
@@ -469,8 +473,8 @@ func Test_ubuntu1804(t *testing.T) {
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu1804Gen2Containerd,
 			Validator: func(ctx context.Context, s *Scenario) {
-				installedPackagedValidator(ctx, s, "moby-containerd", expected1804ContainredVersion)
-				installedPackagedValidator(ctx, s, "moby-runc", getExpectedPackageVersions("runc", "ubuntu", "r1804")[0])
+				ValidateInstalledPackageVersion(ctx, s, "moby-containerd", expected1804ContainredVersion)
+				ValidateInstalledPackageVersion(ctx, s, "moby-runc", getExpectedPackageVersions("runc", "ubuntu", "r1804")[0])
 			},
 
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {},
@@ -583,8 +587,8 @@ func Test_ubuntu2204(t *testing.T) {
 				nbc.ContainerService.Properties.ServicePrincipalProfile.Secret = "SP secret"
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				installedPackagedValidator(ctx, s, "moby-containerd", getExpectedPackageVersions("containerd", "ubuntu", "r2204")[0])
-				installedPackagedValidator(ctx, s, "moby-runc", getExpectedPackageVersions("runc", "ubuntu", "r2204")[0])
+				ValidateInstalledPackageVersion(ctx, s, "moby-containerd", getExpectedPackageVersions("containerd", "ubuntu", "r2204")[0])
+				ValidateInstalledPackageVersion(ctx, s, "moby-runc", getExpectedPackageVersions("runc", "ubuntu", "r2204")[0])
 			},
 		},
 	})
@@ -741,8 +745,10 @@ func Test_ubuntu2204CustomSysctls(t *testing.T) {
 				nbc.AgentPoolProfile.CustomLinuxOSConfig = customLinuxConfig
 			},
 			LiveVMValidators: []*LiveVMValidator{
-				SysctlConfigValidator(customSysctls),
 				UlimitValidator(customContainerdUlimits),
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateSysctlConfig(ctx, s, customSysctls)
 			},
 		},
 	})
@@ -872,7 +878,7 @@ func Test_ubuntu2204ContainerdURL(t *testing.T) {
 				nbc.ContainerdPackageURL = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/moby-containerd/moby-containerd_1.6.9+azure-ubuntu22.04u1_amd64.deb"
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				installedPackagedValidator(ctx, s, "containerd", "1.6.9")
+				ValidateInstalledPackageVersion(ctx, s, "containerd", "1.6.9")
 			},
 		},
 	})
@@ -888,7 +894,7 @@ func Test_ubuntu2204ContainerdHasCurrentVersion(t *testing.T) {
 				nbc.ContainerdVersion = "1.6.9"
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				installedPackagedValidator(ctx, s, "moby-containerd", getExpectedPackageVersions("containerd", "ubuntu", "r2204")[0])
+				ValidateInstalledPackageVersion(ctx, s, "moby-containerd", getExpectedPackageVersions("containerd", "ubuntu", "r2204")[0])
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
 )
 
-func Test_azurelinuxv2(t *testing.T) {
+func Test_AzureLinuxV2(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using a AzureLinuxV2 (CgroupV2) VHD can be properly bootstrapped",
 		Config: Config{
@@ -30,7 +30,7 @@ func Test_azurelinuxv2(t *testing.T) {
 	})
 }
 
-func Test_azurelinuxv2AirGap(t *testing.T) {
+func Test_AzureLinuxV2_AirGap(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using a AzureLinuxV2 (CgroupV2) VHD can be properly bootstrapped",
 		Tags: Tags{
@@ -52,7 +52,7 @@ func Test_azurelinuxv2AirGap(t *testing.T) {
 	})
 }
 
-func Test_azurelinuxv2ARM64(t *testing.T) {
+func Test_AzureLinuxV2_ARM64(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using a AzureLinuxV2 (CgroupV2) VHD on ARM64 architecture can be properly bootstrapped",
 		Config: Config{
@@ -70,7 +70,7 @@ func Test_azurelinuxv2ARM64(t *testing.T) {
 	})
 }
 
-func Test_azurelinuxv2ARM64AirGap(t *testing.T) {
+func Test_AzureLinuxV2_ARM64AirGap(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using a AzureLinuxV2 (CgroupV2) VHD on ARM64 architecture can be properly bootstrapped",
 		Tags: Tags{
@@ -99,7 +99,7 @@ func Test_azurelinuxv2ARM64AirGap(t *testing.T) {
 	})
 }
 
-func Test_azurelinuxv2_azurecni(t *testing.T) {
+func Test_AzureLinuxV2_AzureCNI(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "azurelinuxv2 scenario on a cluster configured with Azure CNI",
 		Config: Config{
@@ -113,7 +113,7 @@ func Test_azurelinuxv2_azurecni(t *testing.T) {
 	})
 }
 
-func Test_azurelinuxv2ChronyRestarts(t *testing.T) {
+func Test_AzureLinuxV2_ChronyRestarts(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that the chrony service restarts if it is killed",
 		Config: Config{
@@ -130,7 +130,7 @@ func Test_azurelinuxv2ChronyRestarts(t *testing.T) {
 	})
 }
 
-func Test_azurelinuxv2CustomSysctls(t *testing.T) {
+func Test_AzureLinuxV2_CustomSysctls(t *testing.T) {
 	customSysctls := map[string]string{
 		"net.ipv4.ip_local_port_range":       "32768 62535",
 		"net.netfilter.nf_conntrack_max":     "2097152",
@@ -171,7 +171,7 @@ func Test_azurelinuxv2CustomSysctls(t *testing.T) {
 }
 
 // Returns config for the 'gpu' E2E scenario
-func Test_azurelinuxv2gpu(t *testing.T) {
+func Test_AzureLinuxV2_GPU(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a GPU-enabled node using a AzureLinuxV2 (CgroupV2) VHD can be properly bootstrapped",
 		Tags: Tags{
@@ -193,7 +193,7 @@ func Test_azurelinuxv2gpu(t *testing.T) {
 	})
 }
 
-func Test_azurelinuxv2gpu_azurecni(t *testing.T) {
+func Test_AzureLinuxV2_GPUAzureCNI(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "AzureLinux V2 (CgroupV2) gpu scenario on cluster configured with Azure CNI",
 		Tags: Tags{
@@ -217,7 +217,7 @@ func Test_azurelinuxv2gpu_azurecni(t *testing.T) {
 	})
 }
 
-func Test_azurelinuxv2Wasm(t *testing.T) {
+func Test_AzureLinuxV2_WASM(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that a new AzureLinuxV2 (CgroupV2) node using krustlet can be properly bootstrapped",
 		Tags: Tags{
@@ -236,7 +236,7 @@ func Test_azurelinuxv2Wasm(t *testing.T) {
 	})
 }
 
-func Test_marinerv2(t *testing.T) {
+func Test_MarinerV2(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using a MarinerV2 VHD can be properly bootstrapped",
 		Config: Config{
@@ -251,7 +251,7 @@ func Test_marinerv2(t *testing.T) {
 	})
 }
 
-func Test_marinerv2AirGap(t *testing.T) {
+func Test_MarinerV2_AirGap(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using a MarinerV2 VHD can be properly bootstrapped",
 		Tags: Tags{
@@ -274,7 +274,7 @@ func Test_marinerv2AirGap(t *testing.T) {
 	})
 }
 
-func Test_marinerv2ARM64(t *testing.T) {
+func Test_MarinerV2_ARM64(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using a MarinerV2 VHD on ARM64 architecture can be properly bootstrapped",
 		Config: Config{
@@ -292,7 +292,7 @@ func Test_marinerv2ARM64(t *testing.T) {
 	})
 }
 
-func Test_marinerv2ARM64AirGap(t *testing.T) {
+func Test_MarinerV2_ARM64AirGap(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using a MarinerV2 VHD on ARM64 architecture can be properly bootstrapped",
 		Tags: Tags{
@@ -322,7 +322,7 @@ func Test_marinerv2ARM64AirGap(t *testing.T) {
 	})
 }
 
-func Test_marinerv2_azurecni(t *testing.T) {
+func Test_MarinerV2_AzureCNI(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "marinerv2 scenario on a cluster configured with Azure CNI",
 		Config: Config{
@@ -336,7 +336,7 @@ func Test_marinerv2_azurecni(t *testing.T) {
 	})
 }
 
-func Test_marinerv2ChronyRestarts(t *testing.T) {
+func Test_MarinerV2_ChronyRestarts(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that the chrony service restarts if it is killed",
 		Config: Config{
@@ -353,7 +353,7 @@ func Test_marinerv2ChronyRestarts(t *testing.T) {
 	})
 }
 
-func Test_marinerv2CustomSysctls(t *testing.T) {
+func Test_MarinerV2_CustomSysctls(t *testing.T) {
 	customSysctls := map[string]string{
 		"net.ipv4.ip_local_port_range":       "32768 62535",
 		"net.netfilter.nf_conntrack_max":     "2097152",
@@ -393,8 +393,7 @@ func Test_marinerv2CustomSysctls(t *testing.T) {
 	})
 }
 
-// Returns config for the 'gpu' E2E scenario
-func Test_marinerv2gpu(t *testing.T) {
+func Test_MarinerV2_GPU(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a GPU-enabled node using a MarinerV2 VHD can be properly bootstrapped",
 		Tags: Tags{
@@ -416,7 +415,7 @@ func Test_marinerv2gpu(t *testing.T) {
 	})
 }
 
-func Test_marinerv2gpu_azurecni(t *testing.T) {
+func Test_MarinerV2_GPUAzureCNI(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "MarinerV2 gpu scenario on cluster configured with Azure CNI",
 		Tags: Tags{
@@ -440,7 +439,7 @@ func Test_marinerv2gpu_azurecni(t *testing.T) {
 	})
 }
 
-func Test_marinerv2Wasm(t *testing.T) {
+func Test_MarinerV2_WASM(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that a new marinerv2 node using krustlet can be properly bootstrapped",
 		Tags: Tags{
@@ -460,7 +459,7 @@ func Test_marinerv2Wasm(t *testing.T) {
 }
 
 // Returns config for the 'base' E2E scenario
-func Test_ubuntu1804(t *testing.T) {
+func Test_Ubuntu1804(t *testing.T) {
 	// for ubuntu1804 containerd version is frozen and its using outdated versioning style, hence this modification
 	expected1804ContainredVersion := strings.Replace(getExpectedPackageVersions("containerd", "ubuntu", "r1804")[0], "-", "+azure-ubuntu18.04u", 1)
 	RunScenario(t, &Scenario{
@@ -478,7 +477,7 @@ func Test_ubuntu1804(t *testing.T) {
 	})
 }
 
-func Test_ubuntu1804_azurecni(t *testing.T) {
+func Test_Ubuntu1804_AzureCNI(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "ubuntu1804 scenario on cluster configured with Azure CNI",
 		Config: Config{
@@ -492,7 +491,7 @@ func Test_ubuntu1804_azurecni(t *testing.T) {
 	})
 }
 
-func Test_ubuntu1804ChronyRestarts(t *testing.T) {
+func Test_Ubuntu1804_ChronyRestarts(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that the chrony service restarts if it is killed",
 		Config: Config{
@@ -509,7 +508,7 @@ func Test_ubuntu1804ChronyRestarts(t *testing.T) {
 	})
 }
 
-func Test_ubuntu2204ScriptlessInstaller(t *testing.T) {
+func Test_Ubuntu2204_ScriptlessInstaller(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that a new ubuntu 2204 node using self contained installer can be properly bootstrapped",
 		Config: Config{
@@ -524,7 +523,7 @@ func Test_ubuntu2204ScriptlessInstaller(t *testing.T) {
 }
 
 // Returns config for the 'gpu' E2E scenario
-func Test_ubuntu1804gpu(t *testing.T) {
+func Test_Ubuntu1804_GPU(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a GPU-enabled node using an Ubuntu 1804 VHD can be properly bootstrapped",
 		Tags: Tags{
@@ -546,7 +545,7 @@ func Test_ubuntu1804gpu(t *testing.T) {
 	})
 }
 
-func Test_ubuntu1804gpu_azurecni(t *testing.T) {
+func Test_Ubuntu1804_GPUAzureCNI(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Ubuntu1804 gpu scenario on cluster configured with Azure CNI",
 		Tags: Tags{
@@ -570,7 +569,7 @@ func Test_ubuntu1804gpu_azurecni(t *testing.T) {
 	})
 }
 
-func Test_ubuntu2204(t *testing.T) {
+func Test_Ubuntu2204(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using the Ubuntu 2204 VHD can be properly bootstrapped",
 		Config: Config{
@@ -590,7 +589,7 @@ func Test_ubuntu2204(t *testing.T) {
 	})
 }
 
-func Test_ubuntu2204AirGap(t *testing.T) {
+func Test_Ubuntu2204_AirGap(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using the Ubuntu 2204 VHD and is airgap can be properly bootstrapped",
 		Tags: Tags{
@@ -612,7 +611,7 @@ func Test_ubuntu2204AirGap(t *testing.T) {
 	})
 }
 
-func Test_Ubuntu2204Gen2ContainerdAirgapped_K8sNotCached(t *testing.T) {
+func Test_Ubuntu2204Gen2_ContainerdAirgappedK8sNotCached(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using the Ubuntu 2204 VHD without k8s binary and is airgap can be properly bootstrapped",
 		Tags: Tags{
@@ -635,7 +634,7 @@ func Test_Ubuntu2204Gen2ContainerdAirgapped_K8sNotCached(t *testing.T) {
 	})
 }
 
-func Test_ubuntu2204ARM64(t *testing.T) {
+func Test_Ubuntu2204ARM64(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that an Ubuntu 2204 Node using ARM64 architecture can be properly bootstrapped",
 		Config: Config{
@@ -654,7 +653,7 @@ func Test_ubuntu2204ARM64(t *testing.T) {
 	})
 }
 
-func Test_ubuntu2204ArtifactStreaming(t *testing.T) {
+func Test_Ubuntu2204_ArtifactStreaming(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that a new ubuntu 2204 node using artifact streaming can be properly bootstrapepd",
 		Config: Config{
@@ -670,7 +669,7 @@ func Test_ubuntu2204ArtifactStreaming(t *testing.T) {
 	})
 }
 
-func Test_ubuntu2204ChronyRestarts(t *testing.T) {
+func Test_Ubuntu2204_ChronyRestarts(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that the chrony service restarts if it is killed",
 		Config: Config{
@@ -687,7 +686,7 @@ func Test_ubuntu2204ChronyRestarts(t *testing.T) {
 	})
 }
 
-func Test_ubuntu2204CustomCATrust(t *testing.T) {
+func Test_Ubuntu2204_CustomCATrust(t *testing.T) {
 	const encodedTestCert = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUgvVENDQmVXZ0F3SUJBZ0lRYUJZRTMvTTA4WEhZQ25OVm1jRkJjakFOQmdrcWhraUc5dzBCQVFzRkFEQnkKTVFzd0NRWURWUVFHRXdKVlV6RU9NQXdHQTFVRUNBd0ZWR1Y0WVhNeEVEQU9CZ05WQkFjTUIwaHZkWE4wYjI0eApFVEFQQmdOVkJBb01DRk5UVENCRGIzSndNUzR3TEFZRFZRUUREQ1ZUVTB3dVkyOXRJRVZXSUZOVFRDQkpiblJsCmNtMWxaR2xoZEdVZ1EwRWdVbE5CSUZJek1CNFhEVEl3TURRd01UQXdOVGd6TTFvWERUSXhNRGN4TmpBd05UZ3oKTTFvd2diMHhDekFKQmdOVkJBWVRBbFZUTVE0d0RBWURWUVFJREFWVVpYaGhjekVRTUE0R0ExVUVCd3dIU0c5MQpjM1J2YmpFUk1BOEdBMVVFQ2d3SVUxTk1JRU52Y25BeEZqQVVCZ05WQkFVVERVNVdNakF3T0RFMk1UUXlORE14CkZEQVNCZ05WQkFNTUMzZDNkeTV6YzJ3dVkyOXRNUjB3R3dZRFZRUVBEQlJRY21sMllYUmxJRTl5WjJGdWFYcGgKZEdsdmJqRVhNQlVHQ3lzR0FRUUJnamM4QWdFQ0RBWk9aWFpoWkdFeEV6QVJCZ3NyQmdFRUFZSTNQQUlCQXhNQwpWVk13Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRREhoZVJrYmIxRkNjN3hSS3N0CndLMEpJR2FLWTh0N0piUzJiUTJiNllJSkRnbkh1SVlIcUJyQ1VWNzlvZWxpa2tva1JrRnZjdnBhS2luRkhEUUgKVXBXRUk2UlVFUlltU0NnM084V2k0MnVPY1YyQjVaYWJtWENrd2R4WTVFY2w1MUJiTThVbkdkb0FHYmRObWlSbQpTbVRqY3MrbGhNeGc0ZkZZNmxCcGlFVkZpR1VqR1JSKzYxUjY3THo2VTRLSmVMTmNDbTA3UXdGWUtCbXBpMDhnCmR5Z1N2UmRVdzU1Sm9wcmVkaitWR3RqVWtCNGhGVDRHUVgvZ2h0NjlSbHF6Lys4dTBkRVFraHVVdXVjcnFhbG0KU0d5NDNIUndCZkRLRndZZVdNN0NQTWQ1ZS9kTyt0MDh0OFBianpWVFR2NWhRRENzRVlJVjJUN0FGSTlTY054TQpraDcvQWdNQkFBR2pnZ05CTUlJRFBUQWZCZ05WSFNNRUdEQVdnQlMvd1ZxSC95ajZRVDM5dDAva0hhK2dZVmdwCnZUQi9CZ2dyQmdFRkJRY0JBUVJ6TUhFd1RRWUlLd1lCQlFVSE1BS0dRV2gwZEhBNkx5OTNkM2N1YzNOc0xtTnYKYlM5eVpYQnZjMmwwYjNKNUwxTlRUR052YlMxVGRXSkRRUzFGVmkxVFUwd3RVbE5CTFRRd09UWXRVak11WTNKMApNQ0FHQ0NzR0FRVUZCekFCaGhSb2RIUndPaTh2YjJOemNITXVjM05zTG1OdmJUQWZCZ05WSFJFRUdEQVdnZ3QzCmQzY3VjM05zTG1OdmJZSUhjM05zTG1OdmJUQmZCZ05WSFNBRVdEQldNQWNHQldlQkRBRUJNQTBHQ3lxRWFBR0cKOW5jQ0JRRUJNRHdHRENzR0FRUUJncWt3QVFNQkJEQXNNQ29HQ0NzR0FRVUZCd0lCRmg1b2RIUndjem92TDNkMwpkeTV6YzJ3dVkyOXRMM0psY0c5emFYUnZjbmt3SFFZRFZSMGxCQll3RkFZSUt3WUJCUVVIQXdJR0NDc0dBUVVGCkJ3TUJNRWdHQTFVZEh3UkJNRDh3UGFBN29EbUdOMmgwZEhBNkx5OWpjbXh6TG5OemJDNWpiMjB2VTFOTVkyOXQKTFZOMVlrTkJMVVZXTFZOVFRDMVNVMEV0TkRBNU5pMVNNeTVqY213d0hRWURWUjBPQkJZRUZBREFGVUlhenc1cgpaSUhhcG5SeElVbnB3K0dMTUE0R0ExVWREd0VCL3dRRUF3SUZvRENDQVgwR0Npc0dBUVFCMW5rQ0JBSUVnZ0Z0CkJJSUJhUUZuQUhjQTlseVVMOUYzTUNJVVZCZ0lNSlJXanVOTkV4a3p2OThNTHlBTHpFN3haT01BQUFGeE0waG8KYndBQUJBTUFTREJHQWlFQTZ4ZWxpTlI4R2svNjNwWWRuUy92T3gvQ2pwdEVNRXY4OVdXaDEvdXJXSUVDSVFEeQpCcmVIVTI1RHp3dWtRYVJRandXNjU1WkxrcUNueGJ4UVdSaU9lbWo5SkFCMUFKUWd2QjZPMVkxc2lITWZnb3NpCkxBM1IyazFlYkUrVVBXSGJUaTlZVGFMQ0FBQUJjVE5JYU53QUFBUURBRVl3UkFJZ0dSRTR3emFiTlJkRDhrcS8KdkZQM3RRZTJobTB4NW5YdWxvd2g0SWJ3M2xrQ0lGWWIvM2xTRHBsUzdBY1I0citYcFd0RUtTVEZXSm1OQ1JiYwpYSnVyMlJHQkFIVUE3c0NWN28xeVpBK1M0OE81RzhjU28ybHFDWHRMYWhvVU9PWkhzc3Z0eGZrQUFBRnhNMGhvCjh3QUFCQU1BUmpCRUFpQjZJdmJvV3NzM1I0SXRWd2plYmw3RDN5b0ZhWDBORGgyZFdoaGd3Q3hySHdJZ0NmcTcKb2NNQzV0KzFqaTVNNXhhTG1QQzRJK1dYM0kvQVJrV1N5aU83SVFjd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dJQgpBQ2V1dXI0UW51anFtZ3VTckhVM21oZitjSm9kelRRTnFvNHRkZStQRDEvZUZkWUFFTHU4eEYrMEF0N3hKaVBZCmk1Ukt3aWx5UDU2diszaVkyVDlsdzdTOFRKMDQxVkxoYUlLcDE0TXpTVXpSeWVvT0FzSjdRQURNQ2xIS1VEbEgKVVUycE51bzg4WTZpZ292VDNic253Sk5pRVFOcXltU1NZaGt0dzB0YWR1b3FqcVhuMDZnc1Zpb1dUVkRYeXNkNQpxRXg0dDZzSWdJY01tMjZZSDF2SnBDUUVoS3BjMnkwN2dSa2tsQlpSdE1qVGh2NGNYeXlNWDd1VGNkVDdBSkJQCnVlaWZDb1YyNUp4WHVvOGQ1MTM5Z3dQMUJBZTdJQlZQeDJ1N0tOL1V5T1hkWm13TWYvVG1GR3dEZENmc3lIZi8KWnNCMndMSG96VFlvQVZtUTlGb1UxSkxnY1ZpdnFKK3ZObEJoSFhobHhNZE4wajgwUjlOejZFSWdsUWplSzNPOApJL2NGR20vQjgrNDJoT2xDSWQ5WmR0bmRKY1JKVmppMHdEMHF3ZXZDYWZBOWpKbEh2L2pzRStJOVV6NmNwQ3loCnN3K2xyRmR4VWdxVTU4YXhxZUs4OUZSK05vNHEwSUlPK0ppMXJKS3I5bmtTQjBCcVhvelZuRTFZQi9LTHZkSXMKdVlaSnVxYjJwS2t1K3p6VDZnVXdIVVRadkJpTk90WEw0Tnh3Yy9LVDdXek9TZDJ3UDEwUUk4REtnNHZmaU5EcwpIV21CMWM0S2ppNmdPZ0E1dVNVemFHbXEvdjRWbmNLNVVyK245TGJmbmZMYzI4SjVmdC9Hb3Rpbk15RGszaWFyCkYxMFlscWNPbWVYMXVGbUtiZGkvWG9yR2xrQ29NRjNURHg4cm1wOURCaUIvCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=" //nolint:lll
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using the Ubuntu 2204 VHD can be properly bootstrapped and custom CA was correctly added",
@@ -708,7 +707,7 @@ func Test_ubuntu2204CustomCATrust(t *testing.T) {
 	})
 }
 
-func Test_ubuntu2204CustomSysctls(t *testing.T) {
+func Test_Ubuntu2204_CustomSysctls(t *testing.T) {
 	customSysctls := map[string]string{
 		"net.ipv4.ip_local_port_range":       "32768 65535",
 		"net.netfilter.nf_conntrack_max":     "2097152",
@@ -748,15 +747,15 @@ func Test_ubuntu2204CustomSysctls(t *testing.T) {
 	})
 }
 
-func Test_ubuntu2204gpuncv(t *testing.T) {
+func Test_Ubuntu2204_GPUNC(t *testing.T) {
 	runScenarioUbuntu2204GPU(t, "Standard_NC6s_v3")
 }
 
-func Test_ubuntu2204gpua100(t *testing.T) {
+func Test_Ubuntu2204_GPUA100(t *testing.T) {
 	runScenarioUbuntu2204GPU(t, "Standard_NC24ads_A100_v4")
 }
 
-func Test_ubuntu2204gpua10(t *testing.T) {
+func Test_Ubuntu2204_GPUA10(t *testing.T) {
 	runScenarioUbuntu2204GPU(t, "Standard_NV6ads_A10_v5")
 }
 
@@ -788,7 +787,7 @@ func runScenarioUbuntu2204GPU(t *testing.T, vmSize string) {
 	})
 }
 
-func Test_ubuntu2204GPUGridDriver(t *testing.T) {
+func Test_Ubuntu2204_GPUGridDriver(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a GPU-enabled node using the Ubuntu 2204 VHD with grid driver can be properly bootstrapped",
 		Tags: Tags{
@@ -815,7 +814,7 @@ func Test_ubuntu2204GPUGridDriver(t *testing.T) {
 	})
 }
 
-func Test_ubuntu2204gpuNoDriver(t *testing.T) {
+func Test_Ubuntu2204_GPUNoDriver(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a GPU-enabled node using the Ubuntu 2204 VHD opting for skipping gpu driver installation can be properly bootstrapped",
 		Tags: Tags{
@@ -844,7 +843,7 @@ func Test_ubuntu2204gpuNoDriver(t *testing.T) {
 	})
 }
 
-func Test_ubuntu2204privatekubepkg(t *testing.T) {
+func Test_Ubuntu2204_PrivateKubePkg(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using the Ubuntu 2204 VHD that was built with private kube packages can be properly bootstrapped with the specified kube version",
 		Config: Config{
@@ -862,7 +861,7 @@ func Test_ubuntu2204privatekubepkg(t *testing.T) {
 // The code path is not hit in either of these tests. In the future, testing with some kind of firewall to ensure no egress
 // calls are made would be beneficial for airgap testing.
 
-func Test_ubuntu2204ContainerdURL(t *testing.T) {
+func Test_Ubuntu2204_ContainerdURL(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that a node using the Ubuntu 2204 VHD with the ContainerdPackageURL override bootstraps with the provided URL and not the components.json containerd version",
 		Config: Config{
@@ -878,7 +877,7 @@ func Test_ubuntu2204ContainerdURL(t *testing.T) {
 	})
 }
 
-func Test_ubuntu2204ContainerdHasCurrentVersion(t *testing.T) {
+func Test_Ubuntu2204_ContainerdHasCurrentVersion(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that a node using an Ubuntu2204 VHD and the ContainerdVersion override bootstraps with the correct components.json containerd version and ignores the override",
 		Config: Config{
@@ -894,7 +893,7 @@ func Test_ubuntu2204ContainerdHasCurrentVersion(t *testing.T) {
 	})
 }
 
-func Test_ubuntu2204Wasm(t *testing.T) {
+func Test_Ubuntu2204_WASM(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that a new ubuntu 2204 node using krustlet can be properly bootstrapepd",
 		Config: Config{
@@ -910,7 +909,7 @@ func Test_ubuntu2204Wasm(t *testing.T) {
 	})
 }
 
-func Test_Ubuntu2204DisableKubeletServingCertificateRotationWithTags(t *testing.T) {
+func Test_Ubuntu2204_DisableKubeletServingCertificateRotationWithTags(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Tags: Tags{
 			ServerTLSBootstrapping: true,
@@ -940,7 +939,7 @@ func Test_Ubuntu2204DisableKubeletServingCertificateRotationWithTags(t *testing.
 	})
 }
 
-func Test_Ubuntu2204DisableKubeletServingCertificateRotationWithTags_CustomKubeletConfig(t *testing.T) {
+func Test_Ubuntu2204_DisableKubeletServingCertificateRotationWithTagsCustomKubeletConfig(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Tags: Tags{
 			ServerTLSBootstrapping: true,
@@ -979,7 +978,7 @@ func Test_Ubuntu2204DisableKubeletServingCertificateRotationWithTags_CustomKubel
 	})
 }
 
-func Test_Ubuntu2204DisableKubeletServingCertificateRotationWithTags_AlreadyDisabled(t *testing.T) {
+func Test_Ubuntu2204_DisableKubeletServingCertificateRotationWithTags_AlreadyDisabled(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Tags: Tags{
 			ServerTLSBootstrapping: true,
@@ -1005,7 +1004,7 @@ func Test_Ubuntu2204DisableKubeletServingCertificateRotationWithTags_AlreadyDisa
 	})
 }
 
-func Test_Ubuntu2204DisableKubeletServingCertificateRotationWithTags_AlreadyDisabled_CustomKubeletConfig(t *testing.T) {
+func Test_Ubuntu2204_DisableKubeletServingCertificateRotationWithTags_AlreadyDisabled_CustomKubeletConfig(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Tags: Tags{
 			ServerTLSBootstrapping: true,
@@ -1038,7 +1037,7 @@ func Test_Ubuntu2204DisableKubeletServingCertificateRotationWithTags_AlreadyDisa
 	})
 }
 
-func Test_ubuntu2204WasmAirGap(t *testing.T) {
+func Test_Ubuntu2204_WASMAirGap(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that a new ubuntu 2204 node using krustlet can be properly bootstrapepd when it is network isolated cluster",
 		Tags: Tags{
@@ -1065,7 +1064,7 @@ func Test_ubuntu2204WasmAirGap(t *testing.T) {
 	})
 }
 
-func Test_ubuntu2204imdsrestriction_filtertable(t *testing.T) {
+func Test_Ubuntu2204_IMDSRestrictionFilterTable(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that the imds restriction filter table is properly set",
 		Config: Config{
@@ -1082,7 +1081,7 @@ func Test_ubuntu2204imdsrestriction_filtertable(t *testing.T) {
 	})
 }
 
-func Test_ubuntu1804imdsrestriction_mangletable(t *testing.T) {
+func Test_Ubuntu1804IMDS_RestrictionMangleTable(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that the imds restriction mangle table is properly set",
 		Config: Config{
@@ -1101,7 +1100,7 @@ func Test_ubuntu1804imdsrestriction_mangletable(t *testing.T) {
 	})
 }
 
-func Test_Ubuntu2204MessageOfTheDay(t *testing.T) {
+func Test_Ubuntu2204_MessageOfTheDay(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that a node on ubuntu 2204 bootstrapped and message of the day is properly added to the node",
 		Config: Config{
@@ -1117,7 +1116,7 @@ func Test_Ubuntu2204MessageOfTheDay(t *testing.T) {
 	})
 }
 
-func Test_AzureLinuxV2MessageOfTheDay(t *testing.T) {
+func Test_AzureLinuxV2_MessageOfTheDay(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using a AzureLinuxV2 can be bootstrapped and message of the day is added to the node",
 		Config: Config{

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -22,9 +23,8 @@ func Test_azurelinuxv2(t *testing.T) {
 			VHD:     config.VHDAzureLinuxV2Gen2,
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				// for now azure linux reports itself as mariner, so expected version for azure linux is the same as that for mariner
-				mobyComponentVersionValidator("containerd", getExpectedPackageVersions("containerd", "mariner", "current")[0], "dnf"),
+			Validator: func(ctx context.Context, s *Scenario) {
+				installedPackagedValidator(ctx, s, "moby-containerd", getExpectedPackageVersions("containerd", "mariner", "current")[0])
 			},
 		},
 	})
@@ -244,8 +244,8 @@ func Test_marinerv2(t *testing.T) {
 			VHD:     config.VHDCBLMarinerV2Gen2,
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				mobyComponentVersionValidator("containerd", getExpectedPackageVersions("containerd", "mariner", "current")[0], "dnf"),
+			Validator: func(ctx context.Context, s *Scenario) {
+				installedPackagedValidator(ctx, s, "moby-containerd", getExpectedPackageVersions("containerd", "mariner", "current")[0])
 			},
 		},
 	})
@@ -468,10 +468,11 @@ func Test_ubuntu1804(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu1804Gen2Containerd,
-			LiveVMValidators: []*LiveVMValidator{
-				mobyComponentVersionValidator("containerd", expected1804ContainredVersion, "apt"),
-				mobyComponentVersionValidator("runc", getExpectedPackageVersions("runc", "ubuntu", "r1804")[0], "apt"),
+			Validator: func(ctx context.Context, s *Scenario) {
+				installedPackagedValidator(ctx, s, "moby-containerd", expected1804ContainredVersion)
+				installedPackagedValidator(ctx, s, "moby-runc", getExpectedPackageVersions("runc", "ubuntu", "r1804")[0])
 			},
+
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {},
 		},
 	})
@@ -581,9 +582,9 @@ func Test_ubuntu2204(t *testing.T) {
 				nbc.ContainerService.Properties.CertificateProfile.ClientPrivateKey = "client cert private key"
 				nbc.ContainerService.Properties.ServicePrincipalProfile.Secret = "SP secret"
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				mobyComponentVersionValidator("containerd", getExpectedPackageVersions("containerd", "ubuntu", "r2204")[0], "apt"),
-				mobyComponentVersionValidator("runc", getExpectedPackageVersions("runc", "ubuntu", "r2204")[0], "apt"),
+			Validator: func(ctx context.Context, s *Scenario) {
+				installedPackagedValidator(ctx, s, "moby-containerd", getExpectedPackageVersions("containerd", "ubuntu", "r2204")[0])
+				installedPackagedValidator(ctx, s, "moby-runc", getExpectedPackageVersions("runc", "ubuntu", "r2204")[0])
 			},
 		},
 	})
@@ -870,8 +871,8 @@ func Test_ubuntu2204ContainerdURL(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerdPackageURL = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/moby-containerd/moby-containerd_1.6.9+azure-ubuntu22.04u1_amd64.deb"
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				mobyComponentVersionValidator("containerd", "1.6.9", "apt"),
+			Validator: func(ctx context.Context, s *Scenario) {
+				installedPackagedValidator(ctx, s, "containerd", "1.6.9")
 			},
 		},
 	})
@@ -886,9 +887,8 @@ func Test_ubuntu2204ContainerdHasCurrentVersion(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerdVersion = "1.6.9"
 			},
-			LiveVMValidators: []*LiveVMValidator{
-				// for containerd we only support one version at a time for each distro/release
-				mobyComponentVersionValidator("containerd", getExpectedPackageVersions("containerd", "ubuntu", "r2204")[0], "apt"),
+			Validator: func(ctx context.Context, s *Scenario) {
+				installedPackagedValidator(ctx, s, "moby-containerd", getExpectedPackageVersions("containerd", "ubuntu", "r2204")[0])
 			},
 		},
 	})

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -121,6 +121,7 @@ type ScenarioRuntime struct {
 	AKSNodeConfig *aksnodeconfigv1.Configuration
 	Cluster       *Cluster
 	VMSSName      string
+	KubeNodeName  string
 	SSHKeyPublic  []byte
 	SSHKeyPrivate []byte
 	VMPrivateIP   string

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -162,10 +162,6 @@ type LiveVMValidator struct {
 	// Asserter is the validator's VMCommandOutputAsserterFn which will be run against command output
 	Asserter VMCommandOutputAsserterFn
 
-	// IsShellBuiltIn is a boolean flag which indicates whether or not the command is a shell built-in
-	// that will fail when executed with sudo - requires separate command to avoid command not found error on node
-	IsShellBuiltIn bool
-
 	// TODO - extract this out of LiveVMValidator into a separate Pod level validator
 	// IsPodNetwork is a boolean flags which indicates whether or not the validator should run on a pod that is NOT using
 	// host's network interface. For example when testing connectivity from user pods to certain endpoints, we will set it to true

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -142,10 +142,6 @@ type Config struct {
 	// VMConfigMutator is a function which mutates the base VMSS model according to the scenario's requirements
 	VMConfigMutator func(*armcompute.VirtualMachineScaleSet)
 
-	//// LiveVMValidators is a slice of LiveVMValidator objects for performing any live VM validation
-	//// specific to the scenario that isn't covered in the set of common validators run with all scenarios
-	LiveVMValidators []*LiveVMValidator
-
 	Validator func(ctx context.Context, s *Scenario)
 }
 

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -9,19 +9,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ValidateNodeHealth(ctx context.Context, s *Scenario) string {
-	nodeName := waitUntilNodeReady(ctx, s.T, s.Runtime.Cluster.Kube, s.Runtime.VMSSName)
-	testPodName := fmt.Sprintf("test-pod-%s", nodeName)
+func ValidatePodRunning(ctx context.Context, s *Scenario) {
+	testPodName := fmt.Sprintf("test-pod-%s", s.Runtime.KubeNodeName)
 	testPodManifest := ""
 	if s.VHD.OS == config.OSWindows {
-		testPodManifest = getHTTPServerTemplateWindows(testPodName, nodeName)
+		testPodManifest = getHTTPServerTemplateWindows(testPodName, s.Runtime.KubeNodeName)
 	} else {
-		testPodManifest = getHTTPServerTemplate(testPodName, nodeName, s.Tags.Airgap)
+		testPodManifest = getHTTPServerTemplate(testPodName, s.Runtime.KubeNodeName, s.Tags.Airgap)
 	}
 	err := ensurePod(ctx, s.T, defaultNamespace, s.Runtime.Cluster.Kube, testPodName, testPodManifest)
-	require.NoError(s.T, err, "failed to validate node health, unable to ensure test pod on node %q", nodeName)
-	s.T.Logf("node health validation: test pod %q is running on node %q", testPodName, nodeName)
-	return nodeName
+	require.NoError(s.T, err, "failed to validate node health, unable to ensure test pod on node %q", s.Runtime.KubeNodeName)
+	s.T.Logf("node health validation: test pod %q is running on node %q", testPodName, s.Runtime.KubeNodeName)
 }
 
 func ValidateWASM(ctx context.Context, s *Scenario, nodeName string) {

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -15,7 +15,7 @@ func (s *Scenario) validateNodeHealth(ctx context.Context) string {
 	nodeName := waitUntilNodeReady(ctx, s.T, s.Runtime.Cluster.Kube, s.Runtime.VMSSName)
 	testPodName := fmt.Sprintf("test-pod-%s", nodeName)
 	testPodManifest := ""
-	if s.VHD.Windows() {
+	if s.VHD.OS == config.OSWindows {
 		testPodManifest = getHTTPServerTemplateWindows(testPodName, nodeName)
 	} else {
 		testPodManifest = getHTTPServerTemplate(testPodName, nodeName, s.Tags.Airgap)
@@ -41,7 +41,7 @@ func validateWasm(ctx context.Context, t *testing.T, kube *Kubeclient, nodeName 
 
 func runLiveVMValidators(ctx context.Context, t *testing.T, vmssName, privateIP, sshPrivateKey string, scenario *Scenario) error {
 	// TODO: test something
-	if scenario.VHD.Windows() {
+	if scenario.VHD.OS == config.OSWindows {
 		return nil
 	}
 	hostPodName, err := getHostNetworkDebugPodName(ctx, scenario.Runtime.Cluster.Kube, t)

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"testing"
 
 	"github.com/Azure/agentbaker/e2e/config"
 	"github.com/stretchr/testify/require"
 )
 
-func (s *Scenario) validateNodeHealth(ctx context.Context) string {
+func ValidateNodeHealth(ctx context.Context, s *Scenario) string {
 	nodeName := waitUntilNodeReady(ctx, s.T, s.Runtime.Cluster.Kube, s.Runtime.VMSSName)
 	testPodName := fmt.Sprintf("test-pod-%s", nodeName)
 	testPodManifest := ""
@@ -25,17 +24,17 @@ func (s *Scenario) validateNodeHealth(ctx context.Context) string {
 	return nodeName
 }
 
-func validateWasm(ctx context.Context, t *testing.T, kube *Kubeclient, nodeName string) {
-	t.Logf("wasm scenario: running wasm validation on %s...", nodeName)
+func ValidateWASM(ctx context.Context, s *Scenario, nodeName string) {
+	s.T.Logf("wasm scenario: running wasm validation on %s...", nodeName)
 	spinClassName := fmt.Sprintf("wasmtime-%s", wasmHandlerSpin)
-	err := createRuntimeClass(ctx, kube, spinClassName, wasmHandlerSpin)
-	require.NoError(t, err)
-	err = ensureWasmRuntimeClasses(ctx, kube)
-	require.NoError(t, err)
+	err := createRuntimeClass(ctx, s.Runtime.Cluster.Kube, spinClassName, wasmHandlerSpin)
+	require.NoError(s.T, err)
+	err = ensureWasmRuntimeClasses(ctx, s.Runtime.Cluster.Kube)
+	require.NoError(s.T, err)
 	spinPodName := fmt.Sprintf("wasm-spin-%s", nodeName)
 	spinPodManifest := getWasmSpinPodTemplate(spinPodName, nodeName)
-	err = ensurePod(ctx, t, defaultNamespace, kube, spinPodName, spinPodManifest)
-	require.NoError(t, err, "unable to ensure wasm pod on node %q", nodeName)
+	err = ensurePod(ctx, s.T, defaultNamespace, s.Runtime.Cluster.Kube, spinPodName, spinPodManifest)
+	require.NoError(s.T, err, "unable to ensure wasm pod on node %q", nodeName)
 }
 
 func ValidateCommonLinux(ctx context.Context, s *Scenario) {

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -86,6 +86,19 @@ func runLiveVMValidators(ctx context.Context, t *testing.T, vmssName, privateIP,
 	return nil
 }
 
+func ValidateCommon(ctx context.Context, s *Scenario) {
+	ValidateSysctlConfig(ctx, s, map[string]string{
+		"net.ipv4.tcp_retries2":             "8",
+		"net.core.message_burst":            "80",
+		"net.core.message_cost":             "40",
+		"net.core.somaxconn":                "16384",
+		"net.ipv4.tcp_max_syn_backlog":      "16384",
+		"net.ipv4.neigh.default.gc_thresh1": "4096",
+		"net.ipv4.neigh.default.gc_thresh2": "8192",
+		"net.ipv4.neigh.default.gc_thresh3": "16384",
+	})
+}
+
 func commonLiveVMValidators(scenario *Scenario) []*LiveVMValidator {
 	validators := []*LiveVMValidator{
 		{
@@ -101,18 +114,6 @@ func commonLiveVMValidators(scenario *Scenario) []*LiveVMValidator {
 				return nil
 			},
 		},
-		SysctlConfigValidator(
-			map[string]string{
-				"net.ipv4.tcp_retries2":             "8",
-				"net.core.message_burst":            "80",
-				"net.core.message_cost":             "40",
-				"net.core.somaxconn":                "16384",
-				"net.ipv4.tcp_max_syn_backlog":      "16384",
-				"net.ipv4.neigh.default.gc_thresh1": "4096",
-				"net.ipv4.neigh.default.gc_thresh2": "8192",
-				"net.ipv4.neigh.default.gc_thresh3": "16384",
-			},
-		),
 		DirectoryValidator(
 			"/var/log/azure/aks",
 			[]string{

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -127,7 +127,7 @@ func NonEmptyDirectoryValidator(dirName string) *LiveVMValidator {
 	}
 }
 
-func FileHasContentsValidator(fileName string, contents string) *LiveVMValidator {
+func FileHasContentsValidator(ctx context.Context, s *Scenario, fileName string, contents string) {
 	steps := []string{
 		fmt.Sprintf("ls -la %[1]s", fileName),
 		fmt.Sprintf("sudo cat %[1]s", fileName),
@@ -135,18 +135,8 @@ func FileHasContentsValidator(fileName string, contents string) *LiveVMValidator
 	}
 
 	command := makeExecutableCommand(steps)
-
-	return &LiveVMValidator{
-		Description: fmt.Sprintf("Assert that %s has defined contents", fileName),
-		// on mariner and ubuntu, the chronyd drop-in file is not readable by the default user, so we run as root.
-		Command: command,
-		Asserter: func(code, stdout, stderr string) error {
-			if code != "0" {
-				return fmt.Errorf("expected to find a file '%s' with contents '%s' but did not", fileName, contents)
-			}
-			return nil
-		},
-	}
+	execResult := execOnVMForScenario(ctx, s, command)
+	require.Equal(s.T, "0", execResult.exitCode, "expected to find a file '%s' with contents '%s' but did not", fileName, contents)
 }
 
 func FileExcludesContentsValidator(fileName string, contents string, contentsName string) *LiveVMValidator {

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -102,17 +102,10 @@ func NvidiaModProbeInstalledValidator() *LiveVMValidator {
 	}
 }
 
-func NonEmptyDirectoryValidator(dirName string) *LiveVMValidator {
-	return &LiveVMValidator{
-		Description: fmt.Sprintf("assert that there are files in %s", dirName),
-		Command:     fmt.Sprintf("ls -1q %s | grep -q '^.*$' && true || false", dirName),
-		Asserter: func(code, stdout, stderr string) error {
-			if code != "0" {
-				return fmt.Errorf("expected to find a file in directory %s, but did not", dirName)
-			}
-			return nil
-		},
-	}
+func ValidateNonEmptyDirectory(ctx context.Context, s *Scenario, dirName string) {
+	command := fmt.Sprintf("ls -1q %s | grep -q '^.*$' && true || false", dirName)
+	execResult := execOnVMForScenario(ctx, s, command)
+	require.Equal(s.T, "0", execResult.exitCode, "expected to find a file in directory %s, but did not", dirName)
 }
 
 func ValidateFileHasContent(ctx context.Context, s *Scenario, fileName string, contents string) {

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -332,17 +332,10 @@ func kubeletNodeIPValidator() *LiveVMValidator {
 	}
 }
 
-func imdsRestrictionRuleValidator(table string) *LiveVMValidator {
-	return &LiveVMValidator{
-		Description: "assert that the IMDS restriction rule is present",
-		Command:     fmt.Sprintf("iptables -t %s -S | grep -q 'AKS managed: added by AgentBaker ensureIMDSRestriction for IMDS restriction feature'", table),
-		Asserter: func(code, stdout, stderr string) error {
-			if code != "0" {
-				return fmt.Errorf("expected to find the IMDS restriction rule, but did not")
-			}
-			return nil
-		},
-	}
+func ValidateIMDSRestrictionRule(ctx context.Context, s *Scenario, table string) {
+	cmd := fmt.Sprintf("iptables -t %s -S | grep -q 'AKS managed: added by AgentBaker ensureIMDSRestriction for IMDS restriction feature'", table)
+	execResult := execOnVMForScenario(ctx, s, cmd)
+	require.Equal(s.T, "0", execResult.exitCode, "expected to find IMDS restriction rule, but did not")
 }
 
 func containerdWasmShimsValidator() *LiveVMValidator {

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -155,12 +155,7 @@ func execOnVMForScenarioOnUnprivilegedPod(ctx context.Context, s *Scenario, cmd 
 }
 
 func execOnVMForScenario(ctx context.Context, s *Scenario, cmd string) *podExecResult {
-	// TODO: cache it
-	vmPrivateIP, err := getVMPrivateIPAddress(ctx, s)
-	require.NoError(s.T, err, "failed to get VM private IP address")
-	hostPodName, err := getHostNetworkDebugPodName(ctx, s.Runtime.Cluster.Kube, s.T)
-	require.NoError(s.T, err, "failed to get host network debug pod name")
-	result, err := execOnVM(ctx, s.Runtime.Cluster.Kube, vmPrivateIP, hostPodName, string(s.Runtime.SSHKeyPrivate), cmd)
+	result, err := execOnVM(ctx, s.Runtime.Cluster.Kube, s.Runtime.VMPrivateIP, s.Runtime.HostPodName, string(s.Runtime.SSHKeyPrivate), cmd)
 	require.NoError(s.T, err, "failed to execute command on VM")
 	return result
 }

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -412,20 +412,10 @@ func KubeletHasNotStoppedValidator() *LiveVMValidator {
 	}
 }
 
-// KubeletHasConfigFlagsValidator checks kubelet is started with the right flags and configs.
-func KubeletHasConfigFlagsValidator(filePath string) *LiveVMValidator {
-	return &LiveVMValidator{
-		Description: "assert that kubelet service is properly configured",
-		Command:     "journalctl -u kubelet",
-		Asserter: func(code, stdout, stderr string) error {
-			if code != "0" {
-				return fmt.Errorf("validator command terminated with exit code %q but expected code 0", code)
-			}
-			configFileFlags := fmt.Sprintf("FLAG: --config=\"%s\"", filePath)
-			if !strings.Contains(stdout, configFileFlags) {
-				return fmt.Errorf(fmt.Sprintf("expected to find flag %s, but not found: %s", "config", stdout))
-			}
-			return nil
-		},
-	}
+// ValidateKubeletHasFlags checks kubelet is started with the right flags and configs.
+func ValidateKubeletHasFlags(ctx context.Context, s *Scenario, filePath string) {
+	execResult := execOnVMForScenario(ctx, s, `journalctl -u kubelet`)
+	require.Equal(s.T, "0", execResult.exitCode, "expected to find kubelet service logs, but did not")
+	configFileFlags := fmt.Sprintf("FLAG: --config=\"%s\"", filePath)
+	require.Containsf(s.T, execResult.stdout.String(), configFileFlags, "expected to find flag %s, but not found", "config")
 }

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -338,48 +338,36 @@ func ValidateIMDSRestrictionRule(ctx context.Context, s *Scenario, table string)
 	require.Equal(s.T, "0", execResult.exitCode, "expected to find IMDS restriction rule, but did not")
 }
 
-func containerdWasmShimsValidator() *LiveVMValidator {
-	return &LiveVMValidator{
-		Description: "assert containerd config.toml contains expected Wasm shims",
-		Command:     "cat /etc/containerd/config.toml",
-		Asserter: func(code, stdout, stderr string) error {
-			if code != "0" {
-				return fmt.Errorf("validator command terminated with exit code %q but expected code 0. stderr: %q", code, stderr)
-			}
-
-			expectedShims := []string{
-				`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin]`,
-				`runtime_type = "io.containerd.spin.v2"`,
-				`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.slight]`,
-				`runtime_type = "io.containerd.slight-v0-3-0.v1"`,
-				`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin-v0-3-0]`,
-				`runtime_type = "io.containerd.spin-v0-3-0.v1"`,
-				`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.slight-v0-3-0]`,
-				`runtime_type = "io.containerd.slight-v0-3-0.v1"`,
-				`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin-v0-5-1]`,
-				`runtime_type = "io.containerd.spin-v0-5-1.v1"`,
-				`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.slight-v0-5-1]`,
-				`runtime_type = "io.containerd.slight-v0-5-1.v1"`,
-				`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin-v0-8-0]`,
-				`runtime_type = "io.containerd.spin-v0-8-0.v1"`,
-				`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.slight-v0-8-0]`,
-				`runtime_type = "io.containerd.slight-v0-8-0.v1"`,
-				`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wws-v0-8-0]`,
-				`runtime_type = "io.containerd.wws-v0-8-0.v1"`,
-				`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin-v0-15-1]`,
-				`runtime_type = "io.containerd.spin.v2"`,
-			}
-
-			for i := 0; i < len(expectedShims); i += 2 {
-				section := expectedShims[i]
-				runtimeType := expectedShims[i+1]
-
-				if !strings.Contains(stdout, section) || !strings.Contains(stdout, runtimeType) {
-					return fmt.Errorf("expected to find section %q with runtime type %q in containerd config.toml, but it was not found. Full config.toml content:\n%s", section, runtimeType, stdout)
-				}
-			}
-			return nil
-		},
+func ValidateContainerdWASMShims(ctx context.Context, s *Scenario) {
+	execResult := execOnVMForScenario(ctx, s, "cat /etc/containerd/config.toml")
+	require.Equal(s.T, "0", execResult.exitCode, "expected to find containerd config.toml, but did not")
+	expectedShims := []string{
+		`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin]`,
+		`runtime_type = "io.containerd.spin.v2"`,
+		`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.slight]`,
+		`runtime_type = "io.containerd.slight-v0-3-0.v1"`,
+		`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin-v0-3-0]`,
+		`runtime_type = "io.containerd.spin-v0-3-0.v1"`,
+		`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.slight-v0-3-0]`,
+		`runtime_type = "io.containerd.slight-v0-3-0.v1"`,
+		`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin-v0-5-1]`,
+		`runtime_type = "io.containerd.spin-v0-5-1.v1"`,
+		`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.slight-v0-5-1]`,
+		`runtime_type = "io.containerd.slight-v0-5-1.v1"`,
+		`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin-v0-8-0]`,
+		`runtime_type = "io.containerd.spin-v0-8-0.v1"`,
+		`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.slight-v0-8-0]`,
+		`runtime_type = "io.containerd.slight-v0-8-0.v1"`,
+		`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wws-v0-8-0]`,
+		`runtime_type = "io.containerd.wws-v0-8-0.v1"`,
+		`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin-v0-15-1]`,
+		`runtime_type = "io.containerd.spin.v2"`,
+	}
+	for i := 0; i < len(expectedShims); i += 2 {
+		section := expectedShims[i]
+		runtimeType := expectedShims[i+1]
+		require.Contains(s.T, execResult.stdout.String(), section, "expected to find section in containerd config.toml, but it was not found")
+		require.Contains(s.T, execResult.stdout.String(), runtimeType, "expected to find section in containerd config.toml, but it was not found")
 	}
 }
 

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -127,7 +127,7 @@ func NonEmptyDirectoryValidator(dirName string) *LiveVMValidator {
 	}
 }
 
-func FileHasContentsValidator(ctx context.Context, s *Scenario, fileName string, contents string) {
+func ValidateFileHasContent(ctx context.Context, s *Scenario, fileName string, contents string) {
 	steps := []string{
 		fmt.Sprintf("ls -la %[1]s", fileName),
 		fmt.Sprintf("sudo cat %[1]s", fileName),

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -131,7 +131,7 @@ func extractLogsFromVMLinux(ctx context.Context, s *Scenario) {
 	for file, sourceCmd := range commandList {
 		s.T.Logf("executing command on remote VM at %s: %q", privateIP, sourceCmd)
 
-		execResult, err := execOnVM(ctx, s.Runtime.Cluster.Kube, privateIP, podName, string(s.Runtime.SSHKeyPrivate), sourceCmd, false)
+		execResult, err := execOnVM(ctx, s.Runtime.Cluster.Kube, privateIP, podName, string(s.Runtime.SSHKeyPrivate), sourceCmd)
 		if err != nil {
 			s.T.Logf("error fetching logs for %s: %s", file, err)
 			continue

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -103,7 +103,7 @@ func cleanupVMSS(ctx context.Context, s *Scenario) {
 }
 
 func extractLogsFromVM(ctx context.Context, s *Scenario) {
-	if s.VHD.Windows() {
+	if s.VHD.OS == config.OSWindows {
 		extractLogsFromVMWindows(ctx, s)
 	} else {
 		extractLogsFromVMLinux(ctx, s)
@@ -422,7 +422,7 @@ func generateVMSSNameWindows(t *testing.T) string {
 }
 
 func generateVMSSName(s *Scenario) string {
-	if s.VHD.Windows() {
+	if s.VHD.OS == config.OSWindows {
 		return generateVMSSNameWindows(s.T)
 	}
 	return generateVMSSNameLinux(s.T)
@@ -518,7 +518,7 @@ func getBaseVMSSModel(s *Scenario, customData, cseCmd string) armcompute.Virtual
 			},
 		}
 	}
-	if s.VHD.Windows() {
+	if s.VHD.OS == config.OSWindows {
 		model.Identity = &armcompute.VirtualMachineScaleSetIdentity{
 			Type: to.Ptr(armcompute.ResourceIdentityTypeSystemAssignedUserAssigned),
 			UserAssignedIdentities: map[string]*armcompute.UserAssignedIdentitiesValue{


### PR DESCRIPTION
Previously, E2E scenarios were limited to executing shell scripts on the VM.

I updated the tests to support more complex validations, such as running a GPU-enabled pod and verifying its functionality.

This change made the tests more flexible and simplified the overall logic.