### PR TITLE
single liner so we don't modify user's default subscription or kubeco…

### DIFF
--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -228,7 +228,7 @@ func uploadSSHKey(ctx context.Context, s *Scenario) error {
 	}
 	result += "\n========================\n"
 	// We combine the az aks get credentials in the same line so we don't overwrite the user's kubeconfig.
-	result += fmt.Sprintf(`kubectl --kubeconfig <(az aks get-credentials --name "${CLUSTER_NAME}" --resource-group "${RESOURCE_GROUP}"  --subscription "${SUBSCRIPTION}" -f -) exec -it %s -- bash -c "chroot /proc/1/root /bin/bash -c '%s'"`, config.Config.SubscriptionID, config.ResourceGroupName(s.Location), *s.Runtime.Cluster.Model.Name, s.Runtime.Cluster.DebugPod.Name, sshString(s.Runtime.VMPrivateIP))
+	result += fmt.Sprintf(`kubectl --kubeconfig <(az aks get-credentials --name "%s" --resource-group "%s"  --subscription "%s" -f -) exec -it %s -- bash -c "chroot /proc/1/root /bin/bash -c '%s'"`, config.Config.SubscriptionID, config.ResourceGroupName(s.Location), *s.Runtime.Cluster.Model.Name, s.Runtime.Cluster.DebugPod.Name, sshString(s.Runtime.VMPrivateIP))
 	s.T.Log(result)
 
 	// Test SSH connectivity once per test to distinguish SSH issues from script failures

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -227,6 +227,7 @@ func uploadSSHKey(ctx context.Context, s *Scenario) error {
 		result += " (VM will be automatically deleted after the test finishes, set KEEP_VMSS=true to preserve it or pause the test with a breakpoint before the test finishes)"
 	}
 	result += "\n========================\n"
+	// We combine the az aks get credentials in the same line so we don't overwrite the user's kubeconfig.
 	result += fmt.Sprintf(`kubectl  kubectl --kubeconfig <(az aks get-credentials --name "${CLUSTER_NAME}" --resource-group "${RESOURCE_GROUP}"  --subscription "${SUBSCRIPTION}" -f -) exec -it %s -- bash -c "chroot /proc/1/root /bin/bash -c '%s'"`, config.Config.SubscriptionID, config.ResourceGroupName(s.Location), *s.Runtime.Cluster.Model.Name, s.Runtime.Cluster.DebugPod.Name, sshString(s.Runtime.VMPrivateIP))
 	s.T.Log(result)
 

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -227,9 +227,7 @@ func uploadSSHKey(ctx context.Context, s *Scenario) error {
 		result += " (VM will be automatically deleted after the test finishes, set KEEP_VMSS=true to preserve it or pause the test with a breakpoint before the test finishes)"
 	}
 	result += "\n========================\n"
-	result += fmt.Sprintf("az account set --subscription %s\n", config.Config.SubscriptionID)
-	result += fmt.Sprintf("az aks get-credentials --resource-group %s --name %s --overwrite-existing\n", config.ResourceGroupName(s.Location), *s.Runtime.Cluster.Model.Name)
-	result += fmt.Sprintf(`kubectl exec -it %s -- bash -c "chroot /proc/1/root /bin/bash -c '%s'"`, s.Runtime.Cluster.DebugPod.Name, sshString(s.Runtime.VMPrivateIP))
+	result += fmt.Sprintf(`kubectl  kubectl --kubeconfig <(az aks get-credentials --name "${CLUSTER_NAME}" --resource-group "${RESOURCE_GROUP}"  --subscription "${SUBSCRIPTION}" -f -) exec -it %s -- bash -c "chroot /proc/1/root /bin/bash -c '%s'"`, config.Config.SubscriptionID, config.ResourceGroupName(s.Location), *s.Runtime.Cluster.Model.Name, s.Runtime.Cluster.DebugPod.Name, sshString(s.Runtime.VMPrivateIP))
 	s.T.Log(result)
 
 	// Test SSH connectivity once per test to distinguish SSH issues from script failures

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -228,7 +228,7 @@ func uploadSSHKey(ctx context.Context, s *Scenario) error {
 	}
 	result += "\n========================\n"
 	// We combine the az aks get credentials in the same line so we don't overwrite the user's kubeconfig.
-	result += fmt.Sprintf(`kubectl  kubectl --kubeconfig <(az aks get-credentials --name "${CLUSTER_NAME}" --resource-group "${RESOURCE_GROUP}"  --subscription "${SUBSCRIPTION}" -f -) exec -it %s -- bash -c "chroot /proc/1/root /bin/bash -c '%s'"`, config.Config.SubscriptionID, config.ResourceGroupName(s.Location), *s.Runtime.Cluster.Model.Name, s.Runtime.Cluster.DebugPod.Name, sshString(s.Runtime.VMPrivateIP))
+	result += fmt.Sprintf(`kubectl --kubeconfig <(az aks get-credentials --name "${CLUSTER_NAME}" --resource-group "${RESOURCE_GROUP}"  --subscription "${SUBSCRIPTION}" -f -) exec -it %s -- bash -c "chroot /proc/1/root /bin/bash -c '%s'"`, config.Config.SubscriptionID, config.ResourceGroupName(s.Location), *s.Runtime.Cluster.Model.Name, s.Runtime.Cluster.DebugPod.Name, sshString(s.Runtime.VMPrivateIP))
 	s.T.Log(result)
 
 	// Test SSH connectivity once per test to distinguish SSH issues from script failures


### PR DESCRIPTION
single liner so we don't modify user's default subscription or kubeconfig

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Changes the suggested way to exec into a debug VM so we don't change the user's default subscription or kubeconfig.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
