### PR TITLE
test: update windows e2e default config

### DIFF
--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -668,8 +668,11 @@ func baseTemplateLinux(t *testing.T, location string, k8sVersion string, arch st
 
 // this been crafted with a lot of trial and pain, some values are not needed, but it takes a lot of time to figure out which ones.
 // and we hope to move on to a different config, so I don't want to invest any more time in this-
+// please keep the kubernetesVersion in sync with componets.json so that during e2e no extra binaries are required.
 func baseTemplateWindows(t *testing.T, location string) *datamodel.NodeBootstrappingConfiguration {
-	kubernetesVersion := "1.29.9"
+	kubernetesVersion := "1.30.12"
+	// kubernetesVersion := "1.31.9"
+	// kubernetesVersion := "v1.32.5"
 	config := &datamodel.NodeBootstrappingConfiguration{
 		TenantID:          "tenantID",
 		SubscriptionID:    config.Config.SubscriptionID,
@@ -684,7 +687,7 @@ func baseTemplateWindows(t *testing.T, location string) *datamodel.NodeBootstrap
 					OrchestratorType:    "Kubernetes",
 					OrchestratorVersion: kubernetesVersion,
 					KubernetesConfig: &datamodel.KubernetesConfig{
-						AzureCNIURLWindows:   "https://packages.aks.azure.com/azure-cni/v1.4.35/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.4.35.zip",
+						AzureCNIURLWindows:   "https://packages.aks.azure.com/azure-cni/v1.6.21/binaries/azure-vnet-cni-windows-amd64-v1.6.21.zip",
 						ClusterSubnet:        "10.224.0.0/16",
 						DNSServiceIP:         "10.0.0.10",
 						LoadBalancerSku:      "Standard",
@@ -692,7 +695,7 @@ func baseTemplateWindows(t *testing.T, location string) *datamodel.NodeBootstrap
 						NetworkPluginMode:    "overlay",
 						ServiceCIDR:          "10.0.0.0/16",
 						UseInstanceMetadata:  to.Ptr(true),
-						UseManagedIdentity:   true,
+						UseManagedIdentity:   false,
 						WindowsContainerdURL: "https://packages.aks.azure.com/containerd/windows/",
 					},
 				},
@@ -725,7 +728,7 @@ func baseTemplateWindows(t *testing.T, location string) *datamodel.NodeBootstrap
 				},
 				WindowsProfile: &datamodel.WindowsProfile{
 					AlwaysPullWindowsPauseImage:    to.Ptr(false),
-					CSIProxyURL:                    "https://packages.aks.azure.com/csi-proxy/v0.2.2/binaries/csi-proxy-v0.2.2.tar.gz",
+					CSIProxyURL:                    "https://packages.aks.azure.com/csi-proxy/v1.1.2-hotfix.20230807/binaries/csi-proxy-v1.1.2-hotfix.20230807.tar.gz",
 					EnableAutomaticUpdates:         to.Ptr(false),
 					EnableCSIProxy:                 to.Ptr(true),
 					HnsRemediatorIntervalInMinutes: to.Ptr[uint32](1),
@@ -734,7 +737,7 @@ func baseTemplateWindows(t *testing.T, location string) *datamodel.NodeBootstrap
 					WindowsDockerVersion:           "",
 					WindowsImageSourceURL:          "",
 					WindowsOffer:                   "aks-windows",
-					WindowsPauseImageURL:           "mcr.microsoft.com/oss/kubernetes/pause:3.9",
+					WindowsPauseImageURL:           "mcr.microsoft.com/oss/kubernetes/pause:3.9-hotfix-20230808",
 					WindowsPublisher:               "microsoft-aks",
 					WindowsSku:                     "",
 				},
@@ -765,9 +768,9 @@ DXRqvV7TWO2hndliQq3BW385ZkiephlrmpUVM= r2k1@arturs-mbp.lan`,
 				AlwaysPullWindowsPauseImage: false,
 				AzureCNIImageBase:           "mcr.microsoft.com/containernetworking/",
 				AzureTelemetryPID:           "",
-				CNIARM64PluginsDownloadURL:  "https://packages.aks.azure.com/cni-plugins/v0.8.7/binaries/cni-plugins-linux-arm64-v0.8.7.tgz",
-				CNIPluginsDownloadURL:       "https://packages.aks.azure.com/cni/cni-plugins-amd64-v0.7.6.tgz",
-				CSIProxyDownloadURL:         "https://packages.aks.azure.com/csi-proxy/v0.1.0/binaries/csi-proxy.tar.gz",
+				// CNIARM64PluginsDownloadURL:  "https://packages.aks.azure.com/cni-plugins/v0.8.7/binaries/cni-plugins-linux-arm64-v0.8.7.tgz",
+				// CNIPluginsDownloadURL:       "https://packages.aks.azure.com/cni/cni-plugins-amd64-v0.7.6.tgz",
+				CSIProxyDownloadURL:         "https://packages.aks.azure.com/csi-proxy/v1.1.2-hotfix.20230807/binaries/csi-proxy-v1.1.2-hotfix.20230807.tar.gz",
 				CalicoImageBase:             "calico/",
 				ContainerdDownloadURLBase:   "https://storage.googleapis.com/cri-containerd-release/",
 				// CseScriptsPackageURL is used to download the CSE scripts for Windows nodes, when use filename it is pinned to that version insteaf of current as defined in components.json
@@ -778,11 +781,11 @@ DXRqvV7TWO2hndliQq3BW385ZkiephlrmpUVM= r2k1@arturs-mbp.lan`,
 				MCRKubernetesImageBase:               "mcr.microsoft.com/",
 				NVIDIAImageBase:                      "nvidia/",
 				TillerImageBase:                      "gcr.io/kubernetes-helm/",
-				VnetCNIARM64LinuxPluginsDownloadURL:  "https://packages.aks.azure.com/azure-cni/v1.4.13/binaries/azure-vnet-cni-linux-arm64-v1.4.14.tgz",
-				VnetCNILinuxPluginsDownloadURL:       "https://packages.aks.azure.com/azure-cni/v1.1.3/binaries/azure-vnet-cni-linux-amd64-v1.1.3.tgz",
-				VnetCNIWindowsPluginsDownloadURL:     "https://packages.aks.azure.com/azure-cni/v1.1.3/binaries/azure-vnet-cni-singletenancy-windows-amd64-v1.1.3.zip",
-				WindowsPauseImageURL:                 "mcr.microsoft.com/oss/kubernetes/pause:1.4.0",
-				WindowsProvisioningScriptsPackageURL: "https://packages.aks.azure.com/aks-engine/windows/provisioning/signedscripts-v0.2.2.zip",
+				// VnetCNIARM64LinuxPluginsDownloadURL:  "https://packages.aks.azure.com/azure-cni/v1.4.13/binaries/azure-vnet-cni-linux-arm64-v1.4.14.tgz",
+				// VnetCNILinuxPluginsDownloadURL:       "https://packages.aks.azure.com/azure-cni/v1.1.3/binaries/azure-vnet-cni-linux-amd64-v1.1.3.tgz",
+				VnetCNIWindowsPluginsDownloadURL:     "https://packages.aks.azure.com/azure-cni/v1.6.21/binaries/azure-vnet-cni-windows-amd64-v1.6.21.zip",
+				WindowsPauseImageURL:                 "mcr.microsoft.com/oss/kubernetes/pause:3.9-hotfix-20230808",
+				WindowsProvisioningScriptsPackageURL: "https://packages.aks.azure.com/aks/windows/cse/aks-windows-cse-scripts-v0.0.52.zip",
 				WindowsTelemetryGUID:                 "fb801154-36b9-41bc-89c2-f4d4f05472b0",
 			},
 			EndpointConfig: datamodel.AzureEndpointConfig{
@@ -827,7 +830,7 @@ DXRqvV7TWO2hndliQq3BW385ZkiephlrmpUVM= r2k1@arturs-mbp.lan`,
 			"--kube-reserved":                   "cpu=100m,memory=3891Mi",
 			"--kubeconfig":                      "c:\\k\\config",
 			"--max-pods":                        "30",
-			"--pod-infra-container-image":       "mcr.microsoft.com/oss/kubernetes/pause:3.9",
+			"--pod-infra-container-image":       "mcr.microsoft.com/oss/kubernetes/pause:3.9-hotfix-20230808",
 			"--resolv-conf":                     "\"\"\"\"",
 			"--cluster-dns":                     "10.0.0.10",
 			"--cluster-domain":                  "cluster.local",

--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/Azure/agentbaker/e2e/config"
@@ -170,13 +171,19 @@ func Test_Windows2019CachingRegression(t *testing.T) {
 }
 
 func Test_Windows2025(t *testing.T) {
+	t.Skip("skipping test for Windows 2025, as we are testing regression issues with k8s 1.31+")
 	RunScenario(t, &Scenario{
 		Description: "Windows Server 2025 with Containerd",
 		Config: Config{
-			Cluster:                ClusterAzureNetwork,
-			VHD:                    config.VHDWindows2025,
-			VMConfigMutator:        EmptyVMConfigMutator,
-			BootstrapConfigMutator: EmptyBootstrapConfigMutator,
+			Cluster:         ClusterAzureNetwork,
+			VHD:             config.VHDWindows2025,
+			VMConfigMutator: EmptyVMConfigMutator,
+			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
+				// 2025 supported in 1.32+ .
+				configuration.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = "1.32.5"
+				configuration.K8sComponents.WindowsPackageURL = fmt.Sprintf("https://packages.aks.azure.com/kubernetes/v%s/windowszip/v%s-1int.zip", "1.32.5", "1.32.5")
+			},
+
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateWindowsVersionFromWindowsSettings(ctx, s, "2025")
 				ValidateWindowsProductName(ctx, s, "Windows Server 2025 Datacenter")
@@ -190,13 +197,19 @@ func Test_Windows2025(t *testing.T) {
 }
 
 func Test_Windows2025Gen2(t *testing.T) {
+	t.Skip("skipping test for Windows 2025, as we are testing regression issues with k8s 1.31+")
 	RunScenario(t, &Scenario{
 		Description: "Windows Server 2025 with Containerd - hyperv gen 2",
 		Config: Config{
-			Cluster:                ClusterAzureNetwork,
-			VHD:                    config.VHDWindows2025Gen2,
-			VMConfigMutator:        EmptyVMConfigMutator,
-			BootstrapConfigMutator: EmptyBootstrapConfigMutator,
+			Cluster:         ClusterAzureNetwork,
+			VHD:             config.VHDWindows2025Gen2,
+			VMConfigMutator: EmptyVMConfigMutator,
+			// BootstrapConfigMutator: EmptyBootstrapConfigMutator,
+			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
+				// 2025 supported in 1.32+ .
+				configuration.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = "1.32.5"
+				configuration.K8sComponents.WindowsPackageURL = fmt.Sprintf("https://packages.aks.azure.com/kubernetes/v%s/windowszip/v%s-1int.zip", "1.32.5", "1.32.5")
+			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateWindowsVersionFromWindowsSettings(ctx, s, "2025-gen2")
 				ValidateWindowsProductName(ctx, s, "Windows Server 2025 Datacenter")


### PR DESCRIPTION
**What type of PR is this?**
/kind test


<!--
Add one of the following kinds:
/kind bug

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

The windows e2e tests have been using outdated default  config.

this PR brings default up to date; it aligns with production environment more closely.


 it will save a lot of time since now all binaries are installed on the VHD and we don't have to download them again while running e2e.


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
