### PR TITLE
Fix location-specific image caching

### DIFF
--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -603,7 +603,7 @@ func ensureResourceGroup(ctx context.Context, location string) error {
 		nil)
 
 	if err != nil {
-		return fmt.Errorf("failed to create RG %q: %w", resourceGroupName, err)
+		return fmt.Errorf("creating or updating RG %q: %w", resourceGroupName, err)
 	}
 	return nil
 }

--- a/e2e/config/vhd.go
+++ b/e2e/config/vhd.go
@@ -205,6 +205,12 @@ var (
 
 var ErrNotFound = fmt.Errorf("not found")
 
+type perLocationVHDCache struct {
+	vhd  VHDResourceID
+	err  error
+	once *sync.Once
+}
+
 type Image struct {
 	Arch    string
 	Distro  datamodel.Distro
@@ -213,9 +219,8 @@ type Image struct {
 	Version string
 	Gallery *Gallery
 
-	vhd     VHDResourceID
-	vhdOnce sync.Once
-	vhdErr  error
+	vhdLocationCache map[string]*perLocationVHDCache
+	vhdMutex         sync.Mutex
 }
 
 func (i *Image) String() string {
@@ -224,26 +229,42 @@ func (i *Image) String() string {
 }
 
 func (i *Image) VHDResourceID(ctx context.Context, t *testing.T, location string) (VHDResourceID, error) {
-	i.vhdOnce.Do(func() {
+	i.vhdMutex.Lock()
+	if i.vhdLocationCache == nil {
+		i.vhdLocationCache = make(map[string]*perLocationVHDCache)
+	}
+
+	cache, ok := i.vhdLocationCache[location]
+	if !ok {
+		cache = &perLocationVHDCache{once: &sync.Once{}}
+		i.vhdLocationCache[location] = cache
+	}
+	i.vhdMutex.Unlock()
+
+	cache.once.Do(func() {
+		var vhd VHDResourceID
+		var err error
 		switch {
 		case i.Version != "":
-			i.vhd, i.vhdErr = Azure.EnsureSIGImageVersion(ctx, t, i, location)
-			if i.vhd != "" {
+			vhd, err = Azure.EnsureSIGImageVersion(ctx, t, i, location)
+			if vhd != "" {
 				t.Logf("Got image by version: %s", i.azurePortalImageVersionUrl())
 			}
 		default:
-			i.vhd, i.vhdErr = Azure.LatestSIGImageVersionByTag(ctx, t, i, Config.SIGVersionTagName, Config.SIGVersionTagValue, location)
-			if i.vhd != "" {
+			vhd, err = Azure.LatestSIGImageVersionByTag(ctx, t, i, Config.SIGVersionTagName, Config.SIGVersionTagValue, location)
+			if vhd != "" {
 				t.Logf("got version by tag %s=%s: %s", Config.SIGVersionTagName, Config.SIGVersionTagValue, i.azurePortalImageVersionUrl())
 			} else {
 				t.Logf("Could not find version by tag %s=%s: %s", Config.SIGVersionTagName, Config.SIGVersionTagValue, i.azurePortalImageUrl())
 			}
 		}
-		if i.vhdErr != nil {
-			i.vhdErr = fmt.Errorf("img: %s, tag %s=%s, err %w", i.azurePortalImageUrl(), Config.SIGVersionTagName, Config.SIGVersionTagValue, i.vhdErr)
+		if err != nil {
+			err = fmt.Errorf("img: %s, tag %s=%s, err %w", i.azurePortalImageUrl(), Config.SIGVersionTagName, Config.SIGVersionTagValue, err)
 		}
+		cache.vhd = vhd
+		cache.err = err
 	})
-	return i.vhd, i.vhdErr
+	return cache.vhd, cache.err
 }
 
 func (i *Image) azurePortalImageUrl() string {

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -72,12 +72,6 @@ func newTestCtx(t *testing.T, location string) context.Context {
 	return ctx
 }
 
-func mustNoError(err error) {
-	if err != nil {
-		panic(err)
-	}
-}
-
 // Global state to track which locations have been initialized
 var (
 	// Track which locations have been initialized
@@ -101,9 +95,9 @@ func ensureLocationInitialized(ctx context.Context, t *testing.T, location strin
 	// Initialize the location
 	t.Logf("Initializing location %s", location)
 	err := ensureResourceGroup(ctx, location)
-	mustNoError(err)
+	require.NoError(t, err, "ensuring resource group")
 	_, err = config.Azure.CreateVMManagedIdentity(ctx, location)
-	mustNoError(err)
+	require.NoError(t, err, "ensuring VM managed identity")
 
 	// Mark this location as initialized
 	initializedLocations[location] = true


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

This PR introduces two main improvements to the E2E test framework: it refactors the VHD (Virtual Hard Disk) caching to be location-specific and enhances test stability by replacing `panic`-inducing error handling with standard test assertions.

1. **Per-Location VHD Caching:**

- The previous implementation cached a single VHD resource ID per `Image` object. This caused issues when tests were run across multiple Azure locations, as a Shared Image Gallery (SIG) image version might not be replicated to all locations at the same time. A lookup failure in one location would be incorrectly cached and reused for subsequent tests in other locations where the image might actually be available.

- This has been fixed by changing the cache from a single value to a `map[string]*perLocationVHDCache`, where the key is the Azure location. This ensures that VHD lookups are performed and cached on a per-location basis, correctly handling regional image availability.

2. **Improved Error Handling in Test Setup:**

The `mustNoError` helper function, which would `panic` on any error, has been removed from the test setup process. It has been replaced with `require.NoError(t, err, ...)` from the `require` package. This is a significant improvement because:

- It avoids crashing the entire test execution on setup failure.
- It integrates with the standard Go testing framework, providing clearer, more informative failure messages.
- It properly marks the specific test as failed instead of halting the process.

3. **Minor Wording Update:**

The error message in `ensureResourceGroup` was updated from "failed to create" to "creating or updating" to more accurately reflect that the operation is idempotent.


**Which issue(s) this PR fixes**:

Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Release note**:

```
none
```
