### PR TITLE
fix(e2e): resolve debug pod before wireserver check retry loop

### DIFF
--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -239,9 +239,15 @@ func getIPTablesRulesCompatibleWithEBPFHostRouting() (map[string][]string, []str
 // validateWireServerBlocked checks that unprivileged pods cannot reach WireServer.
 // The iptables FORWARD DROP rules blocking pod→WireServer traffic can be transiently
 // absent when kube-proxy or CNI flush/recreate iptables chains during node setup.
-// We retry several times before failing to avoid flaky test results.
+// We resolve the debug pod once up front (outside the retry budget) so that pod
+// scheduling latency doesn't eat into the iptables-check timeout.
 func validateWireServerBlocked(ctx context.Context, s *Scenario) {
 	defer toolkit.LogStep(s.T, "validating wireserver is blocked from unprivileged pods")()
+
+	// Resolve the unprivileged debug pod once — this can take 25-30s on cold nodes.
+	// Using the parent context so it has the full scenario timeout, not the short poll timeout.
+	nonHostPod, err := s.Runtime.Cluster.Kube.GetPodNetworkDebugPodForNode(ctx, s.Runtime.VM.KubeName)
+	require.NoError(s.T, err, "failed to get non host debug pod for wireserver validation")
 
 	type wireServerCheck struct {
 		cmd  string
@@ -262,7 +268,12 @@ func validateWireServerBlocked(ctx context.Context, s *Scenario) {
 	for _, check := range checks {
 		var lastResult *podExecResult
 		err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
-			lastResult = execOnVMForScenarioOnUnprivilegedPod(ctx, s, check.cmd)
+			execResult, execErr := execOnUnprivilegedPod(ctx, s.Runtime.Cluster.Kube, nonHostPod.Namespace, nonHostPod.Name, check.cmd)
+			if execErr != nil {
+				s.T.Logf("wireserver check %q: exec error (retrying): %v", check.desc, execErr)
+				return false, nil
+			}
+			lastResult = execResult
 			if lastResult.exitCode == "28" {
 				return true, nil
 			}


### PR DESCRIPTION
## Summary

Fixes flaky `validateWireServerBlocked` E2E failures caused by debug pod scheduling latency consuming the retry budget.

## Root Cause

`execOnVMForScenarioOnUnprivilegedPod` was called **on every poll iteration** inside a 60-second timeout. Since it calls `GetPodNetworkDebugPodForNode` (which waits for the pod to become Ready), and pod scheduling takes 25-30s on cold nodes, only 2 iterations fit — and sometimes the pod doesn't start at all within 60s.

**Data from build [160005315](https://dev.azure.com/msazure/CloudNativeCompute/_build/results?buildId=160005315):**
- 51/71 (72%) wireserver checks needed retries due to pod scheduling latency
- 1 test failure: pod never became ready in 60s, curl was never executed
- Zero actual iptables rule failures (`exit code 28` was never incorrect)

## Fix

Move `GetPodNetworkDebugPodForNode` **outside** the poll loop so it uses the full scenario context timeout. The 60-second retry window is now entirely dedicated to the iptables curl checks.

Also handle exec errors gracefully inside the poll loop (retry instead of fatal abort).

### Before
```
poll(10s, 60s) {
    pod = GetPodNetworkDebugPodForNode(ctx)  // 25-30s each time!
    curl = exec(pod, curl ...)
    check exit code
}
```

### After
```
pod = GetPodNetworkDebugPodForNode(ctx)  // once, full scenario timeout
poll(10s, 60s) {
    curl = exec(pod, curl ...)           // all 60s for actual checks
    check exit code
}
```

## Testing

- `go build ./...` passes in e2e module
- No snapshot regeneration needed (e2e-only change)

## Linked Work Items

AB#37488329