### PR TITLE
fix: increase Flatcar image size from 30GB to 34GB

### DIFF
--- a/vhdbuilder/packer/vhd-image-builder-flatcar-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-flatcar-arm64.json
@@ -41,7 +41,7 @@
       "virtual_network_subnet_name": "{{user `subnet_name`}}",
       "ssh_read_write_timeout": "5m",
       "os_type": "Linux",
-      "os_disk_size_gb": 30,
+      "os_disk_size_gb": 34,
       "image_publisher": "{{user `img_publisher`}}",
       "image_offer": "{{user `img_offer`}}",
       "image_sku": "{{user `img_sku`}}",

--- a/vhdbuilder/packer/vhd-image-builder-flatcar.json
+++ b/vhdbuilder/packer/vhd-image-builder-flatcar.json
@@ -41,7 +41,7 @@
       "virtual_network_subnet_name": "{{user `subnet_name`}}",
       "ssh_read_write_timeout": "5m",
       "os_type": "Linux",
-      "os_disk_size_gb": 30,
+      "os_disk_size_gb": 34,
       "image_publisher": "{{user `img_publisher`}}",
       "image_offer": "{{user `img_offer`}}",
       "image_sku": "{{user `img_sku`}}",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind regression

**What this PR does / why we need it**:

The latest Flatcar Alpha release has inadvertently broken Agent Baker because the image size has changed from 30GB to 34GB. Flatcar did increase the size of some of the partitions, but it didn't shrink the "root" (empty) partition to compensate, which may or may not have been intentional.

**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [X] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

I'll find out from the Flatcar team next week whether we intend to keep this change or not. We presumably don't want Flatcar users to find they now have less space with the default size. However, I've noticed all the other AKS distros use 30GB, so is this change an issue?