### PR TITLE
test: Testing 💚 update e2e checks for NRI plugin enabled status

### DIFF
--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -329,6 +329,8 @@ func ValidateContainerd2Properties(ctx context.Context, s *Scenario, versions []
 	// assert that containerd.server service file does not contain LimitNOFILE
 	// https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md#limitnofile-configuration-has-been-removed
 	ValidateFileExcludesContent(ctx, s, "/etc/systemd/system/containerd.service", "LimitNOFILE", "LimitNOFILE")
+	// nri plugin is enabled by default
+	ValidateDirectoryContent(ctx, s, "/run/nri/nri", []string{"nri.sock"})
 }
 
 func ValidateRunc12Properties(ctx context.Context, s *Scenario, versions []string) {


### PR DESCRIPTION
**What type of PR is this?**
/kind test 

**What this PR does / why we need it**:
with containerd 2.0 NRI plugin is enabled by default. 

however need to make sure other users are not using their own NRI plugins 


**Which issue(s) this PR fixes**:

Fixes #30622519

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
