### PR TITLE
chore: Credscan rules to supress 1ES checks - failing Upstream pipelines

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -1,0 +1,13 @@
+{
+  "tool": "Credential Scanner",
+  "suppressions": [
+    {
+     "file": "vhdbuilder\\packer\\test\\run-test.sh",
+      "_justification": "Hard-coded credential for an ephemeral test resource that only exists for the lifetime of the test being run"
+    },
+    {
+     "file": "parts\\linux\\cloud-init\\artifacts\\cis.sh",
+      "_justification": "Invalid result – output is not a credential or a secret"
+    }
+  ]
+}

--- a/e2e/kubelet/README.md
+++ b/e2e/kubelet/README.md
@@ -162,7 +162,7 @@ map[string]string{
   "--storage-driver-buffer-duration": "\"1m0s\"",
   "--storage-driver-db": "\"cadvisor\"",
   "--storage-driver-host": "\"localhost:8086\"",
-  "--storage-driver-password": "\"root\"",
+  "--storage-driver-password": "\"Placeholder\"",
   "--storage-driver-secure": "\"false\"",
   "--storage-driver-table": "\"stats\"",
   "--storage-driver-user": "\"root\"",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Upstream 1ES publishing pipelines are failing due to false CredScan alerts: https://dev.azure.com/AzureContainerUpstream/Kubernetes/_build/results?buildId=182763&view=results

Supressing the invalid flags as per: https://www.owiki.ms/wiki/Credscan/Suppress_False_Positives#placeholder

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
