### PR TITLE
chore: Remove azure-npm from Agent Baker

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -52,8 +52,7 @@
         "oss/kubernetes/kube-proxy",
         "oss/v2/kubernetes/kube-proxy",
         "oss/binaries/kubernetes/kubernetes-node",
-        "oss/binaries/kubernetes/azure-acr-credential-provider",
-        "containernetworking/azure-npm"
+        "oss/binaries/kubernetes/azure-acr-credential-provider"
       ],
       "matchUpdateTypes": [
         "minor"
@@ -288,20 +287,6 @@
         "behzad-mir",
         "jpayne3506",
         "QxBytes"
-      ]
-    },
-    {
-      "matchPackageNames": [
-        "containernetworking/azure-npm"
-      ],
-      "groupName": "azure-npm",
-      "assignees": [
-        "rayaisaiah",
-        "huntergregory"
-      ],
-      "reviewers": [
-        "rayaisaiah",
-        "huntergregory"
       ]
     },
     {

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -265,17 +265,6 @@
       "windowsVersions": []
     },
     {
-      "downloadURL": "mcr.microsoft.com/containernetworking/azure-npm:*",
-      "amd64OnlyVersions": [],
-      "multiArchVersionsV2": [
-        {
-          "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/azure-npm",
-          "latestVersion": "v1.6.29"
-        }
-      ],
-      "windowsVersions": []
-    },
-    {
       "downloadURL": "mcr.microsoft.com/containernetworking/cilium/cilium:*",
       "amd64OnlyVersions": [],
       "multiArchVersionsV2": [

--- a/vhdbuilder/packer/windows/components-test.json
+++ b/vhdbuilder/packer/windows/components-test.json
@@ -95,28 +95,6 @@
       ]
     },
     {
-      "downloadURL": "mcr.microsoft.com/containernetworking/azure-npm:*",
-      "amd64OnlyVersions": [],
-      "multiArchVersionsV2": [],
-      "windowsVersions": [
-        {
-          "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/azure-npm",
-          "latestVersion": "v1.5.5",
-          "windowsSkuMatch": "2022-containerd*"
-        },
-        {
-          "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/azure-npm",
-          "latestVersion": "v1.5.5",
-          "windowsSkuMatch": "23H2*"
-        },
-        {
-          "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/azure-npm",
-          "latestVersion": "v1.5.5",
-          "windowsSkuMatch": "2025*"
-        }
-      ]
-    },
-    {
       "downloadURL": "mcr.microsoft.com/oss/kubernetes/autoscaler/addon-resizer:*",
       "amd64OnlyVersions": [],
       "multiArchVersionsV2": [
@@ -320,17 +298,6 @@
               ]
             }
           }
