### PR TITLE
cleanup: have labeler workflow use GITHUB_TOKEN secret instead of aks-node-assistant

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -4,38 +4,13 @@ on:
   pull_request:
     branches:
       - master
+      - dev
 
-permissions:
-    id-token: write
-    contents: read
 jobs:
   label:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
-    environment: test
     steps:
-      - uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_KV_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_KV_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_KV_SUBSCRIPTION_ID }}
-      
-      - uses: azure/cli@v2
-        id: app-private-key
-        with:
-          azcliversion: latest
-          inlineScript: |
-              # https://github.com/actions/create-github-app-token?tab=readme-ov-file#inputs
-              private_key=$(az keyvault secret show --vault-name ${{ secrets.AZURE_KV_NAME }} -n ${{ secrets.APP_PRIVATE_KEY_SECRET_NAME }} --query value -o tsv | sed 's/$/\\n/g' | tr -d '\n' | head -c -2) &> /dev/null
-              echo "::add-mask::$private_key"
-              echo "private-key=$private_key" >> $GITHUB_OUTPUT
-
-      - uses: actions/create-github-app-token@v2
-        id: app-token
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ steps.app-private-key.outputs.private-key }}
-          repositories: AgentBaker
-
       - uses: actions/labeler@v5
-        with:
-          repo-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
have labeler workflow use GITHUB_TOKEN secret instead of aks-node-assistant so the labeler workflow will also work properly with dependabot PRs (since workflows triggered by dependabot PRs don't have access to repo secrets if triggered via pull_request instead of pull_request_target).

labels will now be added by the "github-actions" bot instead of aks-node-assistant, for example: https://github.com/Azure/AgentBaker/pull/6429

this change also greatly simplifies and speeds up the runtime of the labeler workflow by removing the need to interact with Azure

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
