### PR TITLE
chore: don't run e2e tests if the VHD isn't being built

### DIFF
--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -33,11 +33,11 @@ parameters:
 
 stages:
   - stage: build_${{ parameters.stageName }}
+    condition: eq('${{ parameters.build }}', True)
     dependsOn: [ ]
     jobs:
       - job: build_${{ parameters.stageName }}
         dependsOn: []
-        condition: eq('${{ parameters.build }}', True)
         timeoutInMinutes: 180
         steps:
           - bash: |

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -57,6 +57,7 @@ stages:
 
   - stage: e2e_${{ parameters.stageName }}
     dependsOn: build_${{ parameters.stageName }}
+    condition: eq('${{ parameters.build }}', True)
     variables:
       TAGS_TO_RUN: imageName=${{ parameters.imageName }}
     jobs:


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What this PR does / why we need it**:

Currently if someone runs the windows VHD build pipelines for 1 VHD, the e2e tests are run for all windows VHDs. This change disables the e2e tests for the VHDs not being built.
 
Sample pipeline: https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=113082893&view=results

![image](https://github.com/user-attachments/assets/e430dac1-24e8-45e2-a2a0-2312c7f4f8ba)


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
