### PR TITLE
Ignore mise-en-place config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ e2e/scenario-logs/
 
 # vhdbuilder generated prefetch scripts
 vhdbuilder/packer/prefetch.sh
+
+# ignore mise configs (https://mise.jdx.dev/)
+.mise
+


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

i use mise-en-place to allow multiple golang versions to exist on my mac. This allows such configuration using https://mise.jdx.dev/. Only added .gitignore .mise config directory.

**Which issue(s) this PR fixes**:
None

**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [X] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
