### PR TITLE
add displayname to e2e pipeline

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -1270,5 +1270,6 @@ stages:
     variables:
       VHD_BUILD_ID: $(Build.BuildId)
       TAGS_TO_SKIP: "os=windows"
+      TAGS_TO_RUN: ""
     jobs:
       - template: ./templates/e2e-template.yaml

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -1272,3 +1272,6 @@ stages:
       TAGS_TO_SKIP: "os=windows"
     jobs:
       - template: ./templates/e2e-template.yaml
+        parameters:
+          name: All Linux
+

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -1270,6 +1270,5 @@ stages:
     variables:
       VHD_BUILD_ID: $(Build.BuildId)
       TAGS_TO_SKIP: "os=windows"
-      TAGS_TO_RUN: ""
     jobs:
       - template: ./templates/e2e-template.yaml

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -82,6 +82,8 @@ stages:
     condition: and(succeeded(), ne(variables.SKIP_E2E_TESTS, 'true'))
     variables:
       VHD_BUILD_ID: $(Build.BuildId)
+      TAGS_TO_RUN: ""
+      TAGS_TO_SKIP: ""
     jobs:
       - template: ./templates/e2e-template.yaml
 

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -82,8 +82,6 @@ stages:
     condition: and(succeeded(), ne(variables.SKIP_E2E_TESTS, 'true'))
     variables:
       VHD_BUILD_ID: $(Build.BuildId)
-      TAGS_TO_RUN: ""
-      TAGS_TO_SKIP: ""
     jobs:
       - template: ./templates/e2e-template.yaml
 

--- a/.pipelines/e2e-windows.yaml
+++ b/.pipelines/e2e-windows.yaml
@@ -1,7 +1,6 @@
 name: $(Date:yyyyMMdd)$(Rev:.r)
 variables:
   TAGS_TO_RUN: "os=windows"
-  TAGS_TO_SKIP: ""
   SKIP_E2E_TESTS: false
 trigger:
   branches:

--- a/.pipelines/e2e-windows.yaml
+++ b/.pipelines/e2e-windows.yaml
@@ -1,6 +1,7 @@
 name: $(Date:yyyyMMdd)$(Rev:.r)
 variables:
   TAGS_TO_RUN: "os=windows"
+  TAGS_TO_SKIP: ""
   SKIP_E2E_TESTS: false
 trigger:
   branches:

--- a/.pipelines/e2e-windows.yaml
+++ b/.pipelines/e2e-windows.yaml
@@ -30,3 +30,5 @@ pr:
       - /**/*.md
 jobs:
   - template: ./templates/e2e-template.yaml
+    parameters:
+      name: Windows Tests

--- a/.pipelines/e2e.yaml
+++ b/.pipelines/e2e.yaml
@@ -29,3 +29,5 @@ pr:
       - /**/*.md
 jobs:
   - template: ./templates/e2e-template.yaml
+    parameters:
+      name: Linux Tests

--- a/.pipelines/e2e.yaml
+++ b/.pipelines/e2e.yaml
@@ -1,6 +1,5 @@
 name: $(Date:yyyyMMdd)$(Rev:.r)
 variables:
-  TAGS_TO_RUN: ""
   TAGS_TO_SKIP: "os=windows"
   SKIP_E2E_TESTS: false
 trigger:

--- a/.pipelines/e2e.yaml
+++ b/.pipelines/e2e.yaml
@@ -1,5 +1,6 @@
 name: $(Date:yyyyMMdd)$(Rev:.r)
 variables:
+  TAGS_TO_RUN: ""
   TAGS_TO_SKIP: "os=windows"
   SKIP_E2E_TESTS: false
 trigger:

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -34,7 +34,7 @@ parameters:
 stages:
   - stage: build_${{ parameters.stageName }}
     # Put the artifact name first so it doesn't get truncated as much in ADO
-    displayName: ${{ parameters.artifactName }} - Build
+    displayName: Build (${{ parameters.artifactName }})
     condition: and(succeeded(), eq('${{ parameters.build }}', True))
     dependsOn: [ ]
     jobs:
@@ -58,8 +58,7 @@ stages:
               artifactName: ${{ parameters.artifactName }}
 
   - stage: e2e_${{ parameters.stageName }}
-    # Put e2e first as we have the artifactName shown in the build step.
-    displayName: E2E - ${{ parameters.artifactName }}
+    displayName: E2E (${{ parameters.artifactName }})
     dependsOn: build_${{ parameters.stageName }}
     condition: and(succeeded(), eq('${{ parameters.build }}', True))
     variables:

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -60,5 +60,6 @@ stages:
     condition: and(succeeded(), eq('${{ parameters.build }}', True))
     variables:
       TAGS_TO_RUN: imageName=${{ parameters.imageName }}
+      TAGS_TO_SKIP: ""
     jobs:
       - template: ./e2e-template.yaml

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -33,7 +33,8 @@ parameters:
 
 stages:
   - stage: build_${{ parameters.stageName }}
-    displayName: Build ${{ parameters.imageName }}
+    # Put the artifact name first so it doesn't get truncated as much in ADO
+    displayName: ${{ parameters.artifactName }} - Build
     condition: and(succeeded(), eq('${{ parameters.build }}', True))
     dependsOn: [ ]
     jobs:
@@ -57,7 +58,8 @@ stages:
               artifactName: ${{ parameters.artifactName }}
 
   - stage: e2e_${{ parameters.stageName }}
