### PR TITLE
fix: update renovate.json to have custom versioning regex for ama-metrics

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -395,10 +395,13 @@
       "matchPackageNames": [
         "azuremonitor/containerinsights/ciprod/prometheus-collector/images"
       ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "versioning": "regex:^(\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?-(\\w+)-(\\d+)-(\\d+)-(\\d+)-(\\w+-*)(?<compatibility>.*)$",
       "groupName": "ama-metrics",
       "automerge": false,
       "enabled": true,
-      "ignoreUnstable": false,
       "assignees": [
         "gracewehner",
         "vishiy",


### PR DESCRIPTION
**What type of PR is this?**
/kind fix

**What this PR does / why we need it**:
Fixes the `renovate.json` file to have a custom versioning regex for `ama-metrics`. This is needed for our images that have different compatibility suffixes. Tested the e2e PR with my fork: https://github.com/gracewehner/AgentBaker/pull/9

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
