### PR TITLE
chore: fix var substitution in components.json for windows and add CPU_ARCH substutition

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -820,7 +820,7 @@
                 "previousLatestVersion": "0.0.50"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v[version].zip"
+            "downloadURL": "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v${version}.zip"
           }
         }
       }
@@ -837,7 +837,7 @@
                 "latestVersion": "1.1.5"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/ccgakvplugin/v1.1.5/binaries/windows-gmsa-ccgakvplugin-v[version].zip"
+            "downloadURL": "https://acs-mirror.azureedge.net/ccgakvplugin/v1.1.5/binaries/windows-gmsa-ccgakvplugin-v${version}.zip"
           }
         }
       }
@@ -854,7 +854,7 @@
                 "latestVersion": "1.1.2-hotfix.20230807"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/csi-proxy/v[version]/binaries/csi-proxy-v[version].tar.gz"
+            "downloadURL": "https://acs-mirror.azureedge.net/csi-proxy/v${version}/binaries/csi-proxy-v${version}.tar.gz"
           }
         }
       }
@@ -872,7 +872,7 @@
                 "previousLatestVersion": "1.30.0"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/cloud-provider-azure/v[version]/binaries/azure-acr-credential-provider-windows-amd64-v[version].tar.gz"
+            "downloadURL": "https://acs-mirror.azureedge.net/cloud-provider-azure/v${version}/binaries/azure-acr-credential-provider-windows-amd64-v${version}.tar.gz"
           }
         }
       }
@@ -889,7 +889,7 @@
                 "latestVersion": "3.24.0"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/calico-node/v[version]/binaries/calico-windows-v[version].zip"
+            "downloadURL": "https://acs-mirror.azureedge.net/calico-node/v${version}/binaries/calico-windows-v${version}.zip"
           }
         }
       }
@@ -907,7 +907,7 @@
                 "previousLatestVersion": "1.5.38"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/azure-cni/v[version]/binaries/azure-vnet-cni-windows-amd64-v[version].zip"
+            "downloadURL": "https://acs-mirror.azureedge.net/azure-cni/v${version}/binaries/azure-vnet-cni-windows-amd64-v${version}.zip"
           }
         }
       }
@@ -925,7 +925,7 @@
                 "previousLatestVersion": "1.4.58"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/azure-cni/v[version]/binaries/azure-vnet-cni-swift-windows-amd64-v[version].zip"
+            "downloadURL": "https://acs-mirror.azureedge.net/azure-cni/v${version}/binaries/azure-vnet-cni-swift-windows-amd64-v${version}.zip"
           }
         }
       }
@@ -943,7 +943,7 @@
                 "previousLatestVersion": "1.4.58"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/azure-cni/v[version]/binaries/azure-vnet-cni-overlay-windows-amd64-v[version].zip"
+            "downloadURL": "https://acs-mirror.azureedge.net/azure-cni/v${version}/binaries/azure-vnet-cni-overlay-windows-amd64-v${version}.zip"
           }
         }
       }
@@ -1092,7 +1092,7 @@
                 "previousLatestVersion": "v1.7.17-azure.1"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/containerd/windows/[version]/binaries/containerd-[version]-windows-amd64.tar.gz"
+            "downloadURL": "https://acs-mirror.azureedge.net/containerd/windows/${version}/binaries/containerd-${version}-windows-amd64.tar.gz"
           },
           "ws2022": {
             "versionsV2": [
@@ -1106,7 +1106,7 @@
                 "previousLatestVersion": "v1.7.17-azure.1"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/containerd/windows/[version]/binaries/containerd-[version]-windows-amd64.tar.gz"
+            "downloadURL": "https://acs-mirror.azureedge.net/containerd/windows/${version}/binaries/containerd-${version}-windows-amd64.tar.gz"
           },
           "default": {
             "versionsV2": [
@@ -1116,7 +1116,7 @@
                 "previousLatestVersion": "v1.7.17-azure.1"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/containerd/windows/[version]/binaries/containerd-[version]-windows-amd64.tar.gz"
+            "downloadURL": "https://acs-mirror.azureedge.net/containerd/windows/${version}/binaries/containerd-${version}-windows-amd64.tar.gz"
           }
         },
         "default": {
@@ -1247,7 +1247,7 @@
               }
             ],
             "downloadURL": "mcr.microsoft.com/oss/binaries/kubernetes/kubernetes-node:${version}-linux-${CPU_ARCH}",
