### PR TITLE
Auto-fill Windows image URLs using WCCT JSON

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -59,7 +59,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows Container Image Json URL
     type: string
-    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/06B/payload.json
+    default: ""
   - name: dryrun
     displayName: Dry run
     type: boolean

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -59,7 +59,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows Container Image Json URL
     type: string
-    default: ""
+    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/06B/payload.json
   - name: dryrun
     displayName: Dry run
     type: boolean

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -56,6 +56,10 @@ parameters:
     displayName: Build 2025 Gen 2
     type: boolean
     default: True
+  - name: windowsContainerImageJsonUrl
+    displayName: Windows Container Image Json URL
+    type: string
+    default: ""
   - name: dryrun
     displayName: Dry run
     type: boolean
@@ -102,6 +106,7 @@ stages:
       build23H2gen2: ${{ parameters.build23H2gen2 }}
       build2025:  ${{ parameters.build2025 }}
       build2025gen2:  ${{ parameters.build2025gen2 }}
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       skipExtensionCheck: ${{ parameters.skipExtensionCheck }}
       installOpenSshServer: ${{ parameters.installOpenSshServer }}
       overrideBranch: ${{ parameters.overrideBranch }}

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -52,6 +52,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
+    default: ""
   - name: overrideBranch
     type: string
     default: master

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -49,6 +49,10 @@ parameters:
   - name: windowsCoreImageUrl
     displayName: Windows core base container image URL Override
     type: string
+  - name: windowsContainerImageJsonUrl
+    displayName: Windows container image JSON URL Override
+    type: string
+    default: ""
   - name: overrideBranch
     type: string
     default: master
@@ -88,6 +92,7 @@ stages:
               windowsBaseImageUrl: ${{ parameters.windowsBaseImageUrl }}
               windowsNanoImageUrl: ${{ parameters.windowsNanoImageUrl }}
               windowsCoreImageUrl: ${{ parameters.windowsCoreImageUrl }}
+              windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
               overrideBranch: ${{ parameters.overrideBranch }}
               useOverrides: ${{ parameters.useOverrides }}
               csePackageDir: ${{ parameters.csePackageDir }}

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -52,7 +52,6 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
-    default: ""
   - name: overrideBranch
     type: string
     default: master

--- a/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
@@ -23,7 +23,6 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
-    default: ""
   - name: dryrun
     displayName: Dry run
     type: boolean

--- a/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
@@ -23,6 +23,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
+    default: ""
   - name: dryrun
     displayName: Dry run
     type: boolean

--- a/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
@@ -20,6 +20,10 @@ parameters:
   - name: build2025gen2
     displayName: Build 2025 Gen 2
     type: boolean
+  - name: windowsContainerImageJsonUrl
+    displayName: Windows container image JSON URL Override
+    type: string
+    default: ""
   - name: dryrun
     displayName: Dry run
     type: boolean
