### PR TITLE
fix: Setup cron job for CA Cert refresh on Mariner

### DIFF
--- a/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-mariner.sh
+++ b/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-mariner.sh
@@ -15,6 +15,16 @@ IFS=$IFS_backup
 cp /root/AzureCACertificates/*.crt /etc/pki/ca-trust/source/anchors/
 /usr/bin/update-ca-trust
 
+# This section creates a cron job to poll for refreshed CA certs daily
+# It can be removed if not needed or desired
+action=${1:-init}
+if [ $action == "ca-refresh" ]
+then
+    exit
+fi
+
+(crontab -l ; echo "0 19 * * * $0 ca-refresh") | crontab -
+
 cloud-init status --wait
 
 marinerRepoDepotEndpoint="$(echo "${REPO_DEPOT_ENDPOINT}" | sed 's/\/ubuntu//')"


### PR DESCRIPTION
**What type of PR is this?**
/kind/fix

**What this PR does / why we need it**:
Duplicate cron job present for Ubuntu hosts to Mariner hosts. This should prevent the need to reboot hosts for additions to custom cloud CA certs.

**Which issue(s) this PR fixes**:
This fixes an issue where CA certs are not reloaded daily by Mariner hosts in custom clouds.

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version