-            "windowsDownloadURL": "https://acs-mirror.azureedge.net/kubernetes/[version]/windowszip/[version]-1int.zip"
+            "windowsDownloadURL": "https://acs-mirror.azureedge.net/kubernetes/${version}/windowszip/${version}-1int.zip"
           }
         }
       }

--- a/vhdbuilder/packer/windows/components_json_helpers.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.ps1
@@ -1,3 +1,19 @@
+
+function SafeReplaceString {
+    Param(
+        [Parameter(Mandatory = $true)][string]
+        $stringToReplace
+    )
+
+    $stringToReplace = &{
+        Clear-Variable -Name * -Exclude version,CPU_ARCH,stringToReplace -ErrorAction SilentlyContinue
+        $executionContext.InvokeCommand.ExpandString($stringToReplace)
+    }
+
+    return $stringToReplace
+}
+
+
 function GetComponentsFromComponentsJson
 {
     Param(
@@ -27,14 +43,14 @@ function GetComponentsFromComponentsJson
             if ($skuMatch -eq $null -or $windowsSku -eq $null -or $windowsSku -Like $skuMatch)
             {
                 $version = $windowsVersion.latestVersion
-                $url = $executionContext.InvokeCommand.ExpandString($downloadUrl)
+                $url = SafeReplaceString($downloadUrl)
                 $url = $url.replace("*", $windowsVersion.latestVersion)
                 $output += $url
 
                 if (-not [string]::IsNullOrEmpty($windowsVersion.previousLatestVersion))
                 {
                     $version = $windowsVersion.previousLatestVersion
-                    $url = $executionContext.InvokeCommand.ExpandString($downloadUrl)
+                    $url = SafeReplaceString($downloadUrl)
                     $url = $url.replace("*", $windowsVersion.previousLatestVersion)
                     $output += $url
                 }
@@ -107,13 +123,13 @@ function GetPackagesFromComponentsJson
         foreach ($windowsVersion in $items)
         {
             $version = $windowsVersion.latestVersion
-            $url = $executionContext.InvokeCommand.ExpandString($downloadUrl)
+            $url = SafeReplaceString($downloadUrl)
             $thisList += $url
 
             if (-not [string]::IsNullOrEmpty($windowsVersion.previousLatestVersion))
             {
                 $version = $windowsVersion.previousLatestVersion
-                $url = $executionContext.InvokeCommand.ExpandString($downloadUrl)
+                $url = SafeReplaceString($downloadUrl)
                 $thisList += $url
             }
         }

--- a/vhdbuilder/packer/windows/components_json_helpers.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.ps1
@@ -102,12 +102,12 @@ function GetPackagesFromComponentsJson
 
         foreach ($windowsVersion in $items)
         {
-            $url = $downloadUrl.replace("[version]", $windowsVersion.latestVersion)
+            $url = $downloadUrl.replace("`${version}", $windowsVersion.latestVersion)
             $thisList += $url
 
             if (-not [string]::IsNullOrEmpty($windowsVersion.previousLatestVersion))
             {
-                $url = $downloadUrl.replace("[version]", $windowsVersion.previousLatestVersion)
+                $url = $downloadUrl.replace("`${version}", $windowsVersion.previousLatestVersion)
                 $thisList += $url
             }
         }

--- a/vhdbuilder/packer/windows/components_json_helpers.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.ps1
@@ -26,12 +26,16 @@ function GetComponentsFromComponentsJson
             $skuMatch = $windowsVersion.windowsSkuMatch
             if ($skuMatch -eq $null -or $windowsSku -eq $null -or $windowsSku -Like $skuMatch)
             {
-                $url = $downloadUrl.replace("*", $windowsVersion.latestVersion)
+                $version = $windowsVersion.latestVersion
+                $url = $executionContext.InvokeCommand.ExpandString($downloadUrl)
+                $url = $url.replace("*", $windowsVersion.latestVersion)
                 $output += $url
 
                 if (-not [string]::IsNullOrEmpty($windowsVersion.previousLatestVersion))
                 {
-                    $url = $downloadUrl.replace("*", $windowsVersion.previousLatestVersion)
+                    $version = $windowsVersion.previousLatestVersion
+                    $url = $executionContext.InvokeCommand.ExpandString($downloadUrl)
+                    $url = $url.replace("*", $windowsVersion.previousLatestVersion)
                     $output += $url
                 }
             }
@@ -102,12 +106,14 @@ function GetPackagesFromComponentsJson
 
         foreach ($windowsVersion in $items)
         {
-            $url = $downloadUrl.replace("`${version}", $windowsVersion.latestVersion)
+            $version = $windowsVersion.latestVersion
+            $url = $executionContext.InvokeCommand.ExpandString($downloadUrl)
             $thisList += $url
 
             if (-not [string]::IsNullOrEmpty($windowsVersion.previousLatestVersion))
             {
-                $url = $downloadUrl.replace("`${version}", $windowsVersion.previousLatestVersion)
+                $version = $windowsVersion.previousLatestVersion
+                $url = $executionContext.InvokeCommand.ExpandString($downloadUrl)
                 $thisList += $url
             }
         }

--- a/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
@@ -344,7 +344,7 @@ Describe 'Gets the Binaries' {
                 "previousLatestVersion": "0.0.51"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v[version].zip"
+            "downloadURL": "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v${version}.zip"
           }
         }
       }
@@ -385,7 +385,7 @@ Describe 'Gets the Binaries' {
             }
         )
         $componentsJson.Packages[0].windowsDownloadLocation = "location"