@@ -93,6 +97,7 @@ stages:
       windowsBaseImageUrl: $(WINDOWS_2019_BASE_IMAGE_URL)
       windowsNanoImageUrl: $(WINDOWS_2019_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2019_CORE_IMAGE_URL)
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}
@@ -115,6 +120,7 @@ stages:
       windowsBaseImageUrl: $(WINDOWS_2022_BASE_IMAGE_URL)
       windowsNanoImageUrl: $(WINDOWS_2022_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2022_CORE_IMAGE_URL)
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}
@@ -137,6 +143,7 @@ stages:
       windowsBaseImageUrl: $(WINDOWS_2022_GEN2_BASE_IMAGE_URL)
       windowsNanoImageUrl: $(WINDOWS_2022_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2022_CORE_IMAGE_URL)
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}
@@ -159,6 +166,7 @@ stages:
       windowsBaseImageUrl: $(WINDOWS_23H2_BASE_IMAGE_URL)
       windowsNanoImageUrl: $(WINDOWS_2022_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2022_CORE_IMAGE_URL)
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}
@@ -181,6 +189,7 @@ stages:
       windowsBaseImageUrl: $(WINDOWS_23H2_GEN2_BASE_IMAGE_URL)
       windowsNanoImageUrl: $(WINDOWS_2022_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2022_CORE_IMAGE_URL)
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}
@@ -203,6 +212,7 @@ stages:
       windowsBaseImageUrl: $(WINDOWS_2025_BASE_IMAGE_URL)
       windowsNanoImageUrl: $(WINDOWS_2025_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2025_CORE_IMAGE_URL)
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}
@@ -225,6 +235,7 @@ stages:
       windowsBaseImageUrl: $(WINDOWS_2025_GEN2_BASE_IMAGE_URL)
       windowsNanoImageUrl: $(WINDOWS_2025_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2025_CORE_IMAGE_URL)
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -40,6 +40,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
+    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/06B/payload.json
   - name: skipExtensionCheck
     displayName: Skip Extension Check
     type: boolean

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -108,7 +108,7 @@ steps:
       WINDOWS_BASE_IMAGE_URL: ${{ parameters.windowsBaseImageUrl }}
       WINDOWS_NANO_IMAGE_URL: ${{ parameters.windowsNanoImageUrl }}
       WINDOWS_CORE_IMAGE_URL: ${{ parameters.windowsCoreImageUrl }}
-      WINDOWS_CONTAINER_IMAGE_JSON_URL: ${{ parameters.windowsContainerImageJsonUrl }}
+      WINDOWS_CONTAINERIMAGE_JSON_URL: ${{ parameters.windowsContainerImageJsonUrl }}
       WINDOWS_PRIVATE_PACKAGES_URL: $(PRIVATE_PACKAGES_URL)
       AZURE_MSI_RESOURCE_STRING: $(AZURE_MSI_RESOURCE_STRING)
       BUILD_DATE: $(BUILD_DATE)

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -124,7 +124,7 @@ steps:
       # the base image tag will be 'ltscxxx', which differs from the values specified in parts/common/component.json.
       # As a result, cache validation behaves differently. To address this, we check if the container base image URL is set,
       # and use this environment variable to control the cache validation logic in run-test.sh.
-      if [[ -n "${{ parameters.windowsNanoImageUrl }}" || -n "${{ parameters.windowsCoreImageUrl }}" || -n "${{ parameters.windowsContainerImageJsonUrl }}"]]; then
+      if [[ -n "${{ parameters.windowsNanoImageUrl }}" || -n "${{ parameters.windowsCoreImageUrl }}" || -n "${{ parameters.windowsContainerImageJsonUrl }}" ]]; then
         export CONTAINTER_BASE_URLS_EXISTING=true
       else
         export CONTAINTER_BASE_URLS_EXISTING=false

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -40,7 +40,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
-    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/06B/payload.json
+    default: ""
   - name: skipExtensionCheck
     displayName: Skip Extension Check
     type: boolean

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -37,6 +37,9 @@ parameters:
   - name: windowsCoreImageUrl
     displayName: Windows core base container image URL Override
     type: string
+  - name: windowsContainerImageJsonUrl
+    displayName: Windows container image JSON URL
+    type: string
   - name: skipExtensionCheck
     displayName: Skip Extension Check
     type: boolean
@@ -104,6 +107,7 @@ steps:
       WINDOWS_BASE_IMAGE_URL: ${{ parameters.windowsBaseImageUrl }}
       WINDOWS_NANO_IMAGE_URL: ${{ parameters.windowsNanoImageUrl }}
       WINDOWS_CORE_IMAGE_URL: ${{ parameters.windowsCoreImageUrl }}
