### PR TITLE
fix: revert azure-ipam image bump

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -250,8 +250,7 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/azure-ipam",
-          "previousLatestVersion": "v0.0.7",
-          "latestVersion": "v0.0.8",
+          "latestVersion": "v0.0.7",
           "containerImagePrefetch": {
             "latestVersion": {
               "binaries": [

--- a/vhdbuilder/lister/go.mod
+++ b/vhdbuilder/lister/go.mod
@@ -1,6 +1,7 @@
 module github.com/Azure/agentbaker/vhdbuilder/lister
 
-go 1.21.13
+go 1.23.0
+
 toolchain go1.24.1
 
 require (


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR reverts the image for containernetworking/azure-ipam to what it was before dependabot bumped it. 

**Which issue(s) this PR fixes**:

Builds are failing due to v0.0.8 not being available for Arm64.

Fixes #

**Requirements**:

- [ x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version