### PR TITLE
fix: cgroup enablement syntax bug

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -511,7 +511,7 @@ capture_benchmark "download_gpu_device_plugin"
 mkdir -p /var/log/azure/Microsoft.Azure.Extensions.CustomScript/events
 
 # Disable cgroup-memory-telemetry on AzureLinux due to incompatibility with cgroup2fs driver and absence of required azure.slice directory
-if [ ! isMarinerOrAzureLinux "$OS" ]; then
+if ! isMarinerOrAzureLinux "$OS"; then
   systemctlEnableAndStart cgroup-memory-telemetry.timer || exit 1
   systemctl enable cgroup-memory-telemetry.service || exit 1
   systemctl restart cgroup-memory-telemetry.service

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -361,6 +361,7 @@ if [[ $OS == $UBUNTU_OS_NAME && $(isARM64) != 1 ]]; then  # No ARM64 SKU with GP
 
   while IFS= read -r imageToBePulled; do
     downloadURL=$(echo "${imageToBePulled}" | jq -r '.downloadURL')
+    # shellcheck disable=SC2001
     imageName=$(echo "$downloadURL" | sed 's/:.*$//')
 
     if [[ "$imageName" == "mcr.microsoft.com/aks/aks-gpu-cuda" ]]; then


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes the conditional that controls whether or not the below code is executed in install-dependencies.sh:

`systemctlEnableAndStart cgroup-memory-telemetry.timer || exit 1`
 `systemctl enable cgroup-memory-telemetry.service || exit 1`
  `systemctl restart cgroup-memory-telemetry.service`

**Which issue(s) this PR fixes**:

Because `isMarinerOrAzureLinux` is a function, the brackets prevent the conditional from executing correctly, resulting in the code not executing when it is supposed to.

If it is true, the code should skip, which it is because its failing. But if it is false, it should execute, but it isn't.

**Requirements**:

- [ x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version