### PR TITLE
add acr-credential-provider release 1.31

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -868,8 +868,15 @@
             "versionsV2": [
               {
                 "renovateTag": "<DO_NOT_UPDATE>",
-                "latestVersion": "1.29.2",
-                "previousLatestVersion": "1.30.0"
+                "latestVersion": "1.31.2"
+              },
+              {
+                "renovateTag": "<DO_NOT_UPDATE>",
+                "latestVersion": "1.30.8"
+              },
+              {
+                "renovateTag": "<DO_NOT_UPDATE>",
+                "latestVersion": "1.29.12"
               }
             ],
             "downloadURL": "https://acs-mirror.azureedge.net/cloud-provider-azure/v${version}/binaries/azure-acr-credential-provider-windows-amd64-v${version}.tar.gz"
@@ -1264,6 +1271,11 @@
         "default": {
           "current": {
             "versionsV2": [
+              {
+                "k8sVersion": "1.31",
+                "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/binaries/kubernetes/azure-acr-credential-provider",
+                "latestVersion": "v1.31.2"
+              },
               {
                 "k8sVersion": "1.30",
                 "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/binaries/kubernetes/azure-acr-credential-provider",

--- a/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
@@ -775,12 +775,6 @@ Describe 'Tests of components.json ' {
         $packages["c:\akse-cache\csi-proxy\"] | Should -Contain "https://acs-mirror.azureedge.net/csi-proxy/v1.1.2-hotfix.20230807/binaries/csi-proxy-v1.1.2-hotfix.20230807.tar.gz"
     }
 
-    it 'has credential provider' {
-        $packages = GetPackagesFromComponentsJson $componentsJson
-        $packages["c:\akse-cache\credential-provider\"] | Should -Contain "https://acs-mirror.azureedge.net/cloud-provider-azure/v1.29.2/binaries/azure-acr-credential-provider-windows-amd64-v1.29.2.tar.gz"
-        $packages["c:\akse-cache\credential-provider\"] | Should -Contain "https://acs-mirror.azureedge.net/cloud-provider-azure/v1.30.0/binaries/azure-acr-credential-provider-windows-amd64-v1.30.0.tar.gz"
-    }
-
     it 'has calico' {
         $packages = GetPackagesFromComponentsJson $componentsJson
         $packages["c:\akse-cache\calico\"] | Should -Contain "https://acs-mirror.azureedge.net/calico-node/v3.24.0/binaries/calico-windows-v3.24.0.zip"

--- a/vhdbuilder/packer/windows/windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/windows/windows-vhd-configuration.ps1
@@ -97,7 +97,6 @@ $global:excludeHashComparisionListInAzureChinaCloud = @(
     "azure-vnet-cni-singletenancy-overlay-windows-amd64",
     # We need upstream's help to republish this package. Before that, it does not impact functionality and 1.26 is only in public preview
     # so we can ignore the different hash values.
-    "v1.26.0-1int.zip",
-    "azure-acr-credential-provider-windows-amd64-v1.29.2.tar.gz"
+    "v1.26.0-1int.zip"
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
bump cloud-node-manager and acr-credential-provider to new release v1.28.14 v1.29.12 v1.30.8 v1.31.2
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
