### PR TITLE
feat: add node bootstrapping fields for Windows Cilium feature

### DIFF
--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -2316,7 +2316,9 @@ type AgentPoolWindowsProfile struct {
 	DisableOutboundNat *bool `json:"disableOutboundNat,omitempty"`
 
 	// Windows next-gen networking uses Windows eBPF for the networking dataplane.
-	NextGenNetworkingURL *string `json:"nextGenNetworkingURL,omitempty"`
+	NextGenNetworkingURL     *string `json:"nextGenNetworkingURL,omitempty"`
+	NextGenNetworkingEnabled *bool   `json:"nextGenNetworkingEnabled,omitempty"`
+	NextGenNetworkingConfig  *string `json:"nextGenNetworkingConfig,omitempty"`
 }
 
 // IsDisableWindowsOutboundNat returns true if the Windows agent pool disable OutboundNAT.
@@ -2327,7 +2329,15 @@ func (a *AgentPoolProfile) IsDisableWindowsOutboundNat() bool {
 }
 
 func (a *AgentPoolWindowsProfile) IsNextGenNetworkingEnabled() bool {
-	return a != nil && a.NextGenNetworkingURL != nil
+	return a != nil &&
+		a.NextGenNetworkingEnabled != nil && *a.NextGenNetworkingEnabled
+}
+
+func (a *AgentPoolWindowsProfile) GetNextGenNetworkingConfig() string {
+	if a == nil || a.NextGenNetworkingConfig == nil {
+		return ""
+	}
+	return *a.NextGenNetworkingConfig
 }
 
 func (a *AgentPoolWindowsProfile) GetNextGenNetworkingURL() string {

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -660,6 +660,79 @@ func TestGetSubnetName(t *testing.T) {
 	}
 }
 
+func TestIsNextGenNetworkingEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  *AgentPoolWindowsProfile
+		expected bool
+	}{
+		{
+			name: "NextGenNetworkingEnabled is true",
+			profile: &AgentPoolWindowsProfile{
+				NextGenNetworkingEnabled: to.BoolPtr(true),
+			},
+			expected: true,
+		},
+		{
+			name: "NextGenNetworkingEnabled is false",
+			profile: &AgentPoolWindowsProfile{
+				NextGenNetworkingEnabled: to.BoolPtr(false),
+			},
+			expected: false,
+		},
+		{
+			name:     "NextGenNetworkingEnabled is nil",
+			profile:  &AgentPoolWindowsProfile{},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			actual := test.profile.IsNextGenNetworkingEnabled()
+
+			if actual != test.expected {
+				t.Errorf("expected %t, but got %t", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestGetNextGenNetworkingConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  *AgentPoolWindowsProfile
+		expected string
+	}{
+		{
+			name: "NextGenNetworkingConfig is set",
+			profile: &AgentPoolWindowsProfile{
+				NextGenNetworkingConfig: to.StringPtr("config"),
+			},
+			expected: "config",
+		},
+		{
+			name:     "NextGenNetworkingConfig is nil",
+			profile:  &AgentPoolWindowsProfile{},
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			actual := test.profile.GetNextGenNetworkingConfig()
+
+			if actual != test.expected {
+				t.Errorf("expected %q, but got %q", test.expected, actual)
+			}
+		})
+	}
+}
+
 func TestGetRouteTableName(t *testing.T) {
 	p := &Properties{
 		OrchestratorProfile: &OrchestratorProfile{

--- a/pkg/agent/variables.go
+++ b/pkg/agent/variables.go
@@ -102,6 +102,11 @@ func getCSECommandVariables(config *datamodel.NodeBootstrappingConfiguration) pa
 		windowsProfile = &datamodel.WindowsProfile{}
 	}
 
+	agentPoolProfileWindows := profile.GetAgentPoolWindowsProfile()
+	if agentPoolProfileWindows == nil {
+		agentPoolProfileWindows = &datamodel.AgentPoolWindowsProfile{}
+	}
+
 	return map[string]interface{}{
 		"tenantID":                             config.TenantID,
 		"subscriptionId":                       config.SubscriptionID,
@@ -140,6 +145,8 @@ func getCSECommandVariables(config *datamodel.NodeBootstrappingConfiguration) pa
 		"windowsCSEScriptsPackageURL":          windowsProfile.CseScriptsPackageURL,
 		"isDisableWindowsOutboundNat":          strconv.FormatBool(config.AgentPoolProfile.IsDisableWindowsOutboundNat()),
 		"isSkipCleanupNetwork":                 strconv.FormatBool(config.AgentPoolProfile.IsSkipCleanupNetwork()),
+		"nextGenNetworkingEnabled":             strconv.FormatBool(agentPoolProfileWindows.IsNextGenNetworkingEnabled()),
+		"nextGenNetworkingConfig":              agentPoolProfileWindows.GetNextGenNetworkingConfig(),
 	}
 }
 

--- a/pkg/agent/variables_test.go
+++ b/pkg/agent/variables_test.go
@@ -295,6 +295,32 @@ var _ = Describe("Windows custom data variables check", func() {
 		Expect(vars["isDisableWindowsOutboundNat"]).To(Equal("false"))
 	})
 
+	It("sets nextGenNetworkingEnabled to true", func() {
+		value := true
+		config.AgentPoolProfile.AgentPoolWindowsProfile = &datamodel.AgentPoolWindowsProfile{
+			NextGenNetworkingEnabled: &value,
+		}
+		vars := getWindowsCustomDataVariables(config)
+		Expect(vars["nextGenNetworkingEnabled"]).To(Equal("true"))
+	})
+
+	It("sets nextGenNetworkingEnabled to false", func() {
+		value := false
+		config.AgentPoolProfile.AgentPoolWindowsProfile = &datamodel.AgentPoolWindowsProfile{
+			NextGenNetworkingEnabled: &value,
+		}
+		vars := getWindowsCustomDataVariables(config)
+		Expect(vars["nextGenNetworkingEnabled"]).To(Equal("false"))
+	})
+
+	It("sets nextGenNetworkingEnabled to false when nil", func() {
+		config.AgentPoolProfile.AgentPoolWindowsProfile = &datamodel.AgentPoolWindowsProfile{
+			NextGenNetworkingEnabled: nil,
+		}
+		vars := getWindowsCustomDataVariables(config)
+		Expect(vars["nextGenNetworkingEnabled"]).To(Equal("false"))
+	})
+
 	It("sets isSkipCleanupNetwork to true", func() {
 		value := true
 		config.AgentPoolProfile.NotRebootWindowsNode = &value

--- a/pkg/agent/variables_test.go
+++ b/pkg/agent/variables_test.go
@@ -321,6 +321,29 @@ var _ = Describe("Windows custom data variables check", func() {
 		Expect(vars["nextGenNetworkingEnabled"]).To(Equal("false"))
 	})
 
+	It("sets nextGenNetworkingConfig", func() {
+		value := "next gen networking config"
+		config.AgentPoolProfile.AgentPoolWindowsProfile = &datamodel.AgentPoolWindowsProfile{
+			NextGenNetworkingConfig: &value,
+		}
+		vars := getWindowsCustomDataVariables(config)
+		Expect(vars["nextGenNetworkingConfig"]).To(Equal("next gen networking config"))
+	})
+
+	It("sets nextGenNetworkingConfig with empty config when nil", func() {
+		config.AgentPoolProfile.AgentPoolWindowsProfile = &datamodel.AgentPoolWindowsProfile{
+			NextGenNetworkingConfig: nil,
+		}
+		vars := getWindowsCustomDataVariables(config)
+		Expect(vars["nextGenNetworkingConfig"]).To(Equal(""))
+	})
+
+	It("sets nextGenNetworkingConfig with empty config when AgentPoolWindowsProfile is nil", func() {
+		config.AgentPoolProfile.AgentPoolWindowsProfile = nil
+		vars := getWindowsCustomDataVariables(config)
+		Expect(vars["nextGenNetworkingConfig"]).To(Equal(""))
+	})
+
 	It("sets isSkipCleanupNetwork to true", func() {
 		value := true
 		config.AgentPoolProfile.NotRebootWindowsNode = &value


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Data model changes needed so that AKS-RP can pass Windows cilium enablement flag and configuration when enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [X] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
