### PR TITLE
Build Image Autofill Using JSON Url

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -63,7 +63,7 @@ parameters:
   - name: useContainerUrlsFromJson
     displayName: Use container base URLs
     type: boolean
-    default: True
+    default: False
   - name: dryrun
     displayName: Dry run
     type: boolean
@@ -112,6 +112,8 @@ stages:
       build2025gen2:  ${{ parameters.build2025gen2 }}
       if ${{ parameters.useContainerUrlsFromJson }} == true:
         windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
+      else:
+        windowsContainerImageJsonUrl: ""
       skipExtensionCheck: ${{ parameters.skipExtensionCheck }}
       installOpenSshServer: ${{ parameters.installOpenSshServer }}
       overrideBranch: ${{ parameters.overrideBranch }}

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -59,7 +59,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows Container Image Json URL
     type: string
-    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/06B/payload.json
+    default: ""
   - name: dryrun
     displayName: Dry run
     type: boolean

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -56,14 +56,14 @@ parameters:
     displayName: Build 2025 Gen 2
     type: boolean
     default: True
-  - name: windowsContainerImageJsonUrl
-    displayName: Windows Container Image Json URL
-    type: string
-    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/07B/payload.json
   - name: useContainerUrlsFromJson
     displayName: Use Container Base URL from JSON
     type: boolean
     default: False
+  - name: windowsContainerImageJsonUrl
+    displayName: Windows Container Image Json URL
+    type: string
+    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/07B/payload.json
   - name: dryrun
     displayName: Dry run
     type: boolean
@@ -106,7 +106,7 @@ stages:
           - script: echo "Setting Windows Container Image JSON URL to ${{ parameters.windowsContainerImageJsonUrl }}"
             displayName: Set Windows Container Image JSON URL
           - powershell: |
-              Write-Host "##vso[task.setvariable variable=windowsContainerImageJsonUrl;isOutput=true]${{ parameters.windowsContainerImageJsonUrl }}"
+              Write-Host "##vso[task.setvariable variable=windowsContainerImageJsonUrl]${{ parameters.windowsContainerImageJsonUrl }}"
             displayName: Set pipeline variable windowsContainerImageJsonUrl
       - job: SetURLToEmpty
         condition: eq(variables['useContainerUrlsFromJson'], 'False')

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -110,7 +110,8 @@ stages:
       build23H2gen2: ${{ parameters.build23H2gen2 }}
       build2025:  ${{ parameters.build2025 }}
       build2025gen2:  ${{ parameters.build2025gen2 }}
-      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
+      if ${{ parameters.useContainerUrlsFromJson }} == true:
+        windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       skipExtensionCheck: ${{ parameters.skipExtensionCheck }}
       installOpenSshServer: ${{ parameters.installOpenSshServer }}
       overrideBranch: ${{ parameters.overrideBranch }}

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -61,7 +61,7 @@ parameters:
     type: string
     default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/07B/payload.json
   - name: useContainerUrlsFromJson
-    displayName: Use container base URLs
+    displayName: Use Container Base URL from JSON
     type: boolean
     default: False
   - name: dryrun
@@ -110,10 +110,7 @@ stages:
       build23H2gen2: ${{ parameters.build23H2gen2 }}
       build2025:  ${{ parameters.build2025 }}
       build2025gen2:  ${{ parameters.build2025gen2 }}
-      if ${{ parameters.useContainerUrlsFromJson }} == true:
-        windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
-      else:
-        windowsContainerImageJsonUrl: ""
+      windowsContainerImageJsonUrl: ${{ parameters.useContainerUrlsFromJson && parameters.windowsContainerImageJsonUrl || '' }}
       skipExtensionCheck: ${{ parameters.skipExtensionCheck }}
       installOpenSshServer: ${{ parameters.installOpenSshServer }}
       overrideBranch: ${{ parameters.overrideBranch }}

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -59,7 +59,11 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows Container Image Json URL
     type: string
-    default: ""
+    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/07B/payload.json
+  - name: useContainerUrlsFromJson
+    displayName: Use container base URLs
+    type: boolean
+    default: False
   - name: dryrun
     displayName: Dry run
     type: boolean

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -59,7 +59,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows Container Image Json URL
     type: string
-    default: ""
+    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/06B/payload.json
   - name: dryrun
     displayName: Dry run
     type: boolean

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -63,7 +63,7 @@ parameters:
   - name: useContainerUrlsFromJson
     displayName: Use container base URLs
     type: boolean
-    default: False
+    default: True
   - name: dryrun
     displayName: Dry run
     type: boolean

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -98,6 +98,24 @@ parameters:
 # Use variable group "ab-windows-ms-tenant" and link it to the pipeline "[TEST All VHDs] AKS Windows VHD Build - Msft Tenant"
 
 stages:
+  - stage: CheckUseContainerUrlsFromJson
+    jobs:
+      - job: SetURLToDefault
+        condition: eq(variables['useContainerUrlsFromJson'], 'True')
+        steps:
+          - script: echo "Setting Windows Container Image JSON URL to ${{ parameters.windowsContainerImageJsonUrl }}"
+            displayName: Set Windows Container Image JSON URL
+          - powershell: |
+              Write-Host "##vso[task.setvariable variable=windowsContainerImageJsonUrl;isOutput=true]${{ parameters.windowsContainerImageJsonUrl }}"
+            displayName: Set pipeline variable windowsContainerImageJsonUrl
+      - job: SetURLToEmpty
+        condition: eq(variables['useContainerUrlsFromJson'], 'False')
+        steps:
+          - script: echo "Setting Windows Container Image JSON URL to an empty string"
+            displayName: Set Windows Container Image JSON URL to empty
+          - powershell: |
+              Write-Host "##vso[task.setvariable variable=windowsContainerImageJsonUrl;isOutput=true]''"
+            displayName: Set pipeline variable windowsContainerImageJsonUrl to empty
   - template: ./templates/.build-and-test-windows-vhds-template.yaml
     parameters:
       vhddebug: ${{ parameters.vhddebug }}
@@ -110,7 +128,6 @@ stages:
       build23H2gen2: ${{ parameters.build23H2gen2 }}
       build2025:  ${{ parameters.build2025 }}
       build2025gen2:  ${{ parameters.build2025gen2 }}
