### PR TITLE
chore: update ciprod to 3.1.25, exclude it from windows 23H2 SKU

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -383,16 +383,18 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=azuremonitor/containerinsights/ciprod",
-          "latestVersion": "3.1.24"
+          "latestVersion": "3.1.25"
         }
       ],
       "windowsVersions": [
         {
+          "comment": "ciprod isn't supported on Win23H2 so is excluded as it makes the VHD too large",
           "renovateTag": "registry=https://mcr.microsoft.com, name=azuremonitor/containerinsights/ciprod",
           "latestVersion": "3.1.25",
           "windowsSkuMatch": "2022*"
         },
         {
+          "comment": "ciprod isn't supported on Win23H2 so is excluded as it makes the VHD too large",
           "renovateTag": "registry=https://mcr.microsoft.com, name=azuremonitor/containerinsights/ciprod",
           "latestVersion": "3.1.25",
           "windowsSkuMatch": "2019*"

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -385,6 +385,18 @@
           "renovateTag": "registry=https://mcr.microsoft.com, name=azuremonitor/containerinsights/ciprod",
           "latestVersion": "3.1.24"
         }
+      ],
+      "windowsVersions": [
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=azuremonitor/containerinsights/ciprod",
+          "latestVersion": "3.1.25",
+          "windowsSkuMatch": "2022*"
+        },
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=azuremonitor/containerinsights/ciprod",
+          "latestVersion": "3.1.25",
+          "windowsSkuMatch": "2019*"
+        }
       ]
     },
     {

--- a/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
@@ -581,10 +581,27 @@ Describe 'Tests of components.json ' {
         $components | Should -Contain "mcr.microsoft.com/oss/kubernetes/pause:3.9"
     }
 
-    it 'has the right version of ciprod' {
+    it 'has the right version of ciprod for win 2019' {
+        $windowsSku = "2019-containerd"
         $components = GetComponentsFromComponentsJson $componentsJson
 
-        $components | Should -Contain "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-3.1.24"
+        $components | Should -Contain "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-3.1.25"
+    }
+
+
+    it 'has the right version of ciprod for win 2022' {
+        $windowsSku = "2022-containerd"
+        $components = GetComponentsFromComponentsJson $componentsJson
+
+        $components | Should -Contain "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-3.1.25"
+    }
+
+
+    it 'has the no version of ciprod for win 23H2' {
+        $windowsSku = "23H2"
+        $components = GetComponentsFromComponentsJson $componentsJson
+
+        $components | Should -Not -Contain "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-3.1.25"
     }
 
     It 'has the latest 2 versions of windows scripts and cgmaplugin' {
@@ -617,6 +634,7 @@ Describe 'Tests of components.json ' {
         $packages["c:\akse-cache\win-vnet-cni\"] | Should -Contain "https://acs-mirror.azureedge.net/azure-cni/v1.6.18/binaries/azure-vnet-cni-windows-amd64-v1.6.18.zip"
         $packages["c:\akse-cache\win-vnet-cni\"] | Should -Contain "https://acs-mirror.azureedge.net/azure-cni/v1.4.58/binaries/azure-vnet-cni-swift-windows-amd64-v1.4.58.zip"
         $packages["c:\akse-cache\win-vnet-cni\"] | Should -Contain "https://acs-mirror.azureedge.net/azure-cni/v1.4.59/binaries/azure-vnet-cni-swift-windows-amd64-v1.4.59.zip"
+
         $packages["c:\akse-cache\win-vnet-cni\"] | Should -Contain "https://acs-mirror.azureedge.net/azure-cni/v1.4.58/binaries/azure-vnet-cni-overlay-windows-amd64-v1.4.58.zip"
         $packages["c:\akse-cache\win-vnet-cni\"] | Should -Contain "https://acs-mirror.azureedge.net/azure-cni/v1.4.59/binaries/azure-vnet-cni-overlay-windows-amd64-v1.4.59.zip"
     }


### PR DESCRIPTION
**What type of PR is this?**
 
/kind chore

**What this PR does / why we need it**:

Updates ciprod container to 3.1.25. This made the windows 23H2 VHD become too large and fail the build. After much discussion, we realised that ciprod isn't supported on windows 23H2, so is not needed there.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
