### PR TITLE
feat: Add CIS compliance scanning to Ubuntu 22/24-base builds

### DIFF
--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -30,6 +30,15 @@ steps:
       vstsPackageVersion: '1.1.0-268'
       downloadDirectory: vhdbuilder/packer
 
+  - task: UniversalPackages@0
+    displayName: Download CIS scanner
+    inputs:
+      command: download
+      vstsFeed: AzCoreLinux-Compliance
+      vstsFeedPackage: cisassessor
+      vstsPackageVersion: '0.0.17'
+      downloadDirectory: vhdbuilder/
+
   - task: DownloadPipelineArtifact@2
     condition: or(eq(variables.OS_SKU, 'CBLMariner'), eq(variables.OS_SKU, 'AzureLinux'))
     displayName: 'Download Kata CC UVM artifact'

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -185,6 +185,16 @@ steps:
       Contents: 'trivy-images-table.txt'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
+  - task: CopyFiles@2
+    condition: and(eq(variables.OS_SKU, 'Ubuntu'), in(variables.OS_VERSION, '22.04', '24.04'), eq(variables.FEATURE_FLAGS, 'None'))
+    displayName: Copy CIS Reports
+    inputs:
+      SourceFolder: '$(System.DefaultWorkingDirectory)'
+      Contents: |
+        cis-report.html
+        cis-report.txt
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
   - task: PublishPipelineArtifact@0
     displayName: Publish Release Notes
     inputs:

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -22,15 +22,6 @@ steps:
     displayName: Get Build Mode
 
   - task: UniversalPackages@0
-    displayName: Download Asc Baseline
-    inputs:
-      command: download
-      vstsFeed: ASMPackages
-      vstsFeedPackage: asc-baseline
-      vstsPackageVersion: '1.1.0-268'
-      downloadDirectory: vhdbuilder/packer
-
-  - task: UniversalPackages@0
     displayName: Download CIS scanner
     inputs:
       command: download

