### PR TITLE
Add function to extract and cache CoreDNS Binary in VHD for localdns

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -660,7 +660,7 @@ extractAndCacheCoreDnsBinary() {
       exit 1
     fi
 
-    if [[ "$vMajorMinorPatch" != "$latest_vMajorMinorPatch" ]]; then
+    if [[ "${vMajorMinorPatch}" != "${latest_vMajorMinorPatch}" ]]; then
       previous_coredns_tag="$tag"
       # Break the loop after next highest major-minor version is found.
       break
@@ -674,7 +674,7 @@ extractAndCacheCoreDnsBinary() {
 
   # Extract the CoreDNS binary for the selected version.
   for coredns_image_url in "${coredns_image_list[@]}"; do
-    if [[ "${coredns_image_url##*:}" != "$previous_coredns_tag" ]]; then
+    if [[ "${coredns_image_url##*:}" != "${previous_coredns_tag}" ]]; then
       continue
     fi
 
@@ -691,7 +691,7 @@ extractAndCacheCoreDnsBinary() {
     done
 
     if [[ $retry_count -eq $max_retries ]]; then
-      echo "Error: Failed to mount ${coredns_image_url} after $max_retries attempts." >> "${VHD_LOGS_FILEPATH}"
+      echo "Error: Failed to mount ${coredns_image_url} after ${max_retries} attempts." >> "${VHD_LOGS_FILEPATH}"
       exit 1
     fi
 

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -652,7 +652,7 @@ extractAndCacheCoreDNSBinaries() {
   done
 
   if [[ -z "${previous_coredns_tag}" ]]; then
-    echo "n-1 major-minor tag not found, using the latest version: $latest_coredns_tag" >> "${VHD_LOGS_FILEPATH}"
+    echo "Previous version (ie n-1, n being the latest version) tag not found, using the latest version: $latest_coredns_tag" >> "${VHD_LOGS_FILEPATH}"
     previous_coredns_tag="$latest_coredns_tag"
   fi
 

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -692,7 +692,6 @@ extractAndCacheCoreDnsBinary() {
 
     if [[ $retry_count -eq $max_retries ]]; then
       echo "Error: Failed to mount ${coredns_image_url} after $max_retries attempts." >> "${VHD_LOGS_FILEPATH}"
-      rm -rf "${ctr_temp}"
       exit 1
     fi
 

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1207,6 +1207,27 @@ checkPerformanceData() {
   return 0
 }
 
+testCoreDnsBinaryExtractedAndCached() {
+  local test="CoreDNSBinaryExtractedAndCached"
+  local localdnsBinaryDir="/opt/azure/containers/localdns/binary"
+  local binaryPath="$localdnsBinaryDir/coredns"
+
+  echo "$test: Checking for existence of coredns binary at $binaryPath"
+  
+  if [[ ! -f "$binaryPath" ]]; then
+    err "$test: coredns binary does not exist at $binaryPath"
+    return 1
+  fi
+  
+  if [[ ! -x "$binaryPath" ]]; then
+    err "$test: coredns binary exists but is not executable at $binaryPath"
+    return 1
+  fi
+  
+  echo "$test: coredns binary is properly extracted and cached at $binaryPath"
+  return 0
+}
+
 # As we call these tests, we need to bear in mind how the test results are processed by the
 # the caller in run-tests.sh. That code uses az vm run-command invoke to run this script
 # on a VM. It then looks at stderr to see if any errors were reported. Notably it doesn't
@@ -1249,3 +1270,4 @@ testContainerImagePrefetchScript
 testAKSNodeControllerBinary
 testAKSNodeControllerService
 testLtsKernel $OS_VERSION $OS_SKU $ENABLE_FIPS
+testCoreDnsBinaryExtractedAndCached

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1208,6 +1208,7 @@ checkPerformanceData() {
 }
 
 testCoreDnsBinaryExtractedAndCached() {
+  local test="CoreDnsBinaryExtractedAndCached"
   local os_version=$1
     # Ubuntu 18.04 and 20.04 ship with GLIBC 2.27 and 2.31, respectively.
   # CoreDNS binary is built with GLIBC 2.32+, which is not compatible with 18.04 and 20.04 OS versions.
@@ -1219,7 +1220,6 @@ testCoreDnsBinaryExtractedAndCached() {
     return 0
   fi
 
-  local test="CoreDnsBinaryExtractedAndCached"
   local localdnsBinaryDir="/opt/azure/containers/localdns/binary"
   local binaryPath="$localdnsBinaryDir/coredns"
   local coredns_image_list=($(ctr -n k8s.io images list -q | grep coredns))

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1216,7 +1216,7 @@ testCoreDnsBinaryExtractedAndCached() {
   # Validation in AKS RP will be done to ensure localdns is not enabled for these OS versions.
   if [[ ${os_version} == "18.04" || ${os_version} == "20.04" ]]; then
     # For Ubuntu 18.04 and 20.04, the coredns binary is located in /opt/azure/containers/localdns/binary/coredns
-    echo "$test: CoreDNS ${expectedVersionWithoutV} is not supported on OS version: ${os_version}"
+    echo "$test: CoreDNS is not supported on OS version: ${os_version}"
     return 0
   fi
 

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1246,13 +1246,23 @@ testCoreDnsBinaryExtractedAndCached() {
   done
 
   if [[ -z "${previous_coredns_tag}" ]]; then
-    echo "$test: Warning: Previous version not found, using the latest version: $latest_coredns_tag"
+    echo "$test: Warning: Previous version not found, using the latest version: ${latest_coredns_tag}"
     previous_coredns_tag="$latest_coredns_tag"
   fi
 
   local expectedVersion="$previous_coredns_tag"
   local expectedVersionWithoutV="${expectedVersion#v}"
   echo "$test: Expected CoreDNS version (n-1 latest revision): ${expectedVersionWithoutV}"
+
+  # Ubuntu 18.04 and 20.04 ship with GLIBC 2.27 and 2.31, respectively.
+  # CoreDNS binary is built with GLIBC 2.32+, which is not compatible with 18.04 and 20.04 OS versions.
+  # Therefore, we skip the test for these OS versions here.
+  # Validation in AKS RP will be done to ensure localdns is not enabled for these OS versions.
+  if [[ ${os_version} == "18.04" || ${os_version} == "20.04" ]]; then
+    # For Ubuntu 18.04 and 20.04, the coredns binary is located in /opt/azure/containers/localdns/binary/coredns
+    echo "$test: CoreDNS ${expectedVersionWithoutV} is not supported on OS version: ${os_version}"
+    return 0
+  fi
 
   # Get the actual version from the extracted CoreDNS binary
   local actualVersion

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1208,6 +1208,7 @@ checkPerformanceData() {
 }
 
 testCoreDnsBinaryExtractedAndCached() {
+  local os_version=$1
     # Ubuntu 18.04 and 20.04 ship with GLIBC 2.27 and 2.31, respectively.
   # CoreDNS binary is built with GLIBC 2.32+, which is not compatible with 18.04 and 20.04 OS versions.
   # Therefore, we skip the test for these OS versions here.
@@ -1327,4 +1328,4 @@ testContainerImagePrefetchScript
 testAKSNodeControllerBinary
 testAKSNodeControllerService
 testLtsKernel $OS_VERSION $OS_SKU $ENABLE_FIPS
-testCoreDnsBinaryExtractedAndCached
+testCoreDnsBinaryExtractedAndCached $OS_VERSION

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1208,6 +1208,16 @@ checkPerformanceData() {
 }
 
 testCoreDnsBinaryExtractedAndCached() {
+    # Ubuntu 18.04 and 20.04 ship with GLIBC 2.27 and 2.31, respectively.
+  # CoreDNS binary is built with GLIBC 2.32+, which is not compatible with 18.04 and 20.04 OS versions.
+  # Therefore, we skip the test for these OS versions here.
+  # Validation in AKS RP will be done to ensure localdns is not enabled for these OS versions.
+  if [[ ${os_version} == "18.04" || ${os_version} == "20.04" ]]; then
+    # For Ubuntu 18.04 and 20.04, the coredns binary is located in /opt/azure/containers/localdns/binary/coredns
+    echo "$test: CoreDNS ${expectedVersionWithoutV} is not supported on OS version: ${os_version}"
+    return 0
+  fi
+
   local test="CoreDnsBinaryExtractedAndCached"
   local localdnsBinaryDir="/opt/azure/containers/localdns/binary"
   local binaryPath="$localdnsBinaryDir/coredns"
@@ -1253,16 +1263,6 @@ testCoreDnsBinaryExtractedAndCached() {
   local expectedVersion="$previous_coredns_tag"
   local expectedVersionWithoutV="${expectedVersion#v}"
   echo "$test: Expected CoreDNS version (n-1 latest revision): ${expectedVersionWithoutV}"
-
-  # Ubuntu 18.04 and 20.04 ship with GLIBC 2.27 and 2.31, respectively.
-  # CoreDNS binary is built with GLIBC 2.32+, which is not compatible with 18.04 and 20.04 OS versions.
-  # Therefore, we skip the test for these OS versions here.
-  # Validation in AKS RP will be done to ensure localdns is not enabled for these OS versions.
-  if [[ ${os_version} == "18.04" || ${os_version} == "20.04" ]]; then
-    # For Ubuntu 18.04 and 20.04, the coredns binary is located in /opt/azure/containers/localdns/binary/coredns
-    echo "$test: CoreDNS ${expectedVersionWithoutV} is not supported on OS version: ${os_version}"
-    return 0
-  fi
 
   # Get the actual version from the extracted CoreDNS binary
   local actualVersion


### PR DESCRIPTION
**What type of PR is this?**
feature

**What this PR does / why we need it**:
This PR adds a function to extract a coredns binary from cached coredns container images in the VHD. It extracts binary of n-1 coredns image version and latest revision version (v.Major.Minor.Patch-Revision) and copies it to /opt/azure/containers/localdns/binary/coredns path. This binary will be used by localdns systemd unit. The function also handles the cleanup of temporary directories and unmounting of images.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # None

**Requirements**:
Build

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
Not sure if there is a way to write unit tests for this file. 

**Release note**:

```
none
```
