### PR TITLE
feat: Add --dry-run option to aks-node-controller

### DIFF
--- a/aks-node-controller/.gitignore
+++ b/aks-node-controller/.gitignore
@@ -1,1 +1,2 @@
 aks-node-controller
+aks-node-controller.log

--- a/aks-node-controller/app_test.go
+++ b/aks-node-controller/app_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"testing"
 	"time"
@@ -145,6 +146,17 @@ func TestApp_Provision(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestApp_Provision_DryRun(t *testing.T) {
+	app := &App{
+		cmdRunner: cmdRunner,
+	}
+	result := app.Run(context.Background(), []string{"aks-node-controller", "provision", "--provision-config=parser/testdata/test_aksnodeconfig.json", "--dry-run"})
+	assert.Equal(t, 0, result)
+	if reflect.ValueOf(app.cmdRunner).Pointer() != reflect.ValueOf(cmdRunnerDryRun).Pointer() {
+		t.Fatal("app.cmdRunner is expected to be cmdRunnerDryRun")
 	}
 }
 

--- a/aks-node-controller/const.go
+++ b/aks-node-controller/const.go
@@ -3,7 +3,7 @@ package main
 // Some options are intentionally non-configurable to avoid customization by users
 // it will help us to avoid introducing any breaking changes in the future.
 const (
-	logFile                   = "/var/log/azure/aks-node-controller.log"
+	logPath                   = "/var/log/azure/aks-node-controller.log"
 	provisionJSONFilePath     = "/var/log/azure/aks/provision.json"
 	provisionCompleteFilePath = "/opt/azure/containers/provision.complete"
 )

--- a/aks-node-controller/main.go
+++ b/aks-node-controller/main.go
@@ -3,23 +3,52 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 )
 
 func main() {
-	logFile, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	// defer calls are not executed on os.Exit
+	logCleanup := configureLogging()
+	app := App{cmdRunner: cmdRunner}
+	exitCode := app.Run(context.Background(), os.Args)
+	logCleanup()
+	os.Exit(exitCode)
+}
+
+func configureLogging() func() {
+	logPath := setupLogPath()
+
+	if err := os.MkdirAll(filepath.Dir(logPath), 0755); err != nil {
+		fmt.Printf("failed to create log directory: %s\n", err)
+		os.Exit(1)
+	}
+
+	logFile, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		//nolint:forbidigo // there is no other way to communicate the error
 		fmt.Printf("failed to open log file: %s\n", err)
 		os.Exit(1)
 	}
-
-	logger := slog.New(slog.NewJSONHandler(logFile, nil))
+	mw := io.MultiWriter(logFile, os.Stderr)
+	logger := slog.New(slog.NewJSONHandler(mw, nil))
 	slog.SetDefault(logger)
+	return func() {
+		err := logFile.Close()
+		if err != nil {
+			// stdout is important, don't pollute with non-important warnings
+			_, _ = fmt.Fprintf(os.Stderr, "failed to close log file: %s\n", err)
+		}
+	}
+}
 
-	app := App{cmdRunner: cmdRunner}
-	exitCode := app.Run(context.Background(), os.Args)
-	_ = logFile.Close()
-	os.Exit(exitCode)
+func setupLogPath() string {
+	// Try to create production directory first
+	if err := os.MkdirAll(filepath.Dir(logPath), 0755); err == nil {
+		return logPath
+	}
+	// If directory creation fails, fallback to current directory
+	return "aks-node-controller.log"
 }


### PR DESCRIPTION
/kind feature

- Add --dry-run flag to aks-node-controller to log commands without executing.
- Log output to both stderr and a file.
- Ensure log directory is created if missing; fallback to current directory (for local mac use).
