### PR TITLE
fix(vhdbuilder): Pass DEBIAN_FRONTEND when installing git during test

### DIFF
--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -15,11 +15,6 @@ GIT_BRANCH="$5"
 IMG_SKU="$6"
 FEATURE_FLAGS="$7"
 
-if [ "${OS_VERSION}" = "18.04" ]; then
-  # 18.04 is failing to run az vm run commands during the testing step without these packages installed
-  sudo apt-get install -y dialog readline-common
-fi
-
 # List of "ERROR/WARNING" message we want to ignore in the cloud-init.log
 # 1. "Command ['hostname', '-f']":
 #   Running hostname -f will fail on current AzureLinux AKS image. We don't not have active plan to resolve
@@ -43,7 +38,7 @@ LOCAL_GIT_BRANCH=${GIT_BRANCH//\//-}
 
 # Git is not present in the base image, so we need to install it.
 if [ "$OS_SKU" = "Ubuntu" ]; then
-  sudo apt-get install -y git
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git
 else
   sudo tdnf install -y git
 fi


### PR DESCRIPTION


**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:
Specify `DEBIAN_FRONTEND=noninteractive` when installing git during tests, to prevent dpkg from trying to bring up a user dialog. The other attempt at fixing the issue (installing dialog/readline) is not needed with this fix so remove those lines again.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6357
Fixes #6115

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

```
none
```
