### PR TITLE
bumping azlinux containerd to latest

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1049,7 +1049,7 @@
             "versionsV2": [
               {
                 "renovateTag": "<DO_NOT_UPDATE>",
-                "latestVersion": "1.6.26-9.cm2"
+                "latestVersion": "1.6.26-10.cm2"
               }
             ]
           }

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1049,7 +1049,7 @@
             "versionsV2": [
               {
                 "renovateTag": "<DO_NOT_UPDATE>",
-                "latestVersion": "1.6.26-8.cm2"
+                "latestVersion": "1.6.26-9.cm2"
               }
             ]
           }
@@ -1069,7 +1069,7 @@
             "versionsV2": [
               {
                 "renovateTag": "<DO_NOT_UPDATE>",
-                "latestVersion": "2.0.0-1.azl3"
+                "latestVersion": "2.0.0-4.azl3"
               }
             ]
           }


### PR DESCRIPTION
**What type of PR is this?**
/kind cve

**What this PR does / why we need it**:
Bump moby-containerd for azlinux2 and containerd2 for azlinux3