-        $componentsJson.Packages[0].downloadUris.windows.default.downloadURL = "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v[version].zip"
+        $componentsJson.Packages[0].downloadUris.windows.default.downloadURL = "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v`${version}.zip"
 
         $packages = GetPackagesFromComponentsJson $componentsJson
 
@@ -403,7 +403,7 @@ Describe 'Gets the Binaries' {
             }
         )
         $componentsJson.Packages[0].windowsDownloadLocation = "location"
-        $componentsJson.Packages[0].downloadUris.windows.default.downloadURL = "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v[version].zip"
+        $componentsJson.Packages[0].downloadUris.windows.default.downloadURL = "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v`${version}.zip"
 
         $packages = GetPackagesFromComponentsJson $componentsJson
 
@@ -418,7 +418,7 @@ Describe 'Gets the Binaries' {
             }
         )
         $componentsJson.Packages[0].windowsDownloadLocation = "location"
-        $componentsJson.Packages[0].downloadUris.windows.default.downloadURL = "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v[version].zip"
+        $componentsJson.Packages[0].downloadUris.windows.default.downloadURL = "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v`${version}.zip"
 
         $packages = GetPackagesFromComponentsJson $componentsJson
 
@@ -439,7 +439,7 @@ Describe 'Gets the Binaries' {
                 "latestVersion": "0.0.48"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v[version].zip"
+            "downloadURL": "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v${version}.zip"
           }
         }
       }
@@ -455,7 +455,7 @@ Describe 'Gets the Binaries' {
                 "latestVersion": "0.0.49"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v[version].zip"
+            "downloadURL": "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v${version}.zip"
           }
         }
       }
@@ -484,7 +484,7 @@ Describe 'Gets the Binaries' {
                 "latestVersion": "0.0.49"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v[version].zip"
+            "downloadURL": "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v${version}.zip"
           },
           "default": {
             "versionsV2": [
@@ -493,7 +493,7 @@ Describe 'Gets the Binaries' {
                 "latestVersion": "0.0.48"
               }
             ],
-            "downloadURL": "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v[version].zip"
+            "downloadURL": "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v${version}.zip"
           }
         }
       }

--- a/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
@@ -522,6 +522,21 @@ Describe 'Gets The Versions' {
         $componentsJson = echo $testString | ConvertFrom-Json
     }
 
