### PR TITLE
Remove "Old Windows VHD Cleanup" step from release pipeline.

### DIFF
--- a/.pipelines/.vsts-vhd-builder-pr-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-pr-windows.yaml
@@ -64,6 +64,7 @@ stages:
       dryrun: False
       overrideBranch: master
       useOverrides: False
+      enableBackfillCleanup: True
       buildVmSize: Standard_D16ds_v5
       build2019containerd: True
       build2022containerd: False

--- a/.pipelines/.vsts-vhd-builder-pr-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-pr-windows.yaml
@@ -75,3 +75,30 @@ stages:
       build23H2gen2: True
       build2025: False
       build2025gen2: True
+  - stage: backfill_cleanup_outdated_resources
+    dependsOn: [ ]
+    condition: always()
+    jobs:
+      - job: build
+        timeoutInMinutes: 180
+        steps:
+          - bash: bash ./.pipelines/scripts/windows-sub-cleanup.sh
+            enabled: true
+            displayName: Old Windows VHD Cleanup
+            condition: eq(  ${{ parameters.enableBackfillCleanup }} , 'True')
+            env:
+              MODE: windowsVhdMode
+              DRY_RUN: ${{ parameters.dryrun }}
+              OS_TYPE: Windows
+
+          - bash: bash ./vhdbuilder/packer/cleanup.sh
+            enabled: true
+            displayName: Cleanup
+            condition: eq(  ${{ parameters.enableBackfillCleanup }} , 'True')
+            env:
+              MODE: windowsVhdMode
+              SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
+              DRY_RUN: ${{ parameters.dryrun }}
+              SIG_GALLERY_NAME: $(SIG_GALLERY_NAME)
+              OS_TYPE: Windows
+

--- a/.pipelines/.vsts-vhd-builder-pr-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-pr-windows.yaml
@@ -73,7 +73,7 @@ stages:
       build23H2gen2: True
       build2025: False
       build2025gen2: True
-  - stage: delete_old_windows_vvhds
+  - stage: delete_old_windows_vhds
     dependsOn: [ ]
     condition: always()
     jobs:

--- a/.pipelines/.vsts-vhd-builder-pr-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-pr-windows.yaml
@@ -55,8 +55,6 @@ variables:
     # if SIG_FOR_PRODUCTION is true, then the VHDs are deleted from the gallery before the e2e tests are run.
   - name: SIG_FOR_PRODUCTION
     value: False
-  - name: ENABLE_BACKFILL_CLEANUP
-    value: True
 
 stages:
   - template: ./templates/.build-and-test-windows-vhds-template.yaml

--- a/.pipelines/.vsts-vhd-builder-pr-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-pr-windows.yaml
@@ -66,7 +66,6 @@ stages:
       dryrun: False
       overrideBranch: master
       useOverrides: False
-      enableBackfillCleanup: True
       buildVmSize: Standard_D16ds_v5
       build2019containerd: True
       build2022containerd: False
@@ -85,9 +84,5 @@ stages:
           - bash: bash ./.pipelines/scripts/windows-sub-cleanup.sh
             enabled: true
             displayName: Old Windows VHD Cleanup
-            condition: eq(  ${{ parameters.enableBackfillCleanup }} , 'True')
             env:
-              MODE: windowsVhdMode
               PROD_SUBSCRIPTION_ID: $(AZURE_PROD_SUBSCRIPTION_ID)
-              DRY_RUN:  ${{ parameters.dryrun }}
-              OS_TYPE: Windows

--- a/.pipelines/.vsts-vhd-builder-pr-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-pr-windows.yaml
@@ -88,9 +88,9 @@ stages:
             condition: eq(  ${{ parameters.enableBackfillCleanup }} , 'True')
             env:
               MODE: windowsVhdMode
-              DRY_RUN: ${{ parameters.dryrun }}
+              PROD_SUBSCRIPTION_ID: $(AZURE_PROD_SUBSCRIPTION_ID)
+              DRY_RUN:  ${{ parameters.dryrun }}
               OS_TYPE: Windows
-
           - bash: bash ./vhdbuilder/packer/cleanup.sh
             enabled: true
             displayName: Cleanup
@@ -98,7 +98,7 @@ stages:
             env:
               MODE: windowsVhdMode
               SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
-              DRY_RUN: ${{ parameters.dryrun }}
+              PROD_SUBSCRIPTION_ID: $(AZURE_PROD_SUBSCRIPTION_ID)
+              DRY_RUN:  ${{ parameters.dryrun }}
               SIG_GALLERY_NAME: $(SIG_GALLERY_NAME)
               OS_TYPE: Windows
-

--- a/.pipelines/.vsts-vhd-builder-pr-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-pr-windows.yaml
@@ -73,7 +73,7 @@ stages:
       build23H2gen2: True
       build2025: False
       build2025gen2: True
-  - stage: Delete Old Windows VHDs
+  - stage: delete_old_windows_vvhds
     dependsOn: [ ]
     condition: always()
     jobs:

--- a/.pipelines/.vsts-vhd-builder-pr-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-pr-windows.yaml
@@ -75,7 +75,7 @@ stages:
       build23H2gen2: True
       build2025: False
       build2025gen2: True
-  - stage: backfill_cleanup_outdated_resources
+  - stage: Delete Old Windows VHDs
     dependsOn: [ ]
     condition: always()
     jobs:
@@ -90,15 +90,4 @@ stages:
               MODE: windowsVhdMode
               PROD_SUBSCRIPTION_ID: $(AZURE_PROD_SUBSCRIPTION_ID)
               DRY_RUN:  ${{ parameters.dryrun }}
-              OS_TYPE: Windows
-          - bash: bash ./vhdbuilder/packer/cleanup.sh
-            enabled: true
-            displayName: Cleanup
-            condition: eq(  ${{ parameters.enableBackfillCleanup }} , 'True')
-            env:
-              MODE: windowsVhdMode
-              SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
-              PROD_SUBSCRIPTION_ID: $(AZURE_PROD_SUBSCRIPTION_ID)
-              DRY_RUN:  ${{ parameters.dryrun }}
-              SIG_GALLERY_NAME: $(SIG_GALLERY_NAME)
               OS_TYPE: Windows

--- a/.pipelines/scripts/windows-sub-cleanup.sh
+++ b/.pipelines/scripts/windows-sub-cleanup.sh
@@ -5,11 +5,6 @@ if [ "${MODE}" != "windowsVhdMode" ]; then
   exit 0
 fi
 
-if [ ${SUBSCRIPTION_ID} = ${PROD_SUBSCRIPTION_ID} ]; then
-  echo "Shouldn't do backfill clean up in production subscription."
-  exit 1
-fi
-
 make -f packer.mk az-login
 
 EXPIRATION_IN_HOURS=168

--- a/.pipelines/scripts/windows-sub-cleanup.sh
+++ b/.pipelines/scripts/windows-sub-cleanup.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -x
 
-if [ "${MODE}" != "windowsVhdMode" ]; then
-  exit 0
-fi
-
 if [ ${SUBSCRIPTION_ID} = ${PROD_SUBSCRIPTION_ID} ]; then
   echo "Shouldn't do backfill clean up in production subscription."
   exit 1

--- a/.pipelines/scripts/windows-sub-cleanup.sh
+++ b/.pipelines/scripts/windows-sub-cleanup.sh
@@ -5,6 +5,11 @@ if [ "${MODE}" != "windowsVhdMode" ]; then
   exit 0
 fi
 
+if [ ${SUBSCRIPTION_ID} = ${PROD_SUBSCRIPTION_ID} ]; then
+  echo "Shouldn't do backfill clean up in production subscription."
+  exit 1
+fi
+
 make -f packer.mk az-login
 
 EXPIRATION_IN_HOURS=168

--- a/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
@@ -229,33 +229,3 @@ stages:
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}
       cseFileName: ${{ parameters.cseFileName }}
-
-  - stage: backfill_cleanup_outdated_resources
-    dependsOn: [ ]
-    condition: always()
-    jobs:
-      - job: build
-        timeoutInMinutes: 180
-        steps:
-          - bash: bash ./.pipelines/scripts/windows-sub-cleanup.sh
-            enabled: true
-            displayName: Old Windows VHD Cleanup
-            condition: eq(  ${{ parameters.enableBackfillCleanup }} , 'True')
-            env:
-              MODE: windowsVhdMode
-              PROD_SUBSCRIPTION_ID: $(AZURE_PROD_SUBSCRIPTION_ID)
-              DRY_RUN:  ${{ parameters.dryrun }}
-              OS_TYPE: Windows
-
-          - bash: bash ./vhdbuilder/packer/cleanup.sh
-            enabled: true
-            displayName: Cleanup
-            condition: eq(  ${{ parameters.enableBackfillCleanup }} , 'True')
-            env:
-              MODE: windowsVhdMode
-              SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
-              PROD_SUBSCRIPTION_ID: $(AZURE_PROD_SUBSCRIPTION_ID)
-              DRY_RUN:  ${{ parameters.dryrun }}
-              SIG_GALLERY_NAME: $(SIG_GALLERY_NAME)
-              OS_TYPE: Windows
-

--- a/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
@@ -230,7 +230,7 @@ stages:
       csePackageDir: ${{ parameters.csePublishDir }}
       cseFileName: ${{ parameters.cseFileName }}
 
-  - stage: Delete Outdated Resources
+  - stage: delete_outdated_resources
     dependsOn: [ ]
     condition: always()
     jobs:

--- a/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
+++ b/.pipelines/templates/.build-and-test-windows-vhds-template.yaml
@@ -229,3 +229,22 @@ stages:
       useOverrides: ${{ parameters.useOverrides }}
       csePackageDir: ${{ parameters.csePublishDir }}
       cseFileName: ${{ parameters.cseFileName }}
+
+  - stage: Delete Outdated Resources
+    dependsOn: [ ]
+    condition: always()
+    jobs:
+      - job: build
+        timeoutInMinutes: 180
+        steps:
+          - bash: bash ./vhdbuilder/packer/cleanup.sh
+            enabled: true
+            displayName: Cleanup
+            condition: eq(  ${{ parameters.enableBackfillCleanup }} , 'True')
+            env:
+              MODE: windowsVhdMode
+              SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
+              PROD_SUBSCRIPTION_ID: $(AZURE_PROD_SUBSCRIPTION_ID)
+              DRY_RUN: ${{ parameters.dryrun }}
+              SIG_GALLERY_NAME: $(SIG_GALLERY_NAME)
+              OS_TYPE: Windows


### PR DESCRIPTION
**What type of PR is this?**

Remove "Old Windows VHD Cleanup" step from release pipeline.

This should be run for release. The step is skiped based on this condition inside a shell script:

```bash
if [ ${SUBSCRIPTION_ID} = ${PROD_SUBSCRIPTION_ID} ]; then
  echo "Shouldn't do backfill clean up in production subscription."
  exit 1
fi
```

A single env variable change may lead to a deletion attempt.

/kind cleanup



