### PR TITLE
test: log SSH instructions

### DIFF
--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -117,7 +117,6 @@ func prepareCluster(ctx context.Context, t *testing.T, cluster *armcontainerserv
 		return nil, fmt.Errorf("get kube client using cluster %q: %w", *cluster.Name, err)
 	}
 
-	t.Logf("ensuring debug daemonsets")
 	if err := kube.EnsureDebugDaemonsets(ctx, t, isAirgap); err != nil {
 		return nil, fmt.Errorf("ensure debug daemonsets for %q: %w", *cluster.Name, err)
 	}

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -153,8 +153,6 @@ func (k *Kubeclient) WaitUntilPodRunning(ctx context.Context, t *testing.T, name
 
 func (k *Kubeclient) WaitUntilNodeReady(ctx context.Context, t *testing.T, vmssName string) string {
 	nodeStatus := corev1.NodeStatus{}
-	found := false
-
 	t.Logf("waiting for node %s to be ready", vmssName)
 
 	watcher, err := k.Typed.CoreV1().Nodes().Watch(ctx, metav1.ListOptions{})
@@ -170,7 +168,6 @@ func (k *Kubeclient) WaitUntilNodeReady(ctx context.Context, t *testing.T, vmssN
 		if !strings.HasPrefix(node.Name, vmssName) {
 			continue
 		}
-		found = true
 		nodeStatus = node.Status
 		if len(node.Spec.Taints) > 0 {
 			continue
@@ -184,10 +181,7 @@ func (k *Kubeclient) WaitUntilNodeReady(ctx context.Context, t *testing.T, vmssN
 		}
 	}
 
-	if !found {
-		t.Logf("node %q isn't connected to the AKS cluster", vmssName)
-	}
-	require.NoError(t, err, "failed to find or wait for %q to be ready %+v", vmssName, nodeStatus)
+	t.Fatalf("failed to find or wait for %q to be ready %+v", vmssName, nodeStatus)
 	return ""
 }
 

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -125,7 +125,7 @@ type ScenarioRuntime struct {
 	SSHKeyPublic  []byte
 	SSHKeyPrivate []byte
 	VMPrivateIP   string
-	HostPodName   string
+	DebugHostPod  string
 }
 
 // Config represents the configuration of an AgentBaker E2E scenario.
@@ -157,7 +157,6 @@ func (s *Scenario) PrepareAKSNodeConfig() {
 // This method will also use the scenario's configured VHD selector to modify the input VMSS to reference the correct VHD resource.
 func (s *Scenario) PrepareVMSSModel(ctx context.Context, t *testing.T, vmss *armcompute.VirtualMachineScaleSet) {
 	resourceID, err := s.VHD.VHDResourceID(ctx, t)
-	t.Logf("using %q for VHD", resourceID)
 	require.NoError(t, err)
 	require.NotEmpty(t, resourceID, "VHDSelector.ResourceID")
 	require.NotNil(t, vmss, "input VirtualMachineScaleSet")

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -38,6 +38,11 @@ func ValidateCommonLinux(ctx context.Context, s *Scenario) {
 	require.Equal(s.T, "0", execResult.exitCode, "cat /etc/default/kubelet failed with exit code %q", execResult.exitCode)
 	require.NotContains(s.T, execResult.stdout.String(), "--dynamic-config-dir", "kubelet flag '--dynamic-config-dir' should not be present in /etc/default/kubelet")
 
+	// the instructions belows expects the SSH key to be uploaded to the user pool VM.
+	// which happens as a side-effect of execOnVMForScenario, it's ugly but works.
+	// maybe we should use a single ssh key per cluster, but need to be careful with parallel test runs.
+	logSSHInstructions(s)
+
 	ValidateSysctlConfig(ctx, s, map[string]string{
 		"net.ipv4.tcp_retries2":             "8",
 		"net.core.message_burst":            "80",

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -159,7 +159,7 @@ func execOnVMForScenarioOnUnprivilegedPod(ctx context.Context, s *Scenario, cmd 
 }
 
 func execOnVMForScenario(ctx context.Context, s *Scenario, cmd string) *podExecResult {
-	result, err := execOnVM(ctx, s.Runtime.Cluster.Kube, s.Runtime.VMPrivateIP, s.Runtime.HostPodName, string(s.Runtime.SSHKeyPrivate), cmd)
+	result, err := execOnVM(ctx, s.Runtime.Cluster.Kube, s.Runtime.VMPrivateIP, s.Runtime.DebugHostPod, string(s.Runtime.SSHKeyPrivate), cmd)
 	require.NoError(s.T, err, "failed to execute command on VM")
 	return result
 }


### PR DESCRIPTION
/kind test

Log instruction on how to easy SSH into VM.

Example:

```
...
    exec.go:199: SSH Instructions: (VM will be automatically deleted after the test finishes, set KEEP_VMSS=true to preserve it or pause the test with a breakpoint before the test finishes)
        ========================
        az account set --subscription 8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8
        az aks get-credentials --resource-group abe2e-westus3 --name abe2e-kubenet-331fc --overwrite-existing
        kubectl exec -it debug-mariner-gxh2f -- bash -c "chroot /proc/1/root /bin/bash -c 'ssh -i sshkey10224010 -o PasswordAuthentication=no -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=5 azureuser@10.224.0.10'"
...
```
