### PR TITLE
e2e: Allow test to specify the region

### DIFF
--- a/e2e/aks_model.go
+++ b/e2e/aks_model.go
@@ -72,7 +72,7 @@ func getLatestGAKubernetesVersion(location string, t *testing.T) (string, error)
 
 // getLatestKubernetesVersionClusterModel returns a cluster model with the latest GA Kubernetes version.
 func getLatestKubernetesVersionClusterModel(name string, t *testing.T) (*armcontainerservice.ManagedCluster, error) {
-	version, err := getLatestGAKubernetesVersion(config.Config.Location, t)
+	version, err := getLatestGAKubernetesVersion(config.Config.DefaultLocation, t)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get latest GA Kubernetes version: %w", err)
 	}
@@ -148,7 +148,7 @@ func getCiliumNetworkClusterModel(name string) *armcontainerservice.ManagedClust
 func getBaseClusterModel(clusterName string) *armcontainerservice.ManagedCluster {
 	return &armcontainerservice.ManagedCluster{
 		Name:     to.Ptr(clusterName),
-		Location: to.Ptr(config.Config.Location),
+		Location: to.Ptr(config.Config.DefaultLocation),
 		Properties: &armcontainerservice.ManagedClusterProperties{
 			DNSPrefix: to.Ptr(clusterName),
 			AgentPoolProfiles: []*armcontainerservice.ManagedClusterAgentPoolProfile{
@@ -186,7 +186,7 @@ func addAirgapNetworkSettings(ctx context.Context, t *testing.T, clusterModel *a
 	}
 	subnetId := vnet.subnetId
 
-	nsgParams, err := airGapSecurityGroup(config.Config.Location, *clusterModel.Properties.Fqdn)
+	nsgParams, err := airGapSecurityGroup(config.Config.DefaultLocation, *clusterModel.Properties.Fqdn)
 	if err != nil {
 		return err
 	}
@@ -367,7 +367,7 @@ func createPrivateAzureContainerRegistry(ctx context.Context, t *testing.T, clus
 
 	t.Logf("ACR does not exist, creating...")
 	createParams := armcontainerregistry.Registry{
-		Location: to.Ptr(config.Config.Location),
+		Location: to.Ptr(config.Config.DefaultLocation),
 		SKU: &armcontainerregistry.SKU{
 			Name: to.Ptr(armcontainerregistry.SKUNamePremium),
 		},
@@ -501,7 +501,7 @@ func createPrivateEndpoint(ctx context.Context, t *testing.T, nodeResourceGroup,
 	acrID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerRegistry/registries/%s", config.Config.SubscriptionID, config.ResourceGroupName, privateACRName)
 
 	peParams := armnetwork.PrivateEndpoint{
-		Location: to.Ptr(config.Config.Location),
+		Location: to.Ptr(config.Config.DefaultLocation),
 		Properties: &armnetwork.PrivateEndpointProperties{
 			Subnet: &armnetwork.Subnet{
 				ID: to.Ptr(vnet.subnetId),

--- a/e2e/aks_model.go
+++ b/e2e/aks_model.go
@@ -71,31 +71,31 @@ func getLatestGAKubernetesVersion(location string, t *testing.T) (string, error)
 }
 
 // getLatestKubernetesVersionClusterModel returns a cluster model with the latest GA Kubernetes version.
-func getLatestKubernetesVersionClusterModel(name string, t *testing.T) (*armcontainerservice.ManagedCluster, error) {
-	version, err := getLatestGAKubernetesVersion(config.Config.DefaultLocation, t)
+func getLatestKubernetesVersionClusterModel(name, location string, t *testing.T) (*armcontainerservice.ManagedCluster, error) {
+	version, err := getLatestGAKubernetesVersion(location, t)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get latest GA Kubernetes version: %w", err)
 	}
-	model := getBaseClusterModel(name)
+	model := getBaseClusterModel(name, location)
 	model.Properties.KubernetesVersion = to.Ptr(version)
 	return model, nil
 }
 
-func getKubenetClusterModel(name string) *armcontainerservice.ManagedCluster {
-	model := getBaseClusterModel(name)
+func getKubenetClusterModel(name, location string) *armcontainerservice.ManagedCluster {
+	model := getBaseClusterModel(name, location)
 	model.Properties.NetworkProfile.NetworkPlugin = to.Ptr(armcontainerservice.NetworkPluginKubenet)
 	return model
 }
 
-func getAzureOverlayNetworkClusterModel(name string) *armcontainerservice.ManagedCluster {
-	model := getBaseClusterModel(name)
+func getAzureOverlayNetworkClusterModel(name, location string) *armcontainerservice.ManagedCluster {
+	model := getBaseClusterModel(name, location)
 	model.Properties.NetworkProfile.NetworkPlugin = to.Ptr(armcontainerservice.NetworkPluginAzure)
 	model.Properties.NetworkProfile.NetworkPluginMode = to.Ptr(armcontainerservice.NetworkPluginModeOverlay)
 	return model
 }
 
-func getAzureOverlayNetworkDualStackClusterModel(name string) *armcontainerservice.ManagedCluster {
-	model := getAzureOverlayNetworkClusterModel(name)
+func getAzureOverlayNetworkDualStackClusterModel(name, location string) *armcontainerservice.ManagedCluster {
+	model := getAzureOverlayNetworkClusterModel(name, location)
 
 	model.Properties.NetworkProfile.IPFamilies = []*armcontainerservice.IPFamily{
 		to.Ptr(armcontainerservice.IPFamilyIPv4),
@@ -122,8 +122,8 @@ func getAzureOverlayNetworkDualStackClusterModel(name string) *armcontainerservi
 	return model
 }
 
-func getAzureNetworkClusterModel(name string) *armcontainerservice.ManagedCluster {
-	cluster := getBaseClusterModel(name)
+func getAzureNetworkClusterModel(name, location string) *armcontainerservice.ManagedCluster {
+	cluster := getBaseClusterModel(name, location)
 	cluster.Properties.NetworkProfile.NetworkPlugin = to.Ptr(armcontainerservice.NetworkPluginAzure)
 	if cluster.Properties.AgentPoolProfiles != nil {
 		for _, app := range cluster.Properties.AgentPoolProfiles {
@@ -132,8 +132,8 @@ func getAzureNetworkClusterModel(name string) *armcontainerservice.ManagedCluste
 	}
 	return cluster
 }
-func getCiliumNetworkClusterModel(name string) *armcontainerservice.ManagedCluster {
-	cluster := getBaseClusterModel(name)
+func getCiliumNetworkClusterModel(name, location string) *armcontainerservice.ManagedCluster {
+	cluster := getBaseClusterModel(name, location)
 	cluster.Properties.NetworkProfile.NetworkPlugin = to.Ptr(armcontainerservice.NetworkPluginAzure)
 	cluster.Properties.NetworkProfile.NetworkDataplane = to.Ptr(armcontainerservice.NetworkDataplaneCilium)
 	cluster.Properties.NetworkProfile.NetworkPolicy = to.Ptr(armcontainerservice.NetworkPolicyCilium)
@@ -145,10 +145,10 @@ func getCiliumNetworkClusterModel(name string) *armcontainerservice.ManagedClust
 	return cluster
 }
 
-func getBaseClusterModel(clusterName string) *armcontainerservice.ManagedCluster {
+func getBaseClusterModel(clusterName, location string) *armcontainerservice.ManagedCluster {
 	return &armcontainerservice.ManagedCluster{
 		Name:     to.Ptr(clusterName),
-		Location: to.Ptr(config.Config.DefaultLocation),
+		Location: to.Ptr(location),
 		Properties: &armcontainerservice.ManagedClusterProperties{
 			DNSPrefix: to.Ptr(clusterName),
 			AgentPoolProfiles: []*armcontainerservice.ManagedClusterAgentPoolProfile{
@@ -177,7 +177,7 @@ func getBaseClusterModel(clusterName string) *armcontainerservice.ManagedCluster
 	}
 }
 
-func addAirgapNetworkSettings(ctx context.Context, t *testing.T, clusterModel *armcontainerservice.ManagedCluster, privateACRName string) error {
+func addAirgapNetworkSettings(ctx context.Context, t *testing.T, clusterModel *armcontainerservice.ManagedCluster, privateACRName, location string) error {
 	t.Logf("Adding network settings for airgap cluster %s in rg %s", *clusterModel.Name, *clusterModel.Properties.NodeResourceGroup)
 
 	vnet, err := getClusterVNet(ctx, *clusterModel.Properties.NodeResourceGroup)
@@ -186,7 +186,7 @@ func addAirgapNetworkSettings(ctx context.Context, t *testing.T, clusterModel *a
 	}
 	subnetId := vnet.subnetId
 
-	nsgParams, err := airGapSecurityGroup(config.Config.DefaultLocation, *clusterModel.Properties.Fqdn)
+	nsgParams, err := airGapSecurityGroup(location, *clusterModel.Properties.Fqdn)
 	if err != nil {
 		return err
 	}
@@ -209,7 +209,7 @@ func addAirgapNetworkSettings(ctx context.Context, t *testing.T, clusterModel *a
 		return err
 	}
 
-	err = addPrivateEndpointForACR(ctx, t, *clusterModel.Properties.NodeResourceGroup, privateACRName, vnet)
+	err = addPrivateEndpointForACR(ctx, t, *clusterModel.Properties.NodeResourceGroup, privateACRName, vnet, location)
 	if err != nil {
 		return err
 	}
@@ -261,7 +261,7 @@ func airGapSecurityGroup(location, clusterFQDN string) (armnetwork.SecurityGroup
 	}, nil
 }
 
-func addPrivateEndpointForACR(ctx context.Context, t *testing.T, nodeResourceGroup, privateACRName string, vnet VNet) error {
+func addPrivateEndpointForACR(ctx context.Context, t *testing.T, nodeResourceGroup, privateACRName string, vnet VNet, location string) error {
 	t.Logf("Checking if private endpoint for private container registry is in rg %s", nodeResourceGroup)
 
 	var err error
@@ -276,7 +276,7 @@ func addPrivateEndpointForACR(ctx context.Context, t *testing.T, nodeResourceGro
 	}
 
 	var peResp armnetwork.PrivateEndpointsClientCreateOrUpdateResponse
-	if peResp, err = createPrivateEndpoint(ctx, t, nodeResourceGroup, privateEndpointName, privateACRName, vnet); err != nil {
+	if peResp, err = createPrivateEndpoint(ctx, t, nodeResourceGroup, privateEndpointName, privateACRName, vnet, location); err != nil {
 		return err
 	}
 
@@ -313,7 +313,7 @@ func privateEndpointExists(ctx context.Context, t *testing.T, nodeResourceGroup,
 }
 
 func createPrivateAzureContainerRegistryPullSecret(ctx context.Context, t *testing.T, cluster *armcontainerservice.ManagedCluster, kubeconfig *Kubeclient, resourceGroup string, isNonAnonymousPull bool) error {
-	privateACRName := config.GetPrivateACRName(isNonAnonymousPull)
+	privateACRName := config.GetPrivateACRName(isNonAnonymousPull, *cluster.Location)
 	if isNonAnonymousPull {
 		t.Logf("Creating the secret for non-anonymous pull ACR for the e2e debug pods")
 		kubeconfigPath := os.Getenv("HOME") + "/.kube/config"
@@ -335,7 +335,7 @@ func createPrivateAzureContainerRegistryPullSecret(ctx context.Context, t *testi
 }
 
 func createPrivateAzureContainerRegistry(ctx context.Context, t *testing.T, cluster *armcontainerservice.ManagedCluster, kubeconfig *Kubeclient, resourceGroup string, isNonAnonymousPull bool) error {
-	privateACRName := config.GetPrivateACRName(isNonAnonymousPull)
+	privateACRName := config.GetPrivateACRName(isNonAnonymousPull, *cluster.Location)
 	t.Logf("Creating private Azure Container Registry %s in rg %s", privateACRName, resourceGroup)
 
 	acr, err := config.Azure.RegistriesClient.Get(ctx, resourceGroup, privateACRName, nil)
@@ -367,7 +367,7 @@ func createPrivateAzureContainerRegistry(ctx context.Context, t *testing.T, clus
 
 	t.Logf("ACR does not exist, creating...")
 	createParams := armcontainerregistry.Registry{
-		Location: to.Ptr(config.Config.DefaultLocation),
+		Location: to.Ptr(*cluster.Location),
 		SKU: &armcontainerregistry.SKU{
 			Name: to.Ptr(armcontainerregistry.SKUNamePremium),
 		},
@@ -393,7 +393,7 @@ func createPrivateAzureContainerRegistry(ctx context.Context, t *testing.T, clus
 
 	t.Logf("Private Azure Container Registry created")
 
-	if err := addCacheRulesToPrivateAzureContainerRegistry(ctx, t, config.ResourceGroupName, privateACRName); err != nil {
+	if err := addCacheRulesToPrivateAzureContainerRegistry(ctx, t, config.ResourceGroupName(*cluster.Location), privateACRName); err != nil {
 		return fmt.Errorf("failed to add cache rules to private acr: %w", err)
 	}
 
@@ -496,12 +496,12 @@ func addCacheRulesToPrivateAzureContainerRegistry(ctx context.Context, t *testin
 	return nil
 }
 
-func createPrivateEndpoint(ctx context.Context, t *testing.T, nodeResourceGroup, privateEndpointName, privateACRName string, vnet VNet) (armnetwork.PrivateEndpointsClientCreateOrUpdateResponse, error) {
+func createPrivateEndpoint(ctx context.Context, t *testing.T, nodeResourceGroup, privateEndpointName, privateACRName string, vnet VNet, location string) (armnetwork.PrivateEndpointsClientCreateOrUpdateResponse, error) {
 	t.Logf("Creating Private Endpoint in rg %s", nodeResourceGroup)
-	acrID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerRegistry/registries/%s", config.Config.SubscriptionID, config.ResourceGroupName, privateACRName)
+	acrID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerRegistry/registries/%s", config.Config.SubscriptionID, config.ResourceGroupName(location), privateACRName)
 
 	peParams := armnetwork.PrivateEndpoint{
-		Location: to.Ptr(config.Config.DefaultLocation),
+		Location: to.Ptr(location),
 		Properties: &armnetwork.PrivateEndpointProperties{
 			Subnet: &armnetwork.Subnet{
 				ID: to.Ptr(vnet.subnetId),

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -91,9 +91,9 @@ func (c *Cluster) MaxPodsPerNode() (int, error) {
 // Same cluster can be attempted to be created concurrently by different tests
 // sync.Once is used to ensure that only one cluster for the set of tests is created
 
-func ClusterLatestKubernetesVersion(ctx context.Context, t *testing.T) (*Cluster, error) {
+func ClusterLatestKubernetesVersion(ctx context.Context, location string, t *testing.T) (*Cluster, error) {
 	clusterLatestKubernetesVersionOnce.Do(func() {
-		model, error := getLatestKubernetesVersionClusterModel("abe2e-latest-kubernetes-version", t)
+		model, error := getLatestKubernetesVersionClusterModel("abe2e-latest-kubernetes-version", location, t)
 		if error != nil {
 			t.Fatalf("failed to get latest kubernetes version cluster model: %v", error)
 		}
@@ -102,51 +102,51 @@ func ClusterLatestKubernetesVersion(ctx context.Context, t *testing.T) (*Cluster
 	return clusterLatestKubernetesVersion, clusterLatestKubernetesVersionError
 }
 
-func ClusterKubenet(ctx context.Context, t *testing.T) (*Cluster, error) {
+func ClusterKubenet(ctx context.Context, location string, t *testing.T) (*Cluster, error) {
 	clusterKubenetOnce.Do(func() {
-		clusterKubenet, clusterKubenetError = prepareCluster(ctx, t, getKubenetClusterModel("abe2e-kubenet"), false, false)
+		clusterKubenet, clusterKubenetError = prepareCluster(ctx, t, getKubenetClusterModel("abe2e-kubenet", location), false, false)
 	})
 	return clusterKubenet, clusterKubenetError
 }
 
-func ClusterKubenetAirgap(ctx context.Context, t *testing.T) (*Cluster, error) {
+func ClusterKubenetAirgap(ctx context.Context, location string, t *testing.T) (*Cluster, error) {
 	clusterKubenetAirgapOnce.Do(func() {
-		clusterKubenetAirgap, clusterKubenetAirgapError = prepareCluster(ctx, t, getKubenetClusterModel("abe2e-kubenet-airgap"), true, false)
+		clusterKubenetAirgap, clusterKubenetAirgapError = prepareCluster(ctx, t, getKubenetClusterModel("abe2e-kubenet-airgap", location), true, false)
 	})
 	return clusterKubenetAirgap, clusterKubenetAirgapError
 }
 
-func ClusterKubenetAirgapNonAnon(ctx context.Context, t *testing.T) (*Cluster, error) {
+func ClusterKubenetAirgapNonAnon(ctx context.Context, location string, t *testing.T) (*Cluster, error) {
 	clusterKubenetNonAnonAirgapOnce.Do(func() {
-		clusterKubenetNonAnonAirgap, clusterKubenetNonAnonAirgapError = prepareCluster(ctx, t, getKubenetClusterModel("abe2e-kubenet-nonanonpull-airgap"), true, true)
+		clusterKubenetNonAnonAirgap, clusterKubenetNonAnonAirgapError = prepareCluster(ctx, t, getKubenetClusterModel("abe2e-kubenet-nonanonpull-airgap", location), true, true)
 	})
 	return clusterKubenetNonAnonAirgap, clusterKubenetNonAnonAirgapError
 }
 
-func ClusterAzureNetwork(ctx context.Context, t *testing.T) (*Cluster, error) {
+func ClusterAzureNetwork(ctx context.Context, location string, t *testing.T) (*Cluster, error) {
 	clusterAzureNetworkOnce.Do(func() {
-		clusterAzureNetwork, clusterAzureNetworkError = prepareCluster(ctx, t, getAzureNetworkClusterModel("abe2e-azure-network"), false, false)
+		clusterAzureNetwork, clusterAzureNetworkError = prepareCluster(ctx, t, getAzureNetworkClusterModel("abe2e-azure-network", location), false, false)
 	})
 	return clusterAzureNetwork, clusterAzureNetworkError
 }
 
-func ClusterAzureOverlayNetwork(ctx context.Context, t *testing.T) (*Cluster, error) {
+func ClusterAzureOverlayNetwork(ctx context.Context, location string, t *testing.T) (*Cluster, error) {
 	clusterAzureOverlayNetworkOnce.Do(func() {
-		clusterAzureOverlayNetwork, clusterAzureOverlayNetworkError = prepareCluster(ctx, t, getAzureOverlayNetworkClusterModel("abe2e-azure-overlay-network"), false, false)
+		clusterAzureOverlayNetwork, clusterAzureOverlayNetworkError = prepareCluster(ctx, t, getAzureOverlayNetworkClusterModel("abe2e-azure-overlay-network", location), false, false)
 	})
 	return clusterAzureOverlayNetwork, clusterAzureOverlayNetworkError
 }
 
-func ClusterAzureOverlayNetworkDualStack(ctx context.Context, t *testing.T) (*Cluster, error) {
+func ClusterAzureOverlayNetworkDualStack(ctx context.Context, location string, t *testing.T) (*Cluster, error) {
 	clusterAzureOverlayNetworkDualStackOnce.Do(func() {
-		clusterAzureOverlayNetworkDualStack, clusterAzureOverlayNetworkDualStackError = prepareCluster(ctx, t, getAzureOverlayNetworkDualStackClusterModel("abe2e-azure-overlay-dualstack"), false, false)
+		clusterAzureOverlayNetworkDualStack, clusterAzureOverlayNetworkDualStackError = prepareCluster(ctx, t, getAzureOverlayNetworkDualStackClusterModel("abe2e-azure-overlay-dualstack", location), false, false)
 	})
 	return clusterAzureOverlayNetworkDualStack, clusterAzureOverlayNetworkDualStackError
 }
 
-func ClusterCiliumNetwork(ctx context.Context, t *testing.T) (*Cluster, error) {
+func ClusterCiliumNetwork(ctx context.Context, location string, t *testing.T) (*Cluster, error) {
 	clusterCiliumNetworkOnce.Do(func() {
-		clusterCiliumNetwork, clusterCiliumNetworkError = prepareCluster(ctx, t, getCiliumNetworkClusterModel("abe2e-cilium-network"), false, false)
+		clusterCiliumNetwork, clusterCiliumNetworkError = prepareCluster(ctx, t, getCiliumNetworkClusterModel("abe2e-cilium-network", location), false, false)
 	})
 	return clusterCiliumNetwork, clusterCiliumNetworkError
 }
@@ -171,38 +171,40 @@ func prepareCluster(ctx context.Context, t *testing.T, cluster *armcontainerserv
 		return nil, fmt.Errorf("get cluster subnet: %w", err)
 	}
 
-	kube, err := getClusterKubeClient(ctx, config.ResourceGroupName, *cluster.Name)
+	resourceGroupName := config.ResourceGroupName(*cluster.Location)
+
+	kube, err := getClusterKubeClient(ctx, resourceGroupName, *cluster.Name)
 	if err != nil {
 		return nil, fmt.Errorf("get kube client using cluster %q: %w", *cluster.Name, err)
 	}
 
-	t.Logf("using private acr %q isAnonyomusPull %v", config.GetPrivateACRName(isNonAnonymousPull), isNonAnonymousPull)
+	t.Logf("using private acr %q isAnonyomusPull %v", config.GetPrivateACRName(isNonAnonymousPull, *cluster.Location), isNonAnonymousPull)
 	if isAirgap {
 		// private acr must be created before we add the debug daemonsets
-		if err := createPrivateAzureContainerRegistry(ctx, t, cluster, kube, config.ResourceGroupName, isNonAnonymousPull); err != nil {
+		if err := createPrivateAzureContainerRegistry(ctx, t, cluster, kube, resourceGroupName, isNonAnonymousPull); err != nil {
 			return nil, fmt.Errorf("failed to create private acr: %w", err)
 		}
 
-		if err := createPrivateAzureContainerRegistryPullSecret(ctx, t, cluster, kube, config.ResourceGroupName, isNonAnonymousPull); err != nil {
+		if err := createPrivateAzureContainerRegistryPullSecret(ctx, t, cluster, kube, resourceGroupName, isNonAnonymousPull); err != nil {
 			return nil, fmt.Errorf("create private acr pull secret: %w", err)
 		}
 
-		if err := addAirgapNetworkSettings(ctx, t, cluster, config.GetPrivateACRName(isNonAnonymousPull)); err != nil {
+		if err := addAirgapNetworkSettings(ctx, t, cluster, config.GetPrivateACRName(isNonAnonymousPull, *cluster.Location), *cluster.Location); err != nil {
 			return nil, fmt.Errorf("add airgap network settings: %w", err)
 		}
 	}
 
 	if isNonAnonymousPull {
-		identity, err := config.Azure.UserAssignedIdentities.Get(ctx, config.ResourceGroupName, config.VMIdentityName, nil)
+		identity, err := config.Azure.UserAssignedIdentities.Get(ctx, resourceGroupName, config.VMIdentityName, nil)
 		if err != nil {
 			t.Fatalf("failed to get VM identity: %v", err)
 		}
-		if err := assignACRPullToIdentity(ctx, t, config.GetPrivateACRName(isNonAnonymousPull), *identity.Properties.PrincipalID); err != nil {
+		if err := assignACRPullToIdentity(ctx, t, config.GetPrivateACRName(isNonAnonymousPull, *cluster.Location), *identity.Properties.PrincipalID, *cluster.Location); err != nil {
 			return nil, fmt.Errorf("assign acr pull to the managed identity: %w", err)
 		}
 	}
 
-	if err := kube.EnsureDebugDaemonsets(ctx, t, isAirgap, config.GetPrivateACRName(isNonAnonymousPull)); err != nil {
+	if err := kube.EnsureDebugDaemonsets(ctx, t, isAirgap, config.GetPrivateACRName(isNonAnonymousPull, *cluster.Location)); err != nil {
 		return nil, fmt.Errorf("ensure debug daemonsets for %q: %w", *cluster.Name, err)
 	}
 
@@ -248,9 +250,9 @@ func extractClusterParameters(ctx context.Context, t *testing.T, kube *Kubeclien
 	}, nil
 }
 
-func assignACRPullToIdentity(ctx context.Context, t *testing.T, privateACRName, principalID string) error {
+func assignACRPullToIdentity(ctx context.Context, t *testing.T, privateACRName, principalID string, location string) error {
 	t.Logf("assigning ACR-Pull role to %s", principalID)
-	scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerRegistry/registries/%s", config.Config.SubscriptionID, config.ResourceGroupName, privateACRName)
+	scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerRegistry/registries/%s", config.Config.SubscriptionID, config.ResourceGroupName(location), privateACRName)
 
 	uid := uuid.New().String()
 	_, err := config.Azure.RoleAssignments.Create(ctx, scope, uid, armauthorization.RoleAssignmentCreateParameters{
@@ -305,7 +307,9 @@ func hash(cluster *armcontainerservice.ManagedCluster) string {
 }
 
 func getOrCreateCluster(ctx context.Context, t *testing.T, cluster *armcontainerservice.ManagedCluster) (*armcontainerservice.ManagedCluster, error) {
-	existingCluster, err := config.Azure.AKS.Get(ctx, config.ResourceGroupName, *cluster.Name, nil)
+	resourceGroupName := config.ResourceGroupName(*cluster.Location)
+
+	existingCluster, err := config.Azure.AKS.Get(ctx, resourceGroupName, *cluster.Name, nil)
 	var azErr *azcore.ResponseError
 	if errors.As(err, &azErr) && azErr.StatusCode == 404 {
 		return createNewAKSClusterWithRetry(ctx, t, cluster)
@@ -313,7 +317,7 @@ func getOrCreateCluster(ctx context.Context, t *testing.T, cluster *armcontainer
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cluster %q: %w", *cluster.Name, err)
 	}
-	t.Logf("cluster %s already exists in rg %s", *cluster.Name, config.ResourceGroupName)
+	t.Logf("cluster %s already exists in rg %s", *cluster.Name, resourceGroupName)
 	switch *existingCluster.Properties.ProvisioningState {
 	case "Succeeded":
 		nodeRGExists, err := isExistingResourceGroup(ctx, *existingCluster.Properties.NodeResourceGroup)
@@ -328,7 +332,7 @@ func getOrCreateCluster(ctx context.Context, t *testing.T, cluster *armcontainer
 		}
 		return &existingCluster.ManagedCluster, nil
 	case "Creating", "Updating":
-		return waitUntilClusterReady(ctx, *cluster.Name)
+		return waitUntilClusterReady(ctx, *cluster.Name, *cluster.Location)
 	default:
 		// this operation will try to update the cluster if it's in a failed state
 		return createNewAKSClusterWithRetry(ctx, t, cluster)
@@ -336,18 +340,19 @@ func getOrCreateCluster(ctx context.Context, t *testing.T, cluster *armcontainer
 }
 
 func deleteCluster(ctx context.Context, t *testing.T, cluster *armcontainerservice.ManagedCluster) error {
-	t.Logf("deleting cluster %s in rg %s", *cluster.Name, config.ResourceGroupName)
-	_, err := config.Azure.AKS.Get(ctx, config.ResourceGroupName, *cluster.Name, nil)
+	resourceGroupName := config.ResourceGroupName(*cluster.Location)
+	t.Logf("deleting cluster %s in rg %s", *cluster.Name, resourceGroupName)
+	_, err := config.Azure.AKS.Get(ctx, resourceGroupName, *cluster.Name, nil)
 	if err != nil {
 		var azErr *azcore.ResponseError
 		if errors.As(err, &azErr) && azErr.StatusCode == 404 {
-			t.Logf("cluster %s does not exist in rg %s", *cluster.Name, config.ResourceGroupName)
+			t.Logf("cluster %s does not exist in rg %s", *cluster.Name, resourceGroupName)
 			return nil
 		}
 		return fmt.Errorf("failed to get cluster %q: %w", *cluster.Name, err)
 	}
 
-	pollerResp, err := config.Azure.AKS.BeginDelete(ctx, config.ResourceGroupName, *cluster.Name, nil)
+	pollerResp, err := config.Azure.AKS.BeginDelete(ctx, resourceGroupName, *cluster.Name, nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete cluster %q: %w", *cluster.Name, err)
 	}
@@ -355,15 +360,15 @@ func deleteCluster(ctx context.Context, t *testing.T, cluster *armcontainerservi
 	if err != nil {
 		return fmt.Errorf("failed to wait for cluster deletion %w", err)
 	}
-	t.Logf("deleted cluster %s in rg %s", *cluster.Name, config.ResourceGroupName)
+	t.Logf("deleted cluster %s in rg %s", *cluster.Name, resourceGroupName)
 	return nil
 }
 
-func waitUntilClusterReady(ctx context.Context, name string) (*armcontainerservice.ManagedCluster, error) {
+func waitUntilClusterReady(ctx context.Context, name string, location string) (*armcontainerservice.ManagedCluster, error) {
 	var cluster armcontainerservice.ManagedClustersClientGetResponse
 	err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
 		var err error
-		cluster, err = config.Azure.AKS.Get(ctx, config.ResourceGroupName, name, nil)
+		cluster, err = config.Azure.AKS.Get(ctx, config.ResourceGroupName(location), name, nil)
 		if err != nil {
 			return false, err
 		}
@@ -396,7 +401,7 @@ func createNewAKSCluster(ctx context.Context, t *testing.T, cluster *armcontaine
 	// Note, it seems like the operation still can start a trigger a new operation even if nothing has changes
 	pollerResp, err := config.Azure.AKS.BeginCreateOrUpdate(
 		ctx,
-		config.ResourceGroupName,
+		config.ResourceGroupName(*cluster.Location),
 		*cluster.Name,
 		*cluster,
 		nil,
@@ -422,7 +427,7 @@ func createNewAKSClusterWithRetry(ctx context.Context, t *testing.T, cluster *ar
 	retryInterval := 30 * time.Second
 	var lastErr error
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		t.Logf("Attempt %d: creating or updating cluster %s in region %s and rg %s", attempt+1, *cluster.Name, *cluster.Location, config.ResourceGroupName)
+		t.Logf("Attempt %d: creating or updating cluster %s in region %s and rg %s", attempt+1, *cluster.Name, *cluster.Location, config.ResourceGroupName(*cluster.Location))
 
 		createdCluster, err := createNewAKSCluster(ctx, t, cluster)
 		if err == nil {
@@ -451,7 +456,7 @@ func createNewAKSClusterWithRetry(ctx context.Context, t *testing.T, cluster *ar
 }
 
 func getOrCreateMaintenanceConfiguration(ctx context.Context, t *testing.T, cluster *armcontainerservice.ManagedCluster) (*armcontainerservice.MaintenanceConfiguration, error) {
-	existingMaintenance, err := config.Azure.Maintenance.Get(ctx, config.ResourceGroupName, *cluster.Name, "default", nil)
+	existingMaintenance, err := config.Azure.Maintenance.Get(ctx, config.ResourceGroupName(*cluster.Location), *cluster.Name, "default", nil)
 	var azErr *azcore.ResponseError
 	if errors.As(err, &azErr) && azErr.StatusCode == 404 {
 		return createNewMaintenanceConfiguration(ctx, t, cluster)
@@ -463,7 +468,7 @@ func getOrCreateMaintenanceConfiguration(ctx context.Context, t *testing.T, clus
 }
 
 func createNewMaintenanceConfiguration(ctx context.Context, t *testing.T, cluster *armcontainerservice.ManagedCluster) (*armcontainerservice.MaintenanceConfiguration, error) {
-	t.Logf("creating maintenance configuration for cluster %s in rg %s", *cluster.Name, config.ResourceGroupName)
+	t.Logf("creating maintenance configuration for cluster %s in rg %s", *cluster.Name, config.ResourceGroupName(*cluster.Location))
 	maintenance := armcontainerservice.MaintenanceConfiguration{
 		Properties: &armcontainerservice.MaintenanceConfigurationProperties{
 			MaintenanceWindow: &armcontainerservice.MaintenanceWindow{
@@ -485,7 +490,7 @@ func createNewMaintenanceConfiguration(ctx context.Context, t *testing.T, cluste
 		},
 	}
 
-	_, err := config.Azure.Maintenance.CreateOrUpdate(ctx, config.ResourceGroupName, *cluster.Name, "default", maintenance, nil)
+	_, err := config.Azure.Maintenance.CreateOrUpdate(ctx, config.ResourceGroupName(*cluster.Location), *cluster.Name, "default", maintenance, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create maintenance configuration: %w", err)
 	}
@@ -552,18 +557,19 @@ func collectGarbageVMSS(ctx context.Context, t *testing.T, cluster *armcontainer
 	return nil
 }
 
-func ensureResourceGroup(ctx context.Context) error {
+func ensureResourceGroup(ctx context.Context, location string) error {
+	resourceGroupName := config.ResourceGroupName(location)
 	_, err := config.Azure.ResourceGroup.CreateOrUpdate(
 		ctx,
-		config.ResourceGroupName,
+		resourceGroupName,
 		armresources.ResourceGroup{
-			Location: to.Ptr(config.Config.DefaultLocation),
-			Name:     to.Ptr(config.ResourceGroupName),
+			Location: to.Ptr(location),
+			Name:     to.Ptr(resourceGroupName),
 		},
 		nil)
 
 	if err != nil {
-		return fmt.Errorf("failed to create RG %q: %w", config.ResourceGroupName, err)
+		return fmt.Errorf("failed to create RG %q: %w", resourceGroupName, err)
 	}
 	return nil
 }

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -557,7 +557,7 @@ func ensureResourceGroup(ctx context.Context) error {
 		ctx,
 		config.ResourceGroupName,
 		armresources.ResourceGroup{
-			Location: to.Ptr(config.Config.Location),
+			Location: to.Ptr(config.Config.DefaultLocation),
 			Name:     to.Ptr(config.ResourceGroupName),
 		},
 		nil)

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -15,10 +15,10 @@ import (
 var (
 	Config                = mustLoadConfig()
 	Azure                 = mustNewAzureClient()
-	ResourceGroupName     = "abe2e-" + Config.Location
+	ResourceGroupName     = "abe2e-" + Config.DefaultLocation
 	VMIdentityName        = "abe2e-vm-identity"
-	PrivateACRNameNotAnon = "privateace2enonanonpull" + Config.Location // will have anonymous pull enabled
-	PrivateACRName        = "privateacre2e" + Config.Location           // will not have anonymous pull enabled
+	PrivateACRNameNotAnon = "privateace2enonanonpull" + Config.DefaultLocation // will have anonymous pull enabled
+	PrivateACRName        = "privateacre2e" + Config.DefaultLocation           // will not have anonymous pull enabled
 
 	DefaultPollUntilDoneOptions = &runtime.PollUntilDoneOptions{
 		Frequency: time.Second,
@@ -48,7 +48,7 @@ type Configuration struct {
 
 	IgnoreScenariosWithMissingVHD bool          `env:"IGNORE_SCENARIOS_WITH_MISSING_VHD"`
 	KeepVMSS                      bool          `env:"KEEP_VMSS"`
-	Location                      string        `env:"E2E_LOCATION" envDefault:"westus3"`
+	DefaultLocation               string        `env:"E2E_LOCATION" envDefault:"westus3"`
 	SIGVersionTagName             string        `env:"SIG_VERSION_TAG_NAME" envDefault:"branch"`
 	SIGVersionTagValue            string        `env:"SIG_VERSION_TAG_VALUE" envDefault:"refs/heads/master"`
 	SkipTestsWithSKUCapacityIssue bool          `env:"SKIP_TESTS_WITH_SKU_CAPACITY_ISSUE"`
@@ -62,7 +62,7 @@ type Configuration struct {
 }
 
 func (c *Configuration) BlobStorageAccount() string {
-	return c.BlobStorageAccountPrefix + c.Location
+	return c.BlobStorageAccountPrefix + c.DefaultLocation
 }
 
 func (c *Configuration) BlobStorageAccountURL() string {

--- a/e2e/config/vhd.go
+++ b/e2e/config/vhd.go
@@ -223,16 +223,16 @@ func (i *Image) String() string {
 	return fmt.Sprintf("%s %s %s %s", i.OS, i.Name, i.Version, i.Arch)
 }
 
-func (i *Image) VHDResourceID(ctx context.Context, t *testing.T) (VHDResourceID, error) {
+func (i *Image) VHDResourceID(ctx context.Context, t *testing.T, location string) (VHDResourceID, error) {
 	i.vhdOnce.Do(func() {
 		switch {
 		case i.Version != "":
-			i.vhd, i.vhdErr = Azure.EnsureSIGImageVersion(ctx, t, i)
+			i.vhd, i.vhdErr = Azure.EnsureSIGImageVersion(ctx, t, i, location)
 			if i.vhd != "" {
 				t.Logf("Got image by version: %s", i.azurePortalImageVersionUrl())
 			}
 		default:
-			i.vhd, i.vhdErr = Azure.LatestSIGImageVersionByTag(ctx, t, i, Config.SIGVersionTagName, Config.SIGVersionTagValue)
+			i.vhd, i.vhdErr = Azure.LatestSIGImageVersionByTag(ctx, t, i, Config.SIGVersionTagName, Config.SIGVersionTagValue, location)
 			if i.vhd != "" {
 				t.Logf("got version by tag %s=%s: %s", Config.SIGVersionTagName, Config.SIGVersionTagValue, i.azurePortalImageVersionUrl())
 			} else {

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -179,7 +179,7 @@ func logSSHInstructions(s *Scenario) {
 	}
 	result += "\n========================\n"
 	result += fmt.Sprintf("az account set --subscription %s\n", config.Config.SubscriptionID)
-	result += fmt.Sprintf("az aks get-credentials --resource-group %s --name %s --overwrite-existing\n", config.ResourceGroupName, *s.Runtime.Cluster.Model.Name)
+	result += fmt.Sprintf("az aks get-credentials --resource-group %s --name %s --overwrite-existing\n", config.ResourceGroupName(s.Location), *s.Runtime.Cluster.Model.Name)
 	result += fmt.Sprintf(`kubectl exec -it %s -- bash -c "chroot /proc/1/root /bin/bash -c '%s'"`, s.Runtime.Cluster.DebugPod.Name, sshString(s.Runtime.VMPrivateIP))
 	s.T.Log(result)
 	//runtime.Breakpoint() // uncomment to pause the test

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -475,7 +475,7 @@ func podHTTPServerLinux(s *Scenario) *corev1.Pod {
 	image := "mcr.microsoft.com/cbl-mariner/busybox:2.0"
 	secretName := ""
 	if s.Tags.Airgap {
-		image = fmt.Sprintf("%s.azurecr.io/cbl-mariner/busybox:2.0", config.GetPrivateACRName(s.Tags.NonAnonymousACR))
+		image = fmt.Sprintf("%s.azurecr.io/cbl-mariner/busybox:2.0", config.GetPrivateACRName(s.Tags.NonAnonymousACR, s.Location))
 		secretName = config.Config.ACRSecretName
 	}
 	return &corev1.Pod{

--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -101,7 +101,7 @@ func getBaseNBC(t *testing.T, cluster *Cluster, vhd *config.Image) *datamodel.No
 	var nbc *datamodel.NodeBootstrappingConfiguration
 
 	if vhd.Distro.IsWindowsDistro() {
-		nbc = baseTemplateWindows(t, config.Config.Location)
+		nbc = baseTemplateWindows(t, config.Config.DefaultLocation)
 
 		// these aren't needed since we use TLS bootstrapping instead, though windows bootstrapping expects non-empty values
 		nbc.ContainerService.Properties.CertificateProfile.ClientCertificate = "none"
@@ -112,7 +112,7 @@ func getBaseNBC(t *testing.T, cluster *Cluster, vhd *config.Image) *datamodel.No
 		nbc.ResourceGroupName = *cluster.Model.Properties.NodeResourceGroup
 		nbc.TenantID = *cluster.Model.Identity.TenantID
 	} else {
-		nbc = baseTemplateLinux(t, config.Config.Location, *cluster.Model.Properties.CurrentKubernetesVersion, vhd.Arch)
+		nbc = baseTemplateLinux(t, config.Config.DefaultLocation, *cluster.Model.Properties.CurrentKubernetesVersion, vhd.Arch)
 	}
 
 	nbc.ContainerService.Properties.CertificateProfile.CaCertificate = string(cluster.ClusterParams.CACert)
@@ -770,17 +770,17 @@ DXRqvV7TWO2hndliQq3BW385ZkiephlrmpUVM= r2k1@arturs-mbp.lan`,
 				AzureTelemetryPID:           "",
 				// CNIARM64PluginsDownloadURL:  "https://packages.aks.azure.com/cni-plugins/v0.8.7/binaries/cni-plugins-linux-arm64-v0.8.7.tgz",
 				// CNIPluginsDownloadURL:       "https://packages.aks.azure.com/cni/cni-plugins-amd64-v0.7.6.tgz",
-				CSIProxyDownloadURL:         "https://packages.aks.azure.com/csi-proxy/v1.1.2-hotfix.20230807/binaries/csi-proxy-v1.1.2-hotfix.20230807.tar.gz",
-				CalicoImageBase:             "calico/",
-				ContainerdDownloadURLBase:   "https://storage.googleapis.com/cri-containerd-release/",
+				CSIProxyDownloadURL:       "https://packages.aks.azure.com/csi-proxy/v1.1.2-hotfix.20230807/binaries/csi-proxy-v1.1.2-hotfix.20230807.tar.gz",
+				CalicoImageBase:           "calico/",
+				ContainerdDownloadURLBase: "https://storage.googleapis.com/cri-containerd-release/",
 				// CseScriptsPackageURL is used to download the CSE scripts for Windows nodes, when use filename it is pinned to that version insteaf of current as defined in components.json
-				CseScriptsPackageURL:                 "https://packages.aks.azure.com/aks/windows/cse/",
-				EtcdDownloadURLBase:                  "",
-				KubeBinariesSASURLBase:               "https://packages.aks.azure.com/kubernetes/",
-				KubernetesImageBase:                  "k8s.gcr.io/",
-				MCRKubernetesImageBase:               "mcr.microsoft.com/",
-				NVIDIAImageBase:                      "nvidia/",
-				TillerImageBase:                      "gcr.io/kubernetes-helm/",
+				CseScriptsPackageURL:   "https://packages.aks.azure.com/aks/windows/cse/",
+				EtcdDownloadURLBase:    "",
+				KubeBinariesSASURLBase: "https://packages.aks.azure.com/kubernetes/",
+				KubernetesImageBase:    "k8s.gcr.io/",
+				MCRKubernetesImageBase: "mcr.microsoft.com/",
+				NVIDIAImageBase:        "nvidia/",
+				TillerImageBase:        "gcr.io/kubernetes-helm/",
 				// VnetCNIARM64LinuxPluginsDownloadURL:  "https://packages.aks.azure.com/azure-cni/v1.4.13/binaries/azure-vnet-cni-linux-arm64-v1.4.14.tgz",
 				// VnetCNILinuxPluginsDownloadURL:       "https://packages.aks.azure.com/azure-cni/v1.1.3/binaries/azure-vnet-cni-linux-amd64-v1.1.3.tgz",
 				VnetCNIWindowsPluginsDownloadURL:     "https://packages.aks.azure.com/azure-cni/v1.6.21/binaries/azure-vnet-cni-windows-amd64-v1.6.21.zip",

--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -101,7 +101,7 @@ func getBaseNBC(t *testing.T, cluster *Cluster, vhd *config.Image) *datamodel.No
 	var nbc *datamodel.NodeBootstrappingConfiguration
 
 	if vhd.Distro.IsWindowsDistro() {
-		nbc = baseTemplateWindows(t, config.Config.DefaultLocation)
+		nbc = baseTemplateWindows(t, *cluster.Model.Location)
 
 		// these aren't needed since we use TLS bootstrapping instead, though windows bootstrapping expects non-empty values
 		nbc.ContainerService.Properties.CertificateProfile.ClientCertificate = "none"
@@ -112,7 +112,7 @@ func getBaseNBC(t *testing.T, cluster *Cluster, vhd *config.Image) *datamodel.No
 		nbc.ResourceGroupName = *cluster.Model.Properties.NodeResourceGroup
 		nbc.TenantID = *cluster.Model.Identity.TenantID
 	} else {
-		nbc = baseTemplateLinux(t, config.Config.DefaultLocation, *cluster.Model.Properties.CurrentKubernetesVersion, vhd.Arch)
+		nbc = baseTemplateLinux(t, *cluster.Model.Location, *cluster.Model.Properties.CurrentKubernetesVersion, vhd.Arch)
 	}
 
 	nbc.ContainerService.Properties.CertificateProfile.CaCertificate = string(cluster.ClusterParams.CACert)

--- a/e2e/scenario_helpers_test.go
+++ b/e2e/scenario_helpers_test.go
@@ -1,11 +1,9 @@
 package e2e
 
 import (
-	"context"
 	"log"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/Azure/agentbaker/e2e/config"
 )
@@ -16,11 +14,5 @@ func TestMain(m *testing.M) {
 	if _, err := os.Stat("scenario-logs"); err == nil {
 		_ = os.RemoveAll("scenario-logs")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-	err := ensureResourceGroup(ctx)
-	mustNoError(err)
-	_, err = config.Azure.CreateVMManagedIdentity(ctx)
-	mustNoError(err)
 	m.Run()
 }

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -28,7 +28,7 @@ func Test_AzureLinuxV2_AirGap(t *testing.T) {
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
 						Enabled:                 true,
-						ContainerRegistryServer: fmt.Sprintf("%s.azurecr.io", config.PrivateACRName),
+						ContainerRegistryServer: fmt.Sprintf("%s.azurecr.io", config.PrivateACRName(config.Config.DefaultLocation)),
 					},
 				}
 			},
@@ -108,7 +108,7 @@ func Test_AzureLinuxV2_ARM64AirGap(t *testing.T) {
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
 						Enabled:                 true,
-						ContainerRegistryServer: fmt.Sprintf("%s.azurecr.io", config.PrivateACRName),
+						ContainerRegistryServer: fmt.Sprintf("%s.azurecr.io", config.PrivateACRName(config.Config.DefaultLocation)),
 					},
 				}
 			},
@@ -300,7 +300,7 @@ func Test_MarinerV2_AirGap(t *testing.T) {
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
 						Enabled:                 true,
-						ContainerRegistryServer: fmt.Sprintf("%s.azurecr.io", config.PrivateACRName),
+						ContainerRegistryServer: fmt.Sprintf("%s.azurecr.io", config.PrivateACRName(config.Config.DefaultLocation)),
 					},
 				}
 			},
@@ -346,7 +346,7 @@ func Test_MarinerV2_ARM64AirGap(t *testing.T) {
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
 						Enabled:                 true,
-						ContainerRegistryServer: fmt.Sprintf("%s.azurecr.io", config.PrivateACRName),
+						ContainerRegistryServer: fmt.Sprintf("%s.azurecr.io", config.PrivateACRName(config.Config.DefaultLocation)),
 					},
 				}
 
@@ -564,7 +564,7 @@ func Test_Ubuntu2204_AirGap(t *testing.T) {
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
 						Enabled:                 true,
-						ContainerRegistryServer: fmt.Sprintf("%s.azurecr.io", config.PrivateACRName),
+						ContainerRegistryServer: fmt.Sprintf("%s.azurecr.io", config.PrivateACRName(config.Config.DefaultLocation)),
 					},
 				}
 			},
@@ -578,8 +578,10 @@ func Test_Ubuntu2204_AirGap(t *testing.T) {
 // TODO: refactor NonAnonymous tests to use the same cluster as Anonymous airgap
 // or deprecate anonymous ACR airgap tests once it is unsupported
 func Test_Ubuntu2204_AirGap_NonAnonymousACR(t *testing.T) {
-	ctx := newTestCtx(t)
-	identity, err := config.Azure.UserAssignedIdentities.Get(ctx, config.ResourceGroupName, config.VMIdentityName, nil)
+	location := config.Config.DefaultLocation
+
+	ctx := newTestCtx(t, location)
+	identity, err := config.Azure.UserAssignedIdentities.Get(ctx, config.ResourceGroupName(location), config.VMIdentityName, nil)
 	if err != nil {
 		t.Fatalf("failed to get identity: %v", err)
 	}
@@ -601,7 +603,7 @@ func Test_Ubuntu2204_AirGap_NonAnonymousACR(t *testing.T) {
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
 						Enabled:                 true,
-						ContainerRegistryServer: fmt.Sprintf("%s.azurecr.io", config.PrivateACRNameNotAnon),
+						ContainerRegistryServer: fmt.Sprintf("%s.azurecr.io", config.PrivateACRNameNotAnon(config.Config.DefaultLocation)),
 					},
 				}
 			},
@@ -626,14 +628,14 @@ func Test_Ubuntu2204Gen2_ContainerdAirgappedK8sNotCached(t *testing.T) {
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
 						Enabled:                 true,
-						ContainerRegistryServer: fmt.Sprintf("%s.azurecr.io", config.PrivateACRName),
+						ContainerRegistryServer: fmt.Sprintf("%s.azurecr.io", config.PrivateACRName(config.Config.DefaultLocation)),
 					},
 				}
 				nbc.AgentPoolProfile.LocalDNSProfile = nil
 				// intentionally using private acr url to get kube binaries
 				nbc.AgentPoolProfile.KubernetesConfig.CustomKubeBinaryURL = fmt.Sprintf(
 					"%s.azurecr.io/oss/binaries/kubernetes/kubernetes-node:v%s-linux-amd64",
-					config.PrivateACRName,
+					config.PrivateACRName(config.Config.DefaultLocation),
 					nbc.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion)
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -1653,4 +1655,30 @@ func Test_Ubuntu2404_NPD_Basic(t *testing.T) {
 				ValidateNPDFilesystemCorruption(ctx, s)
 			},
 		}})
+}
+
+// Custom test for running in southcentralus region
+func Test_MyScenario_BasicDeployment(t *testing.T) {
+	location := "southafricanorth" // Set the region for the test
+
+	RunScenario(t, &Scenario{
+		Description: "Tests basic node deployment in configured region",
+		Location:    location, // Override location for this test
+		Config: Config{
+			Cluster: ClusterKubenet, // Uses config.Config.Location
+			VHD:     config.VHDAzureLinuxV2Gen2,
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+				// Add your custom configuration here
+			},
+			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
+				vmss.Location = to.Ptr(location)
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				// Validate kubelet is running
+				ValidateSystemdUnitIsRunning(ctx, s, "kubelet")
+				// Add your custom validations here
+				t.Logf("Successfully validated deployment in region: %s", location)
+			},
+		},
+	})
 }

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -112,6 +112,8 @@ type Scenario struct {
 	// Config contains the configuration of the scenario
 	Config
 
+	Location string
+
 	// Runtime contains the runtime state of the scenario. It's populated in the beginning of the test run
 	Runtime *ScenarioRuntime
 	T       *testing.T
@@ -131,7 +133,7 @@ type ScenarioRuntime struct {
 // Config represents the configuration of an AgentBaker E2E scenario.
 type Config struct {
 	// Cluster creates, updates or re-uses an AKS cluster for the scenario
-	Cluster func(ctx context.Context, t *testing.T) (*Cluster, error)
+	Cluster func(ctx context.Context, location string, t *testing.T) (*Cluster, error)
 
 	// VHD is the node image used by the scenario.
 	VHD *config.Image
@@ -156,7 +158,7 @@ func (s *Scenario) PrepareAKSNodeConfig() {
 // PrepareVMSSModel mutates the input VirtualMachineScaleSet based on the scenario's VMConfigMutator, if configured.
 // This method will also use the scenario's configured VHD selector to modify the input VMSS to reference the correct VHD resource.
 func (s *Scenario) PrepareVMSSModel(ctx context.Context, t *testing.T, vmss *armcompute.VirtualMachineScaleSet) {
-	resourceID, err := s.VHD.VHDResourceID(ctx, t)
+	resourceID, err := s.VHD.VHDResourceID(ctx, t, s.Location)
 	require.NoError(t, err)
 	require.NotEmpty(t, resourceID, "VHDSelector.ResourceID")
 	require.NotNil(t, vmss, "input VirtualMachineScaleSet")

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -54,10 +54,10 @@ func createVMSS(ctx context.Context, s *Scenario) *armcompute.VirtualMachineScal
 		customData = nodeBootstrapping.CustomData
 	}
 
-	model := getBaseVMSSModel(s, customData, cse)
+	model := getBaseVMSSModel(s, customData, cse, s.Location)
 	if s.Tags.NonAnonymousACR {
 		// add acr pull identity
-		userAssignedIdentity := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", config.Config.SubscriptionID, config.ResourceGroupName, config.VMIdentityName)
+		userAssignedIdentity := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", config.Config.SubscriptionID, config.ResourceGroupName(s.Location), config.VMIdentityName)
 		model.Identity = &armcompute.VirtualMachineScaleSetIdentity{
 			Type: to.Ptr(armcompute.ResourceIdentityTypeSystemAssignedUserAssigned),
 			UserAssignedIdentities: map[string]*armcompute.UserAssignedIdentitiesValue{
@@ -248,7 +248,7 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 					},
 					{
 						Name:  to.Ptr("arg3"),
-						Value: to.Ptr(config.Config.VMIdentityResourceID()),
+						Value: to.Ptr(config.Config.VMIdentityResourceID(s.Location)),
 					},
 				},
 			},
@@ -450,9 +450,9 @@ func generateVMSSName(s *Scenario) string {
 	return generateVMSSNameLinux(s.T)
 }
 
-func getBaseVMSSModel(s *Scenario, customData, cseCmd string) armcompute.VirtualMachineScaleSet {
+func getBaseVMSSModel(s *Scenario, customData, cseCmd, location string) armcompute.VirtualMachineScaleSet {
 	model := armcompute.VirtualMachineScaleSet{
-		Location: to.Ptr(config.Config.DefaultLocation),
+		Location: to.Ptr(location),
 		SKU: &armcompute.SKU{
 			Name:     to.Ptr(config.Config.DefaultVMSKU),
 			Capacity: to.Ptr[int64](1),
@@ -549,7 +549,7 @@ func getBaseVMSSModel(s *Scenario, customData, cseCmd string) armcompute.Virtual
 		model.Identity = &armcompute.VirtualMachineScaleSetIdentity{
 			Type: to.Ptr(armcompute.ResourceIdentityTypeSystemAssignedUserAssigned),
 			UserAssignedIdentities: map[string]*armcompute.UserAssignedIdentitiesValue{
-				config.Config.VMIdentityResourceID(): {},
+				config.Config.VMIdentityResourceID(s.Location): {},
 			},
 		}
 		model.Properties.VirtualMachineProfile.StorageProfile.OSDisk.OSType = to.Ptr(armcompute.OperatingSystemTypesWindows)

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -452,7 +452,7 @@ func generateVMSSName(s *Scenario) string {
 
 func getBaseVMSSModel(s *Scenario, customData, cseCmd string) armcompute.VirtualMachineScaleSet {
 	model := armcompute.VirtualMachineScaleSet{
-		Location: to.Ptr(config.Config.Location),
+		Location: to.Ptr(config.Config.DefaultLocation),
 		SKU: &armcompute.SKU{
 			Name:     to.Ptr(config.Config.DefaultVMSKU),
 			Capacity: to.Ptr[int64](1),


### PR DESCRIPTION
**What type of PR is this?**

/kind test


**What this PR does / why we need it**:

This PR refactors the e2e test framework to support running tests in multiple Azure regions.

First, the Location property in the test configuration was renamed to DefaultLocation. This clarifies that it is the default location for tests and allows for a scenario-specific Location property to be introduced.

Next, the e2e test framework was refactored to support multiple regions. This involved:
  - Adding a location parameter to most functions that interact with Azure resources.
  - Dynamically generating resource group names, private ACR names, and other regional resources based on the provided location.
  - Adding a Location field to the Scenario struct, allowing each test scenario to specify the region it should run in.
  - Moving the resource creation logic (resource group, managed identity) from TestMain to the beginning of each scenario run to ensure resources are provisioned in the correct location.
  - Adding a new test Test_MyScenario_BasicDeployment as an example of a region-specific test.

These changes make the e2e tests more flexible and allow for easier expansion of test coverage to new regions.

**Which issue(s) this PR fixes**:

Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified


