### PR TITLE
test(scan): Switch to apt_get_xxx helpers

### DIFF
--- a/vhdbuilder/packer/trivy-scan.sh
+++ b/vhdbuilder/packer/trivy-scan.sh
@@ -46,6 +46,8 @@ CVE_DIFF_UPLOAD_REPORT_NAME=${30}
 CVE_LIST_UPLOAD_REPORT_NAME=${31}
 SCAN_RESOURCE_PREFIX=${32}
 
+source /opt/azure/containers/provision_source_distro.sh
+
 retrycmd_if_failure() {
     retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
     for i in $(seq 1 $retries); do
@@ -67,8 +69,8 @@ install_azure_cli() {
     TEST_VM_ADMIN_USERNAME=${4}
 
     if [ "$OS_SKU" = "Ubuntu" ] && [ "$OS_VERSION" = "22.04" ] && [ "${ARCHITECTURE,,}" = "arm64" ]; then
-        sudo apt update
-        sudo apt install -y python3-pip
+        apt_get_update
+        apt_get_install 5 1 60 python3-pip
         pip install azure-cli
         export PATH="/home/$TEST_VM_ADMIN_USERNAME/.local/bin:$PATH"
         CHECKAZ=$(pip freeze | grep "azure-cli==")
@@ -77,17 +79,17 @@ install_azure_cli() {
             exit 1
         fi
     elif [ "$OS_SKU" = "Ubuntu" ] && [ "$OS_VERSION" = "24.04" ] && [ "${ARCHITECTURE,,}" = "arm64" ]; then
-        sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
+        apt_get_install 5 1 60 ca-certificates curl apt-transport-https lsb-release gnupg
         curl -sL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
         echo "deb [arch=arm64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-        sudo apt-get update -y && sudo apt-get upgrade -y
-        sudo apt-get install -y azure-cli
+        apt_get_update
+        apt_get_install 5 1 60 azure-cli
     elif [ "$OS_SKU" = "Ubuntu" ] && { [ "$OS_VERSION" = "20.04" ] || [ "$OS_VERSION" = "22.04" ] || [ "$OS_VERSION" = "24.04" ]; } && [ "${ARCHITECTURE,,}" != "arm64" ]; then
-        sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
+        apt_get_install 5 1 60 ca-certificates curl apt-transport-https lsb-release gnupg
         curl -sL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
         echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-        sudo apt-get update -y && sudo apt-get upgrade -y
-        sudo apt-get install -y azure-cli
+        apt_get_update
+        apt_get_install 5 1 60 azure-cli
     elif [ "$OS_SKU" = "CBLMariner" ] || [ "$OS_SKU" = "AzureLinux" ]; then
         sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
         sudo sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo'


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

The package installation of azure-cli during trivy-scan may also fail like this:

    debconf: unable to initialize frontend: Dialog
    debconf: (Dialog frontend will not work on a dumb terminal, an emacs shell buffer, or without a controlling terminal.)
    debconf: falling back to frontend: Readline
    debconf: unable to initialize frontend: Readline
    debconf: (This frontend requires a controlling tty.)
    debconf: falling back to frontend: Teletype
    dpkg-preconfigure: unable to re-open stdin:

We have wrappers that handle this (and other issues) - use them in the trivy-scan script.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
