### PR TITLE
Add NVIDIA kernel as second kernel to ARM64 ubuntu 2404 images

### DIFF
--- a/vhdbuilder/packer/pre-install-dependencies.sh
+++ b/vhdbuilder/packer/pre-install-dependencies.sh
@@ -141,7 +141,17 @@ if [[ ${UBUNTU_RELEASE//./} -ge 2204 && "${ENABLE_FIPS,,}" != "true" ]] && ! gre
   else
       echo "LTS kernel for Ubuntu ${UBUNTU_RELEASE} is not available. Skipping purging and subsequent installation."
   fi
-
+  NVIDIA_KERNEL="linux-azure-nvidia"
+  if "${CPU_ARCH}" == "arm64"; then
+    sudo add-apt-repository ppa:canonical-kernel-team/ppa
+    sudo apt update
+    if apt-cache show "${NVIDIA_KERNEL}" &> /dev/null; then
+      echo "ARM64 image. Installing NVIDIA kernel alongside LTS kernel"
+      sudo apt install -y "${NVIDIA_KERNEL}"
+    else
+      echo "ARM64 image. NVIDIA kernel not available, skipping installation."
+    fi
+  fi
   update-grub
 fi
 capture_benchmark "${SCRIPT_NAME}_purge_ubuntu_kernel_if_2204"

--- a/vhdbuilder/packer/pre-install-dependencies.sh
+++ b/vhdbuilder/packer/pre-install-dependencies.sh
@@ -142,7 +142,8 @@ if [[ ${UBUNTU_RELEASE//./} -ge 2204 && "${ENABLE_FIPS,,}" != "true" ]] && ! gre
       echo "LTS kernel for Ubuntu ${UBUNTU_RELEASE} is not available. Skipping purging and subsequent installation."
   fi
   NVIDIA_KERNEL="linux-azure-nvidia"
-  if "${CPU_ARCH}" == "arm64"; then
+  if [["${CPU_ARCH}" == "arm64" && "${UBUNTU_RELEASE}" = "24.04"]]; then
+    # This is the ubuntu 2404arm64gen2containerd image.
     sudo add-apt-repository ppa:canonical-kernel-team/ppa
     sudo apt update
     if apt-cache show "${NVIDIA_KERNEL}" &> /dev/null; then


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds the NVIDIA kernel alongside the LTS kernel to the ARM64 Ubuntu 2404 VHD.

**Which issue(s) this PR fixes**:

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
Adds NVIDIA kernel for Grace-architecture hardware to ARM64 VHD.
```
