### PR TITLE
bug: don't need to set agentkey in the cs

### DIFF
--- a/parts/windows/kuberneteswindowssetup.ps1
+++ b/parts/windows/kuberneteswindowssetup.ps1
@@ -47,7 +47,6 @@ $Location="{{ GetVariable "location" }}"
 $UserAssignedClientID="{{ GetVariable "userAssignedIdentityID" }}"
 {{ end }}
 $TargetEnvironment="{{ GetTargetEnvironment }}"
-$AgentKey="{{ GetParameter "clientPrivateKey" }}"
 $AADClientId="{{ GetParameter "servicePrincipalClientId" }}"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+CustomCloud+ootcredentialprovider/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+CustomCloud+ootcredentialprovider/CustomData
@@ -45,7 +45,6 @@ $MasterFQDNPrefix="uttestdom"
 $Location="southcentralus"
 
 $TargetEnvironment="akscustom"
-$AgentKey=""
 $AADClientId="ClientID"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+CustomCloud/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+CustomCloud/CustomData
@@ -45,7 +45,6 @@ $MasterFQDNPrefix="uttestdom"
 $Location="southcentralus"
 
 $TargetEnvironment="akscustom"
-$AgentKey=""
 $AADClientId="ClientID"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+CustomVnet/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+CustomVnet/CustomData
@@ -45,7 +45,6 @@ $MasterFQDNPrefix="uttestdom"
 $Location="southcentralus"
 
 $TargetEnvironment="AzurePublicCloud"
-$AgentKey=""
 $AADClientId="ClientID"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+EnablePrivateClusterHostsConfigAgent/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+EnablePrivateClusterHostsConfigAgent/CustomData
@@ -45,7 +45,6 @@ $MasterFQDNPrefix="uttestdom"
 $Location="southcentralus"
 
 $TargetEnvironment="AzurePublicCloud"
-$AgentKey=""
 $AADClientId="ClientID"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+K8S116/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S116/CustomData
@@ -45,7 +45,6 @@ $MasterFQDNPrefix="uttestdom"
 $Location="southcentralus"
 
 $TargetEnvironment="AzurePublicCloud"
-$AgentKey=""
 $AADClientId="ClientID"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+K8S117/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S117/CustomData
@@ -45,7 +45,6 @@ $MasterFQDNPrefix="uttestdom"
 $Location="southcentralus"
 
 $TargetEnvironment="AzurePublicCloud"
-$AgentKey=""
 $AADClientId="ClientID"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+K8S118/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S118/CustomData
@@ -45,7 +45,6 @@ $MasterFQDNPrefix="uttestdom"
 $Location="southcentralus"
 
 $TargetEnvironment="AzurePublicCloud"
-$AgentKey=""
 $AADClientId="ClientID"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+K8S119+CSI/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S119+CSI/CustomData
@@ -45,7 +45,6 @@ $MasterFQDNPrefix="uttestdom"
 $Location="southcentralus"
 
 $TargetEnvironment="AzurePublicCloud"
-$AgentKey=""
 $AADClientId="ClientID"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+K8S119+FIPS/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S119+FIPS/CustomData
@@ -45,7 +45,6 @@ $MasterFQDNPrefix="uttestdom"
 $Location="southcentralus"
 
 $TargetEnvironment="AzurePublicCloud"
-$AgentKey=""
 $AADClientId="ClientID"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+K8S119/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S119/CustomData
@@ -45,7 +45,6 @@ $MasterFQDNPrefix="uttestdom"
 $Location="southcentralus"
 
 $TargetEnvironment="AzurePublicCloud"
-$AgentKey=""
 $AADClientId="ClientID"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+KubeletClientTLSBootstrapping/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+KubeletClientTLSBootstrapping/CustomData
@@ -45,7 +45,6 @@ $MasterFQDNPrefix="uttestdom"
 $Location="southcentralus"
 
 $TargetEnvironment="AzurePublicCloud"
-$AgentKey=""
 $AADClientId="ClientID"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+KubeletServingCertificateRotation/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+KubeletServingCertificateRotation/CustomData
@@ -45,7 +45,6 @@ $MasterFQDNPrefix="uttestdom"
 $Location="southcentralus"
 
 $TargetEnvironment="AzurePublicCloud"
-$AgentKey=""
 $AADClientId="ClientID"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+ManagedIdentity/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+ManagedIdentity/CustomData
@@ -47,7 +47,6 @@ $Location="southcentralus"
 $UserAssignedClientID="userAssignedID"
 
 $TargetEnvironment="AzurePublicCloud"
-$AgentKey=""
 $AADClientId="msi"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+SecurityProfile/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+SecurityProfile/CustomData
@@ -45,7 +45,6 @@ $MasterFQDNPrefix="uttestdom"
 $Location="southcentralus"
 
 $TargetEnvironment="AzurePublicCloud"
-$AgentKey=""
 $AADClientId="ClientID"
 $NetworkAPIVersion="2018-08-01"
 

--- a/pkg/agent/testdata/AKSWindows2019+ootcredentialprovider/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+ootcredentialprovider/CustomData
@@ -45,7 +45,6 @@ $MasterFQDNPrefix="uttestdom"
 $Location="southcentralus"
 
 $TargetEnvironment="AzurePublicCloud"
-$AgentKey=""
 $AADClientId="ClientID"
 $NetworkAPIVersion="2018-08-01"
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

AgentKey is being set both in the CSE and the run command. It only needs to be set in one place. And the run command is more secure.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