-      windowsContainerImageJsonUrl: ${{ parameters.useContainerUrlsFromJson && parameters.windowsContainerImageJsonUrl || '' }}
       skipExtensionCheck: ${{ parameters.skipExtensionCheck }}
       installOpenSshServer: ${{ parameters.installOpenSshServer }}
       overrideBranch: ${{ parameters.overrideBranch }}

--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -56,6 +56,10 @@ parameters:
     displayName: Build 2025 Gen 2
     type: boolean
     default: True
+  - name: windowsContainerImageJsonUrl
+    displayName: Windows Container Image Json URL
+    type: string
+    default: ""
   - name: dryrun
     displayName: Dry run
     type: boolean
@@ -102,6 +106,7 @@ stages:
       build23H2gen2: ${{ parameters.build23H2gen2 }}
       build2025:  ${{ parameters.build2025 }}
       build2025gen2:  ${{ parameters.build2025gen2 }}
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       skipExtensionCheck: ${{ parameters.skipExtensionCheck }}
       installOpenSshServer: ${{ parameters.installOpenSshServer }}
       overrideBranch: ${{ parameters.overrideBranch }}

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -52,6 +52,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
+    default: ""
   - name: overrideBranch
     type: string
     default: master

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -56,7 +56,7 @@ parameters:
   - name: useContainerUrlsFromJson
     displayName: Use container base URLs
     type: boolean
-    default: False
+    default: True
   - name: overrideBranch
     type: string
     default: master

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -52,11 +52,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
-    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/07B/payload.json
-  - name: useContainerUrlsFromJson
-    displayName: Use container base URLs
-    type: boolean
-    default: True
+    default: ""
   - name: overrideBranch
     type: string
     default: master

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -49,6 +49,10 @@ parameters:
   - name: windowsCoreImageUrl
     displayName: Windows core base container image URL Override
     type: string
+  - name: windowsContainerImageJsonUrl
+    displayName: Windows container image JSON URL Override
+    type: string
+    default: ""
   - name: overrideBranch
     type: string
     default: master
@@ -88,6 +92,7 @@ stages:
               windowsBaseImageUrl: ${{ parameters.windowsBaseImageUrl }}
               windowsNanoImageUrl: ${{ parameters.windowsNanoImageUrl }}
               windowsCoreImageUrl: ${{ parameters.windowsCoreImageUrl }}
+              windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
               overrideBranch: ${{ parameters.overrideBranch }}
               useOverrides: ${{ parameters.useOverrides }}
               csePackageDir: ${{ parameters.csePackageDir }}

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -52,7 +52,6 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
-    default: ""
   - name: overrideBranch
     type: string
     default: master

--- a/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhd-template.yaml
@@ -52,7 +52,11 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
-    default: ""
+    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/07B/payload.json
+  - name: useContainerUrlsFromJson
+    displayName: Use container base URLs
+    type: boolean
+    default: False
   - name: overrideBranch
     type: string
     default: master

--- a/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
@@ -23,7 +23,11 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
-    default: ""
+    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/07B/payload.json
+  - name: useContainerUrlsFromJson
+    displayName: Use container base URLs
+    type: boolean
+    default: False
   - name: dryrun
     displayName: Dry run
     type: boolean

--- a/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
@@ -23,7 +23,6 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
-    default: ""
   - name: dryrun
     displayName: Dry run
     type: boolean

--- a/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
@@ -23,6 +23,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
+    default: ""
   - name: dryrun
     displayName: Dry run
     type: boolean

--- a/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
@@ -23,7 +23,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
-    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/07B/payload.json
+    default: ""
   - name: dryrun
     displayName: Dry run
     type: boolean

--- a/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
@@ -27,7 +27,7 @@ parameters:
   - name: useContainerUrlsFromJson
     displayName: Use container base URLs
     type: boolean
-    default: False
+    default: True
   - name: dryrun
     displayName: Dry run
     type: boolean

--- a/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
@@ -24,10 +24,6 @@ parameters:
     displayName: Windows container image JSON URL Override
     type: string
     default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/07B/payload.json
-  - name: useContainerUrlsFromJson
-    displayName: Use container base URLs
-    type: boolean
-    default: True
   - name: dryrun
     displayName: Dry run
     type: boolean

--- a/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
@@ -20,6 +20,10 @@ parameters:
   - name: build2025gen2
     displayName: Build 2025 Gen 2
     type: boolean
+  - name: windowsContainerImageJsonUrl
+    displayName: Windows container image JSON URL Override
+    type: string
+    default: ""
   - name: dryrun
     displayName: Dry run
     type: boolean
@@ -93,6 +97,7 @@ stages:
       windowsBaseImageUrl: $(WINDOWS_2019_BASE_IMAGE_URL)
       windowsNanoImageUrl: $(WINDOWS_2019_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2019_CORE_IMAGE_URL)
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}
@@ -115,6 +120,7 @@ stages:
       windowsBaseImageUrl: $(WINDOWS_2022_BASE_IMAGE_URL)
       windowsNanoImageUrl: $(WINDOWS_2022_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2022_CORE_IMAGE_URL)
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}
@@ -137,6 +143,7 @@ stages:
       windowsBaseImageUrl: $(WINDOWS_2022_GEN2_BASE_IMAGE_URL)
       windowsNanoImageUrl: $(WINDOWS_2022_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2022_CORE_IMAGE_URL)
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}
@@ -159,6 +166,7 @@ stages:
       windowsBaseImageUrl: $(WINDOWS_23H2_BASE_IMAGE_URL)
       windowsNanoImageUrl: $(WINDOWS_2022_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2022_CORE_IMAGE_URL)
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}
@@ -181,6 +189,7 @@ stages:
       windowsBaseImageUrl: $(WINDOWS_23H2_GEN2_BASE_IMAGE_URL)
       windowsNanoImageUrl: $(WINDOWS_2022_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2022_CORE_IMAGE_URL)
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}
@@ -203,6 +212,7 @@ stages:
       windowsBaseImageUrl: $(WINDOWS_2025_BASE_IMAGE_URL)
       windowsNanoImageUrl: $(WINDOWS_2025_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2025_CORE_IMAGE_URL)
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}
@@ -225,6 +235,7 @@ stages:
       windowsBaseImageUrl: $(WINDOWS_2025_GEN2_BASE_IMAGE_URL)
       windowsNanoImageUrl: $(WINDOWS_2025_NANO_IMAGE_URL)
       windowsCoreImageUrl: $(WINDOWS_2025_CORE_IMAGE_URL)
