### PR TITLE
chore: fix auto windows comment when cpu-arch is in components.json

### DIFF
--- a/.github/workflows/check-windows-packages-change.yml
+++ b/.github/workflows/check-windows-packages-change.yml
@@ -50,7 +50,7 @@ jobs:
             Write-Output "" >> $diffFile
             Write-Output "The following dif file shows any additions or deletions from what will be cached on windows VHDs organised by VHD type." >> $diffFile
             Write-Output "* Additions are new things cached." >> $diffFile
-            Write-Output "* deletions are things no longer cached." >> $diffFile
+            Write-Output "* Deletions are things no longer cached." >> $diffFile
             Write-Output "" >> $diffFile
             Write-Output "" >> $diffFile
             Write-Output '```diff' >> $diffFile

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -83,7 +83,7 @@
       "windowsVersions": []
     },
     {
-      "downloadURL": "mcr.microsoft.com/windows/servercore/iis:*-${CPU_ARCH}",
+      "downloadURL": "mcr.microsoft.com/windows/servercore/iis:*",
       "amd64OnlyVersions": [],
       "multiArchVersionsV2": [],
       "windowsVersions": [

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -83,7 +83,7 @@
       "windowsVersions": []
     },
     {
-      "downloadURL": "mcr.microsoft.com/windows/servercore/iis:*",
+      "downloadURL": "mcr.microsoft.com/windows/servercore/iis:*-${CPU_ARCH}",
       "amd64OnlyVersions": [],
       "multiArchVersionsV2": [],
       "windowsVersions": [

--- a/vhdbuilder/packer/windows/components_json_helpers.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.ps1
@@ -5,6 +5,8 @@ function SafeReplaceString {
         $stringToReplace
     )
 
+    # this is a security guard - ensure that only allow-listed variables can be replaced by removing all others.
+    # We run in a sub-shell so clearing all other variables doesn't impact the shell running this code.
     $stringToReplace = &{
         Clear-Variable -Name * -Exclude version,CPU_ARCH,stringToReplace -ErrorAction SilentlyContinue
         $executionContext.InvokeCommand.ExpandString($stringToReplace)

--- a/vhdbuilder/scripts/windows/generate_cached_stuff_list.ps1
+++ b/vhdbuilder/scripts/windows/generate_cached_stuff_list.ps1
@@ -49,6 +49,8 @@ if (![string]::IsNullOrEmpty($componentsJsonFileParam))
 
 . "$HelpersFile"
 
+$CPU_ARCH="cpu-arch"
+
 $componentsJson = Get-Content $ComponentsJsonFile | Out-String | ConvertFrom-Json
 $windowsSettingsJson = Get-Content $WindowsSettingsFile | Out-String | ConvertFrom-Json
 $BaseVersions = GetWindowsBaseVersions $windowsSettingsJson


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What this PR does / why we need it**:

Fixes auto-windows comment on PR to contain cpu arch.

<img width="1074" height="619" alt="image" src="https://github.com/user-attachments/assets/42522a02-87d1-4db4-ad50-60d179465771" />


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
