### PR TITLE
fix: Escape dots in version for JSON path queries

### DIFF
--- a/e2e/components/components.go
+++ b/e2e/components/components.go
@@ -39,6 +39,9 @@ func GetExpectedPackageVersions(packageName, distro, release string) []string {
 	jsonBytes, _ := os.ReadFile(componentsPath)
 	packages := gjson.GetBytes(jsonBytes, fmt.Sprintf("Packages.#(name=%s).downloadURIs", packageName))
 
+	// If there is a dot in the "release" then we need to escape it for the json path
+	release = strings.ReplaceAll(release, ".", "\\.")
+
 	for _, packageItem := range packages.Array() {
 		// check if versionsV2 exists
 		if packageItem.Get(fmt.Sprintf("%s.%s.versionsV2", distro, release)).Exists() {

--- a/e2e/scenario_nvidia_device_plugin_test.go
+++ b/e2e/scenario_nvidia_device_plugin_test.go
@@ -37,7 +37,6 @@ func Test_Ubuntu2404_NvidiaDevicePluginRunning(t *testing.T) {
 				require.Lenf(s.T, versions, 1, "Expected exactly one nvidia-device-plugin version for ubuntu r2404 but got %d", len(versions))
 				ValidateInstalledPackageVersion(ctx, s, "nvidia-device-plugin", versions[0])
 
-
 				// Validate that the NVIDIA device plugin systemd service is running
 				ValidateNvidiaDevicePluginServiceRunning(ctx, s)
 
@@ -110,10 +109,9 @@ func Test_AzureLinux3_NvidiaDevicePluginRunning(t *testing.T) {
 			Validator: func(ctx context.Context, s *Scenario) {
 
 				// Validate that the NVIDIA device plugin binary was installed correctly
-				versions := components.GetExpectedPackageVersions("nvidia-device-plugin", "azurelinux", "3.0")
+				versions := components.GetExpectedPackageVersions("nvidia-device-plugin", "azurelinux", "v3.0")
 				require.Lenf(s.T, versions, 1, "Expected exactly one nvidia-device-plugin version for azurelinux 3.0 but got %d", len(versions))
 				ValidateInstalledPackageVersion(ctx, s, "nvidia-device-plugin", versions[0])
-
 
 				// Validate that the NVIDIA device plugin systemd service is running
 				ValidateNvidiaDevicePluginServiceRunning(ctx, s)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When querying JSON paths with gjson, dots in the release version string (e.g., "v3.0") are interpreted as path separators rather than literal characters. This causes incorrect path resolution when looking up package versions.

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] commits are GPG signed and Github marks them as verified