+      WINDOWS_CONTAINER_IMAGE_JSON_URL: ${{ parameters.windowsContainerImageJsonUrl }}
       WINDOWS_PRIVATE_PACKAGES_URL: $(PRIVATE_PACKAGES_URL)
       AZURE_MSI_RESOURCE_STRING: $(AZURE_MSI_RESOURCE_STRING)
       BUILD_DATE: $(BUILD_DATE)

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -38,8 +38,9 @@ parameters:
     displayName: Windows core base container image URL Override
     type: string
   - name: windowsContainerImageJsonUrl
-    displayName: Windows container image JSON URL
+    displayName: Windows container image JSON URL Override
     type: string
+    default: ""
   - name: skipExtensionCheck
     displayName: Skip Extension Check
     type: boolean

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -40,7 +40,6 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
-    default: ""
   - name: skipExtensionCheck
     displayName: Skip Extension Check
     type: boolean

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -124,7 +124,7 @@ steps:
       # the base image tag will be 'ltscxxx', which differs from the values specified in parts/common/component.json.
       # As a result, cache validation behaves differently. To address this, we check if the container base image URL is set,
       # and use this environment variable to control the cache validation logic in run-test.sh.
-      if [[ -n "${{ parameters.windowsNanoImageUrl }}" || -n "${{ parameters.windowsCoreImageUrl }}" ]]; then
+      if [[ -n "${{ parameters.windowsNanoImageUrl }}" || -n "${{ parameters.windowsCoreImageUrl }}" || -n "${{ parameters.windowsContainerImageJsonUrl }}"]]; then
         export CONTAINTER_BASE_URLS_EXISTING=true
       else
         export CONTAINTER_BASE_URLS_EXISTING=false

--- a/vhdbuilder/packer/WINDOWS-CONTAINERIMAGE-JSON.MD
+++ b/vhdbuilder/packer/WINDOWS-CONTAINERIMAGE-JSON.MD
@@ -1,0 +1,76 @@
+# Using the Windows Container Image JSON Blob
+
+This guide is for developers who want to manually download and inspect the JSON blob used in `produce-packer-settings.sh` for Windows VHD builds. 
+The blob contains image URLs for various Windows SKUs and is used to configure builds dynamically.
+
+## How to download the JSON blob
+⚠️ Access to the WCCT AgentBaker Storage Account is restricted. If you need access, please contact [yuazhang@microsoft.com](mailto:yuazhang@microsoft)
+1. Navigate to the WCCT AgentBaker Storage Account via Azure Portal
+2. Browse to:  
+   `Blob containers > simship > 2025 > 04B` *(or later service releases)*  
+3. Download the `payload.json` file.
+
+## 📄 Here's an example JSON Format 
+```json
+{
+    "datetime": "20250407",
+    "service-release": "04B",
+    "images": [
+        {
+            "name": "WINDOWS_2019_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2019/2019-datacenter-core-smalldisk-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_2019_CORE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2019/CONTAINERS/servercore.tar"
+        },
+        {
+            "name": "WINDOWS_2019_NANO_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2019/CONTAINERS/nanoserver.tar"
+        },
+        {
+            "name": "WINDOWS_2022_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2022/2022-datacenter-core-smalldisk-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_2022_CORE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2022/CONTAINERS/servercore.tar"
+        },
+        {
+            "name": "WINDOWS_2022_NANO_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2022/CONTAINERS/nanoserver.tar"
+        },
+        {
+            "name": "WINDOWS_2022_GEN2_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2022/GEN2/2022-datacenter-core-smalldisk-g2-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_2025_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2025/2025-datacenter-core-smalldisk-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_2025_CORE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2025/CONTAINERS/servercore.tar"
+        },
+        {
+            "name": "WINDOWS_2025_NANO_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2025/CONTAINERS/nanoserver.tar"
+        },
+        {
+            "name": "WINDOWS_2025_GEN2_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2025/GEN2/2025-datacenter-core-smalldisk-g2-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_23H2_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws23H2/23h2-datacenter-core-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_23H2_GEN2_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws23H2/GEN2/23h2-datacenter-core-g2-sim.vhd"
+        }
+    ]
+}
+```
+
+## 🛠️ How It's Used
+The JSON blob is parsed in `produce-packer-settings.sh` to extract image URLs based on the `WINDOWS_SKU`. These URLs are then used to configure the VHD build process dynamically, avoiding hardcoded values.

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -471,9 +471,14 @@ if [ "$OS_TYPE" = "Windows" ]; then
 		fi	
 	fi
 		
