### PR TITLE
fix: update ci agent linux version from 3.1.25 to 3.1.27

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -406,12 +406,7 @@
           "latestVersion": "3.1.27"
         }
       ],
-      "windowsVersions": [
-        {
-          "renovateTag": "<DO_NOT_UPDATE>",
-          "latestVersion": "win-3.1.25"
-        }
-      ]
+      "windowsVersions": []
     },
     {
       "downloadURL": "mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-collector/images:*",

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -399,15 +399,19 @@
     },
     {
       "downloadURL": "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:*",
-      "windowsDownloadURL": "mcr.microsoft.com/azuremonitor/containerinsights/ciprod:win-*",
       "amd64OnlyVersions": [],
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=azuremonitor/containerinsights/ciprod",
-          "latestVersion": "3.1.25"
+          "latestVersion": "3.1.27"
         }
       ],
-      "windowsVersions": []
+      "windowsVersions": [
+        {
+          "renovateTag": "<DO_NOT_UPDATE>",
+          "latestVersion": "win-3.1.25"
+        }
+      ]
     },
     {
       "downloadURL": "mcr.microsoft.com/azuremonitor/containerinsights/ciprod/prometheus-collector/images:*",


### PR DESCRIPTION
**What type of PR is this?**

bug


**What this PR does / why we need it**:
ci team has frequent incident https://portal.microsofticm.com/imp/v5/incidents/details/630890690/summary, we believe it is because of old CI agent version - linux.

**Which issue(s) this PR fixes**:
update ci release Linux version (3.1.25) to 3.1.27.

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
