### PR TITLE
e2e: add GPU XID error validation tests for NPD

### DIFF
--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -772,6 +772,10 @@ func runScenarioGPUNPD(t *testing.T, vmSize, location, k8sSystemPoolSKU string) 
 				ValidateNPDGPUCountCondition(ctx, s)
 				ValidateNPDGPUCountAfterFailure(ctx, s)
 
+				// Validate NPD GPU XID plugin
+				ValidateNPDGPUXIDPlugin(ctx, s)
+				ValidateNPDGPUXIDErrorAfterFailure(ctx, s)
+
 				// Validate the if IB NPD is reporting the flapping condition
 				ValidateNPDIBLinkFlappingCondition(ctx, s)
 				ValidateNPDIBLinkFlappingAfterFailure(ctx, s)


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

Add end-to-end tests to validate NPD's GPU XID plugin functionality:

- ValidateNPDGPUXIDPlugin: Verifies NPD reports initial XIDError condition as False with "XIDErrorIsNotPresent" reason when no GPU errors exist
- ValidateNPDGPUXIDErrorAfterFailure: Simulates GPU XID errors by injecting NVRM Xid messages into syslog and validates NPD detects them, setting XIDError condition to True with "XIDErrorIsPresent" reason and proper fault code (NHC2001)

Integrated into Test_Ubuntu2404_GPU_H100 test suite for H100 GPU validation.


**Which issue(s) this PR fixes**:

Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

Waiting for the XID code to be merged.