### PR TITLE
fix: scanning and resource group tags, use packer subnet for linux test VMs

### DIFF
--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -11,7 +11,7 @@ TEST_RESOURCE_PREFIX="vhd-test"
 TEST_VM_ADMIN_USERNAME="azureuser"
 
 if [ -z "${MANAGED_SIG_ID}" ]; then
-  echo "Managed Sig Id from packer-output is empty, unable to proceed..."
+  echo "SIG image version ID from packer output is empty, unable to proceed..."
   exit 1
 fi
 echo "SIG image version ID from packer output: ${MANAGED_SIG_ID}"

--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -10,6 +10,12 @@ WIN_SCRIPT_PATH="windows-vhd-content-test.ps1"
 TEST_RESOURCE_PREFIX="vhd-test"
 TEST_VM_ADMIN_USERNAME="azureuser"
 
+if [ -z "${MANAGED_SIG_ID}" ]; then
+  echo "Managed Sig Id from packer-output is empty, unable to proceed..."
+  exit 1
+fi
+echo "SIG image version ID from packer output: ${MANAGED_SIG_ID}"
+
 set +x
 TEST_VM_ADMIN_PASSWORD="TestVM@$(date +%s)"
 set -x
@@ -32,11 +38,13 @@ else
     exit 1
   fi
 fi
