### PR TITLE
Update aks-log-collector.sh

### DIFF
--- a/parts/linux/cloud-init/artifacts/aks-log-collector.sh
+++ b/parts/linux/cloud-init/artifacts/aks-log-collector.sh
@@ -73,6 +73,7 @@ GLOBS+=(/var/run/azure-cns*)
 # GPU specific entries
 GLOBS+=(/var/log/nvidia*.log)
 GLOBS+=(/var/log/azure/nvidia*.log)
+GLOBS+=(/var/log/fabricmanager*.log)
 
 # based on MANIFEST_FULL from Azure Linux Agent's log collector
 # https://github.com/Azure/WALinuxAgent/blob/master/azurelinuxagent/common/logcollector_manifests.py


### PR DESCRIPTION
Adding the nvidia fabricmanager log to troubleshoot issues like in CRI 667177754, where it's looping in:

Aug 05 17:16:23 aks-gpupool-24824834-vmss00000J systemd[1]: Started NVIDIA fabric manager service.
Aug 05 17:16:26 aks-gpupool-24824834-vmss00000J systemd[1]: Stopping NVIDIA fabric manager service...

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
PR collects an extra log helpful to troubleshoot nvidia GPU issues

**Which issue(s) this PR fixes**:
Fixes #  CRI 667177754



**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