-        }
-      ],
-      "windowsVersions": []
-    },
-    {
-      "downloadURL": "mcr.microsoft.com/containernetworking/azure-npm:*",
-      "amd64OnlyVersions": [],
-      "multiArchVersionsV2": [
-        {
-          "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/azure-npm",
-          "latestVersion": "v1.5.34"
         }
       ],
       "windowsVersions": []

--- a/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
@@ -1097,7 +1097,6 @@ Describe 'Tests of components-test.json ' {
         # Pause image shouldn't change too often, so let's check that is in there.
         $components | Should -Contain "mcr.microsoft.com/windows/servercore:ltsc2022"
         $components | Should -Contain "mcr.microsoft.com/windows/nanoserver:ltsc2022"
-        $components | Should -Contain "mcr.microsoft.com/containernetworking/azure-npm:v1.5.5"
     }
 
     It 'has specific WS2022-gen2 containers' {
@@ -1109,7 +1108,6 @@ Describe 'Tests of components-test.json ' {
         # Pause image shouldn't change too often, so let's check that is in there.
         $components | Should -Contain "mcr.microsoft.com/windows/servercore:ltsc2022"
         $components | Should -Contain "mcr.microsoft.com/windows/nanoserver:ltsc2022"
-        $components | Should -Contain "mcr.microsoft.com/containernetworking/azure-npm:v1.5.5"
     }
 
 
@@ -1122,7 +1120,6 @@ Describe 'Tests of components-test.json ' {
         # Pause image shouldn't change too often, so let's check that is in there.
         $components | Should -Contain "mcr.microsoft.com/windows/servercore:ltsc2022"
         $components | Should -Contain "mcr.microsoft.com/windows/nanoserver:ltsc2022"
-        $components | Should -Contain "mcr.microsoft.com/containernetworking/azure-npm:v1.5.5"
     }
 
     It 'has specific WS23H2-gen2 containers' {
@@ -1134,7 +1131,6 @@ Describe 'Tests of components-test.json ' {
         # Pause image shouldn't change too often, so let's check that is in there.
         $components | Should -Contain "mcr.microsoft.com/windows/servercore:ltsc2022"
         $components | Should -Contain "mcr.microsoft.com/windows/nanoserver:ltsc2022"
-        $components | Should -Contain "mcr.microsoft.com/containernetworking/azure-npm:v1.5.5"
     }
 
     It 'has specific WS2025 containers' {
@@ -1146,7 +1142,6 @@ Describe 'Tests of components-test.json ' {
         # Pause image shouldn't change too often, so let's check that is in there.
         $components | Should -Contain "mcr.microsoft.com/windows/servercore:ltsc2025"
         $components | Should -Contain "mcr.microsoft.com/windows/nanoserver:ltsc2025"
-        $components | Should -Contain "mcr.microsoft.com/containernetworking/azure-npm:v1.5.5"
     }
 
     It 'has specific WS2025-gen2 containers' {
@@ -1158,7 +1153,6 @@ Describe 'Tests of components-test.json ' {
         # Pause image shouldn't change too often, so let's check that is in there.
         $components | Should -Contain "mcr.microsoft.com/windows/servercore:ltsc2025"
         $components | Should -Contain "mcr.microsoft.com/windows/nanoserver:ltsc2025"
-        $components | Should -Contain "mcr.microsoft.com/containernetworking/azure-npm:v1.5.5"
     }
 
     It 'has containerd versions for 2019' {
@@ -1275,7 +1269,7 @@ Describe 'Tests of components-test.json ' {
 
         $artifacts["c:\akse-cache\oci-test-arch\"] | Should -Contain "mcr.microsoft.com/aks/oci-test-registry-arch-amd64:2.0.0"
     }
-    
+
     it 'can get OCI artifacts with CPU_ARCH and version variable replacement' {
         $CPU_ARCH = "amd64"
         $artifacts = GetOCIArtifactsFromComponentsJson $componentsJson
@@ -1312,7 +1306,7 @@ Describe 'Tests of components-test.json ' {
 
     it 'skips OCI artifacts with missing windowsDownloadLocation' {
         $artifacts = GetOCIArtifactsFromComponentsJson $componentsJson
-        
+
         # No entry should exist for the artifact without a download location
         $artifacts.Keys | ForEach-Object { $_ } | Should -Not -Contain "mcr.microsoft.com/aks/oci-test-registry-no-location:3.0.0"
     }
@@ -1320,7 +1314,7 @@ Describe 'Tests of components-test.json ' {
     it 'can get OCI artifacts from the default when there is no windows override set' {
         # Modify a copy of the components.json to test default behavior
         $componentsJsonCopy = $componentsJson | ConvertTo-Json -Depth 10 | ConvertFrom-Json
-        
+
         # Find the oci-test-registry artifact and set windowsVersions to null to test default behavior
         foreach ($artifact in $componentsJsonCopy.OCIArtifacts) {
             if ($artifact.registry -like "*oci-test-registry*" -and $artifact.repository -like "*oci-test-registry*") {
@@ -1328,9 +1322,9 @@ Describe 'Tests of components-test.json ' {
                 break
             }
         }
-        
+
         $artifacts = GetOCIArtifactsFromComponentsJson $componentsJsonCopy
-        
+
         # Should still get the artifact using the default version
         $artifacts["c:\akse-cache\oci-test\"] | Should -Contain "mcr.microsoft.com/aks/oci-test-registry:1.0.0"
     }


### PR DESCRIPTION
**What type of PR is this?** /kind cleanup

**What this PR does / why we need it**: Removes `azure-npm` from Agent Baker. Azure-NPM is in the process of deprecation and no longer needs to be cached. All users are being recommended to migration to Cilium.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
