### PR TITLE
Fix: Remove GB200 from list of Fabric Manager SKUs

### DIFF
--- a/pkg/agent/datamodel/gpu_components.go
+++ b/pkg/agent/datamodel/gpu_components.go
@@ -120,8 +120,6 @@ var FabricManagerGPUSizes = map[string]bool{
 	"standard_nd96is_h200_v5":   true,
 	"standard_nd96isr_h200_v5":  true,
 	"standard_nd96isrf_h200_v5": true,
-	// GB200 (Grace Blackwell)
-	"standard_nd128isr_ndr_gb200_v6": true,
 	// A100 oddballs.
 	"standard_nc24ads_a100_v4": false, // NCads_v4 will fail to start fabricmanager.
 	"standard_nc48ads_a100_v4": false,


### PR DESCRIPTION
GB200 uses IMEX instead to manage inter-GPU communication.

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Right now the GB200 VHD won't boot (when scriptless is disabled) because the baker thinks it is running fabric manager. Unfortunately, fabric manager is not included on the GB200 VHD, so trying to enable it crashes boot.

Scriptless also seems like it may run into this issue down the road.

**Which issue(s) this PR fixes**:

**Requirements**:

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
Unblocks GB200 VHD to work correctly, whether using scriptless or not.
```
