### PR TITLE
renovate rules for servercore and nanoserver

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -320,7 +320,21 @@
     {
       "matchPackageNames": [
         "windows/nanoserver",
-        "windows/servercore",
+        "windows/servercore"
+      ],
+      "groupName": "windowsbase",
+      "assignees": [
+        "timmy-wright"
+      ],
+      "reviewers": [
+        "timmy-wright"
+      ],
+      "enabled": true,
+      "_comment": "the minor and major are reversed intentionally. Windows versions are formatted 10.0.<winver>.<ver>",
+      "versioning": "regex:^10\\.(?<minor>\\d+)\\.(?<major>\\d+)\\.(?<patch>\\d+)$"
+    },
+    {
+      "matchPackageNames": [
         "windows/servercore/iis",
         "oss/v2/kubernetes/windows-gmsa-webhook"
       ],

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -26,6 +26,12 @@
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=windows/servercore",
+          "latestVersion": "10.0.20348.3453",
+          "previousLatestVersion": "10.0.20348.3328",
+          "windowsSkuMatch": "2025*"
+        },
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=windows/servercore",
           "latestVersion": "10.0.26100.3775",
           "previousLatestVersion": "10.0.26100.3476",
           "windowsSkuMatch": "2025*"


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What this PR does / why we need it**:

This PR adds renovate rules for servercore and nanoserver.

The tags for these containers are strange. They always start with "10.0" and then have a number indicating the windows container version, and then the patch version. Example:

* 10.0.20348.3328

20348 means "windows 2022 style container". Wheras 26100 means "windows 2025 style container" and "17763" means "windows 2019 style container"

To ensure that the upgrade does not upgrade between windows versions - ie a WS2019 container doesn't get changed to 2025, we use the windows version as the major version, and the 4th part as the patch version. Yeah, it's odd, but it seems to work.

I also made WS2025 cache both WS2022 and WS2025 style containers as it supports both.

Screen snapshot of generated PR on my agentbaker fork (seems to be the only way to test renovate changes):

![image](https://github.com/user-attachments/assets/6b7432af-ff7e-4c0b-b3c8-f92a369d5284)


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