+      windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -40,6 +40,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
+    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/06B/payload.json
   - name: skipExtensionCheck
     displayName: Skip Extension Check
     type: boolean

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -108,7 +108,7 @@ steps:
       WINDOWS_BASE_IMAGE_URL: ${{ parameters.windowsBaseImageUrl }}
       WINDOWS_NANO_IMAGE_URL: ${{ parameters.windowsNanoImageUrl }}
       WINDOWS_CORE_IMAGE_URL: ${{ parameters.windowsCoreImageUrl }}
-      WINDOWS_CONTAINER_IMAGE_JSON_URL: ${{ parameters.windowsContainerImageJsonUrl }}
+      WINDOWS_CONTAINERIMAGE_JSON_URL: ${{ parameters.windowsContainerImageJsonUrl }}
       WINDOWS_PRIVATE_PACKAGES_URL: $(PRIVATE_PACKAGES_URL)
       AZURE_MSI_RESOURCE_STRING: $(AZURE_MSI_RESOURCE_STRING)
       BUILD_DATE: $(BUILD_DATE)

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -124,7 +124,7 @@ steps:
       # the base image tag will be 'ltscxxx', which differs from the values specified in parts/common/component.json.
       # As a result, cache validation behaves differently. To address this, we check if the container base image URL is set,
       # and use this environment variable to control the cache validation logic in run-test.sh.
-      if [[ -n "${{ parameters.windowsNanoImageUrl }}" || -n "${{ parameters.windowsCoreImageUrl }}" || -n "${{ parameters.windowsContainerImageJsonUrl }}"]]; then
+      if [[ -n "${{ parameters.windowsNanoImageUrl }}" || -n "${{ parameters.windowsCoreImageUrl }}" || -n "${{ parameters.windowsContainerImageJsonUrl }}" ]]; then
         export CONTAINTER_BASE_URLS_EXISTING=true
       else
         export CONTAINTER_BASE_URLS_EXISTING=false

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -40,7 +40,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
-    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/06B/payload.json
+    default: ""
   - name: skipExtensionCheck
     displayName: Skip Extension Check
     type: boolean

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -37,6 +37,9 @@ parameters:
   - name: windowsCoreImageUrl
     displayName: Windows core base container image URL Override
     type: string
+  - name: windowsContainerImageJsonUrl
+    displayName: Windows container image JSON URL
+    type: string
   - name: skipExtensionCheck
     displayName: Skip Extension Check
     type: boolean
@@ -104,6 +107,7 @@ steps:
       WINDOWS_BASE_IMAGE_URL: ${{ parameters.windowsBaseImageUrl }}
       WINDOWS_NANO_IMAGE_URL: ${{ parameters.windowsNanoImageUrl }}
       WINDOWS_CORE_IMAGE_URL: ${{ parameters.windowsCoreImageUrl }}
+      WINDOWS_CONTAINER_IMAGE_JSON_URL: ${{ parameters.windowsContainerImageJsonUrl }}
       WINDOWS_PRIVATE_PACKAGES_URL: $(PRIVATE_PACKAGES_URL)
       AZURE_MSI_RESOURCE_STRING: $(AZURE_MSI_RESOURCE_STRING)
       BUILD_DATE: $(BUILD_DATE)

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -44,7 +44,7 @@ parameters:
   - name: useContainerUrlsFromJson
     displayName: Use container base URLs
     type: boolean
-    default: False
+    default: True
   - name: skipExtensionCheck
     displayName: Skip Extension Check
     type: boolean

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -38,8 +38,9 @@ parameters:
     displayName: Windows core base container image URL Override
     type: string
   - name: windowsContainerImageJsonUrl
-    displayName: Windows container image JSON URL
+    displayName: Windows container image JSON URL Override
     type: string
+    default: ""
   - name: skipExtensionCheck
     displayName: Skip Extension Check
     type: boolean

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -40,7 +40,6 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
-    default: ""
   - name: skipExtensionCheck
     displayName: Skip Extension Check
     type: boolean

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -40,7 +40,11 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
-    default: ""
+    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/07B/payload.json
+  - name: useContainerUrlsFromJson
+    displayName: Use container base URLs
+    type: boolean
+    default: False
   - name: skipExtensionCheck
     displayName: Skip Extension Check
     type: boolean
@@ -109,6 +113,7 @@ steps:
       WINDOWS_NANO_IMAGE_URL: ${{ parameters.windowsNanoImageUrl }}
       WINDOWS_CORE_IMAGE_URL: ${{ parameters.windowsCoreImageUrl }}
       WINDOWS_CONTAINERIMAGE_JSON_URL: ${{ parameters.windowsContainerImageJsonUrl }}
+      USE_CONTAINER_URLS_FROM_JSON: ${{ parameters.useContainerUrlsFromJson }}
       WINDOWS_PRIVATE_PACKAGES_URL: $(PRIVATE_PACKAGES_URL)
       AZURE_MSI_RESOURCE_STRING: $(AZURE_MSI_RESOURCE_STRING)
       BUILD_DATE: $(BUILD_DATE)

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -41,10 +41,6 @@ parameters:
     displayName: Windows container image JSON URL Override
     type: string
     default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/07B/payload.json
-  - name: useContainerUrlsFromJson
-    displayName: Use container base URLs
-    type: boolean
-    default: True
   - name: skipExtensionCheck
     displayName: Skip Extension Check
     type: boolean
@@ -113,7 +109,6 @@ steps:
       WINDOWS_NANO_IMAGE_URL: ${{ parameters.windowsNanoImageUrl }}
       WINDOWS_CORE_IMAGE_URL: ${{ parameters.windowsCoreImageUrl }}
       WINDOWS_CONTAINERIMAGE_JSON_URL: ${{ parameters.windowsContainerImageJsonUrl }}
-      USE_CONTAINER_URLS_FROM_JSON: ${{ parameters.useContainerUrlsFromJson }}
       WINDOWS_PRIVATE_PACKAGES_URL: $(PRIVATE_PACKAGES_URL)
       AZURE_MSI_RESOURCE_STRING: $(AZURE_MSI_RESOURCE_STRING)
       BUILD_DATE: $(BUILD_DATE)

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -124,7 +124,7 @@ steps:
       # the base image tag will be 'ltscxxx', which differs from the values specified in parts/common/component.json.
       # As a result, cache validation behaves differently. To address this, we check if the container base image URL is set,
       # and use this environment variable to control the cache validation logic in run-test.sh.
