### PR TITLE
chore(deps): bump containerdv2 to 2.2.4 for Ubuntu 2404 and AzureLinux 3.0

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1011,7 +1011,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=moby-containerd, repository=production, os=ubuntu, release=24.04",
-                "latestVersion": "2.2.1-ubuntu24.04u1"
+                "latestVersion": "2.2.4-ubuntu24.04u2"
               }
             ]
           },
@@ -1057,7 +1057,7 @@
             "versionsV2": [
               {
                 "renovateTag": "RPM_registry=https://packages.microsoft.com/azurelinux/3.0/prod/base/x86_64/repodata, name=containerd2, os=azurelinux, release=3.0",
-                "latestVersion": "2.1.6-2.azl3"
+                "latestVersion": "2.1.6-3.azl3"
               }
             ]
           },

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1057,7 +1057,7 @@
             "versionsV2": [
               {
                 "renovateTag": "RPM_registry=https://packages.microsoft.com/azurelinux/3.0/prod/base/x86_64/repodata, name=containerd2, os=azurelinux, release=3.0",
-                "latestVersion": "2.1.6-3.azl3"
+                "latestVersion": "2.2.4-2.azl3"
               }
             ]
           },

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1010,8 +1010,8 @@
           "r2404": {
             "versionsV2": [
               {
-                "renovateTag": "name=moby-containerd, repository=test, os=ubuntu, release=24.04",
-                "latestVersion": "2.1.7-ubuntu24.04u2"
+                "renovateTag": "name=moby-containerd, repository=production, os=ubuntu, release=24.04",
+                "latestVersion": "2.2.1-ubuntu24.04u1"
               }
             ]
           },


### PR DESCRIPTION
## Summary

Bump containerd v2 to **2.2.4** for both Ubuntu 24.04 and AzureLinux 3.0, and switch Ubuntu 24.04 from the test to production PMC repository.

### Version Changes

| OS | Package | Old Version | New Version |
|---|---|---|---|
| Ubuntu 24.04 | `moby-containerd` | `2.1.7-ubuntu24.04u2` (test repo) | `2.2.4-ubuntu24.04u2` (prod repo) |
| AzureLinux 3.0 | `containerd2` | `2.1.6-2.azl3` | `2.2.4-2.azl3` |

### Upstream Changelog: containerd 2.1.x → 2.2.4

This crosses a minor version boundary (2.1 → 2.2). Key changes across 2.2.0 through 2.2.4:

**v2.2.0 — Major Feature Release**
- New mount manager service for filesystem mount lifecycle
- Parallel unpack during image pull (overlayfs/EROFS)
- Pod sandbox metrics API
- ⚠️ Cgroup v1 deprecated (not a concern for Ubuntu 24.04/AZL 3.0 which use cgroup v2)

**v2.2.1 — Patch**
- Security: Redact query parameters in CRI error logs
- Bug fixes: panic fix in WithMediaTypeKeyPrefix, hugetlb events parsing

**v2.2.2 — Patch**
- ✅ **Fixes [containerd#12549](https://github.com/containerd/containerd/issues/12549)** — `ctr image mount` failing with "no such device" due to mount manager bug ([#12831](https://github.com/containerd/containerd/pull/12831))
- Fix CNI DEL never executing after restart
- Fix AppArmor bug on newer kernels
- Fix regression for pulling encrypted images
- runc bumped to v1.3.5

**v2.2.3 — Patch**
- Security: CVE-2026-35469 (spdystream)
- Fix whiteouts ignored with parallel unpack
- Enable mount manager in diff walking for EROFS
- TOCTOU race fix in tar extraction
- Preserve cgroup mount options for privileged containers

**v2.2.4 — Patch**
- Security: **CVE-2026-46680** (containerd), **CVE-2026-34986** (go-jose)
- Fix handling of out-of-range USER values in OCI spec
- Block AF_ALG in default socket policy (hardening)
- Fix sandbox creation config and event publishing bugs
- Support AppArmor abi < 3.0
- Fix overlay layer extraction in user namespaces

### Risk Assessment: 🟡 Medium

**Justification**: Minor version jump (2.1 → 2.2) introduces new subsystems (mount manager, parallel unpack), but:
- Both Ubuntu 24.04 and AzureLinux 3.0 now aligned on 2.2.4
- v2.2.2+ fixes the mount manager bug ([#12549](https://github.com/containerd/containerd/issues/12549)) that was a known issue in 2.2.0/2.2.1
- v2.2.4 includes important security patches (CVE-2026-46680, CVE-2026-34986)
- Ubuntu moves from test → production PMC repo indicating prior validation

## Changes

- `parts/common/components.json`:
  - Ubuntu r2404: `2.1.7-ubuntu24.04u2` (test) → `2.2.4-ubuntu24.04u2` (production)
  - AzureLinux v3.0: `2.1.6-2.azl3` → `2.2.4-2.azl3`

## Testing

- `make generate-testdata` passes ✅

🤖 *Generated by GitHub Copilot*