### PR TITLE
chore: bump go version for node-controller

### DIFF
--- a/aks-node-controller/go.mod
+++ b/aks-node-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/agentbaker/aks-node-controller
 
-go 1.22.11
+go 1.22.12
 
 toolchain go1.23.0
 

--- a/aks-node-controller/go.mod
+++ b/aks-node-controller/go.mod
@@ -2,7 +2,7 @@ module github.com/Azure/agentbaker/aks-node-controller
 
 go 1.22.12
 
-toolchain go1.23.0
+toolchain go1.23.7
 
 require (
 	github.com/Azure/agentbaker v0.20240503.0

--- a/aks-node-controller/go.mod
+++ b/aks-node-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/agentbaker/aks-node-controller
 
-go 1.22.2
+go 1.22.11
 
 toolchain go1.23.0
 


### PR DESCRIPTION
Bump Go version in aks-node-controller, CVE-2024-45336