### PR TITLE
regression: get the WS2019 VHD back to 30GB

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -373,13 +373,13 @@
         {
           "comment": "ciprod isn't supported on Win23H2 so is excluded as it makes the VHD too large",
           "renovateTag": "registry=https://mcr.microsoft.com, name=azuremonitor/containerinsights/ciprod",
-          "latestVersion": "3.1.25",
+          "latestVersion": "3.1.24",
           "windowsSkuMatch": "2022*"
         },
         {
           "comment": "ciprod isn't supported on Win23H2 so is excluded as it makes the VHD too large",
           "renovateTag": "registry=https://mcr.microsoft.com, name=azuremonitor/containerinsights/ciprod",
-          "latestVersion": "3.1.25",
+          "latestVersion": "3.1.24",
           "windowsSkuMatch": "2019*"
         }
       ]

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -64,7 +64,22 @@
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=windows/servercore/iis",
-          "latestVersion": "latest"
+          "latestVersion": "windowsservercore-ltsc2019"
+        },
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=windows/servercore/iis",
+          "latestVersion": "windowsservercore-ltsc2019",
+          "windowsSkuMatch": "2019-containerd"
+        },
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=windows/servercore/iis",
+          "latestVersion": "windowsservercore-ltsc2022",
+          "windowsSkuMatch": "2022-containerd*"
+        },
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=windows/servercore/iis",
+          "latestVersion": "windowsservercore-ltsc2022",
+          "windowsSkuMatch": "23H2*"
         }
       ]
     },

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -64,11 +64,6 @@
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=windows/servercore/iis",
-          "latestVersion": "windowsservercore-ltsc2019",
-          "windowsSkuMatch": "2019-containerd"
-        },
-        {
-          "renovateTag": "registry=https://mcr.microsoft.com, name=windows/servercore/iis",
           "latestVersion": "windowsservercore-ltsc2022",
           "windowsSkuMatch": "2022-containerd*"
         },

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -388,13 +388,13 @@
         {
           "comment": "ciprod isn't supported on Win23H2 so is excluded as it makes the VHD too large",
           "renovateTag": "registry=https://mcr.microsoft.com, name=azuremonitor/containerinsights/ciprod",
-          "latestVersion": "3.1.24",
+          "latestVersion": "3.1.25",
           "windowsSkuMatch": "2022*"
         },
         {
           "comment": "ciprod isn't supported on Win23H2 so is excluded as it makes the VHD too large",
           "renovateTag": "registry=https://mcr.microsoft.com, name=azuremonitor/containerinsights/ciprod",
-          "latestVersion": "3.1.24",
+          "latestVersion": "3.1.25",
           "windowsSkuMatch": "2019*"
         }
       ]

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -64,10 +64,6 @@
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=windows/servercore/iis",
-          "latestVersion": "windowsservercore-ltsc2019"
-        },
-        {
-          "renovateTag": "registry=https://mcr.microsoft.com, name=windows/servercore/iis",
           "latestVersion": "windowsservercore-ltsc2019",
           "windowsSkuMatch": "2019-containerd"
         },

--- a/vhdbuilder/packer/windows/windows_settings.json
+++ b/vhdbuilder/packer/windows/windows_settings.json
@@ -25,7 +25,7 @@
       "base_image_sku": "2019-Datacenter-Core-smalldisk",
       "windows_image_name": "windows-2019-containerd",
       "base_image_version": "17763.6893.250210",
-      "os_disk_size": "31",
+      "os_disk_size": "30",
       "patches_to_apply": []
     },
     "2022-containerd": {


### PR DESCRIPTION
**What type of PR is this?**

/kind regression

**What this PR does / why we need it**:

Product limit for WS2019 to have max 30GB VHD size. We had to increase it to 31 GB recently to re-enforce a size (as VHD size validation wasn't working), this PR fixes the size.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
