### PR TITLE
Fine tuning the localdns UT timeout and max attempt for shorter test time

### DIFF
--- a/parts/linux/cloud-init/artifacts/localdns.sh
+++ b/parts/linux/cloud-init/artifacts/localdns.sh
@@ -58,6 +58,7 @@ NETWORKCTL_RELOAD_CMD="networkctl reload"
 # The health check is a DNS request to the localdns service IPs.
 HEALTH_CHECK_DNS_REQUEST=$'health-check.localdns.local @'"${LOCALDNS_NODE_LISTENER_IP}"$'\nhealth-check.localdns.local @'"${LOCALDNS_CLUSTER_LISTENER_IP}"
 
+START_LOCALDNS_TIMEOUT=10
 
 # Function definitions used in this file. 
 # functions defined until "${__SOURCED__:+return}" are sourced and tested in -
@@ -208,12 +209,11 @@ start_localdns() {
     ${COREDNS_COMMAND} &
 
     # Wait until the PID file is created.
-    local timeout=10
     local elapsed=0
     while [ ! -f "${LOCALDNS_PID_FILE}" ]; do
         sleep 1
         elapsed=$((elapsed + 1))
-        if [ "$elapsed" -ge "$timeout" ]; then
+        if [ "$elapsed" -ge "$START_LOCALDNS_TIMEOUT" ]; then
             echo "Timed out waiting for CoreDNS to create PID file at ${LOCALDNS_PID_FILE}."
             return 1
         fi

--- a/spec/parts/linux/cloud-init/artifacts/localdns_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/localdns_spec.sh
@@ -364,6 +364,7 @@ sleep 60
 EOF
             chmod +x "$MOCK_SCRIPT"
             COREDNS_COMMAND="$MOCK_SCRIPT"
+            START_LOCALDNS_TIMEOUT=2
             When call start_localdns
             The status should be failure
             The output should include "Timed out waiting for CoreDNS to create PID file"
@@ -393,19 +394,19 @@ EOF
         It 'should return failure if localdns is not ready, after timeout'
             CURL_COMMAND="echo NOTOK"
             MAX_ATTEMPTS=1000
-            TIMEOUT=5
+            TIMEOUT=2
             When call wait_for_localdns_ready $MAX_ATTEMPTS $TIMEOUT
             The status should be failure
-            The output should include "Localdns failed to come online after 5 seconds (timeout)."
+            The output should include "Localdns failed to come online after ${TIMEOUT} seconds (timeout)."
         End
 
         It 'should return failure if localdns is not ready, after max attempts'
             CURL_COMMAND="echo NOTOK"
-            MAX_ATTEMPTS=10
+            MAX_ATTEMPTS=2
             TIMEOUT=50
             When call wait_for_localdns_ready $MAX_ATTEMPTS $TIMEOUT
             The status should be failure
-            The output should include "Localdns failed to come online after 10 attempts."
+            The output should include "Localdns failed to come online after ${MAX_ATTEMPTS} attempts."
         End
     End
 
@@ -517,12 +518,12 @@ EOF
             IPTABLES_RULES=("INPUT -p udp --dport 53 -j ACCEPT" "OUTPUT -p udp --sport 53 -j ACCEPT")
             NETWORK_DROPIN_FILE="/tmp/test-network-dropin.conf"
             COREDNS_PID="12345"
-            LOCALDNS_SHUTDOWN_DELAY=1
             mock_iptables() {
                 echo "iptables -C $1"
                 return 0
             }
             Include "./parts/linux/cloud-init/artifacts/localdns.sh"
+            LOCALDNS_SHUTDOWN_DELAY=1
         }
         cleanup() {
             rm -rf "/tmp/test-network-dropin.conf"
@@ -596,7 +597,7 @@ EOF
             IPTABLES=""
             When call cleanup_localdns_configs
             The status should be failure
-            The output should include "Sleeping 5 seconds to allow connections to terminate."
+            The output should include "Sleeping ${LOCALDNS_SHUTDOWN_DELAY} seconds to allow connections to terminate."
             The output should include "Failed to send SIGINT to localdns"
         End
 


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Fine tuning the localdn UT timeout and max attempt for shorter test time.
This shorten shellspec unit test time from 47sec to 13sec while not changing the logic.
Sync'd with Sri Harsha and he is good with that changes.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
