### PR TITLE
fix: Run dpkg-configure before pinning azcli

### DIFF
--- a/vhdbuilder/packer/produce-packer-settings-functions.sh
+++ b/vhdbuilder/packer/produce-packer-settings-functions.sh
@@ -4,8 +4,8 @@ function enforce_azcli_version() {
 	AZ_VER_REQUIRED=$1
 	AZ_DIST=$(lsb_release -cs)
 	echo "Enforcing az cli version to ${AZ_VER_REQUIRED} for ${AZ_DIST}"
-	sudo apt-get install azure-cli=${AZ_VER_REQUIRED}-1~${AZ_DIST} -y --allow-downgrades
-
+	sudo DEBIAN_FRONTEND=noninteractive dpkg --configure -a
+	sudo DEBIAN_FRONTEND=noninteractive apt-get install azure-cli=${AZ_VER_REQUIRED}-1~${AZ_DIST} -y --allow-downgrades
 	AZ_VER_INSTALLED=$(az version --query "[\"azure-cli\"]" -o tsv)
 	if [ "${AZ_VER_INSTALLED}" != "${AZ_VER_REQUIRED}" ]; then
 		echo "Failed to install required az cli version ${AZ_VER_REQUIRED}, installed version is ${AZ_VER_INSTALLED}"


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
The simple apt-get install fails on *some* of the builds with:

    Installing previous version of azcli in order to mitigate az compute bug
    Sourcing cse_helpers_distro.sh for Ubuntu
    Overriding azcli version to 2.77.0
    Enforcing az cli version to 2.77.0 for jammy
    E: dpkg was interrupted, you must manually run 'sudo dpkg --configure -a' to correct the problem.

The apt_get_install helper handles that for us, but it's not trivial to run a bash function as root. So invoke the dpkg-configure manually.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
