### PR TITLE
chore: Add LTS 1.29.100, 1.30.100 into cache, remove 1.27.103 from cache

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -717,13 +717,18 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/kubernetes/kube-proxy",
-          "latestVersion": "v1.27.103-akslts",
-          "previousLatestVersion": "v1.27.102-akslts"
+          "latestVersion": "v1.28.102-akslts",
+          "previousLatestVersion": "v1.28.101-akslts"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/kubernetes/kube-proxy",
-          "latestVersion": "v1.28.102-akslts",
-          "previousLatestVersion": "v1.28.101-akslts"
+          "latestVersion": "v1.29.100-akslts",
+          "previousLatestVersion": "v1.29.100-akslts"
+        },
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=oss/kubernetes/kube-proxy",
+          "latestVersion": "v1.30.100-akslts",
+          "previousLatestVersion": "v1.30.100-akslts"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/kubernetes/kube-proxy",
@@ -1336,16 +1341,22 @@
           "current": {
             "versionsV2": [
               {
-                "k8sVersion": "1.27",
-                "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/binaries/kubernetes/kubernetes-node",
-                "latestVersion": "v1.27.103-akslts",
-                "previousLatestVersion": "v1.27.102-akslts"
-              },
-              {
                 "k8sVersion": "1.28",
                 "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/binaries/kubernetes/kubernetes-node",
                 "latestVersion": "v1.28.102-akslts",
                 "previousLatestVersion": "v1.28.101-akslts"
+              },
+              {
+                "k8sVersion": "1.29",
+                "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/binaries/kubernetes/kubernetes-node",
+                "latestVersion": "v1.29.100-akslts",
+                "previousLatestVersion": "v1.29.100-akslts"
+              },
+              {
+                "k8sVersion": "1.30",
+                "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/binaries/kubernetes/kubernetes-node",
+                "latestVersion": "v1.30.100-akslts",
+                "previousLatestVersion": "v1.30.100-akslts"
               },
               {
                 "k8sVersion": "1.29",


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Cache 1.29.100, 1.30.100 LTS versions, and  remove 1.27.103 since it was deprecated.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
