### PR TITLE
ci: Use debian archive mirror in shellspec dockerfile

### DIFF
--- a/spec/shellspec.Dockerfile
+++ b/spec/shellspec.Dockerfile
@@ -2,7 +2,8 @@
 # Don't forget to log in to the Azure Container Registry before building this image:
 # az acr login --name aksdataplanedev
 FROM aksdataplanedev.azurecr.io/shellspec/shellspec-debian:0.28.1
-RUN apt-get update &&  \
+RUN sed -i -e 's/\(deb\|security\).debian.org/archive.debian.org/g' /etc/apt/sources.list && \
+    apt-get update &&  \
     apt-get install -y --no-install-recommends gawk jq curl &&  \
     apt-get clean &&  \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The previous repo is no longer accessible.

**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
The shellspec action is failing because the previous debian repo is no longer accessible. Switch to using the debian archive.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
