### PR TITLE
fix: Stop passing managed identity ID with --username

### DIFF
--- a/.pipelines/scripts/e2e_run.sh
+++ b/.pipelines/scripts/e2e_run.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 # These are defined in: e2e/config/config.go
 
 # First, login.
-az login --identity --username "${E2E_AGENT_IDENTITY_ID}"
+az login --identity --resource-id "${E2E_AGENT_IDENTITY_ID}"
 az account set -s "${E2E_SUBSCRIPTION_ID}"
 echo "Using subscription ${E2E_SUBSCRIPTION_ID} for e2e tests"
 

--- a/packer.mk
+++ b/packer.mk
@@ -77,11 +77,11 @@ ifeq ($(origin MANAGED_IDENTITY_ID), undefined)
 	@az login --identity
 else
 	@echo "Logging in with Hosted Pool's Managed Identity: ${MANAGED_IDENTITY_ID}"
-	@az login --identity --username ${MANAGED_IDENTITY_ID}
+	@az login --identity --client-id ${MANAGED_IDENTITY_ID}
 endif
 else
 	@echo "Logging into Azure with identity: ${AZURE_MSI_RESOURCE_STRING}..."
-	@az login --identity --username ${AZURE_MSI_RESOURCE_STRING}
+	@az login --identity --resource-id ${AZURE_MSI_RESOURCE_STRING}
 endif
 	@echo "Using the subscription ${SUBSCRIPTION_ID}"
 	@az account set -s ${SUBSCRIPTION_ID}


### PR DESCRIPTION

**What type of PR is this?**

Az CLI now reports:
```
Passing the managed identity ID with --username is deprecated and will be removed in 2.73.0. Use --client-id, --object-id or --resource-id instead.
```

This causes the test/scan/cleanup step to fail.

Fix the failure by being specific in what kind of ID we're passing.

/kind failing-test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
