### PR TITLE
feat: support dynamically booting from NVIDIA/non-NVIDIA Ubuntu kernels

### DIFF
--- a/parts/linux/cloud-init/artifacts/10_azure_nvidia
+++ b/parts/linux/cloud-init/artifacts/10_azure_nvidia
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -e
+
+. /etc/grub.d/10_linux >/dev/null 2>&1
+
+NVIDIA=
+OTHER=
+
+for linux in ${reverse_sorted_list}; do
+	case $linux in
+		*-azure-nvidia) : "${NVIDIA:="${linux}"}" ;;
+		*)              : "${OTHER:="${linux}"}"  ;;
+	esac
+done
+
+if [ -z "${NVIDIA}" ] || [ -z "${OTHER}" ]; then
+	echo "Only one image type (NVIDIA or non-NVIDIA) found" >&2
+	exit 0
+fi
+
+echo "Default NVIDIA image: ${NVIDIA}" >&2
+NVIDIA=${NVIDIA##*/}
+NVIDIA=$(echo "${NVIDIA}" | sed -e "s,^[^0-9]*-,,g")
+
+echo "Default non-NVIDIA image: ${OTHER}" >&2
+OTHER=${OTHER##*/}
+OTHER=$(echo "${OTHER}" | sed -e "s,^[^0-9]*-,,g")
+
+cat << EOF
+insmod smbios
+smbios --type 4 --get-string 7 --set cpu_manufacturer
+
+if [ x\$cpu_manufacturer = xNVIDIA ]; then
+	set default="gnulinux-${NVIDIA}-advanced-${boot_device_id}"
+else
+	set default="gnulinux-${OTHER}-advanced-${boot_device_id}"
+fi
+EOF

--- a/parts/linux/cloud-init/artifacts/51-azure-nvidia.cfg
+++ b/parts/linux/cloud-init/artifacts/51-azure-nvidia.cfg
@@ -1,0 +1,2 @@
+# 10_azure_nvidia changes the default menu entry based on a flat menu.
+GRUB_DISABLE_SUBMENU=true

--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -378,6 +378,16 @@ copyPackerFiles() {
     cpAndMode $PAM_D_COMMON_AUTH_SRC $PAM_D_COMMON_AUTH_DEST 644
     cpAndMode $PAM_D_COMMON_PASSWORD_SRC $PAM_D_COMMON_PASSWORD_DEST 644
     cpAndMode $USU_SH_SRC $USU_SH_DEST 544
+
+    if [[ ${UBUNTU_RELEASE} == "24.04" && ${CPU_ARCH} == "arm64" ]]; then
+      GRUB_AZ_NV_SCRIPT_SRC=/home/packer/10_azure_nvidia
+      GRUB_AZ_NV_SCRIPT_DEST=/etc/grub.d/10_azure_nvidia
+      cpAndMode $GRUB_AZ_NV_SCRIPT_SRC $GRUB_AZ_NV_SCRIPT_DEST 755
+
+      GRUB_AZ_NV_ENV_SRC=/home/packer/51-azure-nvidia.cfg
+      GRUB_AZ_NV_ENV_DEST=/etc/default/grub.d/51-azure-nvidia.cfg
+      cpAndMode $GRUB_AZ_NV_ENV_SRC $GRUB_AZ_NV_ENV_DEST 644
+    fi
   fi
 
   cpAndMode $NOTICE_SRC $NOTICE_DEST 444

--- a/vhdbuilder/packer/pre-install-dependencies.sh
+++ b/vhdbuilder/packer/pre-install-dependencies.sh
@@ -159,9 +159,6 @@ dpkg -l 'linux-*azure*'
 if apt-cache show "linux-image-${CUSTOM_KERNEL_VERSION}" &>/dev/null; then
     echo "Custom kernel ${CUSTOM_KERNEL_VERSION} is available. Proceeding..."
 
-    # Purge old azure kernels
-    DEBIAN_FRONTEND=noninteractive apt-get remove --purge -y $(dpkg-query -W 'linux-*azure*' | awk '$2 != "" { print $1 }' | paste -s)
-
     # Install the new custom kernel
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
       linux-image-${CUSTOM_KERNEL_VERSION} \

--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -615,6 +615,16 @@
       "destination": "/home/packer/localdns-delegate.conf"
     },
     {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/10_azure_nvidia",
+      "destination": "/home/packer/10_azure_nvidia"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/51-azure-nvidia.cfg",
+      "destination": "/home/packer/51-azure-nvidia.cfg"
+    },
+    {
       "type": "shell",
       "inline": [
         "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} HYPERV_GENERATION={{user `hyperv_generation`}} CONTAINER_RUNTIME={{user `container_runtime`}} TELEPORTD_PLUGIN_DOWNLOAD_URL={{user `teleportd_plugin_download_url`}} ENABLE_FIPS={{user `enable_fips`}} SGX_INSTALL={{user `sgx_install`}} IMG_SKU={{user `img_sku`}} VHD_BUILD_TIMESTAMP={{user `vhd_build_timestamp`}} /bin/bash -ux /home/packer/pre-install-dependencies.sh"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

GB200 instances require a different kernel to other arm64 instances. It would be most efficient to include both kernel types in the same image. This feature uses GRUB's `smbios` command to decide which kernel to boot by default based on the CPU manufacturer.

**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [X] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

I am not familiar with AgentBaker. The feature has been tested manually by myself using the latest Canonical:ubuntu-24_04-lts:specialized-hardware:latest image under QEMU. It has also been manually tested by @abenn135 on real Azure instances. The packer changes are untested.