### PR TITLE
Change katacc frozen version to 20250820.1

### DIFF
--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -440,8 +440,8 @@ const (
 	FrozenCBLMarinerV2KataGen2TLSIGImageVersion = "2022.12.15"
 
 	// DO NOT MODIFY: Used for freezing Kata VHD for kata-cc runtime, until the image is deprecated.
-	FrozenCBLMarinerV2KataGen2SIGImageVersion string = "202509.05.0"
-	FrozenAzureLinuxV2KataGen2SIGImageVersion string = "202509.05.0"
+	FrozenCBLMarinerV2KataGen2SIGImageVersion string = "202508.20.1"
+	FrozenAzureLinuxV2KataGen2SIGImageVersion string = "202508.20.1"
 
 	// We do not use AKS Windows image versions in AgentBaker. These fake values are only used for unit tests.
 	Windows2019SIGImageVersion string = "17763.2019.221114"


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Freezing the katacc version to the current publicly available: "202508.20.1"

This is the latest recorded version to be fully working, and the currently frozen version 0905 has been unable to be tested, as well as was not released fully to all regions. This PR ensures that we maintain the current working version to avoid any customer issue.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [X] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