--- a/pkg/agent/const.go
+++ b/pkg/agent/const.go
@@ -54,7 +54,6 @@ const (
 	kubernetesCSEConfig                 = "linux/cloud-init/artifacts/cse_config.sh"
 	kubernetesCSESendLogs               = "linux/cloud-init/artifacts/cse_send_logs.py"
 	kubernetesCSERedactCloudConfig      = "linux/cloud-init/artifacts/cse_redact_cloud_config.py"
-	kubernetesCISScript                 = "linux/cloud-init/artifacts/cis.sh"
 	kubernetesCustomSearchDomainsScript = "linux/cloud-init/artifacts/setup-custom-search-domains.sh"
 	kubeletSystemdService               = "linux/cloud-init/artifacts/kubelet.service"
 	kmsSystemdService                   = "linux/cloud-init/artifacts/kms.service"

--- a/pkg/agent/variables.go
+++ b/pkg/agent/variables.go
@@ -64,7 +64,6 @@ func getCustomDataVariables(config *datamodel.NodeBootstrappingConfiguration) pa
 	}
 
 	if !cs.Properties.IsVHDDistroForAllNodes() {
-		cloudInitData["provisionCIS"] = getBase64EncodedGzippedCustomScript(kubernetesCISScript, config)
 		cloudInitData["kmsSystemdService"] = getBase64EncodedGzippedCustomScript(kmsSystemdService, config)
 		cloudInitData["aptPreferences"] = getBase64EncodedGzippedCustomScript(aptPreferences, config)
 		cloudInitData["dockerClearMountPropagationFlags"] = getBase64EncodedGzippedCustomScript(dockerClearMountPropagationFlags, config)

--- a/vhdbuilder/packer/cis-report.sh
+++ b/vhdbuilder/packer/cis-report.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -eux
+
+# Parameters (passed as environment variables or arguments)
+CISASSESSOR_TARBALL_PATH="/tmp/cisassessor.tar.gz"
+CISASSESSOR_BLOB_NAME=${CISASSESSOR_BLOB_NAME:-""}
+STORAGE_ACCOUNT_NAME=${STORAGE_ACCOUNT_NAME:-""}
+SIG_CONTAINER_NAME=${SIG_CONTAINER_NAME:-""}
+AZURE_MSI_RESOURCE_STRING=${AZURE_MSI_RESOURCE_STRING:-""}
+ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH:-""}
+CIS_REPORT_TXT_NAME=${CIS_REPORT_TXT_NAME:-"cis-report.txt"}
+CIS_REPORT_HTML_NAME=${CIS_REPORT_HTML_NAME:-"cis-report.html"}
+
+# Azure login helper
+login_with_user_assigned_managed_identity() {
+    local TYPE_FLAG="$1"
+    local ID=$2
+    LOGIN_FLAGS="--identity $TYPE_FLAG $ID"
+    if [ "${ENABLE_TRUSTED_LAUNCH,,}" = "true" ]; then
+        LOGIN_FLAGS="$LOGIN_FLAGS --allow-no-subscriptions"
+    fi
+    echo "logging into azure with flags: $LOGIN_FLAGS"
+    az login $LOGIN_FLAGS
+}
+login_with_umsi_resource_id() {
+    login_with_user_assigned_managed_identity "--resource-id" "$1"
+}
+
+# Main logic - OS check is now done in vhd-scanning.sh before calling this script
+
+# Login to Azure before blob download
+if [ -n "$AZURE_MSI_RESOURCE_STRING" ]; then
+    login_with_umsi_resource_id "$AZURE_MSI_RESOURCE_STRING"
+else
+    echo "AZURE_MSI_RESOURCE_STRING must be set for az login"
+    exit 1
+fi
+
+# Fetch cisassessor tarball from storage account
+az storage blob download --container-name "$SIG_CONTAINER_NAME" --name "$CISASSESSOR_BLOB_NAME" --file "$CISASSESSOR_TARBALL_PATH" --account-name "$STORAGE_ACCOUNT_NAME" --auth-mode login
+
+if [ ! -f "$CISASSESSOR_TARBALL_PATH" ]; then
+    echo "CIS assessor tarball not found at $CISASSESSOR_TARBALL_PATH"
+    exit 1
+fi
+pushd "$(dirname "$CISASSESSOR_TARBALL_PATH")" || exit 1
+
+tar xzf "$CISASSESSOR_TARBALL_PATH"
+cisassessor/launch-cis.sh
+TXT_REPORT=$(find cisassessor/lib/app/reports -name "*.txt" | head -n1)
+HTML_REPORT=$(find cisassessor/lib/app/reports -name "*.html" | head -n1)
+
+# Upload reports to storage account
+az storage blob upload --container-name "$SIG_CONTAINER_NAME" --file "$TXT_REPORT" --name "${CIS_REPORT_TXT_NAME}" --account-name "$STORAGE_ACCOUNT_NAME" --auth-mode login
+az storage blob upload --container-name "$SIG_CONTAINER_NAME" --file "$HTML_REPORT" --name "${CIS_REPORT_HTML_NAME}" --account-name "$STORAGE_ACCOUNT_NAME" --auth-mode login
+
+popd || exit 1

--- a/vhdbuilder/packer/post-install-dependencies.sh
+++ b/vhdbuilder/packer/post-install-dependencies.sh
@@ -86,12 +86,6 @@ tee -a ${VHD_LOGS_FILEPATH} < /proc/version
 } >> ${VHD_LOGS_FILEPATH}
 capture_benchmark "${SCRIPT_NAME}_finish_vhd_build_logs"
 
-if [ "$(isARM64)" -ne 1 ]; then
-  # no asc-baseline-1.1.0-268.arm64.deb
-  installAscBaseline
-fi
-capture_benchmark "${SCRIPT_NAME}_install_asc_baseline"
-
 if [ $OS = $UBUNTU_OS_NAME ]; then
   # shellcheck disable=SC3010
   if [[ ${ENABLE_FIPS,,} == "true" || ${CPU_ARCH} == "arm64" ]]; then

--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -311,11 +311,6 @@
     },
     {
       "type": "file",
-      "source": "vhdbuilder/packer/asc-baseline-1.1.0-268.amd64.deb",
-      "destination": "/home/packer/asc-baseline.deb"
-    },
-    {
-      "type": "file",
       "source": "vhdbuilder/packer/pre-install-dependencies.sh",
       "destination": "/home/packer/pre-install-dependencies.sh"
     },

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -314,11 +314,6 @@
     },
     {
       "type": "file",
-      "source": "vhdbuilder/packer/asc-baseline-1.1.0-268.amd64.deb",
-      "destination": "/home/packer/asc-baseline.deb"
-    },
-    {
-      "type": "file",
       "source": "vhdbuilder/packer/pre-install-dependencies.sh",
       "destination": "/home/packer/pre-install-dependencies.sh"
     },

