### PR TITLE
fix: Reorder faillock in common-auth to prevent failures

### DIFF
--- a/parts/linux/cloud-init/artifacts/pam-d-common-auth-2204
+++ b/parts/linux/cloud-init/artifacts/pam-d-common-auth-2204
@@ -14,7 +14,10 @@
 # pam-auth-update(8) for details.
 
 # here are the per-package modules (the "Primary" block)
-auth	[success=1 default=ignore]	pam_unix.so nullok_secure
+# 5.3.2 Ensure lockout for failed password attempts is configured
+auth	requisite pam_faillock.so preauth silent audit deny=5 unlock_time=900
+auth	[success=2 default=ignore]	pam_unix.so nullok_secure
+auth	[default=die] pam_faillock.so authfail audit deny=5 unlock_time=900
 # here's the fallback if no module succeeds
 auth	requisite			pam_deny.so
 # prime the stack with a positive return value if there isn't one already;
@@ -23,7 +26,3 @@ auth	requisite			pam_deny.so
 auth	required			pam_permit.so
 # and here are more per-package modules (the "Additional" block)
 # end of pam-auth-update config
-
-# 5.3.2 Ensure lockout for failed password attempts is configured
-auth required pam_faillock.so preauth silent audit deny=5 unlock_time=900
-auth [default=die] pam_faillock.so authfail audit deny=5 unlock_time=900


### PR DESCRIPTION

**What type of PR is this?**
/kind regression

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
pam_faillock+authfail at the end will result in always reporting failure/permission denied. The correct way to handle this is to place it in the failure chain: after pam_unix but to skip over in case of success.

Without this change, cron fails to run entries as root and fails with "permission denied".

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7061 

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [x] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
