### PR TITLE
test(e2e): simplify cluster parameter extraction

### DIFF
--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -17,7 +18,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
@@ -33,6 +38,12 @@ var (
 	clusterKubenetAirgapOnce sync.Once
 	clusterAzureNetworkOnce  sync.Once
 )
+
+type ClusterParams struct {
+	CACert         []byte
+	BootstrapToken string
+	FQDN           string
+}
 
 type Cluster struct {
 	Model         *armcontainerservice.ManagedCluster
@@ -139,6 +150,43 @@ func prepareCluster(ctx context.Context, t *testing.T, cluster *armcontainerserv
 		Maintenance:   maintenance,
 		ClusterParams: clusterParams,
 	}, nil
+}
+
+func extractClusterParameters(ctx context.Context, t *testing.T, kube *Kubeclient, cluster *armcontainerservice.ManagedCluster) (*ClusterParams, error) {
+	resp, err := config.Azure.AKS.ListClusterAdminCredentials(ctx, config.ResourceGroupName, *cluster.Name, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing cluster admin credentials: %w", err)
+	}
+	kubeconfig, err := clientcmd.Load(resp.Kubeconfigs[0].Value)
+	if err != nil {
+		return nil, fmt.Errorf("loading decoded cluster kubeconfig as Config: %w", err)
+	}
+	clusterConfig, ok := kubeconfig.Clusters[*cluster.Name]
+	if !ok {
+		return nil, fmt.Errorf("kubeconfig missing cluster info for %s", *cluster.Name)
+	}
+	return &ClusterParams{
+		CACert:         clusterConfig.CertificateAuthorityData,
+		BootstrapToken: getBootstrapToken(ctx, t, kube),
+		FQDN:           *cluster.Properties.Fqdn,
+	}, nil
+}
+
+func getBootstrapToken(ctx context.Context, t *testing.T, kube *Kubeclient) string {
+	secrets, err := kube.Typed.CoreV1().Secrets("kube-system").List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	secret := func() *corev1.Secret {
+		for _, secret := range secrets.Items {
+			if strings.HasPrefix(secret.Name, "bootstrap-token-") {
+				return &secret
+			}
+		}
+		t.Fatal("could not find secret with bootstrap-token- prefix")
+		return nil
+	}()
+	id := secret.Data["token-id"]
+	token := secret.Data["token-secret"]
+	return fmt.Sprintf("%s.%s", id, token)
 }
 
 func hash(cluster *armcontainerservice.ManagedCluster) string {

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -159,11 +159,11 @@ func extractClusterParameters(ctx context.Context, t *testing.T, kube *Kubeclien
 	}
 	kubeconfig, err := clientcmd.Load(resp.Kubeconfigs[0].Value)
 	if err != nil {
-		return nil, fmt.Errorf("loading decoded cluster kubeconfig as Config: %w", err)
+		return nil, fmt.Errorf("loading cluster kubeconfig: %w", err)
 	}
-	clusterConfig, ok := kubeconfig.Clusters[*cluster.Name]
-	if !ok {
-		return nil, fmt.Errorf("kubeconfig missing cluster info for %s", *cluster.Name)
+	clusterConfig := kubeconfig.Clusters[*cluster.Name]
+	if clusterConfig == nil {
+		return nil, fmt.Errorf("cluster kubeconfig missing configuration for %s", *cluster.Name)
 	}
 	return &ClusterParams{
 		CACert:         clusterConfig.CertificateAuthorityData,

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -127,12 +127,17 @@ func prepareCluster(ctx context.Context, t *testing.T, cluster *armcontainerserv
 		return nil, fmt.Errorf("collect garbage vmss: %w", err)
 	}
 
+	clusterParams, err := extractClusterParameters(ctx, t, kube, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("extracting cluster parameters: %w", err)
+	}
+
 	return &Cluster{
 		Model:         cluster,
 		Kube:          kube,
 		SubnetID:      subnetID,
 		Maintenance:   maintenance,
-		ClusterParams: extractClusterParameters(ctx, t, kube),
+		ClusterParams: clusterParams,
 	}, nil
 }
 

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -56,7 +56,7 @@ func extractClusterParameters(ctx context.Context, t *testing.T, kube *Kubeclien
 	return &ClusterParams{
 		CACert:         clusterConfig.CertificateAuthorityData,
 		BootstrapToken: getBootstrapToken(ctx, t, kube),
-		FQDN:           fmt.Sprintf("https://%s:443", *cluster.Properties.Fqdn),
+		FQDN:           *cluster.Properties.Fqdn,
 	}, nil
 }
 

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -70,12 +70,10 @@ func execScriptOnVm(ctx context.Context, s *Scenario, vmPrivateIP, jumpboxPodNam
 		interpreter = "powershell"
 		scriptFileName = fmt.Sprintf("script_file_%s.ps1", identifier)
 		remoteScriptFileName = fmt.Sprintf("c:/%s", scriptFileName)
-		break
 	default:
 		interpreter = "bash"
 		scriptFileName = fmt.Sprintf("script_file_%s.sh", identifier)
 		remoteScriptFileName = scriptFileName
-		break
 	}
 
 	steps := []string{

--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -28,7 +28,7 @@ func getBaseNBC(t *testing.T, cluster *Cluster, vhd *config.Image) *datamodel.No
 
 	if vhd.Distro.IsWindowsDistro() {
 		nbc = baseTemplateWindows(t, config.Config.Location)
-		// these aren't needed since we use TLS bootstrapping instead, though windows bootstrapping expected non-empty values
+		// these aren't needed since we use TLS bootstrapping instead, though windows bootstrapping expects non-empty values
 		nbc.ContainerService.Properties.CertificateProfile.ClientCertificate = "none"
 		nbc.ContainerService.Properties.CertificateProfile.ClientPrivateKey = "none"
 		nbc.ContainerService.Properties.ClusterID = *cluster.Model.ID
@@ -37,6 +37,9 @@ func getBaseNBC(t *testing.T, cluster *Cluster, vhd *config.Image) *datamodel.No
 		nbc.TenantID = *cluster.Model.Identity.TenantID
 	} else {
 		nbc = baseTemplateLinux(t, config.Config.Location, *cluster.Model.Properties.CurrentKubernetesVersion, vhd.Arch)
+		// this isn't needed since we already have the cluster CA certificate, though we still pass in a dummy value to be sure provisioning doesn't fail
+		// TODO(cameissner): remove this once we remove APIServerCertificate from CertificateProfile
+		nbc.ContainerService.Properties.CertificateProfile.APIServerCertificate = base64.StdEncoding.EncodeToString([]byte("none"))
 	}
 
 	nbc.ContainerService.Properties.CertificateProfile.CaCertificate = string(cluster.ClusterParams.CACert)

--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -28,18 +28,17 @@ func getBaseNBC(t *testing.T, cluster *Cluster, vhd *config.Image) *datamodel.No
 
 	if vhd.Distro.IsWindowsDistro() {
 		nbc = baseTemplateWindows(t, config.Config.Location)
+
 		// these aren't needed since we use TLS bootstrapping instead, though windows bootstrapping expects non-empty values
 		nbc.ContainerService.Properties.CertificateProfile.ClientCertificate = "none"
 		nbc.ContainerService.Properties.CertificateProfile.ClientPrivateKey = "none"
+
 		nbc.ContainerService.Properties.ClusterID = *cluster.Model.ID
 		nbc.SubscriptionID = config.Config.SubscriptionID
 		nbc.ResourceGroupName = *cluster.Model.Properties.NodeResourceGroup
 		nbc.TenantID = *cluster.Model.Identity.TenantID
 	} else {
 		nbc = baseTemplateLinux(t, config.Config.Location, *cluster.Model.Properties.CurrentKubernetesVersion, vhd.Arch)
-		// this isn't needed since we already have the cluster CA certificate, though we still pass in a dummy value to be sure provisioning doesn't fail
-		// TODO(cameissner): remove this once we remove APIServerCertificate from CertificateProfile
-		nbc.ContainerService.Properties.CertificateProfile.APIServerCertificate = base64.StdEncoding.EncodeToString([]byte("none"))
 	}
 
 	nbc.ContainerService.Properties.CertificateProfile.CaCertificate = string(cluster.ClusterParams.CACert)

--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -30,8 +30,8 @@ func getBaseNBC(t *testing.T, cluster *Cluster, vhd *config.Image) *datamodel.No
 		nbc = baseTemplateWindows(t, config.Config.Location)
 		cert := cluster.Kube.clientCertificate()
 		nbc.ContainerService.Properties.CertificateProfile.ClientCertificate = cert
-		nbc.ContainerService.Properties.CertificateProfile.APIServerCertificate = string(cluster.ClusterParams.APIServerCert)
-		nbc.ContainerService.Properties.CertificateProfile.ClientPrivateKey = string(cluster.ClusterParams.ClientKey)
+		// nbc.ContainerService.Properties.CertificateProfile.APIServerCertificate = string(cluster.ClusterParams.APIServerCert)
+		// nbc.ContainerService.Properties.CertificateProfile.ClientPrivateKey = string(cluster.ClusterParams.ClientKey)
 		nbc.ContainerService.Properties.ClusterID = *cluster.Model.ID
 		nbc.SubscriptionID = config.Config.SubscriptionID
 		nbc.ResourceGroupName = *cluster.Model.Properties.NodeResourceGroup

--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -28,10 +28,9 @@ func getBaseNBC(t *testing.T, cluster *Cluster, vhd *config.Image) *datamodel.No
 
 	if vhd.Distro.IsWindowsDistro() {
 		nbc = baseTemplateWindows(t, config.Config.Location)
-		cert := cluster.Kube.clientCertificate()
-		nbc.ContainerService.Properties.CertificateProfile.ClientCertificate = cert
-		// nbc.ContainerService.Properties.CertificateProfile.APIServerCertificate = string(cluster.ClusterParams.APIServerCert)
-		// nbc.ContainerService.Properties.CertificateProfile.ClientPrivateKey = string(cluster.ClusterParams.ClientKey)
+		// these aren't needed since we use TLS bootstrapping instead, though windows bootstrapping expected non-empty values
+		nbc.ContainerService.Properties.CertificateProfile.ClientCertificate = "none"
+		nbc.ContainerService.Properties.CertificateProfile.ClientPrivateKey = "none"
 		nbc.ContainerService.Properties.ClusterID = *cluster.Model.ID
 		nbc.SubscriptionID = config.Config.SubscriptionID
 		nbc.ResourceGroupName = *cluster.Model.Properties.NodeResourceGroup
@@ -41,7 +40,6 @@ func getBaseNBC(t *testing.T, cluster *Cluster, vhd *config.Image) *datamodel.No
 	}
 
 	nbc.ContainerService.Properties.CertificateProfile.CaCertificate = string(cluster.ClusterParams.CACert)
-
 	nbc.KubeletClientTLSBootstrapToken = &cluster.ClusterParams.BootstrapToken
 	nbc.ContainerService.Properties.HostedMasterProfile.FQDN = cluster.ClusterParams.FQDN
 	nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = vhd.Distro


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

right now we extract all cluster params except for the bootstrap token using a privileged pod running a node of the e2e cluster's system pool - this is an error prone process and requires at least one node to be running in the system pool at the time of test execution. it turns out we can get the cluster CA certificate data and cluster fqdn directly from the `ListClusterAdminCredentials` API on the AKS ARM client instead

further, this PR removes the API server cert and client key cluster parameters, as they aren't strictly needed with how we bootstrap nodes for e2e tests

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
