### PR TITLE
test: Skip windows e2e for Linux testdata update

### DIFF
--- a/.pipelines/e2e-windows.yaml
+++ b/.pipelines/e2e-windows.yaml
@@ -34,7 +34,10 @@ pr:
     exclude:
       - pkg/agent/datamodel/sig_config*.go # SIG config changes
       - pkg/agent/datamodel/*.json # SIG version changes
-      - pkg/agent/testdata/AKSWindows* # Windows test data
+      - pkg/agent/testdata/*Ubuntu* # Linux test data
+      - pkg/agent/testdata/*Flatcar* # Linux test data
+      - pkg/agent/testdata/*Mariner* # Linux test data
+      - pkg/agent/testdata/*AzureLinux* # Linux test data
       - parts/common/components.json # centralized components management file
       - staging/cse/windows/README
       - /**/*.md


### PR DESCRIPTION
**What type of PR is this?**
/kind test
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
The windows e2e pipeline had an exclude on windows testdata updates which looks like it was copied from the linux e2e pipeline definition. Replace this with some linux testdata paths that can safely skip windows e2e runs.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
