### PR TITLE
Refactor mirror proxy version to use components.json

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1625,6 +1625,34 @@
           }
         }
       }
+    },
+    {
+      "name": "acr-mirror",
+      "downloadLocation": "/tmp",
+      "downloadURIs": {
+        "ubuntu": {
+          "default": {
+            "versionsV2": [
+              {
+                "renovateTag": "<DO_NOT_UPDATE>",
+                "latestVersion": "0.2.13"
+              }
+            ],
+            "downloadURL": "https://acrstreamingpackage.blob.core.windows.net/bin/${version}/acr-mirror-${ubuntu_release}.deb"
+          }
+        },
+        "azurelinux": {
+          "current": {
+            "versionsV2": [
+              {
+                "renovateTag": "<DO_NOT_UPDATE>",
+                "latestVersion": "0.2.13"
+              }
+            ],
+            "downloadURL": "https://acrstreamingpackage.blob.core.windows.net/bin/${version}/acr-mirror-mariner.rpm"
+          }
+        }
+      }
     }
   ]
 }

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -434,7 +434,26 @@ installAndConfigureArtifactStreaming() {
   # arguments: package name, package extension
   PACKAGE_NAME=$1
   PACKAGE_EXTENSION=$2
-  MIRROR_PROXY_VERSION='0.2.12'
+  
+  # Extract acr-mirror version from components.json
+  MIRROR_PROXY_VERSION=""
+  acr_mirror_package=$(jq '.Packages[] | select(.name == "acr-mirror")' $COMPONENTS_FILEPATH)
+  if [ -n "$acr_mirror_package" ]; then
+    if [ "$OS" = "$UBUNTU_OS_NAME" ]; then
+      MIRROR_PROXY_VERSION=$(echo "$acr_mirror_package" | jq -r '.downloadURIs.ubuntu.default.versionsV2[0].latestVersion')
+    elif isMarinerOrAzureLinux "$OS"; then
+      MIRROR_PROXY_VERSION=$(echo "$acr_mirror_package" | jq -r '.downloadURIs.azurelinux.current.versionsV2[0].latestVersion')
+    fi
+  fi
+  
+  # Fallback to hardcoded version if not found in components.json
+  if [ -z "$MIRROR_PROXY_VERSION" ] || [ "$MIRROR_PROXY_VERSION" = "null" ]; then
+    echo "Warning: Could not find acr-mirror version in components.json, using fallback version"
+    MIRROR_PROXY_VERSION='0.2.13'
+  fi
+  
+  echo "Using acr-mirror version: $MIRROR_PROXY_VERSION"
+  
   MIRROR_DOWNLOAD_PATH="./$1.$2"
   MIRROR_PROXY_URL="https://acrstreamingpackage.blob.core.windows.net/bin/${MIRROR_PROXY_VERSION}/${PACKAGE_NAME}.${PACKAGE_EXTENSION}"
   retrycmd_curl_file 10 5 60 $MIRROR_DOWNLOAD_PATH $MIRROR_PROXY_URL || exit ${ERR_ARTIFACT_STREAMING_DOWNLOAD}


### PR DESCRIPTION
- Add acr-mirror component to components.json with version 0.2.13
- Update installAndConfigureArtifactStreaming function to read version from components.json
- Support both Ubuntu (deb) and AzureLinux/Mariner (rpm) packages
- Add fallback to hardcoded version if components.json lookup fails
- Centralizes version management for easier maintenance and updates

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
