### PR TITLE
update coredns images to be cached

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -121,15 +121,11 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/coredns",
-          "latestVersion": "v1.11.3-8"
+          "latestVersion": "v1.11.3-11"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/coredns",
-          "latestVersion": "v1.12.1-2"
-        },
-        {
-          "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/coredns",
-          "latestVersion": "v1.9.4-6"
+          "latestVersion": "v1.12.4-2"
         }
       ],
       "windowsVersions": []

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -126,6 +126,10 @@
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/coredns",
           "latestVersion": "v1.12.4-2"
+        },
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/coredns",
+          "latestVersion": "v1.9.4-6"
         }
       ],
       "windowsVersions": []


### PR DESCRIPTION
**What type of PR is this?**
This PR updates coredns images (v1.11.3-11 and v1.12.4-2) that needs to be cached in the VHD. These versions have all current CVEs fixed. 

trivy image --ignore-unfixed --detection-priority comprehensive mcr.microsoft.com/oss/v2/kubernetes/coredns:v1.12.4-2

<img width="1150" height="311" alt="image" src="https://github.com/user-attachments/assets/bf252517-9b7c-46fd-a6be-1ffa3d06f567" />


trivy image --ignore-unfixed --detection-priority comprehensive mcr.microsoft.com/oss/v2/kubernetes/coredns:v1.11.3-11

<img width="1152" height="264" alt="image" src="https://github.com/user-attachments/assets/ff5aff8d-2057-417c-bdd9-770439364200" />



<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
