### PR TITLE
fix: pin Ubuntu 22.04 kernel to 5.15.0-1092 due to regression

### DIFF
--- a/vhdbuilder/packer/pre-install-dependencies.sh
+++ b/vhdbuilder/packer/pre-install-dependencies.sh
@@ -136,8 +136,8 @@ capture_benchmark "${SCRIPT_NAME}_enable_cgroupv2_for_azurelinux"
 if [[ ${UBUNTU_RELEASE//./} -ge 2204 && "${ENABLE_FIPS,,}" != "true" ]] && ! grep -q "cvm" <<< "$FEATURE_FLAGS"; then
   
   # Choose kernel packages based on Ubuntu version and architecture
-  if [[ ${UBUNTU_RELEASE//./} -eq 2204 && "${CPU_ARCH}" == "amd64" ]]; then
-    # Pin to specific kernel version for Ubuntu 22.04 x86_64 due to regression issues
+  if [[ ${UBUNTU_RELEASE//./} -eq 2204 ]]; then
+    # Pin to specific kernel version for Ubuntu 22.04 due to regression issues
     # Canonical confirmed regression in latest kernel packages as of 09.04.2025
     KERNEL_IMAGE="linux-image-5.15.0-1092-azure"
     KERNEL_PACKAGES=(

--- a/vhdbuilder/packer/pre-install-dependencies.sh
+++ b/vhdbuilder/packer/pre-install-dependencies.sh
@@ -135,9 +135,9 @@ capture_benchmark "${SCRIPT_NAME}_enable_cgroupv2_for_azurelinux"
 # shellcheck disable=SC3010
 if [[ ${UBUNTU_RELEASE//./} -ge 2204 && "${ENABLE_FIPS,,}" != "true" ]] && ! grep -q "cvm" <<< "$FEATURE_FLAGS"; then
   
-  # Choose kernel packages based on Ubuntu version
-  if [[ ${UBUNTU_RELEASE//./} -eq 2204 ]]; then
-    # Pin to specific kernel version for Ubuntu 22.04 due to regression issues
+  # Choose kernel packages based on Ubuntu version and architecture
+  if [[ ${UBUNTU_RELEASE//./} -eq 2204 && "${CPU_ARCH}" != "arm64" ]]; then
+    # Pin to specific kernel version for Ubuntu 22.04 x86_64 due to regression issues
     # Canonical confirmed regression in latest kernel packages as of 09.04.2025
     KERNEL_IMAGE="linux-image-5.15.0-1092-azure"
     KERNEL_PACKAGES=(
@@ -148,7 +148,7 @@ if [[ ${UBUNTU_RELEASE//./} -ge 2204 && "${ENABLE_FIPS,,}" != "true" ]] && ! gre
       "linux-tools-5.15.0-1092-azure"
       "linux-cloud-tools-5.15.0-1092-azure"
     )
-    echo "Ubuntu 22.04 detected, installing pinned kernel version 5.15.0-1092"
+    echo "Ubuntu 22.04 x86_64 detected, installing pinned kernel version 5.15.0-1092"
   else
     # Use LTS kernel for other versions  
     KERNEL_IMAGE="linux-image-azure-lts-${UBUNTU_RELEASE}"

--- a/vhdbuilder/packer/pre-install-dependencies.sh
+++ b/vhdbuilder/packer/pre-install-dependencies.sh
@@ -136,7 +136,7 @@ capture_benchmark "${SCRIPT_NAME}_enable_cgroupv2_for_azurelinux"
 if [[ ${UBUNTU_RELEASE//./} -ge 2204 && "${ENABLE_FIPS,,}" != "true" ]] && ! grep -q "cvm" <<< "$FEATURE_FLAGS"; then
   
   # Choose kernel packages based on Ubuntu version and architecture
-  if [[ ${UBUNTU_RELEASE//./} -eq 2204 && "${CPU_ARCH}" != "arm64" ]]; then
+  if [[ ${UBUNTU_RELEASE//./} -eq 2204 && "${CPU_ARCH}" == "amd64" ]]; then
     # Pin to specific kernel version for Ubuntu 22.04 x86_64 due to regression issues
     # Canonical confirmed regression in latest kernel packages as of 09.04.2025
     KERNEL_IMAGE="linux-image-5.15.0-1092-azure"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Canonical confirmed that there is regression in the latest kernel packages for Ubuntu 22.04. This PR implements a simplified approach to pin Ubuntu 22.04 to kernel version 5.15.0-1092 until the issues are resolved.

**Implementation approach:**
1. **Package Selection Phase**: Choose appropriate kernel packages based on Ubuntu version
2. **Installation Phase**: Same purge/install logic for all cases

**Which issue(s) this PR fixes**:
Related to kernel regression issues in Ubuntu 22.04

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation  
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:
This is a simplified alternative to PR #6938 that achieves the same functionality with significantly less code duplication.

**Release note**:
```
Pin Ubuntu 22.04 kernel to version 5.15.0-1092 due to regression in latest kernel packages
```