### PR TITLE
test(e2e): Poll for image Updates with client for gallery subscription

### DIFF
--- a/e2e/config/azure.go
+++ b/e2e/config/azure.go
@@ -533,10 +533,15 @@ func (a *AzureClient) waitForVersionOperationCompletion(ctx context.Context, ima
 
 	logf(ctx, "Image version %s is in 'Updating' state, waiting for operation to complete", *version.ID)
 
+	imgVersionClient, err := armcompute.NewGalleryImageVersionsClient(image.Gallery.SubscriptionID, a.Credential, a.ArmOptions)
+	if err != nil {
+		return fmt.Errorf("create a new image version client: %v", err)
+	}
+
 	// Use the standard wait.PollUntilContextTimeout helper used throughout the codebase
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
 		// Get the latest version state using the existing client
-		resp, err := a.GalleryImageVersions.Get(ctx, image.Gallery.ResourceGroupName, image.Gallery.Name, image.Name, *version.Name, nil)
+		resp, err := imgVersionClient.Get(ctx, image.Gallery.ResourceGroupName, image.Gallery.Name, image.Name, *version.Name, nil)
 		if err != nil {
 			// Return error to stop polling on permanent errors
 			return false, fmt.Errorf("get image version during wait: %w", err)


### PR DESCRIPTION

**What type of PR is this?**
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

The VM subscription and Gallery subscription may differ, so we have to perform gallery operations with a client created for the correct subscription.  This solves a 403 when waiting on replication to complete:
```
    azure.go:534: Image version /subscriptions/c4c3550e-a965-4993-a50c-628fd38cd3e1/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/2404gen2containerd/versions/1.1754467544.11789 is in 'Updating' state, waiting for operation to complete
    test_helpers.go:306: failing scenario "Test_Ubuntu2404_GPU_H100": could not find image for VHD aks-ubuntu-containerd-24.04-gen2 due to failed to get latest image by tag buildId=132861074: failed ensuring image replication: waiting for version operation completion: waiting for image version operation completion: get image version during wait: GET https://management.azure.com/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/2404gen2containerd/versions/1.1754467544.11789
        RESPONSE 403: 403 Forbidden
        ERROR CODE: AuthorizationFailed
        --------------------------------------------------------------------------------
        {
          "error": {
            "code": "AuthorizationFailed",
            "message": "The client 'b0d5ab26-baa6-459d-b189-1599555afdb8' with object id 'b0d5ab26-baa6-459d-b189-1599555afdb8' does not have authorization to perform action 'Microsoft.Compute/galleries/images/versions/read' over scope '/subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aksvhdtestbuildrg/providers/Microsoft.Compute/galleries/PackerSigGalleryEastUS/images/2404gen2containerd/versions/1.1754467544.11789' or the scope is invalid. If access was recently granted, please refresh your credentials."
          }
        }
        --------------------------------------------------------------------------------
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
