### PR TITLE
chore: set pool name on windows pipelines

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -60,6 +60,7 @@ parameters:
 variables:
   VHD_BUILD_ID: $(Build.BuildId)
   LOCATION: $(PACKER_BUILD_LOCATION)
+  POOL_NAME: $(AZURE_POOL_NAME)
 
 # Use variable group "ab-windows-ame-tenant" and link it to the pipeline "AKS Windows VHD Build"
 # Use variable group "ab-windows-ame-tenant" and link it to the pipeline "AKS Windows VHD Build - PR check-in gate"

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -57,6 +57,7 @@ parameters:
   type: boolean
   default: False
 
+# Some templates use POOL_NAME instead of AZURE_POOL_NAME, so set POOL_NAME here just in case.
 variables:
   VHD_BUILD_ID: $(Build.BuildId)
   LOCATION: $(PACKER_BUILD_LOCATION)

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -59,5 +59,6 @@ stages:
     dependsOn: build_${{ parameters.stageName }}
     variables:
       TAGS_TO_RUN: imageName=${{ parameters.imageName }}
+      POOL_NAME: $(AZURE_POOL_NAME)
     jobs:
       - template: ./e2e-template.yaml


### PR DESCRIPTION
/kind chore

**What this PR does / why we need it**:

set POOL_NAME which was missing for windows VHD prod build pipeline

![image](https://github.com/user-attachments/assets/12c5a38f-eea0-47d9-bc9b-099b6ae767c6)


ADO definition of MSIT pipeline: https://msazure.visualstudio.com/CloudNativeCompute/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=210712&view=Tab_Variables

ADO definition of AME pipeline: https://msazure.visualstudio.com/CloudNativeCompute/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=188674&view=Tab_Variables


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
