### PR TITLE
Only build and run one of the gen1/gen2 windows VHDs on PR build

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -46,7 +46,7 @@ parameters:
 - name: build2022containerd
   displayName: Build 2022 containerd
   type: boolean
-  default: ${isNotPR}
+  default: True
 - name: build2022containerdgen2
   displayName: Build 2022 containerd Gen 2
   type: boolean
@@ -54,7 +54,7 @@ parameters:
 - name: build23H2
   displayName: Build 23H2
   type: boolean
-  default: ${isNotPR}
+  default: True
 - name: build23H2gen2
   displayName: Build 23H2 Gen 2
   type: boolean
@@ -91,7 +91,7 @@ stages:
       imageName: windows-2022-containerd
       windowsSku: 2022-containerd
       hyperVGeneration: V1
-      build: ${{ parameters.build2022containerd }}
+      build: $[ and(isNotPr, parameters.build2022containerd) ]
       vhddebug: ${{ parameters.vhddebug }}
       dryrun: ${{ parameters.dryrun }}
 
@@ -113,7 +113,7 @@ stages:
       imageName: windows-23H2
       windowsSku: 23H2
       hyperVGeneration: V1
-      build: ${{ parameters.build23H2 }}
+      build: $[ and(isNotPr, parameters.build23H2) ]
       vhddebug: ${{ parameters.vhddebug }}
       dryrun: ${{ parameters.dryrun }}
 

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -91,7 +91,7 @@ stages:
       imageName: windows-2022-containerd
       windowsSku: 2022-containerd
       hyperVGeneration: V1
-      build: $[ and(isNotPR, parameters.build2022containerd) ]
+      build: and(eq(parameters.build2022containerd, true), eq(variables.isNotPR, true))
       vhddebug: ${{ parameters.vhddebug }}
       dryrun: ${{ parameters.dryrun }}
 
@@ -113,7 +113,7 @@ stages:
       imageName: windows-23H2
       windowsSku: 23H2
       hyperVGeneration: V1
-      build: $[ and(isNotPR, parameters.build23H2) ]
+      build: and(eq(parameters.build23H2, true), eq(variables.isNotPR, true))
       vhddebug: ${{ parameters.vhddebug }}
       dryrun: ${{ parameters.dryrun }}
 

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -91,7 +91,7 @@ stages:
       imageName: windows-2022-containerd
       windowsSku: 2022-containerd
       hyperVGeneration: V1
-      build: $[ and(isNotPr, parameters.build2022containerd) ]
+      build: $[ and(isNotPR, parameters.build2022containerd) ]
       vhddebug: ${{ parameters.vhddebug }}
       dryrun: ${{ parameters.dryrun }}
 
@@ -113,7 +113,7 @@ stages:
       imageName: windows-23H2
       windowsSku: 23H2
       hyperVGeneration: V1
-      build: $[ and(isNotPr, parameters.build23H2) ]
+      build: $[ and(isNotPR, parameters.build23H2) ]
       vhddebug: ${{ parameters.vhddebug }}
       dryrun: ${{ parameters.dryrun }}
 

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -91,7 +91,7 @@ stages:
       imageName: windows-2022-containerd
       windowsSku: 2022-containerd
       hyperVGeneration: V1
-      build: and(eq(parameters.build2022containerd, true), eq(variables.isNotPR, true))
+      build: ${{ and(eq(parameters.build2022containerd, true), eq(variables.isNotPR, true)) }}
       vhddebug: ${{ parameters.vhddebug }}
       dryrun: ${{ parameters.dryrun }}
 
@@ -113,7 +113,7 @@ stages:
       imageName: windows-23H2
       windowsSku: 23H2
       hyperVGeneration: V1
-      build: and(eq(parameters.build23H2, true), eq(variables.isNotPR, true))
+      build: ${{ and(eq(parameters.build23H2, true), eq(variables.isNotPR, true)) }}
       vhddebug: ${{ parameters.vhddebug }}
       dryrun: ${{ parameters.dryrun }}
 

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -30,6 +30,14 @@ pr:
 pool:
   name: $(AZURE_POOL_NAME)
 
+# Some templates use POOL_NAME instead of AZURE_POOL_NAME, so set POOL_NAME here just in case.
+variables:
+  VHD_BUILD_ID: $(Build.BuildId)
+  LOCATION: $(PACKER_BUILD_LOCATION)
+  POOL_NAME: $(AZURE_POOL_NAME)
+  isPR: $[eq(variables['Build.Reason'], 'PullRequest')]
+  isNotPR: $[ne(variables['Build.Reason'], 'PullRequest')]
+
 parameters:
 - name: build2019containerd
   displayName: Build 2019 containerd
@@ -38,7 +46,7 @@ parameters:
 - name: build2022containerd
   displayName: Build 2022 containerd
   type: boolean
-  default: True
+  default: ${isNotPR}
 - name: build2022containerdgen2
   displayName: Build 2022 containerd Gen 2
   type: boolean
@@ -46,7 +54,7 @@ parameters:
 - name: build23H2
   displayName: Build 23H2
   type: boolean
-  default: True
+  default: ${isNotPR}
 - name: build23H2gen2
   displayName: Build 23H2 Gen 2
   type: boolean
@@ -59,12 +67,6 @@ parameters:
   displayName: VHD Debug
   type: boolean
   default: False
-
-# Some templates use POOL_NAME instead of AZURE_POOL_NAME, so set POOL_NAME here just in case.
-variables:
-  VHD_BUILD_ID: $(Build.BuildId)
-  LOCATION: $(PACKER_BUILD_LOCATION)
-  POOL_NAME: $(AZURE_POOL_NAME)
 
 # Use variable group "ab-windows-ame-tenant" and link it to the pipeline "AKS Windows VHD Build"
 # Use variable group "ab-windows-ame-tenant" and link it to the pipeline "AKS Windows VHD Build - PR check-in gate"


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What this PR does / why we need it**:

Currently on PR build we build gen1 and gen2 VHDs for windows 2022 and 23H2. We only need to build a single gen for testing. This will reduce resource demand on Windows related PR builds.

I've tested that all 5 VHDs are still built when producing prod VHDs.

![image](https://github.com/user-attachments/assets/cf911c31-ed07-4b04-ac88-972339bac155)

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
