### PR TITLE
chore: tag windows images

### DIFF
--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -123,10 +123,6 @@ steps:
       fi
       echo "Set build date to $BUILD_DATE" && \
       echo "##vso[task.setvariable variable=BUILD_DATE]$BUILD_DATE" 
-      
-      branch=$(Build.SourceBranch)
-      branch=$(echo "${branch}" | sed 's/refs\/heads\///g')
-      echo "##vso[task.setvariable variable=BRANCH]$branch"
     displayName: Set pipeline variables
     env:
       WINDOWS_SKU: ${{ parameters.windowsSku }}
@@ -137,6 +133,7 @@ steps:
       make -f packer.mk run-packer-windows
     displayName: Building windows VHD
     env:
+      BRANCH: $(Build.SourceBranch)
       MODE: $(MODE)
       POOL_NAME: $(AZURE_POOL_NAME)
       SUBSCRIPTION_ID: $(AZURE_BUILD_SUBSCRIPTION_ID)
@@ -146,10 +143,11 @@ steps:
       GIT_BRANCH: $(BRANCH)
       GIT_REPO: $(Build.Repository.Uri)
       GIT_VERSION: $(Build.SourceVersion)
+      BUILD_DEFINITION_NAME: $(Build.DefinitionName)
       BUILD_ID: $(Build.BuildId)
       BUILD_NUMBER: $(Build.BuildNumber)
       WINDOWS_SKU: ${{ parameters.windowsSku }}
-      OS_TYPE: "Windows"
+      OS_TYPE: Windows
       SKIP_EXTENSION_CHECK: ${{ parameters.skipExtensionCheck }}
       INSTALL_OPEN_SSH_SERVER: ${{ parameters.installOpenSshServer }}
       SIG_GALLERY_NAME: $(SIG_GALLERY_NAME)
@@ -181,6 +179,7 @@ steps:
 
       make -f packer.mk test-building-vhd
     displayName: Run VHD cache test
+    enabled: false
     env:
       SUBSCRIPTION_ID: $(AZURE_BUILD_SUBSCRIPTION_ID)
       AZURE_RESOURCE_GROUP_NAME: $(AZURE_BUILD_RESOURCE_GROUP_NAME)

--- a/vhdbuilder/packer/windows/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows/windows-vhd-builder-sig.json
@@ -63,7 +63,12 @@
                 "SkipASMAzSecPack": "True",
                 "SkipASMAV": "True",
                 "SkipCIExtensionAudit": "True",
-                "SkipCIEmergency": "True"
+                "SkipCIEmergency": "True",
+                "buildDefinitionName": "{{user `build_definition_name`}}",
+                "buildNumber": "{{user `build_number`}}",
+                "buildId": "{{user `build_id`}}",
+                "image_sku": "{{user `img_sku`}}",
+                "branch": "{{user `branch`}}"
             },
             "virtual_network_resource_group_name": "{{user `vnet_resource_group_name`}}",
             "virtual_network_name": "{{user `vnet_name`}}",

--- a/vhdbuilder/packer/windows/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows/windows-vhd-builder-sig.json
@@ -4,6 +4,8 @@
         "build_commit": "{{env `GIT_VERSION`}}",
         "build_id": "{{env `BUILD_ID`}}",
         "build_number": "{{env `BUILD_NUMBER`}}",
+        "build_definition_name": "{{env `BUILD_DEFINITION_NAME`}}",
+        "img_sku": "{{env `WINDOWS_IMAGE_SKU`}}",
         "build_repo": "{{env `GIT_REPO`}}",
         "windows_sku": "{{env `WINDOWS_SKU`}}",
         "subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
@@ -18,6 +20,7 @@
         "vnet_name": "{{env `VNET_NAME`}}",
         "subnet_name": "{{env `SUBNET_NAME`}}",
         "build_date": "{{env `BUILD_DATE`}}",
+        "branch": "{{env `BRANCH`}}",
         "vnet_resource_group_name": "{{env `VNET_RESOURCE_GROUP_NAME`}}"
     },
     "builders": [

--- a/vhdbuilder/packer/windows/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows/windows-vhd-builder-sig.json
@@ -5,7 +5,7 @@
         "build_id": "{{env `BUILD_ID`}}",
         "build_number": "{{env `BUILD_NUMBER`}}",
         "build_definition_name": "{{env `BUILD_DEFINITION_NAME`}}",
-        "img_sku": "{{env `WINDOWS_IMAGE_SKU`}}",
+        "img_sku": "{{env `WINDOWS_SKU`}}",
         "build_repo": "{{env `GIT_REPO`}}",
         "windows_sku": "{{env `WINDOWS_SKU`}}",
         "subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",


### PR DESCRIPTION
**What type of PR is this?**

For e2e tests, we lookup the image to run the tests on by the build id tag on VHD images. These are not being set for Windows. This PR adds the tags in.

There are likely other issues with e2e tests and windows, but this is the first thing I noticed.


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
