### PR TITLE
e2e: Add InfiniBand link flapping validation tests

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1866,6 +1866,10 @@ func Test_Ubuntu2404_GPU_H100(t *testing.T) {
 				ValidateNPDGPUCountPlugin(ctx, s)
 				ValidateNPDGPUCountCondition(ctx, s)
 				ValidateNPDGPUCountAfterFailure(ctx, s)
+
+				// Validate the if IB NPD is reporting the flapping condition
+				ValidateNPDIBLinkFlappingCondition(ctx, s)
+				ValidateNPDIBLinkFlappingAfterFailure(ctx, s)
 			},
 		},
 	})


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

Add end-to-end tests to validate NPD (Node Problem Detector) InfiniBand link flapping detection functionality:

- ValidateNPDIBLinkFlappingCondition: Verifies NPD reports initial stable IB link condition (IBLinkFlapping=False with NoIBLinkFlapping reason)
- ValidateNPDIBLinkFlappingAfterFailure: Simulates IB link flapping by injecting "lost carrier" events into syslog and validates NPD detects the condition (IBLinkFlapping=True with fault code NHC2005)

These validators are called after the GPU plugin is validated.

**Which issue(s) this PR fixes**:

Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Release note**:

```
none
```
