### PR TITLE
fix: add front end lock to wait_for_apt_locks function

### DIFF
--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
@@ -16,7 +16,7 @@ aptmarkWALinuxAgent() {
 }
 
 wait_for_apt_locks() {
-    while fuser /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; do
+    while fuser /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
         echo 'Waiting for release of apt locks'
         sleep 3
     done

--- a/vhdbuilder/packer/pre-install-dependencies.sh
+++ b/vhdbuilder/packer/pre-install-dependencies.sh
@@ -140,10 +140,6 @@ if [[ ${UBUNTU_RELEASE//./} -ge 2204 && "${ENABLE_FIPS,,}" != "true" ]] && ! gre
   LTS_HEADERS="linux-headers-azure-lts-${UBUNTU_RELEASE}"
   LTS_MODULES="linux-modules-extra-azure-lts-${UBUNTU_RELEASE}"
 
-  # Acquiring kernel packages to be removed now to prevent lock conflicts during removal and install
-  wait_for_apt_locks
-  OLD_KERNEL_PACKAGES=$(dpkg-query -W 'linux-*azure*' | awk '$2 != "" { print $1 }' | paste -s)
-
   echo "Logging the currently running kernel: $(uname -r)"
   echo "Before purging kernel, here is a list of kernels/headers installed:"; dpkg -l 'linux-*azure*'
 
@@ -152,7 +148,7 @@ if [[ ${UBUNTU_RELEASE//./} -ge 2204 && "${ENABLE_FIPS,,}" != "true" ]] && ! gre
 
       # Purge all current kernels and dependencies
       wait_for_apt_locks
-      DEBIAN_FRONTEND=noninteractive apt-get remove --purge -y $OLD_KERNEL_PACKAGES
+      DEBIAN_FRONTEND=noninteractive apt-get remove --purge -y $(dpkg-query -W 'linux-*azure*' | awk '$2 != "" { print $1 }' | paste -s)
       echo "After purging kernel, dpkg list should be empty"; dpkg -l 'linux-*azure*'
 
       # Install LTS kernel


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR adds front end locks to the `wait_for_apt_locks` function. This will prevent multiple processes from trying and failing to get a lock on the front end while conducting package updates and modifications.

**Which issue(s) this PR fixes**:

The kernel purge and reinstall logic in `pre-install-dependencies` is occasionally failing due to multiple processes each trying to get a lock on the front end.

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified