### PR TITLE
chore: replace ciprod with latest and latest-1 of servercore

### DIFF
--- a/.pipelines/.vsts-vhd-builder-pr-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-pr-windows.yaml
@@ -58,6 +58,7 @@ stages:
       build2019containerd: True
       build2022containerd: False
       build2022containerdgen2: True
+      skipExtensionCheck: true
       build23H2: False
       build23H2gen2: True
       overrideBranch: master

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -6,23 +6,28 @@
       "multiArchVersionsV2": [],
       "windowsVersions": [
         {
+          "comment": "should have latest version and natest version -1",
           "renovateTag": "registry=https://mcr.microsoft.com, name=windows/servercore",
-          "latestVersion": "ltsc2019",
+          "latestVersion": "10.0.17763.7136",
+          "previousLatestVersion": "10.0.17763.7009",
           "windowsSkuMatch": "2019-containerd"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=windows/servercore",
-          "latestVersion": "ltsc2022",
+          "latestVersion": "10.0.20348.3453",
+          "previousLatestVersion": "10.0.20348.3328",
           "windowsSkuMatch": "2022-containerd*"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=windows/servercore",
-          "latestVersion": "ltsc2022",
+          "latestVersion": "10.0.20348.3453",
+          "previousLatestVersion": "10.0.20348.3328",
           "windowsSkuMatch": "23H2*"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=windows/servercore",
-          "latestVersion": "ltsc2022",
+          "latestVersion": "10.0.26100.3775",
+          "previousLatestVersion": "10.0.26100.3476",
           "windowsSkuMatch": "2025*"
         }
       ]
@@ -360,20 +365,7 @@
           "latestVersion": "3.1.25"
         }
       ],
-      "windowsVersions": [
-        {
-          "comment": "ciprod isn't supported on Win23H2 so is excluded as it makes the VHD too large",
-          "renovateTag": "registry=https://mcr.microsoft.com, name=azuremonitor/containerinsights/ciprod",
-          "latestVersion": "3.1.25",
-          "windowsSkuMatch": "2022*"
-        },
-        {
-          "comment": "ciprod isn't supported on Win23H2 so is excluded as it makes the VHD too large",
-          "renovateTag": "registry=https://mcr.microsoft.com, name=azuremonitor/containerinsights/ciprod",
-          "latestVersion": "3.1.25",
-          "windowsSkuMatch": "2019*"
-        }
-      ]
+      "windowsVersions": []
     },
     {
       "downloadURL": "mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-collector/images:*",


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR removes the ciprod container and replaces it with the current servercore container and the previous servercore container. This was agreed with the ciprod team as a way to support their ciprod rollouts.

It also works around a issue with the subscription the PR builds now run in.

servercore tags list is here: https://mcr.microsoft.com/v2/windows/servercore/tags/list

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
