### PR TITLE
Add owners for some components. Set compponents.json to no code-owner.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -201,10 +201,12 @@
       ],
       "groupName": "acr-credential-provider",
       "assignees": [
-        "mainred"
+        "mainred",
+        "MartinForReal"
       ],
       "reviewers": [
-        "mainred"
+        "mainred",
+        "MartinForReal"
       ]
     },
     {
@@ -246,7 +248,13 @@
       "matchPackageNames": [
         "oss/kubernetes/azure-cloud-node-manager"
       ],
-      "groupName": "azure-cloud-node-manager"
+      "groupName": "azure-cloud-node-manager",
+      "assignees": [
+        "MartinForReal"
+      ],
+      "reviewers": [
+        "MartinForReal"
+      ]
     },
     {
       "matchPackageNames": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -184,6 +184,22 @@
     },
     {
       "matchPackageNames": [
+        "oss/v2/open-policy-agent/gatekeeper",
+        "azure-policy/policy-kubernetes-addon-prod"
+      ],
+      "assignees": [
+        "kevinhwangkr-msft",
+        "anlandu",
+        "nreisch"
+      ],
+      "reviewers": [
+        "kevinhwangkr-msft",
+        "anlandu",
+        "nreisch"
+      ]
+    },
+    {
+      "matchPackageNames": [
         "oss/kubernetes/coredns",
         "oss/v2/kubernetes/coredns"
       ],

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,5 @@ nodecustomdata.yml @Devinwong @lilypan26 @r2k1 @timmy-wright
 # Code owners for the security patch release notes
 vhdbuilder/release-notes/security-patch/ @yagmurbaydogan @yewmsft @juan-lee @cameronmeissner @UtheMan @ganeshkumarashok @anujmaheshwari1 @AlisonB319 @Devinwong @lilypan26 @AbelHu @junjiezhang1997 @jason1028kr @djsly @phealy @r2k1 @timmy-wright @zachary-bailey
 
+# Set compponents.json to no code-owner so that it can be approved and merged by component owner.
+parts/common/components.json


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
1. Add owners for some components
2. Set components.json to no code-owner so that it can be approved and merged by component owner. Now every renovate changes to Renovate.json still needs code-owners to approve. This defeats the purpose of component owner to self-approve/merge their own PRs. If it ends up not going as expected, we can change it back.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
