### PR TITLE
feat: install FDE LTS kernel and handle nullboot for CVM builds

### DIFF
--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -611,8 +611,8 @@ testLtsKernel() {
   enable_fips=$3
 
   # shellcheck disable=SC3010
-  if [[ "$os_sku" == "Ubuntu" && ${enable_fips,,} != "true" ]] && ! grep -q "cvm" <<< "$FEATURE_FLAGS" ; then
-    echo "OS is Ubuntu, FIPS is not enabled, and this is not a CVM; check LTS kernel version"
+  if [[ "$os_sku" == "Ubuntu" && ${enable_fips,,} != "true" ]] ; then
+    echo "OS is Ubuntu, FIPS is not enabled, check LTS kernel version"
     # Check the Ubuntu version and set the expected kernel version
     if [ "$os_version" = "22.04" ]; then
       expected_kernel="5.15"


### PR DESCRIPTION
Install FDE LTS kernel and handle nullboot for CVM builds

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds support for installing Full Disk Encryption (FDE) LTS kernel packages specifically for CVM (Confidential VM) builds, while maintaining the existing kernel selection logic for other builds.

**Changes made:**
- For CVM builds, install `linux-image-azure-fde-lts-${UBUNTU_RELEASE}` instead of regular LTS kernel
- Add nullboot package purge/reinstall sequence for CVM builds to prevent boot errors
- Update conditional logic to handle CVM-specific kernel requirements
- Use LTS kernel packages for CVM (more stable for production AKS nodes vs latest kernel)
- Update test to reflect the modified conditional logic

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
