### PR TITLE
chore: fix release branch indication in pipeline script

### DIFF
--- a/.pipelines/scripts/windows_build_vhd.sh
+++ b/.pipelines/scripts/windows_build_vhd.sh
@@ -39,7 +39,7 @@ if [ -z "${IS_RELEASE_PIPELINE:-}" ]; then
     export IS_RELEASE_PIPELINE="True"
     echo "##vso[task.setvariable variable=IS_RELEASE_PIPELINE]True"
   else
-    echo "The branch ${BRANCH} is not a release branch. Setting IS_RELEASE_PIPELINE to True."
+    echo "The branch ${BRANCH} is not a release branch. Setting IS_RELEASE_PIPELINE to False."
     export IS_RELEASE_PIPELINE="False"
     echo "##vso[task.setvariable variable=IS_RELEASE_PIPELINE]False"
   fi


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
The pipeline output erroneously indicates `IS_RELEASE_PIPELINE` is being set to true for non-release branches, which is misleading:

<img width="504" height="51" alt="image" src="https://github.com/user-attachments/assets/9e14de30-8a73-4018-a14e-5e9d04e39e9c" />
 
**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [X] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
