### PR TITLE
bug: better catch in windows cse

### DIFF
--- a/staging/cse/windows/kubernetesfunc.ps1
+++ b/staging/cse/windows/kubernetesfunc.ps1
@@ -178,30 +178,30 @@ function Check-APIServerConnectivity {
     $retryCount=0
 
     do {
+        $retryString="${retryCount}/${MaxRetryCount}"
         try
         {
             $tcpClient = New-Object Net.Sockets.TcpClient
             $tcpClient.SendTimeout = $ConnectTimeout*1000
             $tcpClient.ReceiveTimeout  = $ConnectTimeout*1000
 
-            Write-Log "Retry $retryCount : Trying to connect to API server $MasterIP"
+            Write-Log "Retry ${retryString}: Trying to connect to API server $MasterIP"
             $tcpClient.Connect($MasterIP, 443)
             if ($tcpClient.Connected)
             {
                 $tcpClient.Close()
-                Write-Log "Retry $retryCount : Connected to API server successfully"
+                Write-Log "Retry ${retryString}: Connected to API server successfully"
                 return
             }
             $tcpClient.Close()
         } catch [System.AggregateException] {
-            $ExStr = $_.Exception.ToString()
-            Write-Log "Retry $retryCount : Failed to connect to API server $MasterIP. AggregateException: ${ExStr}"
+            Write-Log "Retry ${retryString}: Failed to connect to API server $MasterIP. AggregateException: " + $_.Exception.ToString()
         } catch {
-            Write-Log "Retry $retryCount : Failed to connect to API server $MasterIP. Error: $_"
+            Write-Log "Retry ${retryString}: Failed to connect to API server $MasterIP. Error: $_"
         }
 
         $retryCount++
-        Write-Log "Retry $retryCount : Sleep $RetryInterval and then retry to connect to API server"
+        Write-Log "Retry ${retryString}: Sleep $RetryInterval and then retry to connect to API server"
         Sleep $RetryInterval
     } while ($retryCount -lt $MaxRetryCount)
 

--- a/staging/cse/windows/kubernetesfunc.ps1
+++ b/staging/cse/windows/kubernetesfunc.ps1
@@ -181,8 +181,11 @@ function Check-APIServerConnectivity {
         try
         {
             $tcpClient = New-Object Net.Sockets.TcpClient
+            $tcpClient.SendTimeout = $ConnectTimeout*1000
+            $tcpClient.ReceiveTimeout  = $ConnectTimeout*1000
+
             Write-Log "Retry $retryCount : Trying to connect to API server $MasterIP"
-            $tcpClient.ConnectAsync($MasterIP, 443).Wait($ConnectTimeout*1000)
+            $tcpClient.Connect($MasterIP, 443)
             if ($tcpClient.Connected)
             {
                 $tcpClient.Close()

--- a/staging/cse/windows/kubernetesfunc.ps1
+++ b/staging/cse/windows/kubernetesfunc.ps1
@@ -178,19 +178,24 @@ function Check-APIServerConnectivity {
     $retryCount=0
 
     do {
-        try {
-            $tcpClient=New-Object Net.Sockets.TcpClient
+        try
+        {
+            $tcpClient = New-Object Net.Sockets.TcpClient
             Write-Log "Retry $retryCount : Trying to connect to API server $MasterIP"
-            $tcpClient.ConnectAsync($MasterIP, 443).wait($ConnectTimeout*1000)
-            if ($tcpClient.Connected) {
+            $tcpClient.ConnectAsync($MasterIP, 443).Wait($ConnectTimeout*1000)
+            if ($tcpClient.Connected)
+            {
                 $tcpClient.Close()
                 Write-Log "Retry $retryCount : Connected to API server successfully"
                 return
             }
             $tcpClient.Close()
+        } catch [System.AggregateException] {
+            Write-Log "Retry $retryCount : Failed to connect to API server $MasterIP. AggregateException: " + $_.Exception.ToString()
         } catch {
             Write-Log "Retry $retryCount : Failed to connect to API server $MasterIP. Error: $_"
         }
+
         $retryCount++
         Write-Log "Retry $retryCount : Sleep $RetryInterval and then retry to connect to API server"
         Sleep $RetryInterval

--- a/staging/cse/windows/kubernetesfunc.ps1
+++ b/staging/cse/windows/kubernetesfunc.ps1
@@ -191,7 +191,8 @@ function Check-APIServerConnectivity {
             }
             $tcpClient.Close()
         } catch [System.AggregateException] {
-            Write-Log "Retry $retryCount : Failed to connect to API server $MasterIP. AggregateException: " + $_.Exception.ToString()
+            $ExStr = $_.Exception.ToString()
+            Write-Log "Retry $retryCount : Failed to connect to API server $MasterIP. AggregateException: ${ExStr}"
         } catch {
             Write-Log "Retry $retryCount : Failed to connect to API server $MasterIP. Error: $_"
         }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes a logging bug in the Windows CSE.

Currently during Windows CSE, we check API server connectivity. However, when that fails, there is a code path that only prints:

2025-04-08T23:30:48.5157611+00:00: Retry 0 : Failed to connect to API server asdfasdf-asdfasdfasdf.privatelink.eastus.azmk8s.io. Error: Exception calling "Wait" with "1" argument(s): "One or more errors occurred."

This is due to the way powershell prints exceptions of the type "AggregateException". So this PR prints them properly. Hopefully.

### Test 1: DNS and Server address exists:
```
C:\Users\wrightt> Check-ApiServerConnectivity -MasterIP www.google.com -MaxRetryCount 5
2025-04-14T16:50:03.7516430+12:00: Retry 0/5: Trying to connect to API server www.google.com
2025-04-14T16:50:03.7916636+12:00: Retry 0/5: Connected to API server successfully
```

### Test 2: DNS doesn't exist:

```
C:\Users\wrightt> Check-ApiServerConnectivity -MasterIP www.google.coasdfg -MaxRetryCount 5
2025-04-14T16:50:24.1999997+12:00: Retry 0/5: Trying to connect to API server www.google.coasdfg
2025-04-14T16:50:24.2045407+12:00: Retry 0/5: Failed to connect to API server www.google.coasdfg. Error: Exception calling "Connect" with "2" argument(s): "No such host is known."
2025-04-14T16:50:24.2052777+12:00: Retry 0/5: Sleep 1 and then retry to connect to API server
2025-04-14T16:50:25.2155671+12:00: Retry 1/5: Trying to connect to API server www.google.coasdfg
```

### Test 3: Server times out
(using a kusto cluster which is only VPN accessible)

```
C:\Users\wrightt> Check-ApiServerConnectivity -MasterIP aks.kusto.windows.net -MaxRetryCount 5
2025-04-14T16:48:28.5747232+12:00: Retry 0/5: Trying to connect to API server aks.kusto.windows.net
2025-04-14T16:48:49.6643145+12:00: Retry 0/5: Failed to connect to API server aks.kusto.windows.net. Error: Exception calling "Connect" with "2" argument(s): "A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond. [::ffff:20.109.207.81]:443"
2025-04-14T16:48:49.6653324+12:00: Retry 0/5: Sleep 1 and then retry to connect to API server
2025-04-14T16:48:50.6655051+12:00: Retry 1/5: Trying to connect to API server aks.kusto.windows.net
```



**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
