### PR TITLE
fix(e2e): add DAG dependencies to prevent route table race condition

### DIFF
--- a/.pipelines/.vsts-vhd-builder-pr-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-pr-windows.yaml
@@ -34,13 +34,14 @@ pr:
       - parts/windows
       - go.mod
       - go.sum
-      - e2e/scenario_win_test.go
+      - e2e/
       - staging/cse/windows/
 
     exclude:
       - vhdbuilder/release-notes
       - /**/*.md
       - .github/**
+      - e2e/scenario_test.go
       - .pipelines/scripts/verify_shell.sh
 
 pool:

--- a/.pipelines/.vsts-vhd-builder-pr-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-pr-windows.yaml
@@ -34,14 +34,13 @@ pr:
       - parts/windows
       - go.mod
       - go.sum
-      - e2e/
+      - e2e/scenario_win_test.go
       - staging/cse/windows/
 
     exclude:
       - vhdbuilder/release-notes
       - /**/*.md
       - .github/**
-      - e2e/scenario_test.go
       - .pipelines/scripts/verify_shell.sh
 
 pool:

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -78,6 +78,9 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 
 	g := dag.NewGroup(ctx)
 
+	// bastion creates AzureBastionSubnet — a VNet-level mutation that must
+	// finish before other subnet writes (firewall / network-isolated setup)
+	// to avoid Azure VNet serialisation races.
 	bastion := dag.Go(g, func(ctx context.Context) (*Bastion, error) {
 		return getOrCreateBastion(ctx, cluster)
 	})
@@ -87,14 +90,19 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 	identity := dag.Go(g, func(ctx context.Context) (*armcontainerservice.UserAssignedIdentity, error) {
 		return getClusterKubeletIdentity(ctx, cluster)
 	})
-	dag.Run(g, func(ctx context.Context) error { return collectGarbageVMSS(ctx, cluster) })
+	// networkSetup associates a route table with aks-subnet (firewall or
+	// network-isolated NSG).  It must run after bastion (both mutate the
+	// VNet) and before collectGarbageVMSS (VMSS deletion triggers AKS
+	// cloud-controller route reconciliation that can race with the subnet
+	// association and leave the AKS pod route table detached).
 	var networkDeps []dag.Dep
 	if !isNetworkIsolated {
-		networkDeps = append(networkDeps, dag.Run(g, func(ctx context.Context) error { return addFirewallRules(ctx, cluster) }))
+		networkDeps = append(networkDeps, dag.Run(g, func(ctx context.Context) error { return addFirewallRules(ctx, cluster) }, bastion))
 	}
 	if isNetworkIsolated {
-		networkDeps = append(networkDeps, dag.Run(g, func(ctx context.Context) error { return addNetworkIsolatedSettings(ctx, cluster) }))
+		networkDeps = append(networkDeps, dag.Run(g, func(ctx context.Context) error { return addNetworkIsolatedSettings(ctx, cluster) }, bastion))
 	}
+	dag.Run(g, func(ctx context.Context) error { return collectGarbageVMSS(ctx, cluster) }, networkDeps...)
 	needACR := isNetworkIsolated || attachPrivateAcr
 	acrNonAnon := dag.Run2(g, kube, identity, addACR(cluster, needACR, true))
 	acrAnon := dag.Run2(g, kube, identity, addACR(cluster, needACR, false))


### PR DESCRIPTION
## Problem

PR #8149 refactored `prepareCluster` to use concurrent DAG execution. This introduced a race condition between three operations that mutate the VNet/subnet:

1. **`getOrCreateBastion`** — creates AzureBastionSubnet
2. **`addFirewallRules`** — creates AzureFirewallSubnet + associates `abe2e-fw-rt` with `aks-subnet`
3. **`collectGarbageVMSS`** — deletes old VMSS → triggers AKS cloud-controller route reconciliation

Running them concurrently causes the AKS pod route table (`aks-agentpool-*-routetable`) to be **detached** from the subnet. The firewall route table (`abe2e-fw-rt`) wins the association, but has no pod routes. Result:

- `NetworkUnavailable: Waiting for cloud routes` — never cleared
- `cni plugin not initialized` — CNI config never written
- **65/154 E2E tests fail** (100% of kubenet/overlay, 0% of AzureCNI)

### Evidence from Azure

| Route Table | Routes | Subnet Association |
|---|---|---|
| `aks-agentpool-13663576-routetable` | 63 pod routes | **0 subnets** ❌ |
| `abe2e-fw-rt` | 2 (vnet-local + firewall) | 1 (`aks-subnet`) |

## Fix

Add DAG dependency edges to restore the sequential ordering for VNet-mutating operations:

- `addFirewallRules` / `addNetworkIsolatedSettings` → depends on `bastion` (serialize subnet writes)
- `collectGarbageVMSS` → depends on network setup (prevent VMSS deletion from racing with route table association)

All other tasks remain fully concurrent (kube client, identity, maintenance, subnet read, extract params).

## DAG Before vs After

```
BEFORE (#8149):  bastion ──┐
                            ├──► g.Wait()
                 firewall ─┤
                            │
                 gcVMSS ───┘   (all concurrent, race on VNet)

AFTER (this PR): bastion ──► firewall ──► gcVMSS
                                          (serialized VNet mutations)
                 kube ─────┐
                 identity ─┤
                 subnet ───┤  (still concurrent — no VNet writes)
                 maint ────┘
```

Fixes the E2E infrastructure failures observed on PR #8230 and the scriptless E2E gate.