### PR TITLE
Chore: ensure WS2019 e2e tests use k8s 1.32

### DIFF
--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -456,3 +456,18 @@ func createVMExtensionLinuxAKSNode(location *string) (*armcompute.VirtualMachine
 		},
 	}, nil
 }
+
+func GetKubeletVersionByMinorVersion(minorVersion string) string {
+	allCachedKubeletVersions := getExpectedPackageVersions("kubernetes-binaries", "default", "current")
+	rightVersions := toolkit.Filter(allCachedKubeletVersions, func(v string) bool { return strings.HasPrefix(v, minorVersion) })
+	rightVersion := toolkit.Reduce(rightVersions, "", func(sum string, next string) string {
+		if sum == "" {
+			return next
+		}
+		if next > sum {
+			return next
+		}
+		return sum
+	})
+	return rightVersion
+}

--- a/e2e/test_helpers_test.go
+++ b/e2e/test_helpers_test.go
@@ -7,6 +7,12 @@ import (
 	"testing"
 )
 
+// this is mostly for WS2019 - as WS2019 doesn't support anything after 1.32.
+func TestVersion1_32IsCached(t *testing.T) {
+	version := GetKubeletVersionByMinorVersion("v1.32")
+	require.NotEmpty(t, version)
+}
+
 func TestImagesAreFullySpecified(t *testing.T) {
 	images := getWindowsContainerImages("mcr.microsoft.com/windows/servercore:*", "2025-gen2")
 	tags := getWindowsContainerImageTags("mcr.microsoft.com/windows/servercore:*", "2025-gen2")

--- a/e2e/toolkit/arrays.go
+++ b/e2e/toolkit/arrays.go
@@ -1,9 +1,26 @@
 package toolkit
 
-func Map[T, U any](ts []T, f func(T) U) []U {
-	us := make([]U, len(ts))
-	for i := range ts {
-		us[i] = f(ts[i])
+func Map[OriginalElementType, TransformedElementType any](ts []OriginalElementType, f func(OriginalElementType) TransformedElementType) []TransformedElementType {
+	us := make([]TransformedElementType, len(ts))
+	for currentIndex := range ts {
+		us[currentIndex] = f(ts[currentIndex])
 	}
 	return us
+}
+
+func Filter[ElementType any](ss []ElementType, test func(ElementType) bool) (ret []ElementType) {
+	for _, item := range ss {
+		if test(item) {
+			ret = append(ret, item)
+		}
+	}
+	return
+}
+
+func Reduce[ElementType, ReturnType any](s []ElementType, initialValue ReturnType, f func(sum ReturnType, next ElementType) ReturnType) ReturnType {
+	sum := initialValue
+	for _, next := range s {
+		sum = f(sum, next)
+	}
+	return sum
 }

--- a/staging/cse/windows/README
+++ b/staging/cse/windows/README
@@ -6,7 +6,7 @@
     - Courses: https://docs.microsoft.com/en-us/shows/testing-powershell-with-pester/
   1. You need to run unit tests on Windows.
   1. If your git repo is stored in WSL, you can invoke the tests by doing something like this in powershell from windows (not from a WSL shell itself):
-     - ` cd \\wsl$\Ubuntu\home\tim\git\AgentBaker`
+     - `cd \\wsl$\Ubuntu\home\tim\git\AgentBaker`
      - `Invoke-Pester vhdbuilder/packer/windows/*.tests.ps1 -Passthru` (or whatever pester test you want to run)
  1. Run unit test:
     - `Invoke-Pester parts/windows/*.tests.ps1 -Passthru`


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What this PR does / why we need it**:

WS2019 doesn't support k8s 1.33 or later. So make sure WS2019 nodepools use K8s 1.32.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
