### PR TITLE
chore: add exclusions so we don't build linux vhds when the windows settings cue file changes

### DIFF
--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -7,7 +7,7 @@ pr:
     - dev
   paths:
     include:
-    - schemas
+    - schemas/
     - vhdbuilder/packer
     - vhdbuilder/scripts/linux
     - .pipelines/.vsts-vhd-builder.yaml
@@ -18,9 +18,11 @@ pr:
     - aks-node-controller/**
     - parts/common/components.json
     exclude:
+    - schemas/windows_settings.cue
     - vhdbuilder/release-notes
     - vhdbuilder/packer/*.ps1
     - vhdbuilder/packer/**/*.ps1
+    - vhdbuilder/packer/windows/
     - vhdbuilder/packer/*windows*
     - vhdbuilder/packer/**/*windows*
     - /**/*.md


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What this PR does / why we need it**:

Reduces number of linux VHD builds - I noticed an unnecessary one on a windows related PR so this fixes it.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
