### PR TITLE
regression: set windows 2019 disk size

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -814,8 +814,7 @@
             "versionsV2": [
               {
                 "renovateTag": "<DO_NOT_UPDATE>",
-                "latestVersion": "0.0.51",
-                "previousLatestVersion": "0.0.50"
+                "latestVersion": "0.0.51"
               }
             ],
             "downloadURL": "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v${version}.zip"

--- a/schemas/windows_settings.cue
+++ b/schemas/windows_settings.cue
@@ -20,7 +20,7 @@
 
 #WindowsBaseVersion: {
   comment?:           string
-  os_disk_size?:      string
+  os_disk_size:      string
   base_image_sku:     string,
   base_image_version: string
   windows_image_name: string

--- a/vhdbuilder/packer/init-variables.sh
+++ b/vhdbuilder/packer/init-variables.sh
@@ -352,6 +352,8 @@ if [ "$OS_TYPE" == "Windows" ]; then
   if [ "null" != "${OS_DISK_SIZE}" ]; then
     echo "Setting os_disk_size_gb to the value in windows-settings.json for ${WINDOWS_SKU}: ${OS_DISK_SIZE}"
     os_disk_size_gb=${OS_DISK_SIZE}
+  else
+    os_disk_size_gb="30"
   fi
 
   imported_windows_image_name="${WINDOWS_IMAGE_NAME}-imported-${CREATE_TIME}-${RANDOM}"

--- a/vhdbuilder/packer/windows/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/windows/configure-windows-vhd.ps1
@@ -94,6 +94,8 @@ function Download-File
         }
         throw "Curl exited with '$curlExitCode' while attempting to download '$logURL' to '$Dest'"
     }
+
+    dir "$Dest"
 }
 
 function Download-FileWithAzCopy
@@ -134,6 +136,8 @@ function Download-FileWithAzCopy
 
     Write-Log "Copying $URL to $Dest"
     .\azcopy.exe copy "$URL" "$Dest"
+
+    dir "$Dest"
 
     Write-Log "--- START AzCopy Log"
     Get-Content "$env:AZCOPY_LOG_LOCATION\*.log" | Write-Log

--- a/vhdbuilder/packer/windows/windows_settings.json
+++ b/vhdbuilder/packer/windows/windows_settings.json
@@ -25,7 +25,7 @@
       "base_image_sku": "2019-Datacenter-Core-smalldisk",
       "windows_image_name": "windows-2019-containerd",
       "base_image_version": "17763.6893.250210",
-      "os_disk_size": "30",
+      "os_disk_size": "31",
       "patches_to_apply": []
     },
     "2022-containerd": {

--- a/vhdbuilder/packer/windows/windows_settings.json
+++ b/vhdbuilder/packer/windows/windows_settings.json
@@ -18,12 +18,14 @@
       "base_image_sku": "2019-Datacenter-Core-smalldisk",
       "windows_image_name": "windows-2019",
       "base_image_version": "17763.6893.250210",
+      "os_disk_size": "30",
       "patches_to_apply": []
     },
     "2019-containerd": {
       "base_image_sku": "2019-Datacenter-Core-smalldisk",
       "windows_image_name": "windows-2019-containerd",
       "base_image_version": "17763.6893.250210",
+      "os_disk_size": "30",
       "patches_to_apply": []
     },
     "2022-containerd": {


### PR DESCRIPTION
**What type of PR is this?**

/kind regression

**What this PR does / why we need it**:

We should be enforcing a minimum VHD size of 30GB unless a particular VHD overrides this. This default went missing during a refactor. Adding back. It only impacts WS2019 as that VHD doesn't have an override size set.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