--- a/vhdbuilder/packer/vhd-image-builder-cvm.json
+++ b/vhdbuilder/packer/vhd-image-builder-cvm.json
@@ -318,11 +318,6 @@
     },
     {
       "type": "file",
-      "source": "vhdbuilder/packer/asc-baseline-1.1.0-268.amd64.deb",
-      "destination": "/home/packer/asc-baseline.deb"
-    },
-    {
-      "type": "file",
       "source": "vhdbuilder/packer/pre-install-dependencies.sh",
       "destination": "/home/packer/pre-install-dependencies.sh"
     },

--- a/vhdbuilder/packer/vhd-scanning.sh
+++ b/vhdbuilder/packer/vhd-scanning.sh
@@ -192,5 +192,94 @@ if [ -s cve-list.txt ]; then
 fi
 
 echo -e "Trivy Scan Script Completed\n\n\n"
+
+capture_benchmark "${SCRIPT_NAME}_cis_report_start"
+
+# --- CIS Report Generation and Upload ---
+
+# Check if OS requires CIS scan
+isMarinerOrAzureLinux() {
+    local os="$1"
+    if [ "$os" = "CBLMariner" ] || [ "$os" = "AzureLinux" ]; then
+        return 0
+    fi
+    return 1
+}
+isCISUnsupportedUbuntu() {
+    local os="$1"
+    local version="$2"
+
+    # Only 22.04+ are supported
+    if [ "$os" = "Ubuntu" ] && { [ "$version" = "18.04" ] || [ "$version" = "20.04" ]; }; then
+        return 0
+    fi
+    return 1
+}
+requiresCISScan() {
+    local os="$1"
+    local version="$2"
+
+    if isMarinerOrAzureLinux "$os"; then
+        return 1
+    fi
+    if isCISUnsupportedUbuntu "$os" "$version"; then
+        return 1
+    fi
+    return 0 # Requires scan
+}
+
+# First check if this OS requires CIS scanning
+if ! requiresCISScan "${OS_SKU}" "${OS_VERSION}"; then
+    echo "CIS scan not required for ${OS_SKU} ${OS_VERSION}"
+    capture_benchmark "${SCRIPT_NAME}_cis_report_skipped"
+    capture_benchmark "${SCRIPT_NAME}_overall" true
+    process_benchmarks
+    exit 0
+fi
+
+CIS_SCRIPT_PATH="$CDIR/cis-report.sh"
+CIS_REPORT_TXT_NAME="cis-report-${BUILD_ID}-${TIMESTAMP}.txt"
+CIS_REPORT_HTML_NAME="cis-report-${BUILD_ID}-${TIMESTAMP}.html"
+
+# Upload cisassessor tarball to storage account
+if [ "${ARCHITECTURE,,}" = "arm64" ]; then
+    CISASSESSOR_LOCAL_PATH="$CDIR/../cisassessor-arm64.tar.gz"
+else
+    CISASSESSOR_LOCAL_PATH="$CDIR/../cisassessor-amd64.tar.gz"
+fi
+CISASSESSOR_BLOB_NAME="cisassessor-${BUILD_ID}-${TIMESTAMP}.tar.gz"
+az storage blob upload --container-name "${SIG_CONTAINER_NAME}" --file "${CISASSESSOR_LOCAL_PATH}" --name "${CISASSESSOR_BLOB_NAME}" --account-name "${STORAGE_ACCOUNT_NAME}" --auth-mode login
+
+# Run CIS report script on VM (pass storage info)
+ret=$(az vm run-command invoke \
+    --command-id RunShellScript \
+    --name $SCAN_VM_NAME \
+    --resource-group $RESOURCE_GROUP_NAME \
+    --scripts @$CIS_SCRIPT_PATH \
+    --parameters "CISASSESSOR_BLOB_NAME=${CISASSESSOR_BLOB_NAME}" \
+        "STORAGE_ACCOUNT_NAME=${STORAGE_ACCOUNT_NAME}" \
+        "SIG_CONTAINER_NAME=${SIG_CONTAINER_NAME}" \
+        "AZURE_MSI_RESOURCE_STRING=${AZURE_MSI_RESOURCE_STRING}" \
+        "ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH}" \
+        "CIS_REPORT_TXT_NAME=${CIS_REPORT_TXT_NAME}" \
+        "CIS_REPORT_HTML_NAME=${CIS_REPORT_HTML_NAME}"
+)
+echo "$ret"
+msg=$(echo -E "$ret" | jq -r '.value[].message')
+echo "$msg"
+
+# Download CIS report files to working directory
+az storage blob download --container-name "${SIG_CONTAINER_NAME}" --name "${CIS_REPORT_TXT_NAME}" --file cis-report.txt --account-name "${STORAGE_ACCOUNT_NAME}" --auth-mode login
+az storage blob download --container-name "${SIG_CONTAINER_NAME}" --name "${CIS_REPORT_HTML_NAME}" --file cis-report.html --account-name "${STORAGE_ACCOUNT_NAME}" --auth-mode login
+
+# Remove CIS report blobs from storage
+az storage blob delete --account-name "${STORAGE_ACCOUNT_NAME}" --container-name "${SIG_CONTAINER_NAME}" --name "${CIS_REPORT_TXT_NAME}" --auth-mode login
+az storage blob delete --account-name "${STORAGE_ACCOUNT_NAME}" --container-name "${SIG_CONTAINER_NAME}" --name "${CIS_REPORT_HTML_NAME}" --auth-mode login
+# Remove CIS assessor tarball blob from storage
+az storage blob delete --account-name "${STORAGE_ACCOUNT_NAME}" --container-name "${SIG_CONTAINER_NAME}" --name "${CISASSESSOR_BLOB_NAME}" --auth-mode login
+
+echo -e "CIS Report Script Completed\n\n\n"
+capture_benchmark "${SCRIPT_NAME}_cis_report_upload_and_download"
+
 capture_benchmark "${SCRIPT_NAME}_overall" true
 process_benchmarks

