### PR TITLE
remove Renovate schedule as it's not needed now

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,13 +15,6 @@
     "renovate"
   ],
   "rebaseWhen": "automerging",
-  "schedule": [
-    "after 10pm every weekday",
-    "every weekend",
-    "before 5am every weekday"
-  ],
-  "updateNotScheduled": false,
-  "timezone": "America/Los_Angeles",
   "logLevelRemap": [
     {
       "matchMessage": "/^Custom manager fetcher/",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We found that people like Renovate to detect the version update asap.

Remove Renovate schedule for creating PR as it's not needed now. We needed it before because every PR needed rebase from master and it would trigger huge number of tests at the same time. We don't require rebase now so it should be fine to create PR even at daytime.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
