### PR TITLE
Add Linux kernel commandline flags to GRUB on GB200

### DIFF
--- a/parts/linux/cloud-init/artifacts/10_azure_nvidia
+++ b/parts/linux/cloud-init/artifacts/10_azure_nvidia
@@ -33,6 +33,7 @@ smbios --type 4 --get-string 7 --set cpu_manufacturer
 
 if [ x\$cpu_manufacturer = xNVIDIA ]; then
 	set default="gnulinux-${NVIDIA}-advanced-${boot_device_id}"
+	set nvidia_args="iommu.passthrough=1 irqchip.gicv3_nolpi=y arm_smmu_v3.disable_msipolling=1"
 else
 	set default="gnulinux-${OTHER}-advanced-${boot_device_id}"
 fi

--- a/parts/linux/cloud-init/artifacts/51-azure-nvidia.cfg
+++ b/parts/linux/cloud-init/artifacts/51-azure-nvidia.cfg
@@ -1,2 +1,5 @@
 # 10_azure_nvidia changes the default menu entry based on a flat menu.
 GRUB_DISABLE_SUBMENU=true
+
+# 10_azure_nvidia appends additional arguments for azure-nvidia kernels.
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX \$nvidia_args"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Specifies certain boot-time flags to Linux kernel necessary for GPU drivers to work.

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
