### PR TITLE
fix: set EnableLocalDNS to false to unblock AB E2E

### DIFF
--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -352,7 +352,7 @@ func baseTemplateLinux(t *testing.T, location string, k8sVersion string, arch st
 						NotRebootWindowsNode:    nil,
 						AgentPoolWindowsProfile: nil,
 						LocalDNSProfile: &datamodel.LocalDNSProfile{
-							EnableLocalDNS:       true,
+							EnableLocalDNS:       false,
 							CPULimitInMilliCores: to.Ptr(int32(2008)),
 							MemoryLimitInMB:      to.Ptr(int32(128)),
 							VnetDNSOverrides: map[string]*datamodel.LocalDNSOverrides{
@@ -505,7 +505,7 @@ func baseTemplateLinux(t *testing.T, location string, k8sVersion string, arch st
 				ContainerRuntime: "containerd",
 			},
 			LocalDNSProfile: &datamodel.LocalDNSProfile{
-				EnableLocalDNS:       true,
+				EnableLocalDNS:       false,
 				CPULimitInMilliCores: to.Ptr(int32(2008)),
 				MemoryLimitInMB:      to.Ptr(int32(128)),
 				VnetDNSOverrides: map[string]*datamodel.LocalDNSOverrides{

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func ValidatePodRunning(ctx context.Context, s *Scenario, pod *corev1.Pod) {
@@ -115,7 +115,7 @@ func ValidateCommonLinux(ctx context.Context, s *Scenario) {
 	}
 
 	// TODO: Add support for AKSNodeConfig
-	if s.Runtime.NBC != nil && s.Runtime.NBC.AgentPoolProfile.LocalDNSProfile != nil {
+	if s.Runtime.NBC != nil && s.Runtime.NBC.AgentPoolProfile.LocalDNSProfile.EnableLocalDNS != false {
 		ValidateLocalDNSService(ctx, s)
 		ValidateLocalDNSResolution(ctx, s)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

This PR sets EnableLocalDNS to false in the ab NBC to prevent our E2E framework from failing.

**Which issue(s) this PR fixes**:

Fixes an issue where the AB E2E pipeline always fails.

**Requirements**:

- [ x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified