### PR TITLE
e2e: make nvidia-persistenced stop non-failing

### DIFF
--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -477,7 +477,7 @@ func ValidateNPDGPUCountAfterFailure(ctx context.Context, s *Scenario) {
 	command := []string{
 		"set -ex",
 		// Disable and reset the first GPU
-		"sudo systemctl stop nvidia-persistenced.service",
+		"sudo systemctl stop nvidia-persistenced.service || true",
 		"sudo nvidia-smi -i 0 -pm 0", // Disable persistence mode
 		"sudo nvidia-smi -i 0 -c 0",  // Set compute mode to default
 		"PCI_ID=$(sudo nvidia-smi -i 0 --query-gpu=pci.bus_id --format=csv,noheader | sed 's/^0000//')", // sed converts the output into the format needed for NVreg_ExcludeDevices


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind test

**What this PR does / why we need it**:

Allow the nvidia-persistenced service stop command to fail gracefully by adding `|| true`. This prevents the test from failing if the service has not been started for whatever reason.

**Which issue(s) this PR fixes**:

Fixes #6666

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)

**Special notes for your reviewer**:

**Release note**:

```
none
```
