### PR TITLE
Update coredns images v1.12.0-1 and v1.9.4-5 from MCR oss/v2

### DIFF
--- a/parts/linux/cloud-init/artifacts/components.json
+++ b/parts/linux/cloud-init/artifacts/components.json
@@ -37,11 +37,11 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/coredns",
-          "latestVersion": "v1.11.3-4"
+          "latestVersion": "v1.12.0-1"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/coredns",
-          "latestVersion": "v1.9.4-4"
+          "latestVersion": "v1.9.4-5"
         }
       ]
     },


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
We have created, tested and published coredns images v1.12.0-1 and v1.9.4-5 to MCR using the new Dalec framework. The new Dalec framework publish the images to MCR under oss/v2 path. We plan to use v1.12.0-1 on all AKS clusters with 1.32 versions and existing clusters will use v1.9.4-5.

mcr.microsoft.com/oss/v2/kubernetes/coredns:v1.12.0-1
mcr.microsoft.com/oss/v2/kubernetes/coredns:v1.9.4-5

Once the rollout is complete, I will submit another PR to remove -
```
{
  "downloadURL": "mcr.microsoft.com/oss/kubernetes/coredns:*",
  "amd64OnlyVersions": [],
  "multiArchVersionsV2": [
    {
      "renovateTag": "registry=https://mcr.microsoft.com, name=oss/kubernetes/coredns",
      "latestVersion": "v1.9.4-hotfix.20240704"
    }
  ]
},
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # These images have fix for all the CVEs detected in v1.9.4 and v1.12.0 of coredns.

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