--- a/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
+++ b/vhdbuilder/scripts/linux/mariner/tool_installs_mariner.sh
@@ -2,10 +2,6 @@
 
 echo "Sourcing tool_installs_mariner.sh"
 
-installAscBaseline() {
-   echo "Mariner TODO: installAscBaseline"
-}
-
 installBcc() {
     echo "Installing BCC tools..."
     dnf_makecache || exit $ERR_APT_UPDATE_TIMEOUT

--- a/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
+++ b/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
@@ -19,21 +19,6 @@ ERR_CHRONY_START_TIMEOUT=15 {{/* Unable to start CHRONY */}}
 
 echo "Sourcing tool_installs_ubuntu.sh"
 
-installAscBaseline() {
-   echo "Installing ASC Baseline tools..."
-   ASC_BASELINE_TMP=/home/packer/asc-baseline.deb
-   retrycmd_silent 120 5 25 dpkg -i $ASC_BASELINE_TMP || exit $ERR_APT_INSTALL_TIMEOUT
-   cd /opt/microsoft/asc-baseline
-   sudo ./ascbaseline -d baselines
-   sudo ./ascremediate -d baselines -m all
-   sudo ./ascbaseline -d baselines | grep -B2 -A6 "FAIL"
-   cd -
-   echo "Check UDF"
-   cat /etc/modprobe.d/*.conf | grep udf
-   echo "Finished Setting up ASC Baseline"
-   apt_get_purge 20 30 120 asc-baseline || exit $ERR_APT_PURGE_TIMEOUT
-}
-
 installBcc() {
     echo "Installing BCC tools..."
     wait_for_apt_locks


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR introduces scanning for CIS L1 compliance to those Ubuntu 22.04 and Ubuntu 24.04 builds that rely on the `-base` packer template. Scanning is performed during `test-scan-cleanup`. The CIS report is publish to ADO artifacts. This PR will be followed by config changes that increase our CIS compliance.

We can also finally clean up the `asc-baseline` package that is not used any longer.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
