### PR TITLE
enable WS2025 e2e tests, improve e2e test speed by replicating in advance

### DIFF
--- a/.pipelines/scripts/e2e_run.sh
+++ b/.pipelines/scripts/e2e_run.sh
@@ -42,6 +42,7 @@ TAGS_TO_SKIP="${TAGS_TO_SKIP:-}"
 TAGS_TO_RUN="${TAGS_TO_RUN:-}"
 GALLERY_NAME="${GALLERY_NAME:-}"
 SIG_GALLERY_NAME="${SIG_GALLERY_NAME:-}"
+export E2E_LOCATION="${E2E_LOCATION:-westus3}"
 
 # echo some variables so that we have a chance of debugging if things fail due to a pipeline issue
 echo "VHD_BUILD_ID: ${VHD_BUILD_ID}"

--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -29,6 +29,13 @@ func Windows2019BootstrapConfigMutator(t *testing.T, configuration *datamodel.No
 	configuration.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = components.RemoveLeadingV(version)
 }
 
+func Windows2025BootstrapConfigMutator(t *testing.T, configuration *datamodel.NodeBootstrappingConfiguration) {
+	// 2025 supported in 1.32+ - a kubelet bug impacts networking in most of 1.32 and 1.33.0, .1
+	version := components.GetKubeletVersionByMinorVersion("v1.33")
+	require.NotEmpty(t, version)
+	configuration.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = components.RemoveLeadingV(version)
+}
+
 func DualStackVMConfigMutator(set *armcompute.VirtualMachineScaleSet) {
 	ip4Config := set.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations[0].Properties.IPConfigurations[0]
 
@@ -299,8 +306,8 @@ func Test_Windows2025(t *testing.T) {
 			VHD:             config.VHDWindows2025,
 			VMConfigMutator: EmptyVMConfigMutator,
 			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
+				Windows2025BootstrapConfigMutator(t, configuration)
 			},
-
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateWindowsVersionFromWindowsSettings(ctx, s, "2025")
 				ValidateWindowsProductName(ctx, s, "Windows Server 2025 Datacenter")
@@ -320,8 +327,8 @@ func Test_Windows2025Gen2(t *testing.T) {
 			Cluster:         ClusterAzureNetwork,
 			VHD:             config.VHDWindows2025Gen2,
 			VMConfigMutator: EmptyVMConfigMutator,
-			// BootstrapConfigMutator: EmptyBootstrapConfigMutator,
 			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
+				Windows2025BootstrapConfigMutator(t, configuration)
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateWindowsVersionFromWindowsSettings(ctx, s, "2025-gen2")

--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -343,7 +343,6 @@ func Test_Windows2025Gen2(t *testing.T) {
 }
 
 func Test_Windows2022Gen2_k8s_133(t *testing.T) {
-	t.Skip("skipping test for Windows 2022 Gen2 with k8s 1.33, as we are verifying a regression fix for 1.31+")
 	RunScenario(t, &Scenario{
 		Description: "Windows Server 2022 with Containerd 2- hyperv gen 2",
 		Config: Config{
@@ -388,13 +387,13 @@ func Test_Windows23H2_Cilium2(t *testing.T) {
 }
 
 func Test_Windows23H2Gen2_WindowsCiliumNetworking(t *testing.T) {
-	t.Skip("skipping test for Windows Cilium Networking, as it requires post-provisioning reboot validation which is not supported yet")
 	RunScenario(t, &Scenario{
 		Description: "Windows Server 23H2 Gen2 with Windows Cilium Networking (WCN) enabled",
 		Config: Config{
-			Cluster:         ClusterAzureNetwork,
-			VHD:             config.VHDWindows23H2Gen2,
-			VMConfigMutator: EmptyVMConfigMutator,
+			PostProvisioningReboot: to.Ptr(true),
+			Cluster:                ClusterAzureNetwork,
+			VHD:                    config.VHDWindows23H2Gen2,
+			VMConfigMutator:        EmptyVMConfigMutator,
 			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
 				if configuration.AgentPoolProfile.AgentPoolWindowsProfile == nil {
 					configuration.AgentPoolProfile.AgentPoolWindowsProfile = &datamodel.AgentPoolWindowsProfile{}

--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -387,6 +387,7 @@ func Test_Windows23H2_Cilium2(t *testing.T) {
 }
 
 func Test_Windows23H2Gen2_WindowsCiliumNetworking(t *testing.T) {
+	t.Skip("skipping test for Windows Cilium Networking (WCN) on Windows 23H2 Gen2, as it needs a reboot after provisioning - and that is not working yet")
 	RunScenario(t, &Scenario{
 		Description: "Windows Server 23H2 Gen2 with Windows Cilium Networking (WCN) enabled",
 		Config: Config{

--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -292,7 +292,6 @@ func Test_Windows2019CachingRegression(t *testing.T) {
 }
 
 func Test_Windows2025(t *testing.T) {
-	t.Skip("skipping test for Windows 2025, as we are testing regression issues with k8s 1.31+")
 	RunScenario(t, &Scenario{
 		Description: "Windows Server 2025 with Containerd",
 		Config: Config{
@@ -300,9 +299,6 @@ func Test_Windows2025(t *testing.T) {
 			VHD:             config.VHDWindows2025,
 			VMConfigMutator: EmptyVMConfigMutator,
 			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
-				// 2025 supported in 1.32+ .
-				configuration.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = "1.32.5"
-				configuration.K8sComponents.WindowsPackageURL = fmt.Sprintf("https://packages.aks.azure.com/kubernetes/v%s/windowszip/v%s-1int.zip", "1.32.5", "1.32.5")
 			},
 
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -318,7 +314,6 @@ func Test_Windows2025(t *testing.T) {
 }
 
 func Test_Windows2025Gen2(t *testing.T) {
-	t.Skip("skipping test for Windows 2025, as we are testing regression issues with k8s 1.31+")
 	RunScenario(t, &Scenario{
 		Description: "Windows Server 2025 with Containerd - hyperv gen 2",
 		Config: Config{
@@ -327,9 +322,6 @@ func Test_Windows2025Gen2(t *testing.T) {
 			VMConfigMutator: EmptyVMConfigMutator,
 			// BootstrapConfigMutator: EmptyBootstrapConfigMutator,
 			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
-				// 2025 supported in 1.32+ .
-				configuration.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = "1.32.5"
-				configuration.K8sComponents.WindowsPackageURL = fmt.Sprintf("https://packages.aks.azure.com/kubernetes/v%s/windowszip/v%s-1int.zip", "1.32.5", "1.32.5")
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateWindowsVersionFromWindowsSettings(ctx, s, "2025-gen2")

--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -391,10 +391,9 @@ func Test_Windows23H2Gen2_WindowsCiliumNetworking(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Windows Server 23H2 Gen2 with Windows Cilium Networking (WCN) enabled",
 		Config: Config{
-			PostProvisioningReboot: to.Ptr(true),
-			Cluster:                ClusterAzureNetwork,
-			VHD:                    config.VHDWindows23H2Gen2,
-			VMConfigMutator:        EmptyVMConfigMutator,
+			Cluster:         ClusterAzureNetwork,
+			VHD:             config.VHDWindows23H2Gen2,
+			VMConfigMutator: EmptyVMConfigMutator,
 			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
 				if configuration.AgentPoolProfile.AgentPoolWindowsProfile == nil {
 					configuration.AgentPoolProfile.AgentPoolWindowsProfile = &datamodel.AgentPoolWindowsProfile{}

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -248,7 +248,7 @@ func prepareAKSNode(ctx context.Context, s *Scenario) {
 	require.NoError(s.T, err)
 
 	start := time.Now() // Record the start time
-	createVMSS(ctx, s)
+	vmss := createVMSS(ctx, s)
 
 	err = getCustomScriptExtensionStatus(ctx, s)
 	require.NoError(s.T, err)
@@ -268,8 +268,11 @@ func prepareAKSNode(ctx context.Context, s *Scenario) {
 	if s.Config.PostProvisioningReboot != nil && *s.Config.PostProvisioningReboot {
 		vmssAboutToRebootTime := time.Now() // Record the start time
 		s.T.Log("Rebooting the VMSS VM to complete post-provisioning...")
-		restart, err := config.Azure.VMSS.BeginRestart(ctx, *s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, nil)
+
+		restart, err := config.Azure.VMSSVM.BeginRestart(ctx, *s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, "0", nil)
+		// restart, err := config.Azure.VMSS.BeginRestart(ctx, *s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, nil)
 		require.NoError(s.T, err, "failed to start reboot vmss operation")
+		time.Sleep(60 * time.Second)
 
 		_, err = restart.PollUntilDone(ctx, nil)
 		require.NoError(s.T, err, "failed to reboot VMSSM")

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -248,7 +248,7 @@ func prepareAKSNode(ctx context.Context, s *Scenario) {
 	require.NoError(s.T, err)
 
 	start := time.Now() // Record the start time
-	vmss := createVMSS(ctx, s)
+	createVMSS(ctx, s)
 
 	err = getCustomScriptExtensionStatus(ctx, s)
 	require.NoError(s.T, err)

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -269,8 +269,7 @@ func prepareAKSNode(ctx context.Context, s *Scenario) {
 		vmssAboutToRebootTime := time.Now() // Record the start time
 		s.T.Log("Rebooting the VMSS VM to complete post-provisioning...")
 
-		restart, err := config.Azure.VMSSVM.BeginRestart(ctx, *s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, "0", nil)
-		// restart, err := config.Azure.VMSS.BeginRestart(ctx, *s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, nil)
+		restart, err := config.Azure.VMSSVM.BeginRestart(ctx, *s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, "", nil)
 		require.NoError(s.T, err, "failed to start reboot vmss operation")
 		time.Sleep(60 * time.Second)
 

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -267,7 +267,7 @@ func prepareAKSNode(ctx context.Context, s *Scenario) {
 
 	if s.Config.PostProvisioningReboot != nil && *s.Config.PostProvisioningReboot {
 		s.T.Log("Rebooting the VMSS VM to complete post-provisioning...")
-		restart, err := config.Azure.VMSS.BeginRestart(ctx, *s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, options)
+		restart, err := config.Azure.VMSS.BeginRestart(ctx, *s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, nil)
 		require.NoError(s.T, err, "failed to start reboot vmss operation")
 
 		_, err = restart.PollUntilDone(ctx, nil)

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -155,8 +155,6 @@ type Config struct {
 	// SkipDefaultValidation is a flag to indicate whether the common validation (like spawning a pod) should be skipped.
 	// It shouldn't be used for majority of scenarios, currently only used for preparing VHD in a two-stage scenario
 	SkipDefaultValidation bool
-
-	PostProvisioningReboot *bool
 }
 
 func (s *Scenario) PrepareAKSNodeConfig() {

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -155,6 +155,8 @@ type Config struct {
 	// SkipDefaultValidation is a flag to indicate whether the common validation (like spawning a pod) should be skipped.
 	// It shouldn't be used for majority of scenarios, currently only used for preparing VHD in a two-stage scenario
 	SkipDefaultValidation bool
+
+	PostProvisioningReboot *bool
 }
 
 func (s *Scenario) PrepareAKSNodeConfig() {

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -304,8 +304,8 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 		config.Config.BlobStorageAccount(),
 	)
 
-	s.T.Logf("Storage account in Azure portal: %s", azurePortalURL)
-	s.T.Logf("##vso[task.logissue type=warning;]%s", azurePortalURL)
+	s.T.Logf("Storage account %s in Azure portal: %s", blobPrefix, azurePortalURL)
+	s.T.Logf("##vso[task.logissue type=warning;]Storage account %s in Azure portal: %s", blobPrefix, azurePortalURL)
 
 	runCommandTimeout := int32((20 * time.Minute).Seconds())
 	s.T.Logf("run command timeout: %d", runCommandTimeout)

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -297,11 +297,12 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 	// Invoke the RunCommand on the VMSS instance
 	s.T.Logf("uploading windows logs to blob storage at %s, may take a few minutes", blobUrl)
 
-	// Create a reusable URL for the Azure portal link to the storage account. Do this before the upload in case the upload times out.
-	azurePortalURL := fmt.Sprintf("https://portal.azure.com/?feature.customportal=false#@microsoft.onmicrosoft.com/resource/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/overview",
+	azurePortalURL := fmt.Sprintf(
+		"https://portal.azure.com/?feature.customportal=false#@microsoft.onmicrosoft.com/resource/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/containersList",
 		config.Config.SubscriptionID,
 		config.ResourceGroupName(s.Location),
-		config.Config.BlobStorageAccount())
+		config.Config.BlobStorageAccount(),
+	)
 
 	s.T.Logf("Storage account in Azure portal: %s", azurePortalURL)
 	s.T.Logf("##vso[task.logissue type=warning;]%s", azurePortalURL)

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -25,6 +25,7 @@ SUBSCRIPTION_ID="${SUBSCRIPTION_ID:-$(az account show -o json --query="id" | tr 
 GALLERY_SUBSCRIPTION_ID="${GALLERY_SUBSCRIPTION_ID:-${SUBSCRIPTION_ID}}"
 CREATE_TIME="$(date +%s)"
 STORAGE_ACCOUNT_NAME="aksimages${CREATE_TIME}$RANDOM"
+export E2E_LOCATION="${E2E_LOCATION:-westus3}"
 
 # This variable will only be set if a VHD build is triggered from an official branch
 VHD_BUILD_TIMESTAMP=""
@@ -586,6 +587,7 @@ fi
 # windows_image_version refers to the version from azure gallery
 cat <<EOF > vhdbuilder/packer/settings.json
 {
+  "additional_replication_regions": ${E2E_LOCATION},
   "subscription_id": "${SUBSCRIPTION_ID}",
   "gallery_subscription_id": "${GALLERY_SUBSCRIPTION_ID}",
   "resource_group_name": "${AZURE_RESOURCE_GROUP_NAME}",

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -25,7 +25,7 @@ SUBSCRIPTION_ID="${SUBSCRIPTION_ID:-$(az account show -o json --query="id" | tr 
 GALLERY_SUBSCRIPTION_ID="${GALLERY_SUBSCRIPTION_ID:-${SUBSCRIPTION_ID}}"
 CREATE_TIME="$(date +%s)"
 STORAGE_ACCOUNT_NAME="aksimages${CREATE_TIME}$RANDOM"
-export E2E_LOCATION="${E2E_LOCATION:-westus3}"
+E2E_LOCATION="${E2E_LOCATION:-westus3}"
 
 # This variable will only be set if a VHD build is triggered from an official branch
 VHD_BUILD_TIMESTAMP=""
@@ -587,7 +587,7 @@ fi
 # windows_image_version refers to the version from azure gallery
 cat <<EOF > vhdbuilder/packer/settings.json
 {
-  "additional_replication_regions": ${E2E_LOCATION},
+  "additional_replication_regions": "${E2E_LOCATION}",
   "subscription_id": "${SUBSCRIPTION_ID}",
   "gallery_subscription_id": "${GALLERY_SUBSCRIPTION_ID}",
   "resource_group_name": "${AZURE_RESOURCE_GROUP_NAME}",

--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -67,8 +67,9 @@
         "image_name": "{{user `sig_image_name`}}",
         "image_version": "{{user `captured_sig_version`}}",
         "replication_regions": [
-          "{{user `location`}}"
-        ]
+          "{{user `location`}}",
+          "{{user `additional_replication_regions`}}"
+     ]
       },
       "user_assigned_managed_identities": "{{user `msi_resource_strings`}}"
     }

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -70,7 +70,8 @@
         "image_name": "{{user `sig_image_name`}}",
         "image_version": "{{user `captured_sig_version`}}",
         "replication_regions": [
-          "{{user `location`}}"
+          "{{user `location`}}",
+          "{{user `additional_replication_regions`}}"
         ]
       },
       "user_assigned_managed_identities": "{{user `msi_resource_strings`}}"

--- a/vhdbuilder/packer/vhd-image-builder-cvm.json
+++ b/vhdbuilder/packer/vhd-image-builder-cvm.json
@@ -74,7 +74,8 @@
         "image_name": "{{user `sig_image_name`}}",
         "image_version": "{{user `captured_sig_version`}}",
         "replication_regions": [
-          "{{user `location`}}"
+          "{{user `location`}}",
+          "{{user `additional_replication_regions`}}"
         ]
       },
       "user_assigned_managed_identities": "{{user `msi_resource_strings`}}"

--- a/vhdbuilder/packer/vhd-image-builder-flatcar-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-flatcar-arm64.json
@@ -68,7 +68,8 @@
         "image_name": "{{user `sig_image_name`}}",
         "image_version": "{{user `captured_sig_version`}}",
         "replication_regions": [
-          "{{user `location`}}"
+          "{{user `location`}}",
+          "{{user `additional_replication_regions`}}"
         ]
       },
       "user_assigned_managed_identities": "{{user `msi_resource_strings`}}"

--- a/vhdbuilder/packer/vhd-image-builder-flatcar.json
+++ b/vhdbuilder/packer/vhd-image-builder-flatcar.json
@@ -68,7 +68,8 @@
         "image_name": "{{user `sig_image_name`}}",
         "image_version": "{{user `captured_sig_version`}}",
         "replication_regions": [
-          "{{user `location`}}"
+          "{{user `location`}}",
+          "{{user `additional_replication_regions`}}"
         ]
       },
       "user_assigned_managed_identities": "{{user `msi_resource_strings`}}"

--- a/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
@@ -66,7 +66,8 @@
         "image_name": "{{user `sig_image_name`}}",
         "image_version": "{{user `captured_sig_version`}}",
         "replication_regions": [
-          "{{user `location`}}"
+          "{{user `location`}}",
+          "{{user `additional_replication_regions`}}"
         ]
       },
       "user_assigned_managed_identities": "{{user `msi_resource_strings`}}"

--- a/vhdbuilder/packer/vhd-image-builder-mariner-cvm.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-cvm.json
@@ -72,7 +72,8 @@
         "image_name": "{{user `sig_image_name`}}",
         "image_version": "{{user `captured_sig_version`}}",
         "replication_regions": [
-          "{{user `location`}}"
+          "{{user `location`}}",
+          "{{user `additional_replication_regions`}}"
         ]
       },
       "user_assigned_managed_identities": "{{user `msi_resource_strings`}}"

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -68,7 +68,8 @@
         "image_name": "{{user `sig_image_name`}}",
         "image_version": "{{user `captured_sig_version`}}",
         "replication_regions": [
-          "{{user `location`}}"
+          "{{user `location`}}",
+          "{{user `additional_replication_regions`}}"
         ]
       },
       "user_assigned_managed_identities": "{{user `msi_resource_strings`}}"

--- a/vhdbuilder/packer/windows/windows-vhd-builder-sig.json
+++ b/vhdbuilder/packer/windows/windows-vhd-builder-sig.json
@@ -50,7 +50,8 @@
                 "image_name": "{{user `sig_image_name`}}",
                 "image_version": "{{user `sig_image_version`}}",
                 "replication_regions": [
-                    "{{user `location`}}"
+                    "{{user `location`}}",
+                    "{{user `additional_replication_regions`}}"
                 ]
             },
             "polling_duration_timeout": "1h",


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What this PR does / why we need it**:

replicating during the build seems to add no meaningful time, but saves 7 to 10 mins in the e2e tests:

From the "build" step:
* Replicating to westus3 in build: ==> Wait completed after 41 minutes 23 seconds
* Not replicating to westus3 in build ==> ==> Wait completed after 42 minutes 48 seconds


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
