### PR TITLE
fix(cse): remove non-host arguments for `oras repo ls`

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -997,7 +997,7 @@ oras_login_with_kubelet_identity() {
     unset ACCESS_TOKEN REFRESH_TOKEN  # Clears sensitive data from memory
     set -x
 
-    retrycmd_can_oras_ls_acr 10 5 $acr_url$test_image
+    retrycmd_can_oras_ls_acr 10 5 $acr_url
     if [ "$?" -ne 0 ]; then
         echo "failed to login to acr '$acr_url', pull is still unauthorized"
         return $ERR_ORAS_PULL_UNAUTHORIZED


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR removes an unnecessary argument from the `oras repo ls` command in the CSE script. 

At the moment, `$test_image` has not been assigned a value and remains an empty string. Once unintentionally set, it will be treated as a namespace (see [oras examples](https://oras.land/docs/commands/oras_repo_ls#examples)) and will list repositories only within that specified namespace.

- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
