### PR TITLE
chore: bump go for node-controller to 1.23

### DIFF
--- a/aks-node-controller/go.mod
+++ b/aks-node-controller/go.mod
@@ -2,8 +2,6 @@ module github.com/Azure/agentbaker/aks-node-controller
 
 go 1.23.7
 
-toolchain go1.23.7
-
 require (
 	github.com/Azure/agentbaker v0.20240503.0
 	github.com/blang/semver v3.5.1+incompatible

--- a/aks-node-controller/go.mod
+++ b/aks-node-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/agentbaker/aks-node-controller
 
-go 1.22.12
+go 1.23.7
 
 toolchain go1.23.7
 

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/agentbaker/e2e
 
-go 1.23.0
+go 1.23.7
 
 toolchain go1.24.1
 


### PR DESCRIPTION
bump go version to maintained one for aks-node-controller 