### PR TITLE
Use the CSE generated by AgentBaker to provision the current prod VHD

### DIFF
--- a/.pipelines/e2e-windows-regression.yaml
+++ b/.pipelines/e2e-windows-regression.yaml
@@ -37,7 +37,7 @@ pr:
       - dev
   paths:
     include:
-      - .pipelines/e2e-windows.yaml
+      - .pipelines/e2e-windows-regression.yaml
       - .pipelines/templates/e2e-template.yaml
       - .pipelines/scripts/e2e_run.sh
       - .pipelines/scripts/e2e_delete_vmss.sh

--- a/.pipelines/e2e-windows-regression.yaml
+++ b/.pipelines/e2e-windows-regression.yaml
@@ -1,0 +1,65 @@
+name: $(Date:yyyyMMdd)$(Rev:.r)
+variables:
+  - name: TAGS_TO_RUN
+    value: "os=windows"
+  - name: SKIP_E2E_TESTS
+    value: false
+  # this is intentionally blank to force the pipeline to use the VHD built from master
+  - name: VHD_BUILD_ID
+    value: ""
+  - name: LOCATION
+    value: $(PACKER_BUILD_LOCATION)
+  - name: POOL_NAME
+    value: $(AZURE_POOL_NAME)
+  - name: SUBSCRIPTION_ID
+    value: $(AZURE_BUILD_SUBSCRIPTION_ID)
+    # if SIG_FOR_PRODUCTION is true, then the VHDs are deleted from the gallery before the e2e tests are run.
+  - name: SIG_FOR_PRODUCTION
+    value: False
+    # These next vars are used for the e2e tests
+  - name: AZURE_RESOURCE_GROUP_NAME
+    value:  $(AZURE_BUILD_RESOURCE_GROUP_NAME)
+  - name: "AKS-Windows"
+    value: $(AZURE_BUILD_RESOURCE_GROUP_NAME)
+  - name: GALLERY_SUBSCRIPTION_ID
+    value: "4be8920b-2978-43d7-ab14-04d8549c1d05"
+
+trigger:
+  branches:
+    include:
+      - master
+      - dev
+pr:
+  branches:
+    include:
+      - master
+      - official/*
+      - dev
+  paths:
+    include:
+      - .pipelines/e2e-windows.yaml
+      - .pipelines/templates/e2e-template.yaml
+      - .pipelines/scripts/e2e_run.sh
+      - .pipelines/scripts/e2e_delete_vmss.sh
+      - e2e
+      - parts/windows
+      - pkg/agent
+      - parts/common/components.json
+      - staging/cse/windows/
+      - go.mod
+      - go.sum
+    exclude:
+      - pkg/agent/datamodel/sig_config*.go # SIG config changes
+      - pkg/agent/datamodel/*.json # SIG version changes
+      - pkg/agent/testdata/AKSWindows* # Windows test data
+      - parts/common/components.json # centralized components management file
+      - staging/cse/windows/README
+      - /**/*.md
+      - .github/**
+      - e2e/scenario_test.go
+
+jobs:
+  - template: ./templates/e2e-template.yaml
+    parameters:
+      name: Windows Tests
+      IgnoreScenariosWithMissingVhd: false

--- a/.pipelines/e2e-windows.yaml
+++ b/.pipelines/e2e-windows.yaml
@@ -19,10 +19,10 @@ variables:
     # These next vars are used for the e2e tests
   - name: AZURE_RESOURCE_GROUP_NAME
     value:  $(AZURE_BUILD_RESOURCE_GROUP_NAME)
-  - name: GALLERY_RESOURCE_GROUP
+  - name: "AKS-Windows"
     value: $(AZURE_BUILD_RESOURCE_GROUP_NAME)
   - name: GALLERY_SUBSCRIPTION_ID
-    value: $(AZURE_BUILD_SUBSCRIPTION_ID)
+    value: "4be8920b-2978-43d7-ab14-04d8549c1d05"
 
 
 trigger:


### PR DESCRIPTION
**What type of PR is this?**

/kind testing

**What this PR does / why we need it**:

Unlike Linux, Windows always uses the latest AgentBaker service to generate CSE to provision the VHDs. This creates a risk that the CSE might rely on something that is not in old versions of the VHD.

This PR adds a new e2e test that uses the current AgentBaker CSE to provision an older version of the VHD.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
