### PR TITLE
chore: run windows e2e tests in the same location the VHDs are built

### DIFF
--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -82,8 +82,7 @@ fi
 
 # This variable is used within linux builds to inform which region that packer build itself will be running,
 # and subsequently the region in which the 1ES pool the build is running on is in.
-# Note that this variable is ONLY used for linux builds, windows builds simply use AZURE_LOCATION.
-if [ "$MODE" = "linuxVhdMode" ] && [ -z "${PACKER_BUILD_LOCATION}" ]; then
+if [ -z "${PACKER_BUILD_LOCATION}" ]; then
 	echo "PACKER_BUILD_LOCATION is not set, cannot compute VNET_RG_NAME for packer templates"
 	exit 1
 fi
@@ -490,11 +489,9 @@ if [ -n "${PRIVATE_PACKAGES_URL}" ]; then
 	private_packages_url="${PRIVATE_PACKAGES_URL}"
 fi
 
-# set PACKER_BUILD_LOCATION to the value of AZURE_LOCATION for windows
-# since windows doesn't currently distinguish between the 2.
-# also do this in cases where we're running a linux build in AME (for now)
+# set PACKER_BUILD_LOCATION to the value of AZURE_LOCATION where we're running a linux build in AME (for now)
 # TODO(cameissner): remove conditionals for prod once new pool config has been deployed to AME.
-if [ "$MODE" = "windowsVhdMode" ] || [ "${ENVIRONMENT,,}" = "prod" ]; then
+if [ "${ENVIRONMENT,,}" = "prod" ]; then
 	PACKER_BUILD_LOCATION=$AZURE_LOCATION
 fi
 

--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -22,13 +22,12 @@ set -x
 
 # For linux VHDs, override AZURE_LOCATION with PACKER_BUILD_LOCATION to make sure
 # we're in the correct region to access the image version from the staging gallery (PackerSigGalleryEastUS)
-if [ "${OS_TYPE,,}" = "linux" ]; then
-  if [ -z "$PACKER_BUILD_LOCATION" ]; then
-    echo "PACKER_BUILD_LOCATION must be set for linux builds"
-    exit 1
-  fi
-  AZURE_LOCATION=$PACKER_BUILD_LOCATION
+if [ -z "$PACKER_BUILD_LOCATION" ]; then
+  echo "PACKER_BUILD_LOCATION must be set for linux builds"
+  exit 1
 fi
+AZURE_LOCATION=$PACKER_BUILD_LOCATION
+
 
 if [ "${OS_TYPE,,}" = "linux" ]; then
   TEST_VM_RESOURCE_GROUP_NAME="$TEST_RESOURCE_PREFIX-$(date +%s)-$RANDOM"


### PR DESCRIPTION
**What type of PR is this?**
/kind chore

**What this PR does / why we need it**:

Currently the windows VHDs are built in eastus and then e2e tests are run in westus2. Which is a bit crappy really.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
