### PR TITLE
Enable jumbo frame for mana driver

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -215,15 +215,8 @@ EOF
 cat > /etc/udev/rules.d/99-microsoft-mana-mtu.rules <<EOF
 # Udev rule to set MTU to 9000 for Microsoft MANA Ethernet controllers
 # This rule triggers when a network interface is added and checks for Microsoft Ethernet controller with MANA driver
-
-# Rule for network interfaces using Microsoft MANA driver
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mana", ATTR{mtu}="9000"
-
-# Alternative rule that checks for Microsoft vendor ID and device ID 00ba specifically
-SUBSYSTEM=="net", ACTION=="add", ATTRS{vendor}=="0x1414", ATTRS{device}=="0x00ba", ATTR{mtu}="9000"
-
-# Comprehensive rule with inline detection logic: https://learn.microsoft.com/en-us/azure/virtual-network/accelerated-networking-mana-linux
-SUBSYSTEM=="net", ACTION=="add", PROGRAM="/bin/sh -c 'if lspci | grep -q \"Ethernet controller: Microsoft Corporation\" && (grep -q \"/mana.*\\.ko\" /lib/modules/$(uname -r)/modules.builtin 2>/dev/null || find /lib/modules/$(uname -r)/kernel -name \"mana*.ko*\" 2>/dev/null | grep -q mana); then echo 9000 > /sys/class/net/%k/mtu 2>/dev/null; fi'"
+# https://learn.microsoft.com/en-us/azure/virtual-network/accelerated-networking-mana-linux
+SUBSYSTEM=="net", ACTION=="add", PROGRAM="/bin/sh -c 'if [[ -n \`lspci -d 1414:00ba:0200\` ]]; then echo 9000 > /sys/class/net/%k/mtu 2>/dev/null; fi'"
 EOF
 
 udevadm control --reload

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -211,6 +211,21 @@ ENV{DEVTYPE}=="partition", ENV{AZURE_DISK_TYPE}=="?*", ENV{AZURE_DISK_NAME}=="?*
 ENV{DEVTYPE}=="partition", ENV{AZURE_DISK_TYPE}=="?*", ENV{AZURE_DISK_SERIAL}=="?*", SYMLINK+="disk/azure/\$env{AZURE_DISK_TYPE}/by-serial/\$env{AZURE_DISK_SERIAL}-part%n"
 LABEL="azure_disk_end"
 EOF
+
+cat > /etc/udev/rules.d/99-microsoft-mana-mtu.rules <<EOF
+# Udev rule to set MTU to 9000 for Microsoft MANA Ethernet controllers
+# This rule triggers when a network interface is added and checks for Microsoft Ethernet controller with MANA driver
+
+# Rule for network interfaces using Microsoft MANA driver
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mana", ATTR{mtu}="9000"
+
+# Alternative rule that checks for Microsoft vendor ID and device ID 00ba specifically
+SUBSYSTEM=="net", ACTION=="add", ATTRS{vendor}=="0x1414", ATTRS{device}=="0x00ba", ATTR{mtu}="9000"
+
+# Comprehensive rule with inline detection logic: https://learn.microsoft.com/en-us/azure/virtual-network/accelerated-networking-mana-linux
+SUBSYSTEM=="net", ACTION=="add", PROGRAM="/bin/sh -c 'if lspci | grep -q \"Ethernet controller: Microsoft Corporation\" && (grep -q \"/mana.*\\.ko\" /lib/modules/$(uname -r)/modules.builtin 2>/dev/null || find /lib/modules/$(uname -r)/kernel -name \"mana*.ko*\" 2>/dev/null | grep -q mana); then echo 9000 > /sys/class/net/%k/mtu 2>/dev/null; fi'"
+EOF
+
 udevadm control --reload
 capture_benchmark "${SCRIPT_NAME}_set_udev_rules"
 
@@ -234,7 +249,7 @@ if isMarinerOrAzureLinux "$OS" && ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; the
 fi
 capture_benchmark "${SCRIPT_NAME}_handle_azurelinux_configs"
 
-# doing this at vhd allows CSE to be faster with just mv 
+# doing this at vhd allows CSE to be faster with just mv
 unpackTgzToCNIDownloadsDIR() {
   local URL=$1
   CNI_TGZ_TMP=${URL##*/}
@@ -266,7 +281,7 @@ downloadAndInstallCriTools() {
     echo "  - crictl version ${version}" >> ${VHD_LOGS_FILEPATH}
     # other steps are dependent on CRICTL_VERSION and CRICTL_VERSIONS
     # since we only have 1 entry in CRICTL_VERSIONS, we simply set both to the same value
-    CRICTL_VERSION=${version} 
+    CRICTL_VERSION=${version}
     KUBERNETES_VERSION=$CRICTL_VERSION installCrictl || exit $ERR_CRICTL_DOWNLOAD_TIMEOUT
     return 0
   fi
@@ -297,12 +312,12 @@ while IFS= read -r p; do
   # TODO(mheberling): Remove this once kata uses standard containerd. This OS is referenced
   # in file `parts/common/component.json` with the same ${MARINER_KATA_OS_NAME}.
   if isMariner "${OS}" && [ "${IS_KATA}" = "true" ]; then
-    # This is temporary for kata-cc because it uses a modified version of containerd and 
+    # This is temporary for kata-cc because it uses a modified version of containerd and
     # name is referenced in parts/common.json marinerkata.
     os=${MARINER_KATA_OS_NAME}
   fi
   if isAzureLinux "${OS}" && [ "${IS_KATA}" = "true" ]; then
-    # This is temporary for kata-cc because it uses a modified version of containerd and 
+    # This is temporary for kata-cc because it uses a modified version of containerd and
     # name is referenced in parts/common.json azurelinuxkata.
     os=${AZURELINUX_KATA_OS_NAME}
   fi
@@ -563,7 +578,7 @@ while IFS= read -r imageToBePulled; do
     image_pids+=($!)
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
     while [ "$(jobs -p | wc -l)" -ge "$parallel_container_image_pull_limit" ]; do
-      wait -n || { 
+      wait -n || {
         ret=$?
         echo "A background job pullContainerImage failed: ${ret}, ${CONTAINER_IMAGE}. Exiting..." >&2
         for pid in "${image_pids[@]}"; do


### PR DESCRIPTION
This pull request adds a new udev rule to automatically set the MTU to 9000 for Microsoft MANA Ethernet controllers on Linux systems. This helps ensure optimal network performance for accelerated networking in Azure environments.

Networking improvements:

* Added `/etc/udev/rules.d/99-microsoft-mana-mtu.rules` to set MTU to 9000 for network interfaces using the Microsoft MANA driver, leveraging a udev rule that triggers on interface addition.**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
