### PR TITLE
chore: Make name optional in OCIArtifact schema

### DIFF
--- a/schemas/components.cue
+++ b/schemas/components.cue
@@ -95,7 +95,7 @@ package components
 }
 
 #OCIArtifact: {
-	name: string
+	name?: string
 	registry: string
 	windowsDownloadLocation?: string
 	windowsVersions: [...#WindowsVersion]


### PR DESCRIPTION

**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

'make validate-components' (part of 'make generate') currently fails with:

    OCIArtifacts.0.name: incomplete value string
    OCIArtifacts.1.name: incomplete value string
    OCIArtifacts.2.name: incomplete value string
    OCIArtifacts.3.name: incomplete value string
    OCIArtifacts.4.name: incomplete value string

We could add a name to the entries, but the only one that comes to mind is repeating the image name in the registry entry. So make name optional.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
