### PR TITLE
fix: aks-log-collector.sh syntax errors

### DIFF
--- a/parts/linux/cloud-init/artifacts/aks-log-collector.sh
+++ b/parts/linux/cloud-init/artifacts/aks-log-collector.sh
@@ -145,7 +145,7 @@ if [[ ! "$WORKDIR" || "$WORKDIR" == "/" || "$WORKDIR" == "/tmp" || ! -d "$WORKDI
   echo "ERROR: Could not create temporary working directory."
   exit 1
 fi
-cd $WORKDIR || { echo "Failed to change directory to $WORKDIR. Exiting." || exit 1
+cd $WORKDIR || { echo "Failed to change directory to $WORKDIR. Exiting."; exit 1; }
 echo "Created temporary directory: $WORKDIR"
 
 # Function to clean up the output directory and log termination
@@ -176,7 +176,7 @@ trap "cleanup" EXIT
 function collectToZip {
   command -v "${2}" >/dev/null || { printf "%s not found, skipping.\n" "${2}"; return; }
   mkfifo "${1}"
-  ${@:2} >"${1}" 2>&1 &
+  "${@:2}" >"${1}" 2>&1 &
   zip -gumDZ deflate --fifo "${ZIP}" "${1}"
 }
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**: 
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6181

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
Tested on Ubuntu system node pool for AKS v1.30.10
````bash
○ aks-log-collector.service - AKS Log Collector
     Loaded: loaded (/etc/systemd/system/aks-log-collector.service; static)
     Active: inactive (dead) since Thu 2025-04-10 21:05:31 UTC; 3s ago
TriggeredBy: ● aks-log-collector.timer
    Process: 119434 ExecStart=/opt/azure/containers/aks-log-collector.sh (code=exited, status=0/SUCCESS)
   Main PID: 119434 (code=exited, status=0/SUCCESS)
        CPU: 2.779s

Apr 10 21:05:31 aks-system-30979017-vmss00000C aks-log-collector.sh[119796]:   adding: var/log/auth.log (deflated 92%)
Apr 10 21:05:31 aks-system-30979017-vmss00000C aks-log-collector.sh[119798]:   adding: var/log/auth.log.1 (deflated 89%)
Apr 10 21:05:31 aks-system-30979017-vmss00000C aks-log-collector.sh[119434]: Log bundle size: 1.4M        aks_logs.zip
Apr 10 21:05:31 aks-system-30979017-vmss00000C aks-log-collector.sh[119434]: Uploading log bundle:
Apr 10 21:05:31 aks-system-30979017-vmss00000C aks-log-collector.sh[119805]: Successfully uploaded logs
Apr 10 21:05:31 aks-system-30979017-vmss00000C aks-log-collector.sh[119434]: Cleaning up /tmp/tmp.aV2HjZmEaT...
Apr 10 21:05:31 aks-system-30979017-vmss00000C aks-log-collector.sh[119434]: Log collection finished.
Apr 10 21:05:31 aks-system-30979017-vmss00000C systemd[1]: aks-log-collector.service: Deactivated successfully.
Apr 10 21:05:31 aks-system-30979017-vmss00000C systemd[1]: Finished AKS Log Collector.
Apr 10 21:05:31 aks-system-30979017-vmss00000C systemd[1]: aks-log-collector.service: Consumed 2.779s CPU time.
````

**Release note**:

```
none
```
