### PR TITLE
e2e: Add support for testing NPD w/ AKS VM Extension

### DIFF
--- a/e2e/config/azure.go
+++ b/e2e/config/azure.go
@@ -5,14 +5,16 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/Azure/agentbaker/e2e/toolkit"
 	"net"
 	"net/http"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Azure/agentbaker/e2e/toolkit"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -60,6 +62,7 @@ type AzureClient struct {
 	VirutalNetworkLinksClient *armprivatedns.VirtualNetworkLinksClient
 	ArmOptions                *arm.ClientOptions
 	VMSSVMRunCommands         *armcompute.VirtualMachineScaleSetVMRunCommandsClient
+	VMExtensionImages         *armcompute.VirtualMachineExtensionImagesClient
 }
 
 func mustNewAzureClient() *AzureClient {
@@ -241,6 +244,11 @@ func NewAzureClient() (*AzureClient, error) {
 	cloud.VMSSVMRunCommands, err = armcompute.NewVirtualMachineScaleSetVMRunCommandsClient(Config.SubscriptionID, credential, opts)
 	if err != nil {
 		return nil, fmt.Errorf("create vmss vm run command client: %w", err)
+	}
+
+	cloud.VMExtensionImages, err = armcompute.NewVirtualMachineExtensionImagesClient(Config.SubscriptionID, credential, opts)
+	if err != nil {
+		return nil, fmt.Errorf("create vm extension images client: %w", err)
 	}
 
 	cloud.Credential = credential
@@ -599,4 +607,75 @@ func (a *AzureClient) createVMSS(ctx context.Context, resourceGroupName string, 
 	}
 	return &vmssResp.VirtualMachineScaleSet, nil
 
+}
+
+// GetLatestVMExtensionImageVersion lists VM extension images for a given extension name and returns the latest version.
+// This is equivalent to: az vm extension image list -n Compute.AKS.Linux.AKSNode --latest
+func (a *AzureClient) GetLatestVMExtensionImageVersion(ctx context.Context, location, extType, extPublisher string) (string, error) {
+	// List extension versions
+	resp, err := a.VMExtensionImages.ListVersions(ctx, location, extPublisher, extType, &armcompute.VirtualMachineExtensionImagesClientListVersionsOptions{})
+	if err != nil {
+		return "", fmt.Errorf("listing extension versions: %w", err)
+	}
+
+	if len(resp.VirtualMachineExtensionImageArray) == 0 {
+		return "", fmt.Errorf("no extension versions found")
+	}
+
+	version := make([]Version, len(resp.VirtualMachineExtensionImageArray))
+	for i, ext := range resp.VirtualMachineExtensionImageArray {
+		version[i] = parseVersion(ext)
+	}
+
+	sort.Slice(version, func(i, j int) bool {
+		return version[i].Less(version[j])
+	})
+
+	return *version[len(version)-1].Original.Name, nil
+}
+
+// Version represents a parsed version of a VM extension image.
+type Version struct {
+	Original *armcompute.VirtualMachineExtensionImage
+	Major    int
+	Minor    int
+	Patch    int
+}
+
+// parseVersion parses the version from a VM extension image name, which can be in the format 1.151, 1.0.1, etc.
+// You can find all the versions of a specific VM extension by running:
+// az vm extension image list -n Compute.AKS.Linux.AKSNode
+func parseVersion(v *armcompute.VirtualMachineExtensionImage) Version {
+	// Split by dots
+	parts := strings.Split(*v.Name, ".")
+
+	version := Version{Original: v}
+
+	if len(parts) >= 1 {
+		if major, err := strconv.Atoi(parts[0]); err == nil {
+			version.Major = major
+		}
+	}
+	if len(parts) >= 2 {
+		if minor, err := strconv.Atoi(parts[1]); err == nil {
+			version.Minor = minor
+		}
+	}
+	if len(parts) >= 3 {
+		if patch, err := strconv.Atoi(parts[2]); err == nil {
+			version.Patch = patch
+		}
+	}
+
+	return version
+}
+
+func (v Version) Less(other Version) bool {
+	if v.Major != other.Major {
+		return v.Major < other.Major
+	}
+	if v.Minor != other.Minor {
+		return v.Minor < other.Minor
+	}
+	return v.Patch < other.Patch
 }

--- a/e2e/config/azure.go
+++ b/e2e/config/azure.go
@@ -622,7 +622,7 @@ func (a *AzureClient) GetLatestVMExtensionImageVersion(ctx context.Context, loca
 		return "", fmt.Errorf("no extension versions found")
 	}
 
-	version := make([]Version, len(resp.VirtualMachineExtensionImageArray))
+	version := make([]VMExtenstionVersion, len(resp.VirtualMachineExtensionImageArray))
 	for i, ext := range resp.VirtualMachineExtensionImageArray {
 		version[i] = parseVersion(ext)
 	}
@@ -634,8 +634,8 @@ func (a *AzureClient) GetLatestVMExtensionImageVersion(ctx context.Context, loca
 	return *version[len(version)-1].Original.Name, nil
 }
 
-// Version represents a parsed version of a VM extension image.
-type Version struct {
+// VMExtenstionVersion represents a parsed version of a VM extension image.
+type VMExtenstionVersion struct {
 	Original *armcompute.VirtualMachineExtensionImage
 	Major    int
 	Minor    int
@@ -645,11 +645,11 @@ type Version struct {
 // parseVersion parses the version from a VM extension image name, which can be in the format 1.151, 1.0.1, etc.
 // You can find all the versions of a specific VM extension by running:
 // az vm extension image list -n Compute.AKS.Linux.AKSNode
-func parseVersion(v *armcompute.VirtualMachineExtensionImage) Version {
+func parseVersion(v *armcompute.VirtualMachineExtensionImage) VMExtenstionVersion {
 	// Split by dots
 	parts := strings.Split(*v.Name, ".")
 
-	version := Version{Original: v}
+	version := VMExtenstionVersion{Original: v}
 
 	if len(parts) >= 1 {
 		if major, err := strconv.Atoi(parts[0]); err == nil {
@@ -670,7 +670,7 @@ func parseVersion(v *armcompute.VirtualMachineExtensionImage) Version {
 	return version
 }
 
-func (v Version) Less(other Version) bool {
+func (v VMExtenstionVersion) Less(other VMExtenstionVersion) bool {
 	if v.Major != other.Major {
 		return v.Major < other.Major
 	}

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1642,7 +1642,7 @@ func Test_Ubuntu2404_NPD_Basic(t *testing.T) {
 			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
-				extension, err := createAKSVMExtension(vmss.Location)
+				extension, err := createVMExtensionLinuxAKSNode(vmss.Location)
 				if err != nil {
 					t.Fatalf("creating AKS VM extension: %v", err)
 				}

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1632,3 +1632,25 @@ func runScenarioUbuntu2404GRID(t *testing.T, vmSize string) {
 func Test_Ubuntu2404_GPUA10(t *testing.T) {
 	runScenarioUbuntu2404GRID(t, "Standard_NV6ads_A10_v5")
 }
+
+func Test_Ubuntu2404_NPD_Basic(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "Test that a node with AKS VM Extension enabled can report simulated node problem detector events",
+		Config: Config{
+			Cluster: ClusterKubenet,
+			VHD:     config.VHDUbuntu2404Gen2Containerd,
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			},
+			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
+				extension, err := createAKSVMExtension(vmss.Location)
+				if err != nil {
+					t.Fatalf("creating AKS VM extension: %v", err)
+				}
+				vmss.Properties = addVMExtensionToVMSS(vmss.Properties, extension)
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateNodeProblemDetector(ctx, s)
+				ValidateNPDFilesystemCorruption(ctx, s)
+			},
+		}})
+}

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -431,7 +431,7 @@ func addVMExtensionToVMSS(properties *armcompute.VirtualMachineScaleSetPropertie
 	return properties
 }
 
-func createAKSVMExtension(location *string) (*armcompute.VirtualMachineScaleSetExtension, error) {
+func createVMExtensionLinuxAKSNode(location *string) (*armcompute.VirtualMachineScaleSetExtension, error) {
 	// Default to "westus" if location is nil.
 	region := "westus"
 	if location != nil {

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -441,7 +441,7 @@ func createAKSVMExtension(location *string) (*armcompute.VirtualMachineScaleSetE
 	extensionName := "Compute.AKS.Linux.AKSNode"
 	publisher := "Microsoft.AKS"
 
-	// NOTE: If this is gonna be called multiple times, then find a way to cache the latest version.
+	// NOTE (@surajssd): If this is gonna be called multiple times, then find a way to cache the latest version.
 	extensionVersion, err := config.Azure.GetLatestVMExtensionImageVersion(context.TODO(), region, extensionName, publisher)
 	if err != nil {
 		return nil, fmt.Errorf("getting latest VM extension image version: %v", err)

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/agentbaker/e2e/config"
 	"github.com/Azure/agentbaker/e2e/toolkit"
 	"github.com/Azure/agentbaker/pkg/agent/datamodel"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/barkimedes/go-deepcopy"
 	"github.com/stretchr/testify/require"
@@ -406,4 +407,52 @@ func parseLinuxCSEMessage(status armcompute.InstanceViewStatus) (*datamodel.CSES
 		return nil, fmt.Errorf("CSE Json does not contain exit code, raw CSE Message: %s", *status.Message)
 	}
 	return &cseStatus, nil
+}
+
+func addVMExtensionToVMSS(properties *armcompute.VirtualMachineScaleSetProperties, extension *armcompute.VirtualMachineScaleSetExtension) *armcompute.VirtualMachineScaleSetProperties {
+	if properties == nil {
+		properties = &armcompute.VirtualMachineScaleSetProperties{}
+	}
+
+	if properties.VirtualMachineProfile == nil {
+		properties.VirtualMachineProfile = &armcompute.VirtualMachineScaleSetVMProfile{}
+	}
+
+	if properties.VirtualMachineProfile.ExtensionProfile == nil {
+		properties.VirtualMachineProfile.ExtensionProfile = &armcompute.VirtualMachineScaleSetExtensionProfile{}
+	}
+
+	if properties.VirtualMachineProfile.ExtensionProfile.Extensions == nil {
+		properties.VirtualMachineProfile.ExtensionProfile.Extensions = []*armcompute.VirtualMachineScaleSetExtension{}
+	}
+
+	// NOTE: This is not checking if we are adding a duplicate extension.
+	properties.VirtualMachineProfile.ExtensionProfile.Extensions = append(properties.VirtualMachineProfile.ExtensionProfile.Extensions, extension)
+	return properties
+}
+
+func createAKSVMExtension(location *string) (*armcompute.VirtualMachineScaleSetExtension, error) {
+	// Default to "westus" if location is nil.
+	region := "westus"
+	if location != nil {
+		region = *location
+	}
+
+	extensionName := "Compute.AKS.Linux.AKSNode"
+	publisher := "Microsoft.AKS"
+
+	// NOTE: If this is gonna be called multiple times, then find a way to cache the latest version.
+	extensionVersion, err := config.Azure.GetLatestVMExtensionImageVersion(context.TODO(), region, extensionName, publisher)
+	if err != nil {
+		return nil, fmt.Errorf("getting latest VM extension image version: %v", err)
+	}
+
+	return &armcompute.VirtualMachineScaleSetExtension{
+		Name: to.Ptr(extensionName),
+		Properties: &armcompute.VirtualMachineScaleSetExtensionProperties{
+			Publisher:          to.Ptr(publisher),
+			Type:               to.Ptr(extensionName),
+			TypeHandlerVersion: to.Ptr(extensionVersion),
+		},
+	}, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind test


**What this PR does / why we need it**:

- Introduced VMExtensionImagesClient to Azure client and implemented helper to fetch latest VM extension image version.
- Added GetLatestVMExtensionImageVersion utility to programmatically retrieve the most recent version of the AKS Linux VM extension.
- Implemented helper functions to attach VM extensions to VMSS definitions.
- Introduced validators to check NPD service status and simulate filesystem corruption, asserting correct condition reporting on the node.
- Added new E2E test Test_Ubuntu2404_NPD_Basic to validate Node Problem Detector functionality on Ubuntu 24.04 with AKS extension enabled.


**Which issue(s) this PR fixes**:

Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

While we try to resolve the H100 tests https://github.com/Azure/AgentBaker/pull/6533, this PR adds a basic check if NPD is working, simulates an error and checks if the node is reporting the condition correctly.

**Release note**:

```
none
```

**Testing Instructions:**

```bash
go test -run Test_Ubuntu2404_NPD_Basic -v -timeout 90m
```