-az group create --name $TEST_VM_RESOURCE_GROUP_NAME --location ${AZURE_LOCATION} --tags "source=AgentBaker,now=$(date +%s)" "branch=${GIT_BRANCH}"
+
+# Create the testing resource group
+az group create --name $TEST_VM_RESOURCE_GROUP_NAME --location ${AZURE_LOCATION} --tags "source=AgentBaker" "now=$(date +%s)" "branch=${GIT_BRANCH}"
 
 # defer function to cleanup resource group when VHD debug is not enabled
 function cleanup() {
-  if [[ "$VHD_DEBUG" == "True" ]]; then
+  if [ "$VHD_DEBUG" == "True" ]; then
     echo "VHD debug mode is enabled, please manually delete test vm resource group $RESOURCE_GROUP_NAME after debugging"
   else
     echo "Deleting resource group ${TEST_VM_RESOURCE_GROUP_NAME}"
@@ -45,84 +53,70 @@ function cleanup() {
 }
 trap cleanup EXIT
 
-DISK_NAME="${TEST_RESOURCE_PREFIX}-disk"
 VM_NAME="${TEST_RESOURCE_PREFIX}-vm"
 capture_benchmark "${SCRIPT_NAME}_set_variables_and_create_test_resource_group"
+set -x
 
-if [ "$MODE" == "default" ]; then
-  az disk create --resource-group $TEST_VM_RESOURCE_GROUP_NAME \
-    --name $DISK_NAME \
-    --source "${OS_DISK_URI}" \
-    --query id
-  az vm create --name $VM_NAME \
-    --resource-group $TEST_VM_RESOURCE_GROUP_NAME \
-    --attach-os-disk $DISK_NAME \
-    --os-type $OS_TYPE \
-    --public-ip-address ""
-else 
-  if [ "$MODE" == "sigMode" ]; then
-    id=$(az sig show --resource-group ${AZURE_RESOURCE_GROUP_NAME} --gallery-name ${SIG_GALLERY_NAME}) || id=""
-    if [ -z "$id" ]; then
-      echo "Shared Image gallery ${SIG_GALLERY_NAME} does not exist in the resource group ${AZURE_RESOURCE_GROUP_NAME} location ${AZURE_LOCATION}"
+# In SIG mode, Windows VM requires admin-username and admin-password to be set,
+# otherwise 'root' is used by default but not allowed by the Windows Image. See the error image below:
+# ERROR: This user name 'root' meets the general requirements, but is specifically disallowed for this image. Please try a different value.
+TARGET_COMMAND_STRING=""
+if [ "${ARCHITECTURE,,}" == "arm64" ]; then
+  TARGET_COMMAND_STRING+="--size Standard_D2pds_V5"
+else
+  TARGET_COMMAND_STRING="--size Standard_D2ds_v5"
+fi
+
+if [ "${OS_TYPE}" == "Linux" ] && [ "${ENABLE_TRUSTED_LAUNCH}" == "True" ]; then
+  if [ -n "$TARGET_COMMAND_STRING" ]; then
+    # To take care of Mariner Kata TL images
+    TARGET_COMMAND_STRING+=" "
+  fi
+  TARGET_COMMAND_STRING+="--security-type TrustedLaunch --enable-secure-boot true --enable-vtpm true"
+fi
+
+if [ "${OS_TYPE,,}" == "linux" ]; then
+  # in linux mode, explicitly create the NIC referencing the existing packer subnet to be attached to the testing VM so we avoid creating ephemeral vnets
+  PACKER_SUBNET_ID="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${PACKER_VNET_RESOURCE_GROUP_NAME}/providers/Microsoft.Network/virtualNetworks/${PACKER_VNET_NAME}/subnets/packer"
+  if [ -z "$(az network vnet subnet show --ids $PACKER_SUBNET_ID | jq -r '.id')" ]; then
+      echo "packer subnet $PACKER_SUBNET_ID seems to be missing, unable to create test VM"
       exit 1
-    fi
-
-    id=$(az sig image-definition show \
-      --resource-group ${AZURE_RESOURCE_GROUP_NAME} \
-      --gallery-name ${SIG_GALLERY_NAME} \
-      --gallery-image-definition ${SIG_IMAGE_NAME}) || id=""
-    if [ -z "$id" ]; then
-      echo "Image definition ${SIG_IMAGE_NAME} does not exist in gallery ${SIG_GALLERY_NAME} resource group ${AZURE_RESOURCE_GROUP_NAME}"
+  fi
+  TESTING_NIC_ID=$(az network nic create --resource-group $TEST_VM_RESOURCE_GROUP_NAME --name "testing$(date +%s)${RANDOM}" --subnet $PACKER_SUBNET_ID | jq -r '.NewNIC.id')
+  if [ -z "$TESTING_NIC_ID" ]; then
+      echo "unable to create new NIC for test VM"
       exit 1
-    fi
   fi
-
-  if [ -z "${MANAGED_SIG_ID}" ]; then
-    echo "Managed Sig Id from packer-output is empty, unable to proceed..."
-    exit 1
-  else
-    echo "Managed Sig Id from packer-output is ${MANAGED_SIG_ID}"
-    IMG_DEF=${MANAGED_SIG_ID}
-  fi
-
-  # In SIG mode, Windows VM requires admin-username and admin-password to be set,
-  # otherwise 'root' is used by default but not allowed by the Windows Image. See the error image below:
-  # ERROR: This user name 'root' meets the general requirements, but is specifically disallowed for this image. Please try a different value.
-  TARGET_COMMAND_STRING=""
-  if [[ "${ARCHITECTURE,,}" == "arm64" ]]; then
-    TARGET_COMMAND_STRING+="--size Standard_D2pds_V5"
-  else
-    TARGET_COMMAND_STRING="--size Standard_D2ds_v5"
-  fi
-
-  if [[ "${OS_TYPE}" == "Linux" && "${ENABLE_TRUSTED_LAUNCH}" == "True" ]]; then
-    if [[ -n "$TARGET_COMMAND_STRING" ]]; then
-      # To take care of Mariner Kata TL images
-      TARGET_COMMAND_STRING+=" "
-    fi
-    TARGET_COMMAND_STRING+="--security-type TrustedLaunch --enable-secure-boot true --enable-vtpm true"
-  fi
-
   az vm create \
       --resource-group $TEST_VM_RESOURCE_GROUP_NAME \
       --name $VM_NAME \
-      --image $IMG_DEF \
+      --image $MANAGED_SIG_ID \
+      --admin-username $TEST_VM_ADMIN_USERNAME \
+      --admin-password $TEST_VM_ADMIN_PASSWORD \
+      --nics $TESTING_NIC_ID \
+      ${TARGET_COMMAND_STRING}
+else
+  az vm create \
+      --resource-group $TEST_VM_RESOURCE_GROUP_NAME \
+      --name $VM_NAME \
+      --image $MANAGED_SIG_ID \
       --admin-username $TEST_VM_ADMIN_USERNAME \
       --admin-password $TEST_VM_ADMIN_PASSWORD \
       --public-ip-address "" \
       ${TARGET_COMMAND_STRING}
-      
-  echo "VHD test VM username: $TEST_VM_ADMIN_USERNAME, password: $TEST_VM_ADMIN_PASSWORD"
 fi
+    
+echo "VHD test VM username: $TEST_VM_ADMIN_USERNAME, password: $TEST_VM_ADMIN_PASSWORD"
 
 time az vm wait -g $TEST_VM_RESOURCE_GROUP_NAME -n $VM_NAME --created
 capture_benchmark "${SCRIPT_NAME}_create_test_vm"
+set -x
 
 FULL_PATH=$(realpath $0)
 CDIR=$(dirname $FULL_PATH)
 
 if [ "$OS_TYPE" == "Linux" ]; then
-  if [[ -z "${ENABLE_FIPS// }" ]]; then
+  if [ -z "${ENABLE_FIPS// }" ]; then
     ENABLE_FIPS="false"
   fi
 
@@ -151,7 +145,7 @@ if [ "$OS_TYPE" == "Linux" ]; then
   #  We have extract the message field from the json, and get the errors outputted to stderr + remove \n
   errMsg=$(echo -e $(echo $ret | jq ".value[] | .message" | grep -oP '(?<=stderr]).*(?=\\n")'))
   echo $errMsg
-  if [[ $errMsg != '' ]]; then
+  if [ $errMsg != '' ]; then
     exit 1
   fi
 else
@@ -204,7 +198,7 @@ else
   #   Invalid string: control characters from U+0000 through U+001F must be escaped
   errMsg=$(echo -E $ret | jq '.value[]  | select(.code == "ComponentStatus/StdErr/succeeded") | .message')
   # a successful errMsg should be '""' after parsed by `jq`
-  if [[ $errMsg != \"\" ]]; then
+  if [ $errMsg != \"\" ]; then
     exit 1
   fi
 fi

--- a/vhdbuilder/packer/vhd-scanning.sh
+++ b/vhdbuilder/packer/vhd-scanning.sh
@@ -21,7 +21,6 @@ SCAN_VM_ADMIN_USERNAME="azureuser"
 
 # we must create VMs in a vnet subnet which has access to the storage account, otherwise they will not be able to access the VHD blobs
 SCANNING_SUBNET_ID="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${PACKER_VNET_RESOURCE_GROUP_NAME}/providers/Microsoft.Network/virtualNetworks/${PACKER_VNET_NAME}/subnets/scanning"
-
 if [ -z "$(az network vnet subnet show --ids $SCANNING_SUBNET_ID | jq -r '.id')" ]; then
     echo "scanning subnet $SCANNING_SUBNET_ID seems to be missing, unable to create scanning VM"
     exit 1
@@ -46,7 +45,7 @@ SCAN_VM_ADMIN_PASSWORD="ScanVM@$(date +%s)"
 set -x
 
 RESOURCE_GROUP_NAME="$SCAN_RESOURCE_PREFIX-$(date +%s)-$RANDOM"
-az group create --name $RESOURCE_GROUP_NAME --location ${PACKER_BUILD_LOCATION} --tags "source=AgentBaker,now=$(date +%s)" "branch=${GIT_BRANCH}"
+az group create --name $RESOURCE_GROUP_NAME --location ${PACKER_BUILD_LOCATION} --tags "source=AgentBaker" "now=$(date +%s)" "branch=${GIT_BRANCH}"
 
 function cleanup() {
     echo "Deleting resource group ${RESOURCE_GROUP_NAME}"


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

- fixes incorrect "now" tag on VM scanning and testing resource groups
- has test VMs for linux builds use a nic referencing an already-existing subnet rather than always creating ephemeral vnets/subnets on the fly, reducing testing time and resource churn
- removes dead code from testing script

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
