### PR TITLE
Regkey for bugcheck 0x76

### DIFF
--- a/vhdbuilder/packer/windows/windows_settings.json
+++ b/vhdbuilder/packer/windows/windows_settings.json
@@ -889,6 +889,14 @@
       "Name": "3063948942",
       "Value": "1",
       "Type": "DWORD"
+    },
+    {
+      "Comment": "2025-11B",
+      "WindowsSkuMatch": "23H2*",
+      "Path": "HKLM:\\SYSTEM\\CurrentControlSet\\Policies\\Microsoft\\FeatureManagement\\Overrides",
+      "Name": "2112481934",
+      "Value": "1",
+      "Type": "DWORD"
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR introduces necessary registry keys required for the 11B release. The regkeys included are necessary to address the bugcheck 0x76 bug.

commits are GPG signed and Github marks them as verified
Special notes for your reviewer:
Release note:

none
