### PR TITLE
disable windows e2e

### DIFF
--- a/.pipelines/.vsts-vhd-builder-pr-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-pr-windows.yaml
@@ -30,6 +30,17 @@ pr:
       - parts/windows
       - go.mod
       - go.sum
+
+      # the following are from the windows e2e pipeline and should be removed once that pipeline is working again.
+      - .pipelines/e2e-windows.yaml
+      - .pipelines/templates/e2e-template.yaml
+      - e2e
+      - parts/windows
+      - pkg/agent
+      - parts/common/components.json
+      - staging/cse/windows/
+      - go.mod
+      - go.sum
     exclude:
       - vhdbuilder/release-notes
       - /**/*.md

--- a/.pipelines/e2e-windows.yaml
+++ b/.pipelines/e2e-windows.yaml
@@ -36,6 +36,7 @@ pr:
 
 jobs:
   - template: ./templates/e2e-template.yaml
+    disabled: true
     parameters:
       name: Windows Tests
       IgnoreScenariosWithMissingVhd: false


### PR DESCRIPTION
**What type of PR is this?**
/kind chore

**What this PR does / why we need it**:

Disables the standalone windows e2e tests until I fix the pipeline.

These are currently failing because the windows VHD that should be produced from a nightly master build is not being produced.

Windows e2e tests are being run as part of PRs against the VHD built in the PR, so there's not much risk in disabling this pipeline right now.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
