### PR TITLE
remove kubectl and kubelet 1.32 and 1.33

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1328,18 +1328,6 @@
           "r2404": {
             "versionsV2": [
               {
-                "k8sVersion": "1.32",
-                "renovateTag": "name=kubelet, os=ubuntu, release=24.04",
-                "latestVersion": "1.32.7-ubuntu24.04u1",
-                "previousLatestVersion": "1.32.6-ubuntu24.04u1"
-              },
-              {
-                "k8sVersion": "1.33",
-                "renovateTag": "name=kubelet, os=ubuntu, release=24.04",
-                "latestVersion": "1.33.3-ubuntu24.04u1",
-                "previousLatestVersion": "1.33.2-ubuntu24.04u1"
-              },
-              {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=kubelet, os=ubuntu, release=24.04",
                 "latestVersion": "1.34.0-ubuntu24.04u1"
@@ -1349,18 +1337,6 @@
           "r2204": {
             "versionsV2": [
               {
-                "k8sVersion": "1.32",
-                "renovateTag": "name=kubelet, os=ubuntu, release=22.04",
-                "latestVersion": "1.32.8-ubuntu22.04u1",
-                "previousLatestVersion": "1.32.7-ubuntu22.04u1"
-              },
-              {
-                "k8sVersion": "1.33",
-                "renovateTag": "name=kubelet, os=ubuntu, release=22.04",
-                "latestVersion": "1.33.4-ubuntu22.04u1",
-                "previousLatestVersion": "1.33.3-ubuntu22.04u1"
-              },
-              {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=kubelet, os=ubuntu, release=22.04",
                 "latestVersion": "1.34.0-ubuntu22.04u1"
@@ -1369,18 +1345,6 @@
           },
           "r2004": {
             "versionsV2": [
-              {
-                "k8sVersion": "1.32",
-                "renovateTag": "name=kubelet, os=ubuntu, release=20.04",
-                "latestVersion": "1.32.8-ubuntu20.04u1",
-                "previousLatestVersion": "1.32.7-ubuntu20.04u1"
-              },
-              {
-                "k8sVersion": "1.33",
-                "renovateTag": "name=kubelet, os=ubuntu, release=20.04",
-                "latestVersion": "1.33.4-ubuntu20.04u1",
-                "previousLatestVersion": "1.33.3-ubuntu20.04u1"
-              },
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=kubelet, os=ubuntu, release=20.04",
@@ -1392,18 +1356,6 @@
         "azurelinux": {
           "v3.0": {
             "versionsV2": [
-              {
-                "k8sVersion": "1.32",
-                "renovateTag": "name=kubelet, os=azurelinux, release=3.0",
-                "latestVersion": "1.32.7-1.azl3",
-                "previousLatestVersion": "1.32.6-1.azl3"
-              },
-              {
-                "k8sVersion": "1.33",
-                "renovateTag": "name=kubelet, os=azurelinux, release=3.0",
-                "latestVersion": "1.33.3-1.azl3",
-                "previousLatestVersion": "1.33.2-1.azl3"
-              },
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=kubelet, os=azurelinux, release=3.0",
@@ -1423,18 +1375,6 @@
           "r2404": {
             "versionsV2": [
               {
-                "k8sVersion": "1.32",
-                "renovateTag": "name=kubectl, os=ubuntu, release=24.04",
-                "latestVersion": "1.32.7-ubuntu24.04u2",
-                "previousLatestVersion": "1.32.6-ubuntu24.04u2"
-              },
-              {
-                "k8sVersion": "1.33",
-                "renovateTag": "name=kubectl, os=ubuntu, release=24.04",
-                "latestVersion": "1.33.3-ubuntu24.04u2",
-                "previousLatestVersion": "1.33.2-ubuntu24.04u2"
-              },
-              {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=kubectl, os=ubuntu, release=24.04",
                 "latestVersion": "1.34.0-ubuntu24.04u1"
@@ -1444,18 +1384,6 @@
           "r2204": {
             "versionsV2": [
               {
-                "k8sVersion": "1.32",
-                "renovateTag": "name=kubectl, os=ubuntu, release=22.04",
-                "latestVersion": "1.32.8-ubuntu22.04u1",
-                "previousLatestVersion": "1.32.7-ubuntu22.04u2"
-              },
-              {
-                "k8sVersion": "1.33",
-                "renovateTag": "name=kubectl, os=ubuntu, release=22.04",
-                "latestVersion": "1.33.4-ubuntu22.04u1",
-                "previousLatestVersion": "1.33.3-ubuntu22.04u2"
-              },
-              {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=kubectl, os=ubuntu, release=22.04",
                 "latestVersion": "1.34.0-ubuntu22.04u1"
@@ -1464,18 +1392,6 @@
           },
           "r2004": {
             "versionsV2": [
-              {
-                "k8sVersion": "1.32",
-                "renovateTag": "name=kubectl, os=ubuntu, release=20.04",
-                "latestVersion": "1.32.8-ubuntu20.04u1",
-                "previousLatestVersion": "1.32.7-ubuntu20.04u2"
-              },
-              {
-                "k8sVersion": "1.33",
-                "renovateTag": "name=kubectl, os=ubuntu, release=20.04",
-                "latestVersion": "1.33.4-ubuntu20.04u1",
-                "previousLatestVersion": "1.33.3-ubuntu20.04u2"
-              },
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=kubectl, os=ubuntu, release=20.04",
@@ -1487,18 +1403,6 @@
         "azurelinux": {
           "v3.0": {
             "versionsV2": [
-              {
-                "k8sVersion": "1.32",
-                "renovateTag": "name=kubectl, os=azurelinux, release=3.0",
-                "latestVersion": "1.32.7-1.azl3",
-                "previousLatestVersion": "1.32.6-1.azl3"
-              },
-              {
-                "k8sVersion": "1.33",
-                "renovateTag": "name=kubectl, os=azurelinux, release=3.0",
-                "latestVersion": "1.33.3-1.azl3",
-                "previousLatestVersion": "1.33.2-1.azl3"
-              },
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=kubectl, os=azurelinux, release=3.0",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
Remove kubectl and kubelet 1.32 and 1.33 as they are duplicate in Kubernetes-binaries

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
