### PR TITLE
fix: codeql reports that go toolchain want 1.N.P format

### DIFF
--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/agentbaker/hack/tools
 
-go 1.21
+go 1.21.13
 
 require (
 	github.com/go-bindata/go-bindata v3.1.2+incompatible

--- a/vhdbuilder/lister/go.mod
+++ b/vhdbuilder/lister/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/agentbaker/vhdbuilder/lister
 
-go 1.21
+go 1.21.13
 
 require (
 	github.com/containerd/containerd v1.7.20

--- a/vhdbuilder/prefetch/go.mod
+++ b/vhdbuilder/prefetch/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/agentbaker/vhdbuilder/prefetch
 
-go 1.21
+go 1.21.13
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION

/kind cleanup

**What this PR does / why we need it**:
Update go reference to use patch version reported by codeql.

