### PR TITLE
fix(e2e): skip NetworkIsolated tests in GPU E2E pipeline

### DIFF
--- a/.pipelines/e2e-gpu.yaml
+++ b/.pipelines/e2e-gpu.yaml
@@ -1,7 +1,7 @@
 name: $(Date:yyyyMMdd)$(Rev:.r)
 variables:
   TAGS_TO_RUN: "gpu=true"
-  TAGS_TO_SKIP: "os=windows"
+  TAGS_TO_SKIP: "os=windows,NetworkIsolated=true"
   SKIP_E2E_TESTS: false
   SKIP_TESTS_WITH_SKU_CAPACITY_ISSUE: true
   E2E_GO_TEST_TIMEOUT: "75m"


### PR DESCRIPTION
## Summary
- The GPU E2E pipeline (`e2e-gpu.yaml`) runs all tests tagged `gpu=true` but doesn't have network-isolated cluster infrastructure (private ACR, NSG outbound rules, etc.)
- Tests with both `GPU=true` and `NetworkIsolated=true` (e.g., `Test_Ubuntu2404_FullyManagedGPU_NetworkIsolated` from #8253) fail because the pipeline can't provision network-isolated clusters
- Adds `NetworkIsolated=true` to `TAGS_TO_SKIP` in the GPU pipeline so these tests are skipped
- The regular E2E pipeline (`e2e.yaml`) already skips `gpu=true` tests, so this doesn't change behavior there
- Network-isolated GPU tests can still be run locally or via a future dedicated pipeline

## Test plan
- [ ] GPU E2E pipeline no longer fails on `NetworkIsolated` tests
- [ ] Existing GPU tests continue to run (they don't have `NetworkIsolated: true`)