### PR TITLE
fix: remove toolchain line from go.mod via auto-tidy

### DIFF
--- a/.github/workflows/tidy.yaml
+++ b/.github/workflows/tidy.yaml
@@ -65,6 +65,18 @@ jobs:
           done
         name: Run go mod tidy
 
+      - run: |
+          set -e
+          for mod_dir in ./ e2e/ aks-node-controller/; do
+            echo "removing any toolchain lains from go.mod in ${mod_dir}"
+            pushd $mod_dir
+                # this pains me greatly, though adding the toolchain line seems to break our other workflows,
+                # we don't want to be constantly blocking dependabot PRs on failing workflows
+                awk 'BEGIN { skip=0 } { if (skip && $0 ~ /^[[:space:]]*$/) { next } else if (skip) { skip=0 } if ($0 ~ /^toolchain/) { skip=1; next } print }' go.mod > tmp && mv tmp go.mod
+            popd
+          done
+        name: Remove toolchain lines
+
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore: auto-tidy"

--- a/.github/workflows/tidy.yaml
+++ b/.github/workflows/tidy.yaml
@@ -10,6 +10,7 @@ on:
       - go.mod
       - e2e/go.mod
       - aks-node-controller/go.mod
+      - .github/workflows/tidy.yaml
 
 permissions:
     id-token: write


### PR DESCRIPTION
**What type of PR is this?**

remove toolchain from automated PRs, like so: https://github.com/Azure/AgentBaker/pull/6112/commits/baf2aafe45705d929c551ce2e8fdcb992ed5ed26

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