-      if [[ -n "${{ parameters.windowsNanoImageUrl }}" || -n "${{ parameters.windowsCoreImageUrl }}" ]]; then
+      if [[ -n "${{ parameters.windowsNanoImageUrl }}" || -n "${{ parameters.windowsCoreImageUrl }}" || -n "${{ parameters.windowsContainerImageJsonUrl }}"]]; then
         export CONTAINTER_BASE_URLS_EXISTING=true
       else
         export CONTAINTER_BASE_URLS_EXISTING=false

--- a/.pipelines/templates/.builder-release-template-windows.yaml
+++ b/.pipelines/templates/.builder-release-template-windows.yaml
@@ -40,7 +40,7 @@ parameters:
   - name: windowsContainerImageJsonUrl
     displayName: Windows container image JSON URL Override
     type: string
-    default: https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/07B/payload.json
+    default: ""
   - name: skipExtensionCheck
     displayName: Skip Extension Check
     type: boolean

--- a/spec/parts/linux/cloud-init/artifacts/json_parser.sh
+++ b/spec/parts/linux/cloud-init/artifacts/json_parser.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Extract image URL name from a JSON file
+get_image_url_using_name() {
+    local artifact_path="$1"
+    local image_name="$2"
+    jq -r --arg name "$image_name" '.images[] | select(.name == $name) | .value' "$artifact_path"
+}

--- a/spec/parts/linux/cloud-init/artifacts/json_parser_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/json_parser_spec.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# File: spec/parts/linux/cloud-init/artifacts/json_parser_spec.sh
+Describe 'json_parser.sh'
+    Include "./spec/parts/linux/cloud-init/artifacts/json_parser.sh"
+    test -f ./spec/parts/linux/cloud-init/artifacts/sample_payload.json && echo "File exists"
+    chmod 644 ./spec/parts/linux/cloud-init/artifacts/sample_payload.json
+    json_file="./spec/parts/linux/cloud-init/artifacts/sample_payload.json"
+    BeforeAll 'json_file="./spec/parts/linux/cloud-init/artifacts/sample_payload.json"'
+
+    It 'confirms the JSON file exists'
+        When run test -f "$json_file"
+        The status should be success
+    End
+
+    Describe 'get_image_url_using_name'
+        It 'extracts the correct image URL for WINDOWS_2019_BASE_IMAGE_URL'
+            When call get_image_url_using_name "$json_file" "WINDOWS_2019_BASE_IMAGE_URL"
+            The output should equal "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2019/2019-datacenter-core-smalldisk-sim.vhd"
+        End
+        It 'extracts the correct image URL for WINDOWS_2019_CORE_IMAGE_URL'
+            When call get_image_url_using_name "$json_file" "WINDOWS_2019_CORE_IMAGE_URL"
+            The output should equal "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2019/CONTAINERS/servercore.tar"
+        End
+        It 'extracts the correct image URL for WINDOWS_2019_NANO_IMAGE_URL'
+            When call get_image_url_using_name "$json_file" "WINDOWS_2019_NANO_IMAGE_URL"
+            The output should equal "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2019/CONTAINERS/nanoserver.tar"
+        End
+        It 'extracts the correct image URL for WINDOWS_2022_BASE_IMAGE_URL'
+            When call get_image_url_using_name "$json_file" "WINDOWS_2022_BASE_IMAGE_URL"
+            The output should equal "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2022/2022-datacenter-core-smalldisk-sim.vhd"
+        End
+        It 'extracts the correct image URL for WINDOWS_2022_CORE_IMAGE_URL'
+            When call get_image_url_using_name "$json_file" "WINDOWS_2022_CORE_IMAGE_URL"
+            The output should equal "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2022/CONTAINERS/servercore.tar"
+        End
+        It 'extracts the correct image URL for WINDOWS_2022_NANO_IMAGE_URL'
+            When call get_image_url_using_name "$json_file" "WINDOWS_2022_NANO_IMAGE_URL"
+            The output should equal "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2022/CONTAINERS/nanoserver.tar"
+        End
+        It 'extracts the correct image URL for WINDOWS_2022_GEN2_BASE_IMAGE_URL'
+            When call get_image_url_using_name "$json_file" "WINDOWS_2022_GEN2_BASE_IMAGE_URL"
+            The output should equal "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2022/GEN2/2022-datacenter-core-smalldisk-g2-sim.vhd"
+        End
+        It 'extracts the correct image URL for WINDOWS_2025_BASE_IMAGE_URL'
+            When call get_image_url_using_name "$json_file" "WINDOWS_2025_BASE_IMAGE_URL"
+            The output should equal "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2025/2025-datacenter-core-smalldisk-sim.vhd"
+        End
+        It 'extracts the correct image URL for WINDOWS_2025_CORE_IMAGE_URL'
+            When call get_image_url_using_name "$json_file" "WINDOWS_2025_CORE_IMAGE_URL"
+            The output should equal "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2025/CONTAINERS/servercore.tar"
+        End
+        It 'extracts the correct image URL for WINDOWS_2025_NANO_IMAGE_URL'
+            When call get_image_url_using_name "$json_file" "WINDOWS_2025_NANO_IMAGE_URL"
+            The output should equal "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2025/CONTAINERS/nanoserver.tar"
+        End
+        It 'extracts the correct image URL for WINDOWS_2025_GEN2_BASE_IMAGE_URL'
+            When call get_image_url_using_name "$json_file" "WINDOWS_2025_GEN2_BASE_IMAGE_URL"
+            The output should equal "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2025/GEN2/2025-datacenter-core-smalldisk-g2-sim.vhd"
+        End
+        It 'extracts the correct image for WINDOWS_23H2_BASE_IMAGE_URL'
+            When call get_image_url_using_name "$json_file" "WINDOWS_23H2_BASE_IMAGE_URL"
+            The output should equal "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws23H2/23h2-datacenter-core-sim.vhd"
+        End
+        It 'extracts the correct image for WINDOWS_23H2_GEN2_BASE_IMAGE_URL'
+            When call get_image_url_using_name "$json_file" "WINDOWS_23H2_GEN2_BASE_IMAGE_URL"
+            The output should equal "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws23H2/GEN2/23h2-datacenter-core-g2-sim.vhd"
+        End
+    End
+End

--- a/spec/parts/linux/cloud-init/artifacts/sample_payload.json
+++ b/spec/parts/linux/cloud-init/artifacts/sample_payload.json
@@ -1,0 +1,58 @@
+{
+    "datetime": "20250809",
+    "service-release": "08B",
+    "images": [
+        {
+            "name": "WINDOWS_2019_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2019/2019-datacenter-core-smalldisk-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_2019_CORE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2019/CONTAINERS/servercore.tar"
+        },
+        {
+            "name": "WINDOWS_2019_NANO_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2019/CONTAINERS/nanoserver.tar"
+        },
+        {
+            "name": "WINDOWS_2022_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2022/2022-datacenter-core-smalldisk-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_2022_CORE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2022/CONTAINERS/servercore.tar"
+        },
+        {
+            "name": "WINDOWS_2022_NANO_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2022/CONTAINERS/nanoserver.tar"
+        },
+        {
+            "name": "WINDOWS_2022_GEN2_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2022/GEN2/2022-datacenter-core-smalldisk-g2-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_2025_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2025/2025-datacenter-core-smalldisk-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_2025_CORE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2025/CONTAINERS/servercore.tar"
+        },
+        {
+            "name": "WINDOWS_2025_NANO_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2025/CONTAINERS/nanoserver.tar"
+        },
+        {
+            "name": "WINDOWS_2025_GEN2_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws2025/GEN2/2025-datacenter-core-smalldisk-g2-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_23H2_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws23H2/23h2-datacenter-core-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_23H2_GEN2_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/08B/ws23H2/GEN2/23h2-datacenter-core-g2-sim.vhd"
+        }
+    ]
+}

--- a/vhdbuilder/packer/WINDOWS-CONTAINERIMAGE-JSON.MD
+++ b/vhdbuilder/packer/WINDOWS-CONTAINERIMAGE-JSON.MD
@@ -1,0 +1,76 @@
+# Using the Windows Container Image JSON Blob
+
+This guide is for developers who want to manually download and inspect the JSON blob used in `produce-packer-settings.sh` for Windows VHD builds. 
+The blob contains image URLs for various Windows SKUs and is used to configure builds dynamically.
+
+## How to download the JSON blob
+⚠️ Access to the WCCT AgentBaker Storage Account is restricted. If you need access, please contact [yuazhang@microsoft.com](mailto:yuazhang@microsoft)
+1. Navigate to the WCCT AgentBaker Storage Account via Azure Portal
+2. Browse to:  
+   `Blob containers > simship > 2025 > 04B` *(or later service releases)*  
+3. Download the `payload.json` file.
+
+## 📄 Here's an example JSON Format 
+```json
+{
+    "datetime": "20250407",
+    "service-release": "04B",
+    "images": [
+        {
+            "name": "WINDOWS_2019_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2019/2019-datacenter-core-smalldisk-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_2019_CORE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2019/CONTAINERS/servercore.tar"
+        },
+        {
+            "name": "WINDOWS_2019_NANO_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2019/CONTAINERS/nanoserver.tar"
+        },
+        {
+            "name": "WINDOWS_2022_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2022/2022-datacenter-core-smalldisk-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_2022_CORE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2022/CONTAINERS/servercore.tar"
+        },
+        {
+            "name": "WINDOWS_2022_NANO_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2022/CONTAINERS/nanoserver.tar"
+        },
+        {
+            "name": "WINDOWS_2022_GEN2_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2022/GEN2/2022-datacenter-core-smalldisk-g2-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_2025_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2025/2025-datacenter-core-smalldisk-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_2025_CORE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2025/CONTAINERS/servercore.tar"
+        },
+        {
+            "name": "WINDOWS_2025_NANO_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2025/CONTAINERS/nanoserver.tar"
+        },
+        {
+            "name": "WINDOWS_2025_GEN2_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws2025/GEN2/2025-datacenter-core-smalldisk-g2-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_23H2_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws23H2/23h2-datacenter-core-sim.vhd"
+        },
+        {
+            "name": "WINDOWS_23H2_GEN2_BASE_IMAGE_URL",
+            "value": "https://wcctagentbakerstorage.blob.core.windows.net/simship/2025/04B/ws23H2/GEN2/23h2-datacenter-core-g2-sim.vhd"
+        }
+    ]
+}
+```
+
+## 🛠️ How It's Used
+The JSON blob is parsed in `produce-packer-settings.sh` to extract image URLs based on the `WINDOWS_SKU`. These URLs are then used to configure the VHD build process dynamically, avoiding hardcoded values.

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -471,9 +471,14 @@ if [ "$OS_TYPE" = "Windows" ]; then
 		fi	
 	fi
 		
-	# Check if nano and core urls are set
-	if [ -z "${windows_nanoserver_image_url}" ] || [ -z "${windows_servercore_image_url}" ]; then
-		echo "Error: One or both Windows image URLs are not set."
+	# Check if base, nano, and servercore urls are set
+	if [ -z "${windows_nanoserver_image_url}" ] || [ -z "${windows_servercore_image_url}" ] || [ -z "${WINDOWS_BASE_IMAGE_URL}" ]; then
+		echo "Error: One of the Windows image URLs are not set."
+	else
+		# If all URLs are set, print them
+		echo "Using Windows base image URL: ${WINDOWS_BASE_IMAGE_URL}"
+		echo "Using Windows Nano Server image URL: ${windows_nanoserver_image_url}"
+		echo "Using Windows Server Core image URL: ${windows_servercore_image_url}"
 	fi
 
 	# build from a pre-supplied VHD blob a.k.a. external raw VHD

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -407,11 +407,12 @@ if [ "$OS_TYPE" = "Windows" ]; then
 		filename=$(basename "$WINDOWS_CONTAINERIMAGE_JSON_URL")
 		echo "Downloading $filename from wcct storage account using AzCopy with Managed Identity Auth"
 