+    It 'replaces CPU_ARCH in the string' {
+        $componentsJson.ContainerImages[0].windowsVersions = @(
+            [PSCustomObject]@{
+                latestVersion = "1.8.22"
+            }
+        )
+        $componentsJson.ContainerImages[0].downloadURL = "mcr.microsoft.com/oss/kubernetes/autoscaler/`${CPU_ARCH}/addon-resizer:*"
+
+        $CPU_ARCH="x86"
+        $components = GetComponentsFromComponentsJson $componentsJson
+
+        $components | Should -HaveCount 1
+        $components | Should -Contain "mcr.microsoft.com/oss/kubernetes/autoscaler/x86/addon-resizer:1.8.22"
+    }
+
     It 'given there are no container images, it returns an empty array' {
         $componentsJson.ContainerImages = @()
 

--- a/vhdbuilder/packer/windows/windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/windows/windows-vhd-configuration.ps1
@@ -28,8 +28,10 @@ $CPU_ARCH = switch ($cpu.Architecture) {
 Write-Output ($cpu | ConvertTo-Json)
 
 if ([string]::IsNullOrEmpty($CPU_ARCH)) {
-    Write-Output "Unknown architecture for CPU ${cpu.Name} with arch ${cpu.Architecture}"
-    throw "Unsupported architecture for SKU $windowsSKU for CPU ${cpu.Name} with arch ${cpu.Architecture}"
+    $cpuName = $cpu.Name
+    $cpuArch = $cpu.Architecture
+    Write-Output "Unknown architecture for CPU $cpuName with arch $cpuArch"
+    throw "Unsupported architecture for SKU $windowsSKU for CPU $cpuName with arch $cpuArch"
 }
 
 $HelpersFile = "c:/k/components_json_helpers.ps1"

--- a/vhdbuilder/packer/windows/windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/windows/windows-vhd-configuration.ps1
@@ -27,11 +27,10 @@ $CPU_ARCH = switch ($cpu.Architecture) {
 
 Write-Output ($cpu | ConvertTo-Json)
 
-if ([string]::IsNullOrEmpty($windowsVersion.previousLatestVersion)) {
+if ([string]::IsNullOrEmpty($CPU_ARCH)) {
     Write-Output "Unknown architecture for CPU ${cpu.Name} with arch ${cpu.Architecture}"
     throw "Unsupported architecture for SKU $windowsSKU for CPU ${cpu.Name} with arch ${cpu.Architecture}"
 }
-
 
 $HelpersFile = "c:/k/components_json_helpers.ps1"
 $ComponentsJsonFile = "c:/k/components.json"

--- a/vhdbuilder/packer/windows/windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/windows/windows-vhd-configuration.ps1
@@ -22,12 +22,14 @@ $CPU_ARCH = switch ($cpu.Architecture) {
     5 { "arm64" } # ARM
     6 { "amd64" } # Itanium
     9 { "amd64" } # x64
-    default { "Unknown" }
+    default { "" }
 }
 
+Write-Output ($cpu | ConvertTo-Json)
+
 if ([string]::IsNullOrEmpty($windowsVersion.previousLatestVersion)) {
-    Write-Output "Unknown architecture for CPU $($cpu.Name) with arch $cpu.Architecture"
-    throw "Unsupported architecture for SKU $windowsSKU for CPU $($cpu.Name) with arch $cpu.Architecture"
+    Write-Output "Unknown architecture for CPU ${cpu.Name} with arch ${cpu.Architecture}"
+    throw "Unsupported architecture for SKU $windowsSKU for CPU ${cpu.Name} with arch ${cpu.Architecture}"
 }
 
 

--- a/vhdbuilder/packer/windows/windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/windows/windows-vhd-configuration.ps1
@@ -13,6 +13,24 @@ $global:aksToolsDir = "c:\aks-tools"
 # We need to guarantee that the node provisioning will not fail because the vhd is full before resize-osdisk is called in AKS Windows CSE script.
 $global:lowestFreeSpace = 1*1024*1024*1024 # 1GB
 
+$cpu = Get-WmiObject -Class Win32_Processor
+$CPU_ARCH = switch ($cpu.Architecture) {
+    0 { "amd64" } # x86
+    1 { "" } # MIPS
+    2 { "" } # Alpha
+    3 { "" } # PowerPC
+    5 { "arm64" } # ARM
+    6 { "amd64" } # Itanium
+    9 { "amd64" } # x64
+    default { "Unknown" }
+}
+
+if ([string]::IsNullOrEmpty($windowsVersion.previousLatestVersion)) {
+    Write-Output "Unknown architecture for CPU $($cpu.Name) with arch $cpu.Architecture"
+    throw "Unsupported architecture for SKU $windowsSKU for CPU $($cpu.Name) with arch $cpu.Architecture"
+}
+
+
 $HelpersFile = "c:/k/components_json_helpers.ps1"
 $ComponentsJsonFile = "c:/k/components.json"
 $WindowsSettingsFile = "c:/k/windows_settings.json"


### PR DESCRIPTION
**What type of PR is this?**
/kind chore

**What this PR does / why we need it**:

Currently windows components and linux components use different variable substitution mechanisms in components.json, which makes it hard to share urls and download sources. This PR makes Windows consistent with Linux and also sets CPU_ARCH for Windows so it can be used in urls.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
