### PR TITLE
Revert "chore(deps): update azure-cloud-node-manager (patch)"

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -452,13 +452,13 @@
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.30.9",
-          "previousLatestVersion": "v1.30.8"
+          "latestVersion": "v1.30.8",
+          "previousLatestVersion": "v1.30.7"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.31.3",
-          "previousLatestVersion": "v1.31.2"
+          "latestVersion": "v1.31.2",
+          "previousLatestVersion": "v1.31.1"
         }
       ],
       "windowsVersions": [
@@ -492,7 +492,7 @@
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.30.9"
+          "latestVersion": "v1.30.8"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/kubernetes/azure-cloud-node-manager",
@@ -500,7 +500,7 @@
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.31.3"
+          "latestVersion": "v1.31.2"
         }
       ]
     },


### PR DESCRIPTION
Reverts Azure/AgentBaker#5966
This seems to breaking e2e test `Test_Ubuntu2204_AirGap_NonAnonymousACR`. The symptom is that the node will be tainted with `Taints:             node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule`. Reverting this for further investigation.