### PR TITLE
fix: use current cse pacakge in e2e as defined in componts.json

### DIFF
--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -3,10 +3,11 @@ package e2e
 import (
 	"encoding/base64"
 	"fmt"
+	"testing"
+
 	"github.com/Azure/agentbaker/aks-node-controller/helpers"
 	aksnodeconfigv1 "github.com/Azure/agentbaker/aks-node-controller/pkg/gen/aksnodeconfig/v1"
 	"github.com/Masterminds/semver"
-	"testing"
 
 	"github.com/Azure/agentbaker/e2e/config"
 	"github.com/Azure/agentbaker/pkg/agent"
@@ -468,7 +469,7 @@ func baseTemplateLinux(t *testing.T, location string, k8sVersion string, arch st
 				WindowsProvisioningScriptsPackageURL: "https://packages.aks.azure.com/aks-engine/windows/provisioning/signedscripts-v0.2.2.zip",
 				WindowsPauseImageURL:                 "mcr.microsoft.com/oss/kubernetes/pause:1.4.0",
 				AlwaysPullWindowsPauseImage:          false,
-				CseScriptsPackageURL:                 "https://packages.aks.azure.com/aks/windows/cse/csescripts-v0.0.1.zip",
+				CseScriptsPackageURL:                 "https://packages.aks.azure.com/aks/windows/cse/",
 				CNIARM64PluginsDownloadURL:           "https://acs-mirror.azureedge.net/cni-plugins/v0.8.7/binaries/cni-plugins-linux-arm64-v0.8.7.tgz",
 				VnetCNIARM64LinuxPluginsDownloadURL:  "https://acs-mirror.azureedge.net/azure-cni/v1.4.13/binaries/azure-vnet-cni-linux-arm64-v1.4.14.tgz",
 			},
@@ -762,16 +763,17 @@ DXRqvV7TWO2hndliQq3BW385ZkiephlrmpUVM= r2k1@arturs-mbp.lan`,
 				DockerComposeDownloadURL: "https://github.com/docker/compose/releases/download",
 			},
 			KubernetesSpecConfig: datamodel.KubernetesSpecConfig{
-				ACIConnectorImageBase:                "microsoft/",
-				AlwaysPullWindowsPauseImage:          false,
-				AzureCNIImageBase:                    "mcr.microsoft.com/containernetworking/",
-				AzureTelemetryPID:                    "",
-				CNIARM64PluginsDownloadURL:           "https://acs-mirror.azureedge.net/cni-plugins/v0.8.7/binaries/cni-plugins-linux-arm64-v0.8.7.tgz",
-				CNIPluginsDownloadURL:                "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-v0.7.6.tgz",
-				CSIProxyDownloadURL:                  "https://packages.aks.azure.com/csi-proxy/v0.1.0/binaries/csi-proxy.tar.gz",
-				CalicoImageBase:                      "calico/",
-				ContainerdDownloadURLBase:            "https://storage.googleapis.com/cri-containerd-release/",
-				CseScriptsPackageURL:                 "https://packages.aks.azure.com/aks/windows/cse/csescripts-v0.0.1.zip",
+				ACIConnectorImageBase:       "microsoft/",
+				AlwaysPullWindowsPauseImage: false,
+				AzureCNIImageBase:           "mcr.microsoft.com/containernetworking/",
+				AzureTelemetryPID:           "",
+				CNIARM64PluginsDownloadURL:  "https://acs-mirror.azureedge.net/cni-plugins/v0.8.7/binaries/cni-plugins-linux-arm64-v0.8.7.tgz",
+				CNIPluginsDownloadURL:       "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-v0.7.6.tgz",
+				CSIProxyDownloadURL:         "https://packages.aks.azure.com/csi-proxy/v0.1.0/binaries/csi-proxy.tar.gz",
+				CalicoImageBase:             "calico/",
+				ContainerdDownloadURLBase:   "https://storage.googleapis.com/cri-containerd-release/",
+				// CseScriptsPackageURL is used to download the CSE scripts for Windows nodes, when use filename it is pinned to that version insteaf of current as defined in components.json
+				CseScriptsPackageURL:                 "https://packages.aks.azure.com/aks/windows/cse/",
 				EtcdDownloadURLBase:                  "",
 				KubeBinariesSASURLBase:               "https://packages.aks.azure.com/kubernetes/",
 				KubernetesImageBase:                  "k8s.gcr.io/",

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -2,6 +2,13 @@ BeforeAll {
   . $PSScriptRoot\windowscsehelper.ps1
   . $PSScriptRoot\..\..\staging\cse\windows\containerdfunc.ps1
   . $PSCommandPath.Replace('.tests.ps1','.ps1')
+
+  # Basic mock of Set-Content
+  $capturedContent = $null
+  Mock Set-Content -MockWith { 
+      param($Path, $Value)
+      $script:capturedContent = $Value 
+  } -Verifiable
 }
 
 Describe 'Install-Containerd-Based-On-Kubernetes-Version' {
@@ -171,13 +178,6 @@ Describe "Mock Write-Log" {
 Describe "Resolve-PackagesSourceUrl" {
   BeforeEach {
     $global:PackageDownloadFqdn = $null
-
-    # Basic mock of Set-Content
-    $capturedContent = $null
-    Mock Set-Content -MockWith { 
-        param($Path, $Value)
-        $script:capturedContent = $Value 
-    } -Verifiable
   }
 
   It 'given valid preferred fqdn, returns preferred' {

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -3,7 +3,6 @@ BeforeAll {
   . $PSScriptRoot\..\..\staging\cse\windows\containerdfunc.ps1
   . $PSCommandPath.Replace('.tests.ps1','.ps1')
 
-  # Basic mock of Set-Content
   $capturedContent = $null
   Mock Set-Content -MockWith { 
       param($Path, $Value)

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -171,6 +171,13 @@ Describe "Mock Write-Log" {
 Describe "Resolve-PackagesSourceUrl" {
   BeforeEach {
     $global:PackageDownloadFqdn = $null
+
+    # Basic mock of Set-Content
+    $capturedContent = $null
+    Mock Set-Content -MockWith { 
+        param($Path, $Value)
+        $script:capturedContent = $Value 
+    } -Verifiable
   }
 
   It 'given valid preferred fqdn, returns preferred' {

--- a/staging/cse/windows/azurecnifunc.tests.ps1
+++ b/staging/cse/windows/azurecnifunc.tests.ps1
@@ -1,6 +1,12 @@
 BeforeAll {
     . $PSScriptRoot\..\..\..\parts\windows\windowscsehelper.ps1
     . $PSCommandPath.Replace('.tests.ps1','.ps1')
+
+    $capturedContent = $null
+    Mock Set-Content -MockWith { 
+        param($Path, $Value)
+        $script:capturedContent = $Value 
+    } -Verifiable
 }
 
 Describe 'GetBroadestRangesForEachAddress' {

--- a/staging/cse/windows/credentialProvider.tests.suites/credential-provider-config.yaml
+++ b/staging/cse/windows/credentialProvider.tests.suites/credential-provider-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: kubelet.config.k8s.io/v1
+kind: CredentialProviderConfig
+providers:
+  - name: acr-credential-provider
+    matchImages:
+      - "*.azurecr.io"
+      - "*.azurecr.cn"
+      - "*.azurecr.de"
+      - "*.azurecr.us"
+      - "*.azurecr.microsoft.fakecloud"
+    defaultCacheDuration: "10m"
+    apiVersion: credentialprovider.kubelet.k8s.io/v1
+    args:
+      - staging\cse\windows\credentialProvider.tests.suites\azure.json

--- a/staging/cse/windows/nvidiagpudriverfunc.tests.ps1
+++ b/staging/cse/windows/nvidiagpudriverfunc.tests.ps1
@@ -1,6 +1,8 @@
 BeforeAll {
     . $PSScriptRoot\..\..\..\parts\windows\windowscsehelper.ps1
     . $PSCommandPath.Replace('.tests.ps1', '.ps1')
+
+    Mock Set-Content
 }
 
 Describe 'Start-InstallGPUDriver' {


### PR DESCRIPTION
**What type of PR is this?**
/kind test


**What this PR does / why we need it**:
the current default e2e windows profile is using an outdated version of cse script. use folder path so that the current one is  used in e2e test.

previously this does not matter since e2e always uses the cse on the branch, however this has been fixed by another PR.

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [x] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
