### PR TITLE
Add NVLink failure simulation to GPU NPD E2E tests

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1872,6 +1872,10 @@ func Test_Ubuntu2404_GPU_H100(t *testing.T) {
 				// Validate the if IB NPD is reporting the flapping condition
 				ValidateNPDIBLinkFlappingCondition(ctx, s)
 				ValidateNPDIBLinkFlappingAfterFailure(ctx, s)
+
+				// Validate NVLink error detection
+				ValidateNPDNVLinkCondition(ctx, s)
+				ValidateNPDNVLinkAfterFailure(ctx, s)
 			},
 		},
 	})

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -689,6 +689,77 @@ func ValidateNPDIBLinkFlappingAfterFailure(ctx context.Context, s *Scenario) {
 	require.Contains(s.T, ibLinkFlappingCondition.Message, expectedMessage, "expected IBLinkFlapping message to indicate flapping")
 }
 
+func ValidateNPDNVLinkCondition(ctx context.Context, s *Scenario) {
+	s.T.Helper()
+	// Wait for the NPD to report initial NVLink condition
+	var nvlinkCondition *corev1.NodeCondition
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		node, err := s.Runtime.Cluster.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.KubeNodeName, metav1.GetOptions{})
+		if err != nil {
+			s.T.Logf("Failed to get node %q: %v", s.Runtime.KubeNodeName, err)
+			return false, nil // Continue polling on transient errors
+		}
+
+		// Check for NVLinkError condition with correct reason
+		for i := range node.Status.Conditions {
+			if node.Status.Conditions[i].Type == "NVLinkError" && node.Status.Conditions[i].Reason == "NoNVLinkError" {
+				nvlinkCondition = &node.Status.Conditions[i]
+				return true, nil // Found the condition we are looking for
+			}
+		}
+
+		return false, nil // Continue polling until the condition is found or timeout occurs
+	})
+	require.NoError(s.T, err, "timed out waiting for NVLinkError condition with reason NoNVLinkError to appear on node %q", s.Runtime.KubeNodeName)
+
+	require.NotNil(s.T, nvlinkCondition, "expected to find NVLinkError condition with NoNVLinkError reason on node")
+	require.Equal(s.T, corev1.ConditionFalse, nvlinkCondition.Status, "expected NVLinkError condition to be False")
+	require.Contains(s.T, nvlinkCondition.Message, "No NVLink errors detected", "expected NVLinkError message to indicate no errors")
+}
+
+func ValidateNPDNVLinkAfterFailure(ctx context.Context, s *Scenario) {
+	s.T.Helper()
+
+	// Simulate NVLink failure by injecting NVIDIA driver error logs
+	command := []string{
+		"set -ex",
+		"echo \"$(date '+%b %d %H:%M:%S') $(hostname) kernel: [12345.123456] NVRM: GPU at PCI:0000:01:00: GPU-12345678-1234-1234-1234-123456789abc\" | sudo tee -a /var/log/syslog",
+		"echo \"$(date '+%b %d %H:%M:%S') $(hostname) kernel: [12345.123456] NVRM: GPU 0: NVLink: Link training failed on link 0\" | sudo tee -a /var/log/syslog",
+		"sleep 5",
+		"echo \"$(date '+%b %d %H:%M:%S') $(hostname) kernel: [12346.123456] NVRM: GPU 0: NVLink: Link training failed on link 1\" | sudo tee -a /var/log/syslog",
+		"sleep 5", 
+		"echo \"$(date '+%b %d %H:%M:%S') $(hostname) kernel: [12347.123456] NVRM: GPU 0: NVLink: Fatal error detected on link 0\" | sudo tee -a /var/log/syslog",
+	}
+	execScriptOnVMForScenarioValidateExitCode(ctx, s, strings.Join(command, "\n"), 0, "failed to simulate NVLink failure")
+
+	// Wait for NPD to detect the change
+	var nvlinkCondition *corev1.NodeCondition
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		node, err := s.Runtime.Cluster.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.KubeNodeName, metav1.GetOptions{})
+		if err != nil {
+			s.T.Logf("Failed to get node %q: %v", s.Runtime.KubeNodeName, err)
+			return false, nil // Continue polling on transient errors
+		}
+
+		// Check for NVLinkError condition with correct reason
+		for i := range node.Status.Conditions {
+			if node.Status.Conditions[i].Type == "NVLinkError" && node.Status.Conditions[i].Reason == "NVLinkError" {
+				nvlinkCondition = &node.Status.Conditions[i]
+				return true, nil // Found the condition we are looking for
+			}
+		}
+
+		return false, nil // Continue polling until the condition is found or timeout occurs
+	})
+	require.NoError(s.T, err, "timed out waiting for NVLinkError condition with reason NVLinkError to appear on node %q", s.Runtime.KubeNodeName)
+
+	require.NotNil(s.T, nvlinkCondition, "expected to find NVLinkError condition with NVLinkError reason on node")
+	require.Equal(s.T, corev1.ConditionTrue, nvlinkCondition.Status, "expected NVLinkError condition to be True")
+
+	expectedMessage := "check_nvlink_status: NVLink errors detected. FaultCode: NHC2010"
+	require.Contains(s.T, nvlinkCondition.Message, expectedMessage, "expected NVLinkError message to indicate NVLink failures")
+}
+
 func ValidateRunc12Properties(ctx context.Context, s *Scenario, versions []string) {
 	s.T.Helper()
 	require.Lenf(s.T, versions, 1, "Expected exactly one version for moby-runc but got %d", len(versions))


### PR DESCRIPTION
- Add ValidateNPDNVLinkCondition to check baseline NVLink status
- Add ValidateNPDNVLinkAfterFailure to simulate NVLink errors by injecting NVRM logs
- Integrate NVLink tests into existing GPU NPD test scenario
- Tests check for NVLinkError node condition and proper error detection
- Uses realistic NVIDIA driver error messages for simulation

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