-	# Check if nano and core urls are set
-	if [ -z "${windows_nanoserver_image_url}" ] || [ -z "${windows_servercore_image_url}" ]; then
-		echo "Error: One or both Windows image URLs are not set."
+	# Check if base, nano, and servercore urls are set
+	if [ -z "${windows_nanoserver_image_url}" ] || [ -z "${windows_servercore_image_url}" ] || [ -z "${WINDOWS_BASE_IMAGE_URL}" ]; then
+		echo "Error: One of the Windows image URLs are not set."
+	else
+		# If all URLs are set, print them
+		echo "Using Windows base image URL: ${WINDOWS_BASE_IMAGE_URL}"
+		echo "Using Windows Nano Server image URL: ${windows_nanoserver_image_url}"
+		echo "Using Windows Server Core image URL: ${windows_servercore_image_url}"
 	fi
 
 	# build from a pre-supplied VHD blob a.k.a. external raw VHD

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -407,11 +407,12 @@ if [ "$OS_TYPE" = "Windows" ]; then
 		filename=$(basename "$WINDOWS_CONTAINERIMAGE_JSON_URL")
 		echo "Downloading $filename from wcct storage account using AzCopy with Managed Identity Auth"
 
+		# For details on the expected format and how to manually retrieve the JSON blob,
+		# see: [WINDOWS-CONTAINERIMAGE-JSON.MD](vhdbuilder/packer/WINDOWS-CONTAINERIMAGE-JSON.MD)
 		if azcopy copy "${WINDOWS_CONTAINERIMAGE_JSON_URL}" "${BUILD_ARTIFACTSTAGINGDIRECTORY}/"; then
 			echo "Successfully downloaded the latest artifact: $filename"
 		else
 			echo "Failed to download the latest artifact"
-			exit 1
 		fi
 
 		# Parse the json artifact to get the image urls

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -400,17 +400,18 @@ if [ "$OS_TYPE" = "Windows" ]; then
 	# default: build VHD images from a marketplace base image
 	IMPORTED_IMAGE_NAME=$imported_windows_image_name
 	IMPORTED_IMAGE_URL="https://${STORAGE_ACCOUNT_NAME}.blob.core.windows.net/system/$IMPORTED_IMAGE_NAME.vhd"
- 
+ 	export AZCOPY_AUTO_LOGIN_TYPE="MSI" # use Managed Identity for AzCopy authentication
+
 	if [ -n "${WINDOWS_CONTAINERIMAGE_JSON_URL}" ]; then
 		# Download the json artifact from the url
 		filename=$(basename "$WINDOWS_CONTAINERIMAGE_JSON_URL")
 		echo "Downloading $filename from wcct storage account using AzCopy with Managed Identity Auth"
-		export AZCOPY_AUTO_LOGIN_TYPE="MSI"
 
 		if azcopy copy "${WINDOWS_CONTAINERIMAGE_JSON_URL}" "${BUILD_ARTIFACTSTAGINGDIRECTORY}/"; then
 			echo "Successfully downloaded the latest artifact: $filename"
 		else
 			echo "Failed to download the latest artifact"
+			exit 1
 		fi
 
 		# Parse the json artifact to get the image urls
@@ -481,7 +482,6 @@ if [ "$OS_TYPE" = "Windows" ]; then
 		WINDOWS_IMAGE_URL=${IMPORTED_IMAGE_URL}
 
 		echo "Copy Windows base image to ${WINDOWS_IMAGE_URL}"
