### PR TITLE
cleanup: remove kata containers image files from cvm vhd-image-builde…

### DIFF
--- a/vhdbuilder/packer/vhd-image-builder-mariner-cvm.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-cvm.json
@@ -561,26 +561,6 @@
     },
     {
       "type": "file",
-      "source": "kata-containers-igvm-debug.img",
-      "destination": "/home/packer/kata-containers-igvm-debug.img"
-    },
-    {
-      "type": "file",
-      "source": "kata-containers-igvm.img",
-      "destination": "/home/packer/kata-containers-igvm.img"
-    },
-    {
-      "type": "file",
-      "source": "kata-containers-initrd-base.img",
-      "destination": "/home/packer/kata-containers-initrd-base.img"
-    },
-    {
-      "type": "file",
-      "source": "kata-containers.img",
-      "destination": "/home/packer/kata-containers.img"
-    },
-    {
-      "type": "file",
       "source": "reference-info-base64",
       "destination": "/home/packer/reference-info-base64"
     },


### PR DESCRIPTION
Kata uses different boot components than cvm and therefor is not supported by the cvm image. This PR removes the kata containers image files from the cvm vhd-image-builder configuration. If kata is tried to be used by cvm the user will likely experience issues with kata pods not running.

**What type of PR is this?**
cleanup
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
^see above
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
