### PR TITLE
feat: install aznfs package on AzureLinux 3.0

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -2239,6 +2239,31 @@
       }
     },
     {
+      "name": "aznfs",
+      "downloadLocation": "/opt/aznfs/downloads",
+      "downloadURIs": {
+        "azurelinux": {
+          "v3.0": {
+            "versionsV2": [
+              {
+                "renovateTag": "<DO_NOT_UPDATE>",
+                "latestVersion": "3.0.15-1"
+              }
+            ],
+            "downloadURL": "https://packages.microsoft.com/rhel/9/prod/Packages/a/aznfs-${version}.$(uname -m).rpm"
+          },
+          "OSGUARD/v3.0": {
+            "versionsV2": [
+              {
+                "renovateTag": "<DO_NOT_UPDATE>",
+                "latestVersion": "<SKIP>"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
       "name": "blobfuse",
       "downloadURIs": {
         "ubuntu": {

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -158,6 +158,8 @@ ERR_SYSEXT_VERSION_ID_NOT_FOUND=232 # VERSION_ID not found in /etc/os-release, r
 
 # ----------------------- AKS Node Controller----------------------------------
 ERR_AKS_NODE_CONTROLLER_ERROR=240 # Generic error in AKS Node Controller
+ERR_AZNFS_RPM_DOWNLOAD_TIMEOUT=241 # Timeout downloading aznfs RPM from PMC
+ERR_AZNFS_INSTALL_FAIL=242 # Failed to install aznfs RPM package
 # -----------------------------------------------------------------------------
 
 # This probably wasn't launched via a login shell, so ensure the PATH is correct.

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -237,6 +237,48 @@ installKubeletKubectlFromPkg() {
     installRPMPackageFromFile "kubectl" "${desiredVersion}" "/opt/bin/kubectl" || exit "$ERR_KUBECTL_INSTALL_FAIL"
 }
 
+findAznfsRpm() {
+  local dir="$1"
+  find "${dir}" -name "aznfs-*.rpm" -type f 2>/dev/null | sort -V | tail -1
+}
+
+installAznfsPackage() {
+  if [ "$OS_VERSION" != "3.0" ]; then
+    echo "aznfs package install is only supported on Azure Linux 3.0"
+    return
+  fi
+
+  # The aznfs RPM is pre-downloaded to /opt/aznfs/downloads during VHD build
+  # (via components.json). It must be present; fail immediately if not found.
+  local aznfs_download_dir="/opt/aznfs/downloads"
+  local aznfs_rpm_file
+  aznfs_rpm_file=$(findAznfsRpm "${aznfs_download_dir}")
+  if [ -z "${aznfs_rpm_file}" ]; then
+    echo "Error: aznfs RPM not found in ${aznfs_download_dir}. It should have been pre-downloaded during VHD build."
+    return $ERR_AZNFS_INSTALL_FAIL
+  fi
+
+  echo "Installing aznfs from pre-downloaded RPM: ${aznfs_rpm_file}"
+  if ! AZNFS_NONINTERACTIVE_INSTALL=1 dnf_install 30 1 600 "${aznfs_rpm_file}"; then
+    return $ERR_AZNFS_INSTALL_FAIL
+  fi
+
+  # Disable aznfs auto-upgrade to respect operator OS update settings and AKS SDP
+  local aznfs_config="/opt/microsoft/aznfs/data/config"
+  if [ -f "${aznfs_config}" ]; then
+    sed -i 's/AUTOUPDATE=.*/AUTOUPDATE=false/' "${aznfs_config}"
+    echo "Disabled aznfs auto-upgrade in ${aznfs_config}"
+  fi
+
+  # Restart aznfswatchdogv4 to pick up the updated config
+  systemctl restart aznfswatchdogv4
+
+  # Disable aznfswatchdog since aznfs install enables both aznfswatchdog and aznfswatchdogv4
+  # services at the same time while we only need aznfswatchdogv4
+  systemctl disable aznfswatchdog
+  systemctl stop aznfswatchdog
+}
+
 installToolFromLocalRepo() {
     local tool_name=$1
     local tool_download_dir=$2

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
@@ -282,4 +282,57 @@ Describe 'cse_install_mariner.sh'
             The variable GRID_CALLED should not equal "true"
         End
     End
+
+    Describe 'installAznfsPackage'
+        ERR_AZNFS_INSTALL_FAIL=242
+        aznfs_test_dir="$PWD/spec/tmp/aznfs-test"
+
+        setup_aznfs() {
+            mkdir -p "${aznfs_test_dir}/opt/aznfs/downloads"
+            # Create a fake aznfs RPM file
+            touch "${aznfs_test_dir}/opt/aznfs/downloads/aznfs-3.0.15-1.x86_64.rpm"
+        }
+
+        cleanup_aznfs() {
+            rm -rf "${aznfs_test_dir}"
+        }
+
+        # Mock gpg/rpm to avoid 'command not found' on CI
+        gpg() {
+            return 0
+        }
+        rpm() {
+            return 0
+        }
+
+        BeforeEach 'setup_aznfs'
+        AfterEach 'cleanup_aznfs'
+
+        It 'skips install on non-AzureLinux 3.0'
+            OS_VERSION="2.0"
+            When call installAznfsPackage
+            The output should include "only supported on Azure Linux 3.0"
+        End
+
+        It 'installs pre-downloaded RPM on AzureLinux 3.0'
+            OS_VERSION="3.0"
+            # Override findAznfsRpm to return our test RPM
+            findAznfsRpm() {
+                echo "${aznfs_test_dir}/opt/aznfs/downloads/aznfs-3.0.15-1.x86_64.rpm"
+            }
+            When call installAznfsPackage
+            The output should include "Installing aznfs from pre-downloaded RPM"
+        End
+
+        It 'fails when pre-downloaded RPM is not found'
+            OS_VERSION="3.0"
+            # Override findAznfsRpm to return empty (no RPM found)
+            findAznfsRpm() {
+                echo ""
+            }
+            When call installAznfsPackage
+            The output should include "aznfs RPM not found"
+            The status should equal 242
+        End
+    End
 End

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -579,6 +579,17 @@ while IFS= read -r p; do
     "acr-mirror")
       # acr-mirror is handled separately below via installAndConfigureArtifactStreaming.
       ;;
+    "aznfs")
+      for version in ${PACKAGE_VERSIONS[@]}; do
+        evaluatedURL=$(evalPackageDownloadURL "${PACKAGE_DOWNLOAD_URL}")
+        mkdir -p "${downloadDir}"
+        aznfsFilename=$(basename "${evaluatedURL}")
+        echo "Downloading aznfs RPM from ${evaluatedURL} to ${downloadDir}/${aznfsFilename}"
+        retrycmd_curl_file 120 5 25 "${downloadDir}/${aznfsFilename}" "${evaluatedURL}" || exit $ERR_AZNFS_RPM_DOWNLOAD_TIMEOUT
+        echo "  - aznfs version ${version}" >> ${VHD_LOGS_FILEPATH}
+      done
+      installAznfsPackage || exit $ERR_AZNFS_INSTALL_FAIL
+      ;;
     "blobfuse"|"blobfuse2")
       for version in "${PACKAGE_VERSIONS[@]}"; do
         if isUbuntu "$OS"; then


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: install aznfs package on AzureLinux 3.0

Install the aznfs NFS mount helper on AzureLinux 3.0 VHDs. The aznfs RPM is
downloaded directly from PMC at VHD build time (via `components.json`) and
stored in `/opt/aznfs/downloads`. During node provisioning, `installAznfsPkgFromPMC`
installs the pre-downloaded RPM locally with `dnf_install`, avoiding the need to
add the rhel9 PMC repo to the RPM database (which could cause versioning
conflicts with AzureLinux packages).

Additional configuration:
- Disable aznfs auto-upgrade (`AUTOUPDATE=false`) to respect operator OS update settings and AKS SDP
- Disable the legacy `aznfswatchdog` service (only `aznfswatchdogv4` is needed)
- Import the Microsoft RPM GPG key into the RPM database
- Use `sort -V` to deterministically select the newest RPM when multiple versions exist

there is no azl3 package due to GNU TLS dependency, this is only the way to install aznfs package on AzureLinux3, check here: https://learn.microsoft.com/en-us/azure/storage/files/encryption-in-transit-for-nfs-shares?tabs=azure-portal%2CAzureLinux

 - logs on AzureLinuxV3gen2 shows aznfs package install is succeeded
```
2026-04-28T10:08:20.4228096Z [1;32m2026-04-28T10:08:20Z: ==> azure-arm: Installed:[0m
2026-04-28T10:08:20.4233235Z [1;32m2026-04-28T10:08:20Z: ==> azure-arm:   aznfs-3.0.15-1.x86_64                stunnel-5.74-1.azl3.x86_64[0m
2026-04-28T10:08:20.4238101Z [1;32m2026-04-28T10:08:20Z: ==> azure-arm:[0m
2026-04-28T10:08:20.4243708Z [1;32m2026-04-28T10:08:20Z: ==> azure-arm: Complete![0m
2026-04-28T10:08:20.4769684Z [1;32m2026-04-28T10:08:20Z: ==> azure-arm: Executed dnf install -y "/opt/aznfs/downloads/aznfs-3.0.15-1.x86_64.rpm" 1 times[0m
2026-04-28T10:08:20.4774246Z [1;31m2026-04-28T10:08:20Z: ==> azure-arm: + break[0m
2026-04-28T10:08:20.4779938Z [1;31m2026-04-28T10:08:20Z: ==> azure-arm: + echo Executed dnf install -y '"/opt/aznfs/downloads/aznfs-3.0.15-1.x86_64.rpm"' 1 times[0m
2026-04-28T10:08:20.4783675Z [1;32m2026-04-28T10:08:20Z: ==> azure-arm: Disabled aznfs auto-upgrade in /opt/microsoft/aznfs/data/config[0m
2026-04-28T10:08:20.4788602Z [1;31m2026-04-28T10:08:20Z: ==> azure-arm: + local aznfs_config=/opt/microsoft/aznfs/data/config[0m
2026-04-28T10:08:20.4793881Z [1;31m2026-04-28T10:08:20Z: ==> azure-arm: + '[' -f /opt/microsoft/aznfs/data/config ']'[0m
2026-04-28T10:08:20.4798855Z [1;31m2026-04-28T10:08:20Z: ==> azure-arm: + sed -i 's/AUTOUPDATE=.*/AUTOUPDATE=false/' /opt/microsoft/aznfs/data/config[0m
2026-04-28T10:08:20.4806152Z [1;31m2026-04-28T10:08:20Z: ==> azure-arm: + echo 'Disabled aznfs auto-upgrade in /opt/microsoft/aznfs/data/config'[0m
2026-04-28T10:08:20.4809410Z [1;31m2026-04-28T10:08:20Z: ==> azure-arm: + systemctl restart aznfswatchdogv4[0m
2026-04-28T10:08:20.5091899Z [1;31m2026-04-28T10:08:20Z: ==> azure-arm: + systemctl disable aznfswatchdog[0m
2026-04-28T10:08:20.5196556Z [1;31m2026-04-28T10:08:20Z: ==> azure-arm: Removed "/etc/systemd/system/nfs-client.target.wants/aznfswatchdog.service".[0m
2026-04-28T10:08:20.7423609Z [1;31m2026-04-28T10:08:20Z: ==> azure-arm: + systemctl stop aznfswatchdog[0m
```


**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version
- [ ] commits are GPG signed and Github marks them as verified

**Special notes for your reviewer**:

**Release note**:

```
none
```