### PR TITLE
Add code to update kubelet flag if localdns is enabled

### DIFF
--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -362,6 +362,12 @@ func GetOrderedKubeletConfigFlagString(config *datamodel.NodeBootstrappingConfig
 	sort.Strings(keys)
 	var buf bytes.Buffer
 	for _, key := range keys {
+		/* Override --cluster-dns if LocalDNS is enabled for the agentpool.
+		If localdns is enabled for the agentpool,
+		then Kubelet's --cluster-dns flag should be pointed to localdns clusterlistenerIP address. */
+		if key == "--cluster-dns" && profile.ShouldEnableLocalDNS() {
+			k[key] = profile.GetLocalDNSClusterListenerIP()
+		}
 		buf.WriteString(fmt.Sprintf("%s=%s ", key, k[key]))
 	}
 	return buf.String()

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -673,6 +673,95 @@ var _ = Describe("Test GetOrderedKubeletConfigFlagString", func() {
 		actualStr := GetOrderedKubeletConfigFlagString(config)
 		Expect(expectedStr).To(Equal(actualStr))
 	})
+
+	// ------------------------------- Start of tests related to Localdns ---------------------------------------.
+	It("should return localdns clusterlistenerIP value for --cluster-dns when localdns is enabled", func() {
+		config := &datamodel.NodeBootstrappingConfiguration{
+			KubeletConfig: map[string]string{
+				"--node-status-update-frequency": "10s",
+				"--node-status-report-frequency": "5m0s",
+				"--image-gc-high-threshold":      "85",
+				"--event-qps":                    "0",
+				"--cluster-dns":                  "10.0.0.10",
+			},
+			ContainerService: &datamodel.ContainerService{
+				Location:   "southcentralus",
+				Type:       "Microsoft.ContainerService/ManagedClusters",
+				Properties: &datamodel.Properties{},
+			},
+			EnableKubeletConfigFile: false,
+			AgentPoolProfile:        &datamodel.AgentPoolProfile{},
+		}
+
+		config.AgentPoolProfile.LocalDNSProfile = &datamodel.LocalDNSProfile{
+			EnableLocalDNS:       true,
+			CPULimitInMilliCores: to.Int32Ptr(2008),
+			MemoryLimitInMB:      to.Int32Ptr(128),
+			VnetDNSOverrides:     nil,
+			KubeDNSOverrides:     nil,
+		}
+
+		actucalStr := GetOrderedKubeletConfigFlagString(config)
+		expectStr := "--cluster-dns=169.254.10.11 --event-qps=0 --image-gc-high-threshold=85 --node-status-update-frequency=10s "
+		Expect(expectStr).To(Equal(actucalStr))
+	})
+
+	It("should return default coredns serviceIP for --cluster-dns when localdns is disabled", func() {
+		config := &datamodel.NodeBootstrappingConfiguration{
+			KubeletConfig: map[string]string{
+				"--node-status-update-frequency": "10s",
+				"--node-status-report-frequency": "5m0s",
+				"--image-gc-high-threshold":      "85",
+				"--event-qps":                    "0",
+				"--cluster-dns":                  "10.0.0.10",
+			},
+			ContainerService: &datamodel.ContainerService{
+				Location:   "southcentralus",
+				Type:       "Microsoft.ContainerService/ManagedClusters",
+				Properties: &datamodel.Properties{},
+			},
+			EnableKubeletConfigFile: false,
+			AgentPoolProfile:        &datamodel.AgentPoolProfile{},
+		}
+
+		config.AgentPoolProfile.LocalDNSProfile = &datamodel.LocalDNSProfile{
+			EnableLocalDNS:       false,
+			CPULimitInMilliCores: to.Int32Ptr(2008),
+			MemoryLimitInMB:      to.Int32Ptr(128),
+			VnetDNSOverrides:     nil,
+			KubeDNSOverrides:     nil,
+		}
+
+		actucalStr := GetOrderedKubeletConfigFlagString(config)
+		expectStr := "--cluster-dns=10.0.0.10 --event-qps=0 --image-gc-high-threshold=85 --node-status-update-frequency=10s "
+		Expect(expectStr).To(Equal(actucalStr))
+	})
+
+	It("should return default coredns serviceIP for --cluster-dns when localdns is nil", func() {
+		config := &datamodel.NodeBootstrappingConfiguration{
+			KubeletConfig: map[string]string{
+				"--node-status-update-frequency": "10s",
+				"--node-status-report-frequency": "5m0s",
+				"--image-gc-high-threshold":      "85",
+				"--event-qps":                    "0",
+				"--cluster-dns":                  "10.0.0.10",
+			},
+			ContainerService: &datamodel.ContainerService{
+				Location:   "southcentralus",
+				Type:       "Microsoft.ContainerService/ManagedClusters",
+				Properties: &datamodel.Properties{},
+			},
+			EnableKubeletConfigFile: false,
+			AgentPoolProfile:        &datamodel.AgentPoolProfile{},
+		}
+
+		config.AgentPoolProfile.LocalDNSProfile = nil
+
+		actucalStr := GetOrderedKubeletConfigFlagString(config)
+		expectStr := "--cluster-dns=10.0.0.10 --event-qps=0 --image-gc-high-threshold=85 --node-status-update-frequency=10s "
+		Expect(expectStr).To(Equal(actucalStr))
+	})
+	// ------------------------------- End of tests related to Localdns ---------------------------------------.
 })
 
 var _ = Describe("Assert datamodel.CSEStatus can be used to parse output JSON", func() {


### PR DESCRIPTION
**What type of PR is this?**
feature

**What this PR does / why we need it**:
This PR has code changes to override '--cluster-dns' flag of kubelet, if LocalDNS is enabled for the agentpool.
If localdns is enabled for the agentpool, then Kubelet's --cluster-dns flag should be pointed to localdns clusterlistenerIP address. This is because, all the pods created by kubelet on the node will be pointing to clusterlistenerIP when localdns is enabled (ie etc/resolv.conf). In the next few PRs, we will see that ensureKubelet will be called after enableLocalDNS in cse_main file. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
