### PR TITLE
chore: move base image urls to pipeline vars

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -59,6 +59,22 @@ parameters:
     displayName: Branch in aks-rp to use for overrides
     type: string
     default: master
+  - name: ws2019BaseImageUrl
+    displayName: WS2019 base image URL
+    type: string
+    default:
+  - name: ws2022BaseImageUrl
+    displayName: WS2022 base image URL
+    type: string
+    default:
+  - name: ws23H2BaseImageUrl
+    displayName: WS23H2 base image URL
+    type: string
+    default:
+  - name: ws2025BaseImageUrl
+    displayName: ws2025 base image URL
+    type: string
+    default:
 
 # Use variable group "ab-windows-ame-tenant" and link it to the pipeline "AKS Windows VHD Build"
 # Use variable group "ab-windows-ame-tenant" and link it to the pipeline "AKS Windows VHD Build - PR check-in gate"
@@ -79,3 +95,7 @@ stages:
       installOpenSshServer: ${{ parameters.installOpenSshServer }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
+      ws2019BaseImageUrl: {{ parameters.ws2019BaseImageUrl }}
+      ws2022BaseImageUrl: {{ parameters.ws2022BaseImageUrl }}
+      ws23H2BaseImageUrl: {{ parameters.ws23H2BaseImageUrl }}
+      ws2025BaseImageUrl: {{ parameters.ws2025BaseImageUrl }}

--- a/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
@@ -39,6 +39,22 @@ parameters:
   - name: useOverrides
     displayName: Use component overrides
     type: boolean
+  - name: ws2019BaseImageUrl
+    displayName: WS2019 base image URL
+    type: string
+    default:
+  - name: ws2022BaseImageUrl
+    displayName: WS2022 base image URL
+    type: string
+    default:
+  - name: ws23H2BaseImageUrl
+    displayName: WS23H2 base image URL
+    type: string
+    default:
+  - name: ws2025BaseImageUrl
+    displayName: ws2025 base image URL
+    type: string
+    default:
 
 stages:
   - template: ./.build-and-test-windows-vhd-template.yaml
@@ -55,7 +71,7 @@ stages:
       buildVmSize: ${{ parameters.buildVmSize }}
       installOpenSshServer: ${{ parameters.installOpenSshServer }}
       skipExtensionCheck: ${{ parameters.skipExtensionCheck }}
-      windowsBaseImageUrl: $(WINDOWS_2019_BASE_IMAGE_URL)
+      windowsBaseImageUrl: ${{ parameters.ws2019BaseImageUrl }}
       windowsNanoImageUrl: $(WINDOWS_2019_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2019_CORE_IMAGE_URL)
       overrideBranch: ${{ parameters.overrideBranch }}
@@ -75,7 +91,7 @@ stages:
       buildVmSize: ${{ parameters.buildVmSize }}
       installOpenSshServer: ${{ parameters.installOpenSshServer }}
       skipExtensionCheck: ${{ parameters.skipExtensionCheck }}
-      windowsBaseImageUrl: $(WINDOWS_2022_BASE_IMAGE_URL)
+      windowsBaseImageUrl: ${{ parameters.ws2022BaseImageUrl }}
       windowsNanoImageUrl: $(WINDOWS_2022_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2022_CORE_IMAGE_URL)
       overrideBranch: ${{ parameters.overrideBranch }}
@@ -95,7 +111,7 @@ stages:
       dryrun: ${{ parameters.dryrun }}
       installOpenSshServer: ${{ parameters.installOpenSshServer }}
       skipExtensionCheck: ${{ parameters.skipExtensionCheck }}
-      windowsBaseImageUrl: $(WINDOWS_23H2_GEN2_BASE_IMAGE_URL)
+      windowsBaseImageUrl: ${{ parameters.ws2022BaseImageUrl }}
       windowsNanoImageUrl: $(WINDOWS_2022_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2022_CORE_IMAGE_URL)
       overrideBranch: ${{ parameters.overrideBranch }}
@@ -115,7 +131,7 @@ stages:
       dryrun: ${{ parameters.dryrun }}
       installOpenSshServer: ${{ parameters.installOpenSshServer }}
       skipExtensionCheck: ${{ parameters.skipExtensionCheck }}
-      windowsBaseImageUrl: $(WINDOWS_23H2_BASE_IMAGE_URL)
+      windowsBaseImageUrl: ${{ parameters.ws23H2BaseImageUrl }}
       windowsNanoImageUrl: $(WINDOWS_2022_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2022_CORE_IMAGE_URL)
       overrideBranch: ${{ parameters.overrideBranch }}
@@ -135,7 +151,7 @@ stages:
       dryrun: ${{ parameters.dryrun }}
       installOpenSshServer: ${{ parameters.installOpenSshServer }}
       skipExtensionCheck: ${{ parameters.skipExtensionCheck }}
-      windowsBaseImageUrl: $(WINDOWS_23H2_GEN2_BASE_IMAGE_URL)
+      windowsBaseImageUrl: ${{ parameters.ws23H2BaseImageUrl }}
       windowsNanoImageUrl: $(WINDOWS_2022_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2022_CORE_IMAGE_URL)
       overrideBranch: ${{ parameters.overrideBranch }}


### PR DESCRIPTION
**What type of PR is this?**

 /kind chore

**What this PR does / why we need it**:

Moves the base image URLs to pipeline params rather than pipeline vars. This will make it easier to add new windows versions in the future.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
