### PR TITLE
[bug] Make sure test step fails if VHD not found

### DIFF
--- a/vhdbuilder/packer/test-scan-and-cleanup.sh
+++ b/vhdbuilder/packer/test-scan-and-cleanup.sh
@@ -75,7 +75,8 @@ SIG_VERSION=$(az sig image-version show \
 if [ -z "${SIG_VERSION}" ]; then
   echo -e "\nBuild step did not produce an image version. Running cleanup and then exiting."
   retrycmd_if_failure 2 3 "${SCRIPT_ARRAY[@]}"
-  exit $?
+  # Always return error even if cleanup succeeded
+  exit $(($? > 0 ? $? : 1))
 fi
 
 # Setup testing


### PR DESCRIPTION
Currently if the VHD is missing, the test step returns the status code of the cleanup script. This often succeeds, erroneously resulting in the test step succeeding even if the VHD is missing. Instead, we should always return error if the VHD is missing.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Returns non-OK status from the test step whenever the VHD is not found.

**Which issue(s) this PR fixes**:
not tracked

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
