### PR TITLE
Add non-sec reg keys for 10B release

### DIFF
--- a/vhdbuilder/packer/windows/windows_settings.json
+++ b/vhdbuilder/packer/windows/windows_settings.json
@@ -817,6 +817,30 @@
       "Name": "502146190",
       "Value": "1",
       "Type": "DWORD"
+    },
+    {
+      "Comment": "2025-10B",
+      "WindowsSkuMatch": "2022*",
+      "Path": "HKLM:\\SYSTEM\\CurrentControlSet\\Policies\\Microsoft\\FeatureManagement\\Overrides",
+      "Name": "140377743",
+      "Value": "1",
+      "Type": "DWORD"
+    },
+    {
+      "Comment": "2025-10B",
+      "WindowsSkuMatch": "23H2*",
+      "Path": "HKLM:\\SYSTEM\\CurrentControlSet\\Policies\\Microsoft\\FeatureManagement\\Overrides",
+      "Name": "66715279",
+      "Value": "1",
+      "Type": "DWORD"
+    },
+    {
+      "Comment": "2025-10B",
+      "WindowsSkuMatch": "23H2*",
+      "Path": "HKLM:\\SYSTEM\\CurrentControlSet\\Policies\\Microsoft\\FeatureManagement\\Overrides",
+      "Name": "403177103",
+      "Value": "1",
+      "Type": "DWORD"
     }
   ]
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind configuration
/kind feature
/kind enhancement

-->

**What this PR does / why we need it**:
This PR introduces non-secure registry keys required for the 10B release. These keys are added to ensure compatibility and proper configuration for the new release without impacting existing secure settings. The changes are scoped to non-secure keys only and do not modify any security-sensitive configurations.
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
