### PR TITLE
Flatcar "scriptless" support

### DIFF
--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -131,7 +131,7 @@ func nbcToAKSNodeConfigV1(nbc *datamodel.NodeBootstrappingConfiguration) *aksnod
 
 	config := &aksnodeconfigv1.Configuration{
 		Version:            "v1",
-		DisableCustomData:  false,
+		DisableCustomData:  nbc.AgentPoolProfile.IsFlatcar(),
 		LinuxAdminUsername: "azureuser",
 		VmSize:             config.Config.DefaultVMSKU,
 		ClusterConfig: &aksnodeconfigv1.ClusterConfig{

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -72,6 +72,21 @@ func Test_Flatcar_CustomCATrust(t *testing.T) {
 	})
 }
 
+func Test_Flatcar_Scriptless(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "Tests that a node using a Flatcar and the self-contained installer can be properly bootstrapped",
+		Config: Config{
+			Cluster: ClusterKubenet,
+			VHD:     config.VHDFlatcarGen2,
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log", "aks-node-controller finished successfully")
+			},
+			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			},
+		},
+	})
+}
+
 func Test_Flatcar_ARM64(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using a Flatcar VHD on ARM64 architecture can be properly bootstrapped",

--- a/parts/linux/cloud-init/artifacts/aks-node-controller.service
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Parse contract and run csecmd
 After=cloud-init.target
+After=oem-cloudinit.service enable-oem-cloudinit.service
 Wants=cloud-init.target
 
 [Service]
@@ -10,3 +11,4 @@ RemainAfterExit=No
 
 [Install]
 WantedBy=cloud-init.target
+WantedBy=oem-cloudinit.service

--- a/parts/linux/cloud-init/artifacts/aks-node-controller.service
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Parse contract and run csecmd
+ConditionPathExists=/opt/azure/containers/aks-node-controller-config.json
 After=cloud-init.target
 After=oem-cloudinit.service enable-oem-cloudinit.service
 Wants=cloud-init.target


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Add Flatcar support for "scriptless"/aks-node-controller. Not introducing anything new into the contract because the only change in control-flow that we need is to skip waiting for `cloud-init` to complete. This code is guarded by `DisableCustomData` , so we'll make sure to set that to true for Flatcar.

The other change that would be necessary is to generate customdata in ignition format, but we can also rely on the limited `coreos-cloudinit` fallback implementation that Flatcar ships with. It doesn't support enough for the non-scriptless mode but in scriptless mode the customdata is so simple that we can use this approach.

To make `coreos-cloudinit` work we need to tweak `aks-node-controller.service` dependencies slightly.

**Which issue(s) this PR fixes**:

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
