### PR TITLE
fix(e2e): skip GPU tests on additional allocation failure error codes

### DIFF
--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -510,18 +510,30 @@ func skipTestIfSKUNotAvailableErr(t testing.TB, err error) {
 		return
 	}
 	var respErr *azcore.ResponseError
-	if !errors.As(err, &respErr) || respErr.StatusCode != 409 {
+	if !errors.As(err, &respErr) {
 		return
 	}
-	// sometimes the SKU is not available and we can't do anything. Skip the test in this case.
+	// SKU not available in region (409)
 	if respErr.ErrorCode == "SkuNotAvailable" {
 		t.Skip("skipping scenario SKU not available", t.Name(), err)
 	}
-	// sometimes the SKU quota is exceeded and we can't do anything. Skip the test in this case.
+	// Quota exceeded (409)
 	if respErr.ErrorCode == "OperationNotAllowed" &&
 		strings.Contains(respErr.Error(), "exceeding approved") &&
 		strings.Contains(respErr.Error(), "quota") {
 		t.Skip("skipping scenario SKU quota exceeded", t.Name(), err)
+	}
+	// Allocation failures for GPU/exotic SKUs with limited availability.
+	// AllocationFailed returns HTTP 200 (not 409), so it won't be caught by status code checks.
+	// These can persist even after CreateVMSSWithRetry exhausts its retries.
+	if respErr.ErrorCode == "AllocationFailed" {
+		t.Skip("skipping scenario allocation failed", t.Name(), err)
+	}
+	// Zonal allocation constraints — no capacity in the requested zone (409)
+	if respErr.ErrorCode == "OverconstrainedZonalAllocationRequest" ||
+		respErr.ErrorCode == "OverconstrainedAllocationRequest" ||
+		respErr.ErrorCode == "ZonalAllocationFailed" {
+		t.Skip("skipping scenario zonal allocation constrained", t.Name(), err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `skipTestIfSKUNotAvailableErr` previously required HTTP 409 status and only handled `SkuNotAvailable` and quota `OperationNotAllowed` errors
- `AllocationFailed` returns HTTP **200** (not 409), so after `CreateVMSSWithRetry` exhausts its 10 retries, the error leaked through as a **test failure** instead of being skipped — this is the likely cause of intermittent GPU E2E pipeline failures on main
- Adds handling for `AllocationFailed`, `OverconstrainedZonalAllocationRequest`, `OverconstrainedAllocationRequest`, and `ZonalAllocationFailed` error codes
- Removes the `StatusCode == 409` gate so non-409 allocation errors (like `AllocationFailed` at 200) are properly caught

## Context
The GPU E2E pipeline has been intermittently failing on main (alternating success/failure across recent commits). GPU VMs (NC6s_v3, NC24ads_A100_v4, NV6ads_A10_v5) have limited regional availability, and Azure returns various allocation error codes depending on the specific failure mode. The pipeline sets `SKIP_TESTS_WITH_SKU_CAPACITY_ISSUE=true`, but the skip function wasn't catching all allocation-related errors.

## Test plan
- [ ] `go build ./...` passes
- [ ] GPU E2E pipeline stops failing on allocation-related errors (they become skips instead of failures)