### PR TITLE
fix: convert to VHD blob step fix

### DIFF
--- a/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
+++ b/vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
@@ -85,7 +85,7 @@ capture_benchmark "${SCRIPT_NAME}_convert_image_version_to_disk"
 
 echo "Granting access to $disk_resource_id for 1 hour"
 # shellcheck disable=SC2102
-sas=$(az disk grant-access --ids $disk_resource_id --duration-in-seconds 3600 --query [accessSas] -o tsv)
+sas=$(az disk grant-access --ids $disk_resource_id --duration-in-seconds 3600 --query [accessSAS] -o tsv)
 capture_benchmark "${SCRIPT_NAME}_grant_access_to_disk"
 
 echo "Uploading $disk_resource_id to ${CLASSIC_BLOB}/${CAPTURED_SIG_VERSION}.vhd"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This unblocks the `Convert Shared Image Gallery To VHD Blob In Classic Storage Account` step in our VHD build pipelines.

**Which issue(s) this PR fixes**:

The parameter for `accessSas` changed to `accessSAS`, resulting in no SAS being present for the AzCopy command to execute.

**Requirements**:

- [x ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version