### PR TITLE
fix: add cloud native preview repo on OS Guard

### DIFF
--- a/parts/linux/cloud-init/artifacts/azlosguard/azurelinux-cloud-native-preview.repo
+++ b/parts/linux/cloud-init/artifacts/azlosguard/azurelinux-cloud-native-preview.repo
@@ -1,0 +1,9 @@
+[azurelinux-official-cloud-native-preview]
+name=Azure Linux Official Cloud Native Preview $releasever $basearch
+baseurl=https://packages.microsoft.com/azurelinux/$releasever/preview/cloud-native/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1
+skip_if_unavailable=True
+sslverify=1

--- a/vhdbuilder/packer/imagecustomizer/azlosguard/azlosguard.yml
+++ b/vhdbuilder/packer/imagecustomizer/azlosguard/azlosguard.yml
@@ -6,6 +6,9 @@ os:
     - source: /AgentBaker/parts/linux/cloud-init/artifacts/azlosguard/azurelinux-cloud-native.repo
       destination: /etc/yum.repos.d/azurelinux-cloud-native.repo
       permissions: 644
+    - source: /AgentBaker/parts/linux/cloud-init/artifacts/azlosguard/azurelinux-cloud-native-preview.repo
+      destination: /etc/yum.repos.d/azurelinux-cloud-native-preview.repo
+      permissions: 644
     # Build-time scripts and tools
     - source: /AgentBaker/vhdbuilder/packer/install-dependencies.sh
       destination: /opt/azure/containers/install-dependencies.sh


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR adds azurelinux-cloud-native-preview.repo to the OS Guard image so that K8s 1.34 preview binaries can be cached

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
