### PR TITLE
chore: adjust behavior of cse_cmd in scriptless to allow recoverable errors from cloud-init 

### DIFF
--- a/aks-node-controller/parser/templates/cse_cmd.sh.gtpl
+++ b/aks-node-controller/parser/templates/cse_cmd.sh.gtpl
@@ -1,8 +1,9 @@
 echo $(date),$(hostname) > ${PROVISION_OUTPUT};
 {{if not .GetDisableCustomData}}
-cloud-init status --wait > /dev/null 2>&1;
-[ "$?" -ne 0 ] && echo 'cloud-init failed' >> ${PROVISION_OUTPUT} && exit 1;
-echo "cloud-init succeeded" >> ${PROVISION_OUTPUT};
+. /does/not/exist.sh
+/bin/bash -c "source /opt/azure/containers/cloud-init-status-check.sh; handleCloudInitStatus \"${PROVISION_OUTPUT}\"; returnStatus=\$?; echo \"Cloud init status check exit code: \$returnStatus\" >> ${PROVISION_OUTPUT}; exit \$returnStatus" >> ${PROVISION_OUTPUT} 2>&1;
+cloudInitExitCode=$?;
+[ "$cloudInitExitCode" -ne 0 ] && echo "cloud-init failed with exit code ${cloudInitExitCode}" >> ${PROVISION_OUTPUT} && exit ${cloudInitExitCode};
 {{end}}
 {{if getIsAksCustomCloud .CustomCloudConfig}}
 REPO_DEPOT_ENDPOINT="{{.CustomCloudConfig.RepoDepotEndpoint}}"


### PR DESCRIPTION
See https://github.com/Azure/AgentBaker/pull/6473 for context, adjusts the behavior of scriptless to match changes added in that PR.