### PR TITLE
feat: set SDNRemoteArpMacAddress for HNS during AzCNI setup

### DIFF
--- a/staging/cse/windows/azurecnifunc.ps1
+++ b/staging/cse/windows/azurecnifunc.ps1
@@ -161,14 +161,16 @@ function Set-AzureCNIConfig
     }
 
     # Set the SDNRemoteArpMacAddress RegKey for HNS when AzureCNI is enabled
+    Write-Log "Setting SDNRemoteArpMacAddress to 12-34-56-78-9a-bc for HNS"
     Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name SDNRemoteArpMacAddress -Value "12-34-56-78-9a-bc"
     # Restart hns service if it is exsting and running, to make the system regkey changes effective.
     $hnsServiceName = 'hns'
     $hnsService = Get-Service -Name $hnsServiceName -ErrorAction SilentlyContinue
     if ($hnsService -and $hnsService.Status -eq 'Running') {
-        Write-Log "hns service is already running. Restart hns."
+        Write-Log "HNS service is already running. Restart HNS."
         Restart-Service -Name $hnsServiceName
     }
+    Write-Log "Done configuring HNS"
 
     if ($global:KubeproxyFeatureGates.Contains("WinDSR=true")) {
         Write-Log "Setting enableLoopbackDSR in Azure CNI conflist for WinDSR"

--- a/staging/cse/windows/azurecnifunc.tests.ps1
+++ b/staging/cse/windows/azurecnifunc.tests.ps1
@@ -225,6 +225,12 @@ Describe 'Set-AzureCNIConfig' {
     }
 
     Context 'AzureCNIOverlay is enabled' {
+        BeforeEach {
+            $hnsServiceName = "hns"
+            Mock Get-Service -MockWith { return $hnsServiceName }
+            Mock Restart-Service -MockWith { Write-Host "Restart-Service -Name $hnsServiceName" } -Verifiable
+        }
+
         It "Should not include Cluster CIDR when AzureCNIOverlay is enabled" {
             Set-Default-AzureCNI "AzureCNI.Default.Overlay.conflist"
 
@@ -263,6 +269,12 @@ Describe 'Set-AzureCNIConfig' {
     }
 
     Context 'SwiftCNI' {
+        BeforeEach {
+            $hnsServiceName = "hns"
+            Mock Get-Service -MockWith { return $hnsServiceName }
+            Mock Restart-Service -MockWith { Write-Host "Restart-Service -Name $hnsServiceName" } -Verifiable
+        }
+
         It "Should has hnsTimeoutDurationInSeconds and enableLoopbackDSR" {
             Set-Default-AzureCNI  "AzureCNI.Default.Swift.conflist"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature 

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**: 
The SDNRemoteArpMacAddress needs to be set for HNS when AzureCNI is enabled in certain scenarios. We have done this in CNS for a very long time (https://github.com/Azure/azure-container-networking/pull/1306) but some recent changes (https://github.com/Azure/azure-container-networking/pull/2993) have exposed how very fragile HNS is and how dangerous it is to restart it unnecessarily (https://github.com/Azure/azure-container-networking/pull/3498).

This change will move setting the regkey to the CSE scripts so that it is complete and HNS is restarted well before CNS lands, and guarantees it only happens once for the lifetime of the Node.


**Release note**: 

```
set SDNRemoteArpMacAddress for HNS during AzCNI setup
```
