### PR TITLE
Enable fabric manager for H200 GPUs

### DIFF
--- a/pkg/agent/datamodel/gpu_components.go
+++ b/pkg/agent/datamodel/gpu_components.go
@@ -116,6 +116,10 @@ var FabricManagerGPUSizes = map[string]bool{
 	"standard_nd92isr_h100_v5":  true,
 	"standard_nd96isr_h100_v5":  true,
 	"standard_nd100isr_h100_v5": true,
+	// H200
+	"standard_nd96is_h200_v5":   true,
+	"standard_nd96isr_h200_v5":  true,
+	"standard_nd96isrf_h200_v5": true,
 	// A100 oddballs.
 	"standard_nc24ads_a100_v4": false, // NCads_v4 will fail to start fabricmanager.
 	"standard_nc48ads_a100_v4": false,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This enables nvidia fabric manager for H200 GPUs. Fabric manager is used for GPU-to-GPU connectivity. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
