### PR TITLE
chore: don't run PR e2e pipelines when merging release notes

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -21,6 +21,8 @@ pr:
     - vhdbuilder/packer/init-variables.sh
     - vhdbuilder/packer/windows-image.env
     - vhdbuilder/packer/windows-vhd-builder-sig.json
+    exclude:
+    - vhdbuilder/release-notes
 
 pool:
   name: $(AZURE_POOL_NAME)

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -15,6 +15,7 @@ pr:
     - parts/linux/*
     - packer.mk
     exclude:
+    - vhdbuilder/release-notes
     - vhdbuilder/packer/*.ps1
     - vhdbuilder/packer/**/*.ps1
     - vhdbuilder/packer/*windows*


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What this PR does / why we need it**:

Noticed that VHD builds were happening. They shouldn't because the VHDs don't include release notes.

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
