### PR TITLE
fix: remove debug flag from test vm create command

### DIFF
--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -92,7 +92,6 @@ if [ "${OS_TYPE,,}" = "linux" ]; then
       exit 1
   fi
   az vm create \
-      --debug \
       --resource-group "$TEST_VM_RESOURCE_GROUP_NAME" \
       --name "$VM_NAME" \
       --image "$MANAGED_SIG_ID" \


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

This PR removes the `--debug` flag from the `az vm create` command during Linux content tests in the VHD Build pipeline.

**Which issue(s) this PR fixes**:

The `--debug` flag has caused significant clutter in the logs and is not needed.

**Requirements**:

- [ x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified