### PR TITLE
Purge asc-baseline after execution

### DIFF
--- a/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
+++ b/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
@@ -23,11 +23,10 @@ installAscBaseline() {
    echo "Installing ASC Baseline tools..."
    ASC_BASELINE_TMP=/home/packer/asc-baseline.deb
    retrycmd_if_failure_no_stats 120 5 25 dpkg -i $ASC_BASELINE_TMP || exit $ERR_APT_INSTALL_TIMEOUT
-   sudo cp /opt/microsoft/asc-baseline/baselines/*.xml /opt/microsoft/asc-baseline/
    cd /opt/microsoft/asc-baseline
-   sudo ./ascbaseline -d .
-   sudo ./ascremediate -d . -m all
-   sudo ./ascbaseline -d . | grep -B2 -A6 "FAIL"
+   sudo ./ascbaseline -d baselines
+   sudo ./ascremediate -d baselines -m all
+   sudo ./ascbaseline -d baselines | grep -B2 -A6 "FAIL"
    cd -
    echo "Check UDF"
    cat /etc/modprobe.d/*.conf | grep udf

--- a/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
+++ b/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
@@ -32,6 +32,7 @@ installAscBaseline() {
    echo "Check UDF"
    cat /etc/modprobe.d/*.conf | grep udf
    echo "Finished Setting up ASC Baseline"
+   apt_get_purge 20 30 120 asc-baseline || exit $ERR_APT_PURGE_TIMEOUT
 }
 
 installBcc() {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind test

/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR removes the asc-baseline package from Ubuntu images after its job is done. This reduces the number of packages in the final image that need to be checked for CVEs.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