+		# For details on the expected format and how to manually retrieve the JSON blob,
+		# see: [WINDOWS-CONTAINERIMAGE-JSON.MD](vhdbuilder/packer/WINDOWS-CONTAINERIMAGE-JSON.MD)
 		if azcopy copy "${WINDOWS_CONTAINERIMAGE_JSON_URL}" "${BUILD_ARTIFACTSTAGINGDIRECTORY}/"; then
 			echo "Successfully downloaded the latest artifact: $filename"
 		else
 			echo "Failed to download the latest artifact"
-			exit 1
 		fi
 
 		# Parse the json artifact to get the image urls

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -404,7 +404,7 @@ if [ "$OS_TYPE" = "Windows" ]; then
 	export AZCOPY_MSI_RESOURCE_STRING="${AZURE_MSI_RESOURCE_STRING}"
 
 	echo "VALID IMAGE URL: ${WINDOWS_CONTAINERIMAGE_JSON_URL}"
-	if [ "${USE_CONTAINER_URLS_FROM_JSON}" = true ]; then
+	if [ -n "${WINDOWS_CONTAINERIMAGE_JSON_URL}" ]; then
 		# Download the json artifact from the url
 		filename=$(basename "$WINDOWS_CONTAINERIMAGE_JSON_URL")
 		echo "Downloading $filename from wcct storage account using AzCopy with Managed Identity Auth"

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -400,17 +400,18 @@ if [ "$OS_TYPE" = "Windows" ]; then
 	# default: build VHD images from a marketplace base image
 	IMPORTED_IMAGE_NAME=$imported_windows_image_name
 	IMPORTED_IMAGE_URL="https://${STORAGE_ACCOUNT_NAME}.blob.core.windows.net/system/$IMPORTED_IMAGE_NAME.vhd"
- 
+ 	export AZCOPY_AUTO_LOGIN_TYPE="MSI" # use Managed Identity for AzCopy authentication
+
 	if [ -n "${WINDOWS_CONTAINERIMAGE_JSON_URL}" ]; then
 		# Download the json artifact from the url
 		filename=$(basename "$WINDOWS_CONTAINERIMAGE_JSON_URL")
 		echo "Downloading $filename from wcct storage account using AzCopy with Managed Identity Auth"
-		export AZCOPY_AUTO_LOGIN_TYPE="MSI"
 
 		if azcopy copy "${WINDOWS_CONTAINERIMAGE_JSON_URL}" "${BUILD_ARTIFACTSTAGINGDIRECTORY}/"; then
 			echo "Successfully downloaded the latest artifact: $filename"
 		else
 			echo "Failed to download the latest artifact"
+			exit 1
 		fi
 
 		# Parse the json artifact to get the image urls
@@ -481,7 +482,6 @@ if [ "$OS_TYPE" = "Windows" ]; then
 		WINDOWS_IMAGE_URL=${IMPORTED_IMAGE_URL}
 
 		echo "Copy Windows base image to ${WINDOWS_IMAGE_URL}"
-		export AZCOPY_AUTO_LOGIN_TYPE="MSI"
 		export AZCOPY_MSI_RESOURCE_STRING="${AZURE_MSI_RESOURCE_STRING}"
 		azcopy copy "${WINDOWS_BASE_IMAGE_URL}" "${WINDOWS_IMAGE_URL}"
 		# https://www.packer.io/plugins/builders/azure/arm#image_url

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -401,12 +401,14 @@ if [ "$OS_TYPE" = "Windows" ]; then
 	IMPORTED_IMAGE_NAME=$imported_windows_image_name
 	IMPORTED_IMAGE_URL="https://${STORAGE_ACCOUNT_NAME}.blob.core.windows.net/system/$IMPORTED_IMAGE_NAME.vhd"
  	export AZCOPY_AUTO_LOGIN_TYPE="MSI" # use Managed Identity for AzCopy authentication
+	export AZCOPY_MSI_RESOURCE_STRING="${AZURE_MSI_RESOURCE_STRING}"
 
 	if [ -n "${WINDOWS_CONTAINERIMAGE_JSON_URL}" ]; then
 		# Download the json artifact from the url
 		filename=$(basename "$WINDOWS_CONTAINERIMAGE_JSON_URL")
 		echo "Downloading $filename from wcct storage account using AzCopy with Managed Identity Auth"
 
+		# The JSON blob is formatted where each build image name is mapped to its corresponding image URL.
 		# For details on the expected format and how to manually retrieve the JSON blob,
 		# see: [WINDOWS-CONTAINERIMAGE-JSON.MD](vhdbuilder/packer/WINDOWS-CONTAINERIMAGE-JSON.MD)
 		if azcopy copy "${WINDOWS_CONTAINERIMAGE_JSON_URL}" "${BUILD_ARTIFACTSTAGINGDIRECTORY}/"; then
@@ -488,7 +490,6 @@ if [ "$OS_TYPE" = "Windows" ]; then
 		WINDOWS_IMAGE_URL=${IMPORTED_IMAGE_URL}
 
 		echo "Copy Windows base image to ${WINDOWS_IMAGE_URL}"
-		export AZCOPY_MSI_RESOURCE_STRING="${AZURE_MSI_RESOURCE_STRING}"
 		azcopy copy "${WINDOWS_BASE_IMAGE_URL}" "${WINDOWS_IMAGE_URL}"
 		# https://www.packer.io/plugins/builders/azure/arm#image_url
 		# WINDOWS_IMAGE_URL to a custom VHD to use for your base image. If this value is set, image_publisher, image_offer, image_sku, or image_version should not be set.

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -403,6 +403,7 @@ if [ "$OS_TYPE" = "Windows" ]; then
  	export AZCOPY_AUTO_LOGIN_TYPE="MSI" # use Managed Identity for AzCopy authentication
 	export AZCOPY_MSI_RESOURCE_STRING="${AZURE_MSI_RESOURCE_STRING}"
 
+	echo "VALID IMAGE URL: ${WINDOWS_CONTAINERIMAGE_JSON_URL}"
 	if [ -n "${WINDOWS_CONTAINERIMAGE_JSON_URL}" ]; then
 		# Download the json artifact from the url
 		filename=$(basename "$WINDOWS_CONTAINERIMAGE_JSON_URL")

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -424,54 +424,48 @@ if [ "$OS_TYPE" = "Windows" ]; then
 		
 		sudo chmod 600 "$artifact_path"
 		echo "Reading image URLs from $artifact_path"