-    displayName: E2E tests of ${{ parameters.imageName }}
+    # Put e2e first as we have the artifactName shown in the build step.
+    displayName: E2E - ${{ parameters.artifactName }}
     dependsOn: build_${{ parameters.stageName }}
     condition: and(succeeded(), eq('${{ parameters.build }}', True))
     variables:

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -60,6 +60,8 @@ stages:
     condition: and(succeeded(), eq('${{ parameters.build }}', True))
     variables:
       TAGS_TO_RUN: imageName=${{ parameters.imageName }}
-      TAGS_TO_SKIP: ""
     jobs:
       - template: ./e2e-template.yaml
+        parameters:
+          name: For image ${{ parameters.imageName }}
+

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -33,6 +33,7 @@ parameters:
 
 stages:
   - stage: build_${{ parameters.stageName }}
+    displayName: Build ${{ parameters.imageName }}
     condition: and(succeeded(), eq('${{ parameters.build }}', True))
     dependsOn: [ ]
     jobs:
@@ -56,6 +57,7 @@ stages:
               artifactName: ${{ parameters.artifactName }}
 
   - stage: e2e_${{ parameters.stageName }}
+    displayName: E2E tests of ${{ parameters.imageName }}
     dependsOn: build_${{ parameters.stageName }}
     condition: and(succeeded(), eq('${{ parameters.build }}', True))
     variables:

--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -6,7 +6,7 @@ jobs:
     pool:
       name: $(E2E_POOL_NAME)
     timeoutInMinutes: 90
-    displayName: Run AgentBaker E2E TAGS_TO_RUN="${{TAGS_TO_RUN}}" TAGS_TO_SKIP="${{TAGS_TO_SKIP}}" VHD_BUILD_ID="${{VHD_BUILD_ID}}"
+    displayName: Run AgentBaker E2E TAGS_TO_RUN="$(TAGS_TO_RUN)" TAGS_TO_SKIP="$(TAGS_TO_SKIP)" VHD_BUILD_ID="$(VHD_BUILD_ID)"
     steps:
       - bash: |
           set -ex

--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -1,3 +1,9 @@
+parameters:
+  - name: name
+    type: string
+    displayName: Additional name for the pipeline step
+    default: ""
+
 jobs:
   - job: e2e
     condition: and(succeeded(), ne(variables.SKIP_E2E_TESTS, 'true'))
@@ -6,7 +12,7 @@ jobs:
     pool:
       name: $(E2E_POOL_NAME)
     timeoutInMinutes: 90
-    displayName: Run AgentBaker E2E TAGS_TO_RUN="$(variables.TAGS_TO_RUN)" TAGS_TO_SKIP="$(variables.TAGS_TO_SKIP)"
+    displayName: Run AgentBaker E2E ${{parameters.name}}
     steps:
       - bash: |
           set -ex

--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -6,7 +6,7 @@ jobs:
     pool:
       name: $(E2E_POOL_NAME)
     timeoutInMinutes: 90
-    displayName: Run AgentBaker E2E
+    displayName: Run AgentBaker E2E TAGS_TO_RUN="${{TAGS_TO_RUN}}" TAGS_TO_SKIP="${{TAGS_TO_SKIP}}" VHD_BUILD_ID="${{VHD_BUILD_ID}}"
     steps:
       - bash: |
           set -ex

--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -6,7 +6,7 @@ jobs:
     pool:
       name: $(E2E_POOL_NAME)
     timeoutInMinutes: 90
-    displayName: Run AgentBaker E2E TAGS_TO_RUN="$(TAGS_TO_RUN)" TAGS_TO_SKIP="$(TAGS_TO_SKIP)" VHD_BUILD_ID="$(VHD_BUILD_ID)"
+    displayName: Run AgentBaker E2E TAGS_TO_RUN="${{TAGS_TO_RUN}}" TAGS_TO_SKIP="${{TAGS_TO_SKIP}}"
     steps:
       - bash: |
           set -ex

--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -6,7 +6,7 @@ jobs:
     pool:
       name: $(E2E_POOL_NAME)
     timeoutInMinutes: 90
-    displayName: Run AgentBaker E2E TAGS_TO_RUN="${{TAGS_TO_RUN}}" TAGS_TO_SKIP="${{TAGS_TO_SKIP}}"
+    displayName: Run AgentBaker E2E TAGS_TO_RUN="${{variables.TAGS_TO_RUN}}" TAGS_TO_SKIP="${{variables.TAGS_TO_SKIP}}"
     steps:
       - bash: |
           set -ex

--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -6,7 +6,7 @@ jobs:
     pool:
       name: $(E2E_POOL_NAME)
     timeoutInMinutes: 90
-    displayName: Run AgentBaker E2E TAGS_TO_RUN="${{variables.TAGS_TO_RUN}}" TAGS_TO_SKIP="${{variables.TAGS_TO_SKIP}}"
+    displayName: Run AgentBaker E2E TAGS_TO_RUN="$(variables.TAGS_TO_RUN)" TAGS_TO_SKIP="$(variables.TAGS_TO_SKIP)"
     steps:
       - bash: |
           set -ex


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What this PR does / why we need it**:

Currently all the pipeline jobs that run e2e tests have the same name. Which is confusing when bouncing between pipelines. This PR adds more detail to the e2e pipeline name.

![image](https://github.com/user-attachments/assets/16872d93-1c00-4395-acf6-1f9284f1ef6d)


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
