### PR TITLE
Add a new validation for e2e to catch errors regarding exec command on a pod

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -702,6 +702,8 @@ func Test_Ubuntu2204_Scriptless(t *testing.T) {
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log", "aks-node-controller finished successfully")
+				// Validate exec command `sh` works on a specific test pod
+				ValidateExecCmdOnVM(ctx, s, "sh")
 			},
 			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
 			},
@@ -717,6 +719,8 @@ func Test_Ubuntu2404_Scriptless(t *testing.T) {
 			VHD:     config.VHDUbuntu2404Gen2Containerd,
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log", "aks-node-controller finished successfully")
+				// Validate exec command `sh` works on a specific test pod
+				ValidateExecCmdOnVM(ctx, s, "sh")
 			},
 			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
 			},
@@ -741,6 +745,8 @@ func Test_Ubuntu2204(t *testing.T) {
 				ValidateInstalledPackageVersion(ctx, s, "moby-containerd", components.GetExpectedPackageVersions("containerd", "ubuntu", "r2204")[0])
 				ValidateInstalledPackageVersion(ctx, s, "moby-runc", components.GetExpectedPackageVersions("runc", "ubuntu", "r2204")[0])
 				ValidateSSHServiceEnabled(ctx, s)
+				// Validate exec command `sh` works on a specific test pod
+				ValidateExecCmdOnVM(ctx, s, "sh")
 			},
 		},
 	})
@@ -1897,6 +1903,8 @@ func Test_Ubuntu2404Gen2(t *testing.T) {
 				ValidateRunc12Properties(ctx, s, runcVersions)
 				ValidateContainerRuntimePlugins(ctx, s)
 				ValidateSSHServiceEnabled(ctx, s)
+				// Validate exec command `sh` works on a specific test pod
+				ValidateExecCmdOnVM(ctx, s, "sh")
 			},
 		},
 	})
@@ -1965,6 +1973,8 @@ func Test_Ubuntu2404Gen1(t *testing.T) {
 				runcVersions := components.GetExpectedPackageVersions("runc", "ubuntu", "r2404")
 				ValidateContainerd2Properties(ctx, s, containerdVersions)
 				ValidateRunc12Properties(ctx, s, runcVersions)
+				// Validate exec command `sh` works on a specific test pod
+				ValidateExecCmdOnVM(ctx, s, "sh")
 			},
 		},
 	})

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -102,9 +102,6 @@ func ValidateCommonLinux(ctx context.Context, s *Scenario) {
 	execResult = execOnVMForScenarioOnUnprivilegedPod(ctx, s, "curl http://168.63.129.16:32526/vmSettings --connect-timeout 4")
 	require.Equal(s.T, "28", execResult.exitCode, "curl to wireserver port 32526 shouldn't succeed")
 
-	// Validate exec command `sh` works on a specific test pod
-	ValidateExecCmdOnVM(ctx, s, "sh")
-
 	// base NBC templates define a mock service principal profile that we can still use to test
 	// the correct bootstrapping logic: https://github.com/Azure/AgentBaker/blob/master/e2e/node_config.go#L438-L441
 	if hasServicePrincipalData(s) {


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Add a new validation for e2e to catch errors regarding exec command on a pod. This will allow us to catch unexpected errors such as an issue caused by Runc 1.3.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
