### PR TITLE
feat: expose iptables block to agentbaker

### DIFF
--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -171,7 +171,7 @@ func (t *TemplateGenerator) getFlatcarLinuxNodeCustomDataJSONObject(config *data
 						Inline: to.StringPtr(string(ignjson)),
 						// TODO: butane 0.24.0 broke support for explicit compression
 						// so we depend on automatic resource compression.
-						//Compression: to.StringPtr("gzip"),
+						// Compression: to.StringPtr("gzip"),
 					},
 				},
 			},
@@ -843,7 +843,6 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 				}
 				return containerdV1NoGPUConfigTemplate
 			}(profile))
-
 			if err != nil {
 				panic(err)
 			}
@@ -1154,6 +1153,9 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 			return profile.GetLocalDNSMemoryLimitInMB()
 		},
 		"GetPreProvisionOnly": func() bool { return config.PreProvisionOnly },
+		"BlockIptables": func() bool {
+			return cs.Properties.OrchestratorProfile.KubernetesConfig.BlockIptables
+		},
 	}
 }
 

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -723,6 +723,7 @@ type KubernetesConfig struct {
 	PrivateAzureRegistryServer        string            `json:"privateAzureRegistryServer,omitempty"`
 	NetworkPluginMode                 string            `json:"networkPluginMode,omitempty"`
 	EbpfDataplane                     EbpfDataplane     `json:"ebpfDataplane,omitempty"`
+	BlockIptables                     bool              `json:"blockIptables,omitempty"`
 }
 
 /*
@@ -1217,6 +1218,7 @@ func (a *AgentPoolProfile) IsCustomVNET() bool {
 func (a *AgentPoolProfile) IsWindows() bool {
 	return strings.EqualFold(string(a.OSType), string(Windows))
 }
+
 func (a *AgentPoolProfile) IsFlatcar() bool {
 	return a.Distro.IsFlatcarDistro()
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
We need to enable a systemd service that blocks iptables rule installation on nodes of clusters that uses Cilium eBPF host routing. This PR exposes a flag to pass that information from RP to AgentBaker.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
