### PR TITLE
chore: run validate-windows-binary-signature workflow jobs on latest windows runners

### DIFF
--- a/.github/workflows/validate-windows-binary-signature.yaml
+++ b/.github/workflows/validate-windows-binary-signature.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   check-files-for-ws2019:
     name: Check for Windows 2019
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
           ./vhdbuilder/packer/test/windows-files-check.ps1 2019-containerd
   check-files-for-ws2022:
     name: Check for Windows 2022
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4


### PR DESCRIPTION

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

windows-2019 is now a deprecated GitHub runner agent: https://github.com/actions/runner-images/issues/12045.

as a result, any PR which triggers the `validate-windows-binary-signature` workflow will converge on a failed PR check status, which is annoying and misleading - this PR fixes the issue by bumping the windows runner agent image referenced in the workflow to `windows-latest`

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
