### PR TITLE
kata-cc: Fix kata-containers image naming

### DIFF
--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -178,7 +178,7 @@ copyPackerFiles() {
       cpAndMode $KATA_IMAGE_SRC $KATA_IMAGE_DEST 0755
 
       KATACC_IMAGE_SRC=/home/packer/kata-containers-cc.img
-      KATACC_IMAGE_DEST=$KATACC_CONFIG_DIR/kata-containers-cc.img
+      KATACC_IMAGE_DEST=$KATACC_CONFIG_DIR/kata-containers.img
       cpAndMode $KATACC_IMAGE_SRC $KATACC_IMAGE_DEST 0755
     fi
 


### PR DESCRIPTION
The kata-cc config expects the root file system image to be named kata-containers.img, see our initial AzL3 template commit for AgentBaker: https://github.com/Azure/AgentBaker/commit/49ba197db5ec11fe887b0978994a94c0196ba6a1

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
