### PR TITLE
fix(e2e): strip --pod-infra-container-image for Kubernetes >= 1.35

### DIFF
--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -21,9 +21,8 @@ func baseKubeletConfig() *aksnodeconfigv1.KubeletConfig {
 	return &aksnodeconfigv1.KubeletConfig{
 		EnableKubeletConfigFile: true,
 		KubeletFlags: map[string]string{
-			"--cloud-provider":            "external",
-			"--kubeconfig":                "/var/lib/kubelet/kubeconfig",
-			"--pod-infra-container-image": "mcr.microsoft.com/oss/v2/kubernetes/pause:3.6",
+			"--cloud-provider": "external",
+			"--kubeconfig":     "/var/lib/kubelet/kubeconfig",
 		},
 		KubeletNodeLabels: map[string]string{
 			"agentpool":                               "nodepool2",
@@ -716,7 +715,6 @@ func baseTemplateLinux(t testing.TB, location string, k8sVersion string, arch st
 			"--max-pods":                          "110",
 			"--network-plugin":                    "kubenet",
 			"--node-status-update-frequency":      "10s",
-			"--pod-infra-container-image":         "mcr.microsoft.com/oss/v2/kubernetes/pause:3.6",
 			"--pod-manifest-path":                 "/etc/kubernetes/manifests",
 			"--pod-max-pids":                      "-1",
 			"--protect-kernel-defaults":           "true",
@@ -934,7 +932,6 @@ DXRqvV7TWO2hndliQq3BW385ZkiephlrmpUVM= r2k1@arturs-mbp.lan`,
 			"--kube-reserved":                   "cpu=100m,memory=3891Mi",
 			"--kubeconfig":                      "c:\\k\\config",
 			"--max-pods":                        "30",
-			"--pod-infra-container-image":       "mcr.microsoft.com/oss/v2/kubernetes/pause:3.10.1",
 			"--resolv-conf":                     "\"\"\"\"",
 			"--cluster-dns":                     "10.0.0.10",
 			"--cluster-domain":                  "cluster.local",


### PR DESCRIPTION
## Summary

Kubernetes 1.35 removed the `--pod-infra-container-image` kubelet flag (deprecated since 1.24). When AKS RP sends this flag for 1.35+ clusters, kubelet crash-loops with:

```
"command failed" err="failed to parse kubelet flag: unknown flag: --pod-infra-container-image"
```

The sandbox image is already configured separately via `containerd.toml` (`PodInfraContainerSpec`), so removing the CLI flag has no functional impact.

## Root Cause

Discovered during E2E gate failures where Random VHD tests selected AzureLinuxV3gen2 with kubelet 1.35.1. CSE reported exit 0 (kubelet hadn't crash-looped yet), but nodes never joined the cluster.

## Changes

| File | Change |
|------|--------|
| `pkg/agent/baker.go` | Version-gated `delete(kubeletFlags, "--pod-infra-container-image")` for K8s >= 1.35, both Linux and Windows paths |
| `aks-node-controller/parser/helper.go` | Strip flag in `getKubeletFlags()` for >= 1.35 |
| `parts/linux/cloud-init/artifacts/cse_config.sh` | Defensive strip before writing `KUBELET_FLAGS` (forward-compat: old AgentBaker + new kubelet) |
| `e2e/node_config.go` | Remove hardcoded flag from test configs (not needed, containerd config handles sandbox image) |

## Why the flag is safe to remove

- The sandbox (pause) image is configured via `containerd.toml` → `sandbox_image` setting
- `PodInfraContainerSpec` in `KubeBinaryConfig` populates containerd config independently
- `get_sandbox_image()` in `cse_helpers.sh` already has a 1.35 guard — only falls back to kubelet flags for < 1.35
- Flag was deprecated since Kubernetes 1.24; containerd has been the default since then

## Testing

- All `pkg/agent` tests pass
- All `aks-node-controller/parser` tests pass
- Snapshot test data regenerated

## Linked Work Items

AB#37487803