### PR TITLE
chore: remove nanoserver from renovate and add a comment explaining why

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -28,8 +28,9 @@
       "multiArchVersionsV2": [],
       "windowsVersions": [
         {
-          "renovateTag": "registry=https://mcr.microsoft.com, name=windows/nanoserver",
-          "latestVersion": "ltsc2019",
+          "comment": "1809 gets patches every 6 months or so. The alternative is ltsc2019 which gets patches every couple of years. Most customers use 1809, so we keep that on the VHD",
+          "renovateTag": "<DO_NOT_UPDATE>",
+          "latestVersion": "1809",
           "windowsSkuMatch": "2019-containerd"
         },
         {

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -29,7 +29,7 @@
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=windows/nanoserver",
-          "latestVersion": "1809",
+          "latestVersion": "ltsc2019",
           "windowsSkuMatch": "2019-containerd"
         },
         {

--- a/schemas/components.cue
+++ b/schemas/components.cue
@@ -23,6 +23,7 @@ package components
 }
 
 #WindowsVersion: {
+	comment?:                string
 	k8sVersion?:             string
 	renovateTag?:            string
 	latestVersion:           string

--- a/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
@@ -645,7 +645,7 @@ Describe 'Tests of components.json ' {
 
         $components.Length | Should -BeGreaterThan 0
 
-        # Pause image shouldn't change too often, so let's check that is in there.
+        # core images shouldn't change too often, so let's check that is in there.
         $components | Should -Contain "mcr.microsoft.com/windows/servercore:ltsc2019"
         $components | Should -Contain "mcr.microsoft.com/windows/nanoserver:1809"
     }


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What this PR does / why we need it**:

Renovate identified nanoserver 1809 as a container that has a more recent version. It doesn't. Added a comment explaining why and have disabled renovate for nanoserver on ws2019.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