-
-		W2019_BASE_IMAGE_URL="$(jq -r '.images[] | select(.name == "WINDOWS_2019_BASE_IMAGE_URL") | .value' "$artifact_path")"
-		W2019_CORE_IMAGE_URL="$(jq -r '.images[] | select(.name == "WINDOWS_2019_CORE_IMAGE_URL") | .value' "$artifact_path")"
-		W2019_NANO_IMAGE_URL="$(jq -r '.images[] | select(.name == "WINDOWS_2019_NANO_IMAGE_URL") | .value' "$artifact_path")"
-		W2022_BASE_IMAGE_URL="$(jq -r '.images[] | select(.name == "WINDOWS_2022_BASE_IMAGE_URL") | .value' "$artifact_path")"
-		W2022_CORE_IMAGE_URL="$(jq -r '.images[] | select(.name == "WINDOWS_2022_CORE_IMAGE_URL") | .value' "$artifact_path")"
-		W2022_NANO_IMAGE_URL="$(jq -r '.images[] | select(.name == "WINDOWS_2022_NANO_IMAGE_URL") | .value' "$artifact_path")"
-		W2022_GEN2_BASE_IMAGE_URL="$(jq -r '.images[] | select(.name == "WINDOWS_2022_GEN2_BASE_IMAGE_URL") | .value' "$artifact_path")"
-		W2025_BASE_IMAGE_URL="$(jq -r '.images[] | select(.name == "WINDOWS_2025_BASE_IMAGE_URL") | .value' "$artifact_path")"
-		W2025_CORE_IMAGE_URL="$(jq -r '.images[] | select(.name == "WINDOWS_2025_CORE_IMAGE_URL") | .value' "$artifact_path")"
-		W2025_NANO_IMAGE_URL="$(jq -r '.images[] | select(.name == "WINDOWS_2025_NANO_IMAGE_URL") | .value' "$artifact_path")"
-		W2025_GEN2_BASE_IMAGE_URL="$(jq -r '.images[] | select(.name == "WINDOWS_2025_GEN2_BASE_IMAGE_URL") | .value' "$artifact_path")"
-		W23H2_BASE_IMAGE_URL="$(jq -r '.images[] | select(.name == "WINDOWS_23H2_BASE_IMAGE_URL") | .value' "$artifact_path")"
-		W23H2_GEN2_BASE_IMAGE_URL="$(jq -r '.images[] | select(.name == "WINDOWS_23H2_GEN2_BASE_IMAGE_URL") | .value' "$artifact_path")"
-
-		# Based on the windows_sku, set the windows_nanoserver_image_url and windows_servercore_image_url
-		# For the 2025 base image, cache both 2022 and 2025 nanoserver and servercore images
-		if [ "${WINDOWS_SKU}" = "2019-containerd" ]; then
-			WINDOWS_BASE_IMAGE_URL="${W2019_BASE_IMAGE_URL}"
-			windows_nanoserver_image_url="${W2019_NANO_IMAGE_URL}"
-			windows_servercore_image_url="${W2019_CORE_IMAGE_URL}"
-		elif [ "${WINDOWS_SKU}" = "2022-containerd" ]; then
-			WINDOWS_BASE_IMAGE_URL="${W2022_BASE_IMAGE_URL}"
-			windows_nanoserver_image_url="${W2022_NANO_IMAGE_URL}"
-			windows_servercore_image_url="${W2022_CORE_IMAGE_URL}"
-		elif [ "${WINDOWS_SKU}" = "2022-containerd-gen2" ]; then
-			WINDOWS_BASE_IMAGE_URL="${W2022_GEN2_BASE_IMAGE_URL}"
-			windows_nanoserver_image_url="${W2022_NANO_IMAGE_URL}"
-			windows_servercore_image_url="${W2022_CORE_IMAGE_URL}"
-		elif [ "${WINDOWS_SKU}" = "2025" ]; then
-			WINDOWS_BASE_IMAGE_URL="${W2025_BASE_IMAGE_URL}"
-			windows_nanoserver_image_url="${W2025_NANO_IMAGE_URL},${W2022_NANO_IMAGE_URL}"
-			windows_servercore_image_url="${W2025_CORE_IMAGE_URL},${W2022_CORE_IMAGE_URL}"
-		elif [ "${WINDOWS_SKU}" = "2025-gen2" ]; then
-			WINDOWS_BASE_IMAGE_URL="${W2025_GEN2_BASE_IMAGE_URL}"
-			windows_nanoserver_image_url="${W2025_NANO_IMAGE_URL},${W2022_NANO_IMAGE_URL}"
-			windows_servercore_image_url="${W2025_CORE_IMAGE_URL},${W2022_CORE_IMAGE_URL}"
-		elif [ "${WINDOWS_SKU}" = "23H2" ]; then
-			WINDOWS_BASE_IMAGE_URL="${W23H2_BASE_IMAGE_URL}"
-			windows_nanoserver_image_url="${W2022_NANO_IMAGE_URL}"
-			windows_servercore_image_url="${W2022_CORE_IMAGE_URL}"
-		elif [ "${WINDOWS_SKU}" = "23H2-gen2" ]; then
-			WINDOWS_BASE_IMAGE_URL="${W23H2_GEN2_BASE_IMAGE_URL}"
-			windows_nanoserver_image_url="${W2022_NANO_IMAGE_URL}"
-			windows_servercore_image_url="${W2022_CORE_IMAGE_URL}"
-		else
-			echo "Unsupported WINDOWS_SKU: ${WINDOWS_SKU}"
-		fi	
+		
+		# Extract image URLs from the artifact JSON using a case statement for WINDOWS_SKU
+		case "${WINDOWS_SKU}" in
+			"2019-containerd")
+				WINDOWS_BASE_IMAGE_URL=$(jq -r '.images[] | select(.name == "WINDOWS_2019_BASE_IMAGE_URL") | .value' "$artifact_path")
+				windows_nanoserver_image_url=$(jq -r '.images[] | select(.name == "WINDOWS_2019_NANO_IMAGE_URL") | .value' "$artifact_path")
+				windows_servercore_image_url=$(jq -r '.images[] | select(.name == "WINDOWS_2019_CORE_IMAGE_URL") | .value' "$artifact_path")
+				;;
+			"2022-containerd")
+				WINDOWS_BASE_IMAGE_URL=$(jq -r '.images[] | select(.name == "WINDOWS_2022_BASE_IMAGE_URL") | .value' "$artifact_path")
+				windows_nanoserver_image_url=$(jq -r '.images[] | select(.name == "WINDOWS_2022_NANO_IMAGE_URL") | .value' "$artifact_path")
+				windows_servercore_image_url=$(jq -r '.images[] | select(.name == "WINDOWS_2022_CORE_IMAGE_URL") | .value' "$artifact_path")
+				;;
+			"2022-containerd-gen2")
+				WINDOWS_BASE_IMAGE_URL=$(jq -r '.images[] | select(.name == "WINDOWS_2022_GEN2_BASE_IMAGE_URL") | .value' "$artifact_path")
+				windows_nanoserver_image_url=$(jq -r '.images[] | select(.name == "WINDOWS_2022_NANO_IMAGE_URL") | .value' "$artifact_path")
+				windows_servercore_image_url=$(jq -r '.images[] | select(.name == "WINDOWS_2022_CORE_IMAGE_URL") | .value' "$artifact_path")
+				;;
+			"2025")
+				WINDOWS_BASE_IMAGE_URL=$(jq -r '.images[] | select(.name == "WINDOWS_2025_BASE_IMAGE_URL") | .value' "$artifact_path")
+				windows_nanoserver_image_url="$(jq -r '.images[] | select(.name == "WINDOWS_2025_NANO_IMAGE_URL") | .value' "$artifact_path"),$(jq -r '.images[] | select(.name == "WINDOWS_2022_NANO_IMAGE_URL") | .value' "$artifact_path")"
+				windows_servercore_image_url="$(jq -r '.images[] | select(.name == "WINDOWS_2025_CORE_IMAGE_URL") | .value' "$artifact_path"),$(jq -r '.images[] | select(.name == "WINDOWS_2022_CORE_IMAGE_URL") | .value' "$artifact_path")"
+				;;
+			"2025-gen2")
+				WINDOWS_BASE_IMAGE_URL=$(jq -r '.images[] | select(.name == "WINDOWS_2025_GEN2_BASE_IMAGE_URL") | .value' "$artifact_path")
+				windows_nanoserver_image_url="$(jq -r '.images[] | select(.name == "WINDOWS_2025_NANO_IMAGE_URL") | .value' "$artifact_path"),$(jq -r '.images[] | select(.name == "WINDOWS_2022_NANO_IMAGE_URL") | .value' "$artifact_path")"
+				windows_servercore_image_url="$(jq -r '.images[] | select(.name == "WINDOWS_2025_CORE_IMAGE_URL") | .value' "$artifact_path"),$(jq -r '.images[] | select(.name == "WINDOWS_2022_CORE_IMAGE_URL") | .value' "$artifact_path")"
+				;;
+			"23H2")
+				WINDOWS_BASE_IMAGE_URL=$(jq -r '.images[] | select(.name == "WINDOWS_23H2_BASE_IMAGE_URL") | .value' "$artifact_path")
+				windows_nanoserver_image_url=$(jq -r '.images[] | select(.name == "WINDOWS_2022_NANO_IMAGE_URL") | .value' "$artifact_path")
+				windows_servercore_image_url=$(jq -r '.images[] | select(.name == "WINDOWS_2022_CORE_IMAGE_URL") | .value' "$artifact_path")
+				;;
+			"23H2-gen2")
+				WINDOWS_BASE_IMAGE_URL=$(jq -r '.images[] | select(.name == "WINDOWS_23H2_GEN2_BASE_IMAGE_URL") | .value' "$artifact_path")
+				windows_nanoserver_image_url=$(jq -r '.images[] | select(.name == "WINDOWS_2022_NANO_IMAGE_URL") | .value' "$artifact_path")
+				windows_servercore_image_url=$(jq -r '.images[] | select(.name == "WINDOWS_2022_CORE_IMAGE_URL") | .value' "$artifact_path")
+				;;
+			*)
+				echo "Unsupported WINDOWS_SKU: ${WINDOWS_SKU}"
+				;;
+		esac
 	else
 		# If USE_CONTAINER_URLS_FROM_JSON is not true, fall back to default URLs
 		echo "Falling back to default Windows image URLs"

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -404,7 +404,7 @@ if [ "$OS_TYPE" = "Windows" ]; then
 	export AZCOPY_MSI_RESOURCE_STRING="${AZURE_MSI_RESOURCE_STRING}"
 
 	echo "VALID IMAGE URL: ${WINDOWS_CONTAINERIMAGE_JSON_URL}"
