### PR TITLE
fix: prevent PodSandbox image from getting GCed by configuring pinned=true

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -65,11 +65,9 @@ ERR_SYSTEMD_DOCKER_STOP_FAIL=116 # Error stopping dockerd
 ERR_CRICTL_DOWNLOAD_TIMEOUT=117 # Timeout waiting for crictl downloads
 ERR_CRICTL_OPERATION_ERROR=118 # Error executing a crictl operation
 ERR_CTR_OPERATION_ERROR=119 # Error executing a ctr containerd cli operation
+ERR_INVALID_CLI_TOOL=120 # Invalid CLI tool specified, should be one of ctr, crictl, docker
 
-# Azure Stack specific errors
-ERR_AZURE_STACK_GET_ARM_TOKEN=120 # Error generating a token to use with Azure Resource Manager
-ERR_AZURE_STACK_GET_NETWORK_CONFIGURATION=121 # Error fetching the network configuration for the node
-ERR_AZURE_STACK_GET_SUBNET_PREFIX=122 # Error fetching the subnet address prefix for a subnet ID
+# 121, 122, 123 are free for use
 
 # Error code 124 is returned when a `timeout` command times out, and --preserve-status is not specified: https://man7.org/linux/man-pages/man1/timeout.1.html
 ERR_VHD_BUILD_ERROR=125 # Reserved for VHD CI exit conditions

--- a/parts/linux/cloud-init/artifacts/cse_install.sh
+++ b/parts/linux/cloud-init/artifacts/cse_install.sh
@@ -789,6 +789,14 @@ retagContainerImage() {
     fi
 }
 
+labelContainerImage() {
+    CONTAINER_IMAGE_URL=$1
+    LABEL_KEY=$2
+    LABEL_VALUE=$3
+    echo "labeling image ${CONTAINER_IMAGE_URL} with ${LABEL_KEY}=${LABEL_VALUE} using ctr"
+    ctr --namespace k8s.io image label $CONTAINER_IMAGE_URL $LABEL_KEY=$LABEL_VALUE
+}
+
 retagMCRImagesForChina() {
     if [ "${CONTAINER_RUNTIME}" = "containerd" ]; then
         # shellcheck disable=SC2016

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -543,26 +543,48 @@ while IFS= read -r imageToBePulled; do
 done <<< "$ContainerImages"
 echo "Waiting for container image pulls to finish. PID: ${image_pids[@]}"
 wait ${image_pids[@]}
+capture_benchmark "${SCRIPT_NAME}_caching_container_images"
 
-watcher=$(jq '.ContainerImages[] | select(.downloadURL | contains("aks-node-ca-watcher"))' $COMPONENTS_FILEPATH)
-watcherBaseImg=$(echo $watcher | jq -r .downloadURL)
-watcherVersion=$(echo $watcher | jq -r .multiArchVersionsV2[0].latestVersion)
-watcherFullImg=${watcherBaseImg//\*/$watcherVersion}
+retagAKSNodeCAWatcher() {
+  # This function retags the aks-node-ca-watcher image to a static tag
+  # The static tag is used to bootstrap custom CA trust when MCR egress may be intercepted by an untrusted TLS MITM firewall.
+  # The image is never pulled, it is only retagged.
 
-# this image will never get pulled, the tag must be the same across different SHAs.
-# it will only ever be upgraded via node image changes.
-# we do this because the image is used to bootstrap custom CA trust when MCR egress
-# may be intercepted by an untrusted TLS MITM firewall.
-watcherStaticImg=${watcherBaseImg//\*/static}
+  watcher=$(jq '.ContainerImages[] | select(.downloadURL | contains("aks-node-ca-watcher"))' $COMPONENTS_FILEPATH)
+  watcherBaseImg=$(echo $watcher | jq -r .downloadURL)
+  watcherVersion=$(echo $watcher | jq -r .multiArchVersionsV2[0].latestVersion)
+  watcherFullImg=${watcherBaseImg//\*/$watcherVersion}
 
-# can't use cliTool because crictl doesn't support retagging.
-retagContainerImage "ctr" ${watcherFullImg} ${watcherStaticImg}
+  # this image will never get pulled, the tag must be the same across different SHAs.
+  # it will only ever be upgraded via node image changes.
+  # we do this because the image is used to bootstrap custom CA trust when MCR egress
+  # may be intercepted by an untrusted TLS MITM firewall.
+  watcherStaticImg=${watcherBaseImg//\*/static}
+
+  # can't use cliTool because crictl doesn't support retagging.
+  retagContainerImage "ctr" ${watcherFullImg} ${watcherStaticImg}
+}
+retagAKSNodeCAWatcher
+capture_benchmark "${SCRIPT_NAME}_retag_aks_node_ca_watcher"
+
+pinPodSandboxImage() {
+  # This function pins the pod sandbox image to avoid he GC from removing it.
+  # This is achieved by setting the "io.cri-containerd.pinned" label on the image with a value of "pinned".
+
+  podSandbox=$(jq '.ContainerImages[] | select(.downloadURL | contains("pause"))' $COMPONENTS_FILEPATH)
+  podSandboxBaseImg=$(echo $podSandbox | jq -r .downloadURL)
+  podSandboxVersion=$(echo $podSandbox | jq -r .multiArchVersionsV2[0].latestVersion)
+  podSandboxFullImg=${podSandboxBaseImg//\*/$podSandboxVersion}
+
+  labelContainerImage ${podSandboxFullImg} "io.cri-containerd.pinned" "pinned"
+}
+pinPodSandboxImage
+capture_benchmark "${SCRIPT_NAME}_pin_pod_sandbox_image"
 
 # IPv6 nftables rules are only available on Ubuntu or Mariner/AzureLinux
 if [ $OS = $UBUNTU_OS_NAME ] || isMarinerOrAzureLinux "$OS"; then
   systemctlEnableAndStart ipv6_nftables 30 || exit 1
 fi
-capture_benchmark "${SCRIPT_NAME}_pull_and_retag_container_images"
 
 mkdir -p /var/log/azure/Microsoft.Azure.Extensions.CustomScript/events
 


### PR DESCRIPTION
**What this PR does / why we need it**:
prevent PodSandbox image from getting GCed by configuring pinned=true
```
root@aks-agentpool-11430180-vmss000000:/# crictl image --pinned | grep pause
mcr.microsoft.com/oss/kubernetes/pause                                                3.6                                               7b178dc69474d       301kB               false
```
```
root@aks-agentpool-11430180-vmss000000:/# ctr --namespace k8s.io image label mcr.microsoft.com/oss/kubernetes/pause:3.6 io.cri-containerd.pinned=pinned   
io.cri-containerd.image=managed,io.cri-containerd.pinned=pinned
```
```
root@aks-agentpool-11430180-vmss000000:/# crictl image --pinned | grep pause
mcr.microsoft.com/oss/kubernetes/pause                                                3.6                                               7b178dc69474d       301kB               true
```
**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
