### PR TITLE
test: update e2e config to match evictionHard default value to 100Mi

### DIFF
--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -83,7 +83,7 @@ var baseKubeletConfig = &aksnodeconfigv1.KubeletConfig{
 		PodPidsLimit:                   to.Ptr(int32(-1)),
 		ResolvConf:                     "/run/systemd/resolve/resolv.conf",
 		EvictionHard: map[string]string{
-			"memory.available":  "750Mi",
+			"memory.available":  "100Mi",
 			"nodefs.available":  "10%",
 			"nodefs.inodesFree": "5%",
 		},

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1794,25 +1794,3 @@ func Test_Ubuntu2404ARM(t *testing.T) {
 		},
 	})
 }
-
-func Test_Ubuntu2404Gen2_Cilium(t *testing.T) {
-	RunScenario(t, &Scenario{
-		Description: "Tests Ubuntu 2404 VHD containerd v2 with cilium network plugin",
-		Config: Config{
-			Cluster: ClusterAzureNetwork,
-			VHD:     config.VHDUbuntu2404Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
-				nbc.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = "cilium"
-				nbc.AgentPoolProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
-				nbc.AgentPoolProfile.KubernetesConfig.NetworkPolicy = "cilium"
-			},
-			Validator: func(ctx context.Context, s *Scenario) {
-				containerdVersions := getExpectedPackageVersions("containerd", "ubuntu", "r2404")
-				runcVersions := getExpectedPackageVersions("runc", "ubuntu", "r2404")
-				ValidateContainerd2Properties(ctx, s, containerdVersions)
-				ValidateRunc12Properties(ctx, s, runcVersions)
-			},
-		},
-	})
-}

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -347,8 +347,8 @@ func ValidateKubeletHasFlags(ctx context.Context, s *Scenario, filePath string) 
 // ValidateKubeletHasCLIFlag checks kubelet is started with the right flags and configs.
 func ValidateKubeletHasCLIFlag(ctx context.Context, s *Scenario, flagName, flagValue string) {
 	execResult := execScriptOnVMForScenarioValidateExitCode(ctx, s, "sudo journalctl -u kubelet", 0, "could not retrieve kubelet logs with journalctl")
-	configFileFlags := fmt.Sprintf("FLAG: --%s=\"%s\"", flagName, flagValue)
-	require.Containsf(s.T, execResult.stdout.String(), configFileFlags, "expected to find flag %s, but not found", "config")
+	configFileFlags := fmt.Sprintf("FLAG: --%s=\"%s", flagName, flagValue)
+	require.Containsf(s.T, execResult.stdout.String(), configFileFlags, "expected to find flag %s=%s, but not found", flagName, flagValue)
 }
 
 func ValidatePodUsingNVidiaGPU(ctx context.Context, s *Scenario) {

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -95,7 +95,6 @@ func ValidateNvidiaPersistencedRunning(ctx context.Context, s *Scenario) {
 	execScriptOnVMForScenarioValidateExitCode(ctx, s, strings.Join(command, "\n"), 0, "failed to validate nvidia-persistenced.service status")
 }
 
-
 func ValidateNonEmptyDirectory(ctx context.Context, s *Scenario, dirName string) {
 	command := []string{
 		"set -ex",
@@ -342,6 +341,13 @@ func ValidateServicesDoNotRestartKubelet(ctx context.Context, s *Scenario) {
 func ValidateKubeletHasFlags(ctx context.Context, s *Scenario, filePath string) {
 	execResult := execScriptOnVMForScenarioValidateExitCode(ctx, s, "sudo journalctl -u kubelet", 0, "could not retrieve kubelet logs with journalctl")
 	configFileFlags := fmt.Sprintf("FLAG: --config=\"%s\"", filePath)
+	require.Containsf(s.T, execResult.stdout.String(), configFileFlags, "expected to find flag %s, but not found", "config")
+}
+
+// ValidateKubeletHasCLIFlag checks kubelet is started with the right flags and configs.
+func ValidateKubeletHasCLIFlag(ctx context.Context, s *Scenario, flagName, flagValue string) {
+	execResult := execScriptOnVMForScenarioValidateExitCode(ctx, s, "sudo journalctl -u kubelet", 0, "could not retrieve kubelet logs with journalctl")
+	configFileFlags := fmt.Sprintf("FLAG: --%s=\"%s\"", flagName, flagValue)
 	require.Containsf(s.T, execResult.stdout.String(), configFileFlags, "expected to find flag %s, but not found", "config")
 }
 

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -557,7 +557,7 @@ func GetKubeletConfigFileContent(kc map[string]string, customKc *datamodel.Custo
 	}
 
 	// EvictionHard.
-	// default: "memory.available<750Mi,nodefs.available<10%,nodefs.inodesFree<5%".
+	// default: "memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%".
 	if eh, ok := kc["--eviction-hard"]; ok && eh != "" {
 		kubeletConfig.EvictionHard = strKeyValToMap(eh, ",", "<")
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind test


**What this PR does / why we need it**:

after k8s 1.29 the evictionHard is set to 100Mi by default

https://learn.microsoft.com/en-us/azure/aks/node-resource-reservations

the PR update the default node config in e2e test to match the default, so that the node created are closer to real life.


**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
