### PR TITLE
Fail fast to unblock aks-node-controller provision-wait from waiting until timeout

### DIFF
--- a/aks-node-controller/app.go
+++ b/aks-node-controller/app.go
@@ -138,11 +138,11 @@ func (a *App) writeCompleteFileOnError(err error) {
 	if _, statErr := os.Stat(provisionCompleteFilePath); statErr == nil {
 		return // already exists
 	} else if !errors.Is(statErr, os.ErrNotExist) { // unexpected error
-		slog.Error("failed to stat provision.complete file", "error", statErr)
+		slog.Error("failed to stat provision.complete file", "path", provisionCompleteFilePath, "error", statErr)
 		return
 	}
 	if writeErr := os.WriteFile(provisionCompleteFilePath, []byte{}, 0600); writeErr != nil {
-		slog.Error("failed to write provision.complete file", "error", writeErr)
+		slog.Error("failed to write provision.complete file", "path", provisionCompleteFilePath, "error", writeErr)
 	}
 }
 

--- a/aks-node-controller/app.go
+++ b/aks-node-controller/app.go
@@ -64,11 +64,11 @@ func (a *App) run(ctx context.Context, args []string) error {
 		return err
 	case "provision-wait":
 		provisionStatusFiles := ProvisionStatusFiles{ProvisionJSONFile: provisionJSONFilePath, ProvisionCompleteFile: provisionCompleteFilePath}
-		provisionOutput, waitErr := a.ProvisionWait(ctx, provisionStatusFiles)
+		provisionOutput, err := a.ProvisionWait(ctx, provisionStatusFiles)
 		//nolint:forbidigo // stdout is part of the interface
 		fmt.Println(provisionOutput)
 		slog.Info("provision-wait finished", "provisionOutput", provisionOutput)
-		return waitErr
+		return err
 	default:
 		return fmt.Errorf("unknown command: %s", args[1])
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Fail fast to unblock aks-node-controller provision-wait from waiting until timeout.
Now if the aksnodeconfig is invalid, it will fail immediately.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
