### PR TITLE
feat: install -debug UVMs for kata images

### DIFF
--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -76,9 +76,13 @@ steps:
       itemPattern: |
         **/kata-containers-igvm-debug.img**
         **/igvm-measurement**
+        **/igvm-debug-measurement**
         **/kata-containers-igvm.img**
         **/kata-containers-cc.img**
         **/kata-containers.img**
+        **/kata-containers-debug.img**
+        **/kata-containers-cc.img**
+        **/kata-containers-cc-debug.img**
         **/kata-containers-initrd-base.img**
         **/reference-info-base64**
       downloadPath: $(Build.SourcesDirectory)

--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -160,27 +160,31 @@ copyPackerFiles() {
       KATA_INITRD_SRC=/home/packer/kata-containers-initrd-base.img
       KATA_INITRD_DEST=$KATA_CONFIG_DIR/kata-containers-initrd.img
       cpAndMode $KATA_INITRD_SRC $KATA_INITRD_DEST 0755
-
-      KATACC_IMAGE_SRC=/home/packer/kata-containers.img
-      KATACC_IMAGE_DEST=$KATACC_CONFIG_DIR/kata-containers.img
-      cpAndMode $KATACC_IMAGE_SRC $KATACC_IMAGE_DEST 0755
-    elif [[ $OS_VERSION == "3.0" ]]; then
-      KATA_IMAGE_SRC=/home/packer/kata-containers.img
-      KATA_IMAGE_DEST=$KATA_CONFIG_DIR/kata-containers.img
-      cpAndMode $KATA_IMAGE_SRC $KATA_IMAGE_DEST 0755
-
-      KATACC_IMAGE_SRC=/home/packer/kata-containers-cc.img
-      KATACC_IMAGE_DEST=$KATACC_CONFIG_DIR/kata-containers.img
-      cpAndMode $KATACC_IMAGE_SRC $KATACC_IMAGE_DEST 0755
     fi
+
+    IGVM_BIN_SRC=/home/packer/kata-containers-igvm.img
+    IGVM_BIN_DEST=$KATACC_CONFIG_DIR/kata-containers-igvm.img
+    cpAndMode $IGVM_BIN_SRC $IGVM_BIN_DEST 0755
 
     IGVM_DEBUG_BIN_SRC=/home/packer/kata-containers-igvm-debug.img
     IGVM_DEBUG_BIN_DEST=$KATACC_CONFIG_DIR/kata-containers-igvm-debug.img
     cpAndMode $IGVM_DEBUG_BIN_SRC $IGVM_DEBUG_BIN_DEST 0755
 
-    IGVM_BIN_SRC=/home/packer/kata-containers-igvm.img
-    IGVM_BIN_DEST=$KATACC_CONFIG_DIR/kata-containers-igvm.img
-    cpAndMode $IGVM_BIN_SRC $IGVM_BIN_DEST 0755
+    KATA_IMAGE_SRC=/home/packer/kata-containers.img
+    KATA_IMAGE_DEST=$KATA_CONFIG_DIR/kata-containers.img
+    cpAndMode $KATA_IMAGE_SRC $KATA_IMAGE_DEST 0755
+
+    KATA_DBG_IMAGE_SRC=/home/packer/kata-containers-debug.img
+    KATA_DBG_IMAGE_DEST=$KATA_CONFIG_DIR/kata-containers-debug.img
+    cpAndMode $KATA_DBG_IMAGE_SRC $KATA_DBG_IMAGE_DEST 0755
+
+    KATACC_IMAGE_SRC=/home/packer/kata-containers-cc.img
+    KATACC_IMAGE_DEST=$KATACC_CONFIG_DIR/kata-containers-cc.img
+    cpAndMode $KATACC_IMAGE_SRC $KATACC_IMAGE_DEST 0755
+
+    KATACC_DBG_IMAGE_SRC=/home/packer/kata-containers-cc-debug.img
+    KATACC_DBG_IMAGE_DEST=$KATACC_CONFIG_DIR/kata-containers-cc-debug.img
+    cpAndMode $KATACC_DBG_IMAGE_SRC $KATACC_DBG_IMAGE_DEST 0755
 
     REF_INFO_SRC=/home/packer/reference-info-base64
     REF_INFO_DEST=$KATACC_CONFIG_DIR/reference-info-base64

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -572,8 +572,18 @@
     },
     {
       "type": "file",
+      "source": "kata-containers-debug.img",
+      "destination": "/home/packer/kata-containers-debug.img"
+    },
+    {
+      "type": "file",
       "source": "kata-containers-cc.img",
       "destination": "/home/packer/kata-containers-cc.img"
+    },
+    {
+      "type": "file",
+      "source": "kata-containers-cc-debug.img",
+      "destination": "/home/packer/kata-containers-cc-debug.img"
     },
     {
       "type": "file",


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
-->

**What this PR does / why we need it**:
Introduce logic to install the new schema of UVM images/components for kata containers and kata-cc, which are as follows:

kata-containers.img
kata-containers-debug.img
kata-containers-cc.img
kata-containers-cc-debug.img

Associated igvm, igvm-debug files for CC now map to the -cc and -cc-debug images respectively. This will allow for greater flexibility in composing these UVM images, allowing us to have different package compositions for production vs. debug pod sandboxes. 

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