-	if [ -n "${WINDOWS_CONTAINERIMAGE_JSON_URL}" ]; then
+	if [ "${USE_CONTAINER_URLS_FROM_JSON}" = true ]; then
 		# Download the json artifact from the url
 		filename=$(basename "$WINDOWS_CONTAINERIMAGE_JSON_URL")
 		echo "Downloading $filename from wcct storage account using AzCopy with Managed Identity Auth"
@@ -472,8 +472,11 @@ if [ "$OS_TYPE" = "Windows" ]; then
 		else
 			echo "Unsupported WINDOWS_SKU: ${WINDOWS_SKU}"
 		fi	
+	else
+		# If USE_CONTAINER_URLS_FROM_JSON is not true, fall back to default URLs
+		echo "Falling back to default Windows image URLs"
 	fi
-		
+
 	# Check if base, nano, and servercore urls are set
 	if [ -z "${windows_nanoserver_image_url}" ] || [ -z "${windows_servercore_image_url}" ] || [ -z "${WINDOWS_BASE_IMAGE_URL}" ]; then
 		echo "Error: One of the Windows image URLs are not set."


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind feature

**What this PR does / why we need it**:
This PR introduces an automation feature that streamlines the process of populating Windows image URLs (base, nano, and servercore) in AgentBaker. Instead of manually updating each image URL during every Patch Tuesday, this feature enables automatic population using a JSON payload file. The payload is downloaded from the WCCT Agentbaker Storage account and parsed to extract the latest image URLs.

**Which issue(s) this PR fixes**:
This reduces manual intervention, minimizes the risk of human error, and ensures consistency across image updates. It also includes comments and conditions in the case where a valid URL is not available for use, falling back to the pipeline's initial [manually filled] URLs.

**Requirements**:
