### PR TITLE
chore: move e2e and gc to use service connection

### DIFF
--- a/.pipelines/.vsts-garabge-collection.yaml
+++ b/.pipelines/.vsts-garabge-collection.yaml
@@ -23,9 +23,14 @@ jobs:
       fetchTags: false
       fetchDepth: 1
 
-    - bash: |
-        chmod +x ./vhdbuilder/scripts/gc.sh
-        ./vhdbuilder/scripts/gc.sh
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(ARM_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          chmod +x ./vhdbuilder/scripts/gc.sh
+          ./vhdbuilder/scripts/gc.sh
       env:
         SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
         DRY_RUN: ${{ parameters.DRY_RUN }}

--- a/.pipelines/scripts/e2e_run.sh
+++ b/.pipelines/scripts/e2e_run.sh
@@ -4,7 +4,6 @@
 set -euo pipefail
 
 # This script runs the AgentBaker e2e tests for a VHD. It uses the following environment variables:
-# * E2E_AGENT_IDENTITY_ID: this variable contains the managed identity ID to log into azure with
 # * E2E_SUBSCRIPTION_ID: this variable contains the subscription to run the e2e tests in
 # * DefaultWorkingDirectory: this variable contains the default working directory. Likely "." is sufficient
 # * VHD_BUILD_ID - the build identifier for the pipeline. This is optional and if it is missing then the latest build from
@@ -15,8 +14,6 @@ set -euo pipefail
 # In addition, the e2e test framework reads a whole lot of environment variables.
 # These are defined in: e2e/config/config.go
 
-# First, login.
-az login --identity --resource-id "${E2E_AGENT_IDENTITY_ID}"
 az account set -s "${E2E_SUBSCRIPTION_ID}"
 echo "Using subscription ${E2E_SUBSCRIPTION_ID} for e2e tests"
 

--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -24,10 +24,15 @@ jobs:
         fetchTags: false
         fetchDepth: 1
 
-      - bash: bash .pipelines/scripts/e2e_run.sh
+      - task: AzureCLI@2
+        inputs:
+          azureSubscription: $(E2E_ARM_SERVICE_CONNECTION)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            bash .pipelines/scripts/e2e_run.sh
         displayName: Run AgentBaker E2E
         env:
-          E2E_AGENT_IDENTITY_ID: $(E2E_AGENT_IDENTITY_ID)
           E2E_SUBSCRIPTION_ID: $(E2E_SUBSCRIPTION_ID)
           BUILD_SRC_DIR: $(System.DefaultWorkingDirectory)
           DefaultWorkingDirectory: $(Build.SourcesDirectory)
@@ -46,6 +51,12 @@ jobs:
         condition: always()
         continueOnError: true
 
-      - bash: bash .pipelines/scripts/e2e_delete_vmss.sh
+      - task: AzureCLI@2
+        inputs:
+          azureSubscription: $(E2E_ARM_SERVICE_CONNECTION)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            bash .pipelines/scripts/e2e_delete_vmss.sh
         displayName: ensure vmss deletion
         condition: always()

--- a/vhdbuilder/scripts/gc.sh
+++ b/vhdbuilder/scripts/gc.sh
@@ -12,7 +12,6 @@ STANDARD_DEADLINE=$(( $(date +%s) - 14400 )) # 4 hours ago
 WEEK_AGO=$(( $(date +%s) - 604800 )) # 7 days ago
 
 function main() {
-    az login --identity # relies on an appropriately permissioned identity being attached to the build agent
     az account set -s $SUBSCRIPTION_ID
 
     echo "garbage collecting ephemeral resource groups..."


### PR DESCRIPTION
**What type of PR is this?**

Move E2E to use service connection, this removes the need for attaching managed identity to build agents.

/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [X] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [X] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```