-		export AZCOPY_AUTO_LOGIN_TYPE="MSI"
 		export AZCOPY_MSI_RESOURCE_STRING="${AZURE_MSI_RESOURCE_STRING}"
 		azcopy copy "${WINDOWS_BASE_IMAGE_URL}" "${WINDOWS_IMAGE_URL}"
 		# https://www.packer.io/plugins/builders/azure/arm#image_url

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -401,12 +401,14 @@ if [ "$OS_TYPE" = "Windows" ]; then
 	IMPORTED_IMAGE_NAME=$imported_windows_image_name
 	IMPORTED_IMAGE_URL="https://${STORAGE_ACCOUNT_NAME}.blob.core.windows.net/system/$IMPORTED_IMAGE_NAME.vhd"
  	export AZCOPY_AUTO_LOGIN_TYPE="MSI" # use Managed Identity for AzCopy authentication
+	export AZCOPY_MSI_RESOURCE_STRING="${AZURE_MSI_RESOURCE_STRING}"
 
 	if [ -n "${WINDOWS_CONTAINERIMAGE_JSON_URL}" ]; then
 		# Download the json artifact from the url
 		filename=$(basename "$WINDOWS_CONTAINERIMAGE_JSON_URL")
 		echo "Downloading $filename from wcct storage account using AzCopy with Managed Identity Auth"
 
+		# The JSON blob is formatted where each build image name is mapped to its corresponding image URL.
 		# For details on the expected format and how to manually retrieve the JSON blob,
 		# see: [WINDOWS-CONTAINERIMAGE-JSON.MD](vhdbuilder/packer/WINDOWS-CONTAINERIMAGE-JSON.MD)
 		if azcopy copy "${WINDOWS_CONTAINERIMAGE_JSON_URL}" "${BUILD_ARTIFACTSTAGINGDIRECTORY}/"; then
@@ -488,7 +490,6 @@ if [ "$OS_TYPE" = "Windows" ]; then
 		WINDOWS_IMAGE_URL=${IMPORTED_IMAGE_URL}
 
 		echo "Copy Windows base image to ${WINDOWS_IMAGE_URL}"
-		export AZCOPY_MSI_RESOURCE_STRING="${AZURE_MSI_RESOURCE_STRING}"
 		azcopy copy "${WINDOWS_BASE_IMAGE_URL}" "${WINDOWS_IMAGE_URL}"
 		# https://www.packer.io/plugins/builders/azure/arm#image_url
 		# WINDOWS_IMAGE_URL to a custom VHD to use for your base image. If this value is set, image_publisher, image_offer, image_sku, or image_version should not be set.

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -403,6 +403,7 @@ if [ "$OS_TYPE" = "Windows" ]; then
  	export AZCOPY_AUTO_LOGIN_TYPE="MSI" # use Managed Identity for AzCopy authentication
 	export AZCOPY_MSI_RESOURCE_STRING="${AZURE_MSI_RESOURCE_STRING}"
 
+	echo "VALID IMAGE URL: ${WINDOWS_CONTAINERIMAGE_JSON_URL}"
 	if [ -n "${WINDOWS_CONTAINERIMAGE_JSON_URL}" ]; then
 		# Download the json artifact from the url
 		filename=$(basename "$WINDOWS_CONTAINERIMAGE_JSON_URL")


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind cleanup

**What this PR does / why we need it:**

This PR introduces an automation feature that streamlines the process of populating Windows image URLs (base, nano, and servercore) in AgentBaker. Instead of manually updating each image URL during every Patch Tuesday, this feature enables automatic population using a JSON payload file. The payload is downloaded from the WCCT Agentbaker Storage account and parsed to extract the latest image URLs.

**Which issue(s) this PR fixes:**
This reduces manual intervention, minimizes the risk of human error, and ensures consistency across image updates. It also includes comments and conditions in the case where a valid URL is not available for use, falling back to the pipeline's initial [manually filled] URLs.

Requirements: