### PR TITLE
Replace manual REST API call with Azure SDK in getVMPrivateIPAddress

### DIFF
--- a/e2e/config/azure.go
+++ b/e2e/config/azure.go
@@ -44,6 +44,7 @@ type AzureClient struct {
 	Core                      *azcore.Client
 	Credential                *azidentity.DefaultAzureCredential
 	Maintenance               *armcontainerservice.MaintenanceConfigurationsClient
+	NetworkInterfaces         *armnetwork.InterfacesClient
 	PrivateDNSZoneGroup       *armnetwork.PrivateDNSZoneGroupsClient
 	PrivateEndpointClient     *armnetwork.PrivateEndpointsClient
 	PrivateZonesClient        *armprivatedns.PrivateZonesClient
@@ -189,6 +190,11 @@ func NewAzureClient() (*AzureClient, error) {
 	cloud.Maintenance, err = armcontainerservice.NewMaintenanceConfigurationsClient(Config.SubscriptionID, credential, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create maintenance client: %w", err)
+	}
+
+	cloud.NetworkInterfaces, err = armnetwork.NewInterfacesClient(Config.SubscriptionID, credential, opts)
+	if err != nil {
+		return nil, fmt.Errorf("create network interfaces client: %w", err)
 	}
 
 	cloud.VMSS, err = armcompute.NewVirtualMachineScaleSetsClient(Config.SubscriptionID, credential, opts)


### PR DESCRIPTION
## Summary
Replace manual REST API call in `getVMPrivateIPAddress` with proper Azure SDK methods to improve reliability and fix potential flaky tests.

## Changes
- Add `NetworkInterfaces` client to `AzureClient` struct
- Replace manual REST call with `NewListVirtualMachineScaleSetVMNetworkInterfacesPager()`
- Remove custom JSON parsing and 87 lines of manual code
- Clean up unused imports and constants

## Benefits
- Better error handling and type safety
- More reliable than manual REST calls
- Reduces maintenance burden of custom JSON parsing