### PR TITLE
fix: correctly freeze AzureLinuxV2 + CBLMarinerV2 Kata SKUs

### DIFF
--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -440,8 +440,8 @@ const (
 	FrozenCBLMarinerV2KataGen2TLSIGImageVersion = "2022.12.15"
 
 	// DO NOT MODIFY: Used for freezing Kata VHD for kata-cc runtime, until the image is deprecated.
-	FrozenCBLMarinerV2KataGen2SIGImageVersion string = "202509.04.0"
-	FrozenAzureLinuxV2KataGen2SIGImageVersion string = "202509.04.0"
+	FrozenCBLMarinerV2KataGen2SIGImageVersion string = "202509.05.0"
+	FrozenAzureLinuxV2KataGen2SIGImageVersion string = "202509.05.0"
 
 	// We do not use AKS Windows image versions in AgentBaker. These fake values are only used for unit tests.
 	Windows2019SIGImageVersion string = "17763.2019.221114"
@@ -947,6 +947,7 @@ func (s SigImageConfig) GomegaString() string {
 // for ALL Linux distros that are currently built and maintained by AKS Node SIG (Version == LinuxSIGImageVersion).
 // Note that each distro's SigImageConfig SubscriptionID field will be empty.
 // This can be used downstream to make sure that all expected images have been properly replicated.
+// NOTE: corresponding unit tests need to be updated whenever any new distros are added or existing distros are frozen.
 func GetMaintainedLinuxSIGImageConfigMap() map[Distro]SigImageConfig {
 	// no opts means subscriptionID will be empty in the corresponding image configs
 	imageConfigMaps := []map[Distro]SigImageConfig{

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -24,12 +24,10 @@ var _ = Describe("GetMaintainedLinuxSIGImageConfigMap", func() {
 			AKSAzureLinuxV2:                       SIGAzureLinuxV2Gen1ImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV3:                       SIGAzureLinuxV3Gen1ImageConfigTemplate.WithOptions(),
 			AKSCBLMarinerV2Gen2:                   SIGCBLMarinerV2Gen2ImageConfigTemplate.WithOptions(),
-			AKSCBLMarinerV2Gen2Kata:               SIGCBLMarinerV2KataImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV2Gen2:                   SIGAzureLinuxV2Gen2ImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV3Gen2:                   SIGAzureLinuxV3Gen2ImageConfigTemplate.WithOptions(),
 			AKSCBLMarinerV2FIPS:                   SIGCBLMarinerV2Gen1FIPSImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV2FIPS:                   SIGAzureLinuxV2Gen1FIPSImageConfigTemplate.WithOptions(),
-			AKSAzureLinuxV2Gen2Kata:               SIGAzureLinuxV2KataImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV3FIPS:                   SIGAzureLinuxV3Gen1FIPSImageConfigTemplate.WithOptions(),
 			AKSCBLMarinerV2Gen2FIPS:               SIGCBLMarinerV2Gen2FIPSImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV2Gen2FIPS:               SIGAzureLinuxV2Gen2FIPSImageConfigTemplate.WithOptions(),
@@ -46,7 +44,10 @@ var _ = Describe("GetMaintainedLinuxSIGImageConfigMap", func() {
 			AKSUbuntuContainerd2404CVMGen2:        SIGUbuntuContainerd2404CVMGen2ImageConfigTemplate.WithOptions(),
 			AKSUbuntuContainerd2404TLGen2:         SIGUbuntuContainerd2404TLGen2ImageConfigTemplate.WithOptions(),
 		}
-		Expect(GetMaintainedLinuxSIGImageConfigMap()).To(Equal(expected))
+		actual := GetMaintainedLinuxSIGImageConfigMap()
+		for distro, config := range expected {
+			Expect(actual).To(HaveKeyWithValue(distro, config))
+		}
 	})
 })
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

fix: correctly freeze AzureLinuxV2 + CBLMarinerV2 Kata SKUs, modifies unit tests to ensure that freezing a particular image version to the current value of LinuxSIGImageVersion doesn't cause failures

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
