### PR TITLE
feat: add arm64 and fips to PR gate

### DIFF
--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -87,7 +87,7 @@ stages:
         - template: ./templates/.builder-release-template.yaml
           parameters:
             artifactName: azurelinuxv2-gen2
-    - job: buildAzureLinuxV3gen2fips
+    - job: buildAzureLinuxV3ARM64gen2fips
       timeoutInMinutes: 180
       steps:
         - bash: |
@@ -95,21 +95,21 @@ stages:
             echo '##vso[task.setvariable variable=OS_VERSION]V3'
             echo '##vso[task.setvariable variable=IMG_PUBLISHER]MicrosoftCBLMariner'
             echo '##vso[task.setvariable variable=IMG_OFFER]azure-linux-3'
-            echo '##vso[task.setvariable variable=IMG_SKU]azure-linux-3-gen2'
+            echo '##vso[task.setvariable variable=IMG_SKU]azure-linux-3-arm64-gen2-fips'
             echo '##vso[task.setvariable variable=IMG_VERSION]latest'
             echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
-            echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ds_v5'
+            echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16pds_v5'
             echo '##vso[task.setvariable variable=FEATURE_FLAGS]None'
             echo '##vso[task.setvariable variable=CONTAINER_RUNTIME]containerd'
-            echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
+            echo '##vso[task.setvariable variable=ARCHITECTURE]ARM64'
             echo '##vso[task.setvariable variable=ENABLE_FIPS]True'
             echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]False'
-            echo '##vso[task.setvariable variable=SGX_INSTALL]True'
+            echo '##vso[task.setvariable variable=SGX_INSTALL]False'
             echo '##vso[task.setvariable variable=ENABLE_CGROUPV2]True'
           displayName: Setup Build Variables
         - template: ./templates/.builder-release-template.yaml
           parameters:
-            artifactName: azurelinuxv3-gen2-fips
+            artifactName: azurelinuxv3-gen2-arm64-fips
     - job: buildMarinerV2gen2
       timeoutInMinutes: 180
       steps:

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -87,7 +87,7 @@ stages:
         - template: ./templates/.builder-release-template.yaml
           parameters:
             artifactName: azurelinuxv2-gen2
-    - job: buildAzureLinuxV3gen2
+    - job: buildAzureLinuxV3gen2fips
       timeoutInMinutes: 180
       steps:
         - bash: |
@@ -102,14 +102,14 @@ stages:
             echo '##vso[task.setvariable variable=FEATURE_FLAGS]None'
             echo '##vso[task.setvariable variable=CONTAINER_RUNTIME]containerd'
             echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
-            echo '##vso[task.setvariable variable=ENABLE_FIPS]false'
+            echo '##vso[task.setvariable variable=ENABLE_FIPS]True'
             echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]False'
             echo '##vso[task.setvariable variable=SGX_INSTALL]True'
             echo '##vso[task.setvariable variable=ENABLE_CGROUPV2]True'
           displayName: Setup Build Variables
         - template: ./templates/.builder-release-template.yaml
           parameters:
-            artifactName: azurelinuxv3-gen2
+            artifactName: azurelinuxv3-gen2-fips
     - job: buildMarinerV2gen2
       timeoutInMinutes: 180
       steps:

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -87,6 +87,29 @@ stages:
         - template: ./templates/.builder-release-template.yaml
           parameters:
             artifactName: azurelinuxv2-gen2
+    - job: buildAzureLinuxV3gen2
+      timeoutInMinutes: 180
+      steps:
+        - bash: |
+            echo '##vso[task.setvariable variable=OS_SKU]AzureLinux'
+            echo '##vso[task.setvariable variable=OS_VERSION]V3'
+            echo '##vso[task.setvariable variable=IMG_PUBLISHER]MicrosoftCBLMariner'
+            echo '##vso[task.setvariable variable=IMG_OFFER]azure-linux-3'
+            echo '##vso[task.setvariable variable=IMG_SKU]azure-linux-3-gen2'
+            echo '##vso[task.setvariable variable=IMG_VERSION]latest'
+            echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
+            echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ds_v5'
+            echo '##vso[task.setvariable variable=FEATURE_FLAGS]None'
+            echo '##vso[task.setvariable variable=CONTAINER_RUNTIME]containerd'
+            echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
+            echo '##vso[task.setvariable variable=ENABLE_FIPS]false'
+            echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]False'
+            echo '##vso[task.setvariable variable=SGX_INSTALL]True'
+            echo '##vso[task.setvariable variable=ENABLE_CGROUPV2]True'
+          displayName: Setup Build Variables
+        - template: ./templates/.builder-release-template.yaml
+          parameters:
+            artifactName: azurelinuxv3-gen2
     - job: buildAzureLinuxV3ARM64gen2fips
       timeoutInMinutes: 180
       steps:


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

This adds arm64 and FIPs coverage to the PR gate for AgentBaker code changes.

This is accomplished by replacing the azurelinuxV3gen2 VHD with the azurelinuxV3arm64gen2fips VHD. This maintains coverage for azurelinuxV3gen2, while also adding coverage for Arm64 and FIPs.

**Which issue(s) this PR fixes**:

Prevents changes from unexpectedly failing builds for certain features that don't have PR gate test coverage.

**Requirements**:

- [ x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version