### PR TITLE
Freezing kata mariner vhd for kata-cc.

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -64,11 +64,11 @@ parameters:
   - name: buildMarinerV2gen2kata
     displayName: Build MarinerV2 Gen2 Kata
     type: boolean
-    default: true
+    default: false
   - name: buildAzureLinuxV2gen2kata
     displayName: Build AzureLinuxV2 Gen2 Kata
     type: boolean
-    default: true
+    default: false
   - name: buildAzureLinuxV3gen2kata
     displayName: Build AzureLinuxV3 Gen2 Kata
     type: boolean

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -439,6 +439,10 @@ const (
 	// DO NOT MODIFY: used for freezing MarinerV2KataGen2TL.
 	FrozenCBLMarinerV2KataGen2TLSIGImageVersion = "2022.12.15"
 
+	// DO NOT MODIFY: Used for freezing Kata VHD for kata-cc runtime, until the image is deprecated.
+	FrozenCBLMarinerV2KataGen2SIGImageVersion string = "202509.04.0"
+	FrozenAzureLinuxV2KataGen2SIGImageVersion string = "202509.04.0"
+
 	// We do not use AKS Windows image versions in AgentBaker. These fake values are only used for unit tests.
 	Windows2019SIGImageVersion string = "17763.2019.221114"
 	Windows2022SIGImageVersion string = "20348.2022.221114"
@@ -782,14 +786,14 @@ var (
 		ResourceGroup: AKSCBLMarinerResourceGroup,
 		Gallery:       AKSCBLMarinerGalleryName,
 		Definition:    "V2katagen2",
-		Version:       LinuxSIGImageVersion,
+		Version:       FrozenCBLMarinerV2KataGen2SIGImageVersion,
 	}
 
 	SIGAzureLinuxV2KataImageConfigTemplate = SigImageConfigTemplate{
 		ResourceGroup: AKSAzureLinuxResourceGroup,
 		Gallery:       AKSAzureLinuxGalleryName,
 		Definition:    "V2katagen2",
-		Version:       LinuxSIGImageVersion,
+		Version:       FrozenAzureLinuxV2KataGen2SIGImageVersion,
 	}
 
 	SIGAzureLinuxV3KataImageConfigTemplate = SigImageConfigTemplate{

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -24,16 +24,16 @@ var _ = Describe("GetMaintainedLinuxSIGImageConfigMap", func() {
 			AKSAzureLinuxV2:                       SIGAzureLinuxV2Gen1ImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV3:                       SIGAzureLinuxV3Gen1ImageConfigTemplate.WithOptions(),
 			AKSCBLMarinerV2Gen2:                   SIGCBLMarinerV2Gen2ImageConfigTemplate.WithOptions(),
+			AKSCBLMarinerV2Gen2Kata:               SIGCBLMarinerV2KataImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV2Gen2:                   SIGAzureLinuxV2Gen2ImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV3Gen2:                   SIGAzureLinuxV3Gen2ImageConfigTemplate.WithOptions(),
 			AKSCBLMarinerV2FIPS:                   SIGCBLMarinerV2Gen1FIPSImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV2FIPS:                   SIGAzureLinuxV2Gen1FIPSImageConfigTemplate.WithOptions(),
+			AKSAzureLinuxV2Gen2Kata:               SIGAzureLinuxV2KataImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV3FIPS:                   SIGAzureLinuxV3Gen1FIPSImageConfigTemplate.WithOptions(),
 			AKSCBLMarinerV2Gen2FIPS:               SIGCBLMarinerV2Gen2FIPSImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV2Gen2FIPS:               SIGAzureLinuxV2Gen2FIPSImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV3Gen2FIPS:               SIGAzureLinuxV3Gen2FIPSImageConfigTemplate.WithOptions(),
-			AKSCBLMarinerV2Gen2Kata:               SIGCBLMarinerV2KataImageConfigTemplate.WithOptions(),
-			AKSAzureLinuxV2Gen2Kata:               SIGAzureLinuxV2KataImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV3Gen2Kata:               SIGAzureLinuxV3KataImageConfigTemplate.WithOptions(),
 			AKSCBLMarinerV2Arm64Gen2:              SIGCBLMarinerV2Arm64ImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV2Arm64Gen2:              SIGAzureLinuxV2Arm64ImageConfigTemplate.WithOptions(),
@@ -338,7 +338,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(azurelinuxV2Gen2Kata.ResourceGroup).To(Equal("resourcegroup"))
 		Expect(azurelinuxV2Gen2Kata.Gallery).To(Equal("aksazurelinux"))
 		Expect(azurelinuxV2Gen2Kata.Definition).To(Equal("V2katagen2"))
-		Expect(azurelinuxV2Gen2Kata.Version).To(Equal(LinuxSIGImageVersion))
+		Expect(azurelinuxV2Gen2Kata.Version).To(Equal(FrozenAzureLinuxV2KataGen2SIGImageVersion))
 
 		azurelinuxV3Gen2Kata := sigConfig.SigAzureLinuxImageConfig[AKSAzureLinuxV3Gen2Kata]
 		Expect(azurelinuxV3Gen2Kata.ResourceGroup).To(Equal("resourcegroup"))


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Freezing the Kata AzL2 VHD since the build pipeline is no longer working since AzL2 is has begun deprecation and is being actively removed from ACRs. Additionally, can't migrate to AzL3 because components required to run Kata-CC have been getting removed in Kata-CC, and we need to support the feature at least until ~March 2026. This PR freezes the VHDs in a previous already working build.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [X] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
