### PR TITLE
cherry-pick: fix: default AKSAADServerAppID in kuberneteswindowssetup.ps1 (#7278)

### DIFF
--- a/parts/windows/kuberneteswindowssetup.ps1
+++ b/parts/windows/kuberneteswindowssetup.ps1
@@ -185,6 +185,11 @@ $global:SecureTLSBootstrappingAADResource = "{{GetSecureTLSBootstrappingAADResou
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "{{GetSecureTLSBootstrappingUserAssignedIdentityID}}";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "{{GetCustomSecureTLSBootstrappingClientDownloadURL}}";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("{{GetVariable "isDisableWindowsOutboundNat" }}");
 

--- a/pkg/agent/testdata/AKSWindows2019+CustomCloud+ootcredentialprovider/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+CustomCloud+ootcredentialprovider/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows2019+CustomCloud/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+CustomCloud/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows2019+CustomVnet/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+CustomVnet/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows2019+EnablePrivateClusterHostsConfigAgent/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+EnablePrivateClusterHostsConfigAgent/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows2019+K8S116/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S116/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows2019+K8S117/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S117/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows2019+K8S118/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S118/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows2019+K8S119+CSI/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S119+CSI/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows2019+K8S119+FIPS/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S119+FIPS/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows2019+K8S119/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+K8S119/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows2019+KubeletClientTLSBootstrapping/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+KubeletClientTLSBootstrapping/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows2019+KubeletServingCertificateRotation/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+KubeletServingCertificateRotation/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows2019+ManagedIdentity/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+ManagedIdentity/CustomData
@@ -181,6 +181,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows2019+SecurityProfile/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+SecurityProfile/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows2019+ootcredentialprovider/CustomData
+++ b/pkg/agent/testdata/AKSWindows2019+ootcredentialprovider/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows23H2Gen2+NextGenNetworking/CustomData
+++ b/pkg/agent/testdata/AKSWindows23H2Gen2+NextGenNetworking/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows23H2Gen2+NextGenNetworkingDisabled/CustomData
+++ b/pkg/agent/testdata/AKSWindows23H2Gen2+NextGenNetworkingDisabled/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 

--- a/pkg/agent/testdata/AKSWindows23H2Gen2+NextGenNetworkingNoConfig/CustomData
+++ b/pkg/agent/testdata/AKSWindows23H2Gen2+NextGenNetworkingNoConfig/CustomData
@@ -179,6 +179,11 @@ $global:SecureTLSBootstrappingAADResource = "";
 $global:SecureTLSBootstrappingUserAssignedIdentityID = "";
 $global:CustomSecureTLSBootstrappingClientDownloadURL = "";
 
+# uniquely identifies AKS's Entra ID application, see: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+# this is used by aks-secure-tls-bootstrap-client.exe when requesting AAD tokens
+# TODO(cameissner): remove once 2025-10B image is released
+$global:AKSAADServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
 # Disable OutBoundNAT in Azure CNI configuration
 $global:IsDisableWindowsOutboundNat = [System.Convert]::ToBoolean("false");
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

default AKSAADServerAppID in kuberneteswindowssetup.ps1 (#7278) to fix secure TLS bootstrapping E2E tests

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
