### PR TITLE
fix(renovate): enable Renovate version tracking for DCGM AzureLinux 3.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -487,7 +487,7 @@
         "oss/binaries/kubernetes/kubernetes-node",
         "oss/binaries/kubernetes/azure-acr-credential-provider"
       ],
-      "extractVersion": "^(?P<version>.*?)-[^-]*-[^-]*$"
+      "extractVersion": "^(?<version>.*?)-[^-]*-[^-]*$"
     },
     {
       "matchDatasources": [
@@ -497,7 +497,7 @@
         "oss/v2/kubernetes/*-sysext"
       ],
       "matchCurrentVersion": "/-azlinux3$/",
-      "extractVersion": "^(?P<version>.+-azlinux3)-"
+      "extractVersion": "^(?<version>.+-azlinux3)-"
     },
     {
       "matchPackageNames": [
@@ -683,6 +683,20 @@
     },
     {
       "customType": "regex",
+      "description": "auto update Nvidia DCGM packages for OS AzureLinux 3.0 in components.json",
+      "managerFilePatterns": [
+        "/parts/common/components.json/"
+      ],
+      "matchStringsStrategy": "any",
+      "matchStrings": [
+        "\"renovateTag\":\\s*\"name=(?<packageName>datacenter-gpu-manager-4-core|datacenter-gpu-manager-4-proprietary), repository=nvidia, os=azurelinux, release=3\\.0\",\\s*\"latestVersion\":\\s*\"(?<currentValue>[^\"]+)\"(?:[^}]*\"previousLatestVersion\":\\s*\"(?<depType>[^\"]+)\")?"
+      ],
+      "datasourceTemplate": "custom.nvidia-rpm-azl3",
+      "versioningTemplate": "deb",
+      "autoReplaceStringTemplate": "\"renovateTag\": \"name={{{packageName}}}, repository=nvidia, os=azurelinux, release=3.0\",\n                \"latestVersion\": \"{{{newValue}}}\"{{#if depType}},\n                \"previousLatestVersion\": \"{{{currentValue}}}\"{{/if}}"
+    },
+    {
+      "customType": "regex",
       "description": "auto update GitHub release versions in components.json",
       "managerFilePatterns": [
         "/parts/common/components.json/"
@@ -752,6 +766,13 @@
       "format": "plain",
       "transformTemplates": [
         "{\"releases\": $map(($index := releases#$i[version=\"Package: {{packageName}}\"].$i; $map($index, function($i) { $substringAfter(releases[$i + 1].version, \"Version: \") })), function($v) { {\"version\": $v} })[]}"
+      ]
+    },
+    "nvidia-rpm-azl3": {
+      "defaultRegistryUrlTemplate": "https://developer.download.nvidia.com/compute/cuda/repos/azl3/x86_64/",
+      "format": "html",
+      "transformTemplates": [
+        "{\"releases\": [releases[$contains(version, \"{{packageName}}-\") and $contains(version, \".x86_64.rpm\") and $not($contains(version, \"debuginfo\")) and $match($substringAfter(version, \"{{packageName}}-\"), /^[0-9]/)].{\"version\": \"1:\" & $substringBefore($substringAfter(version, \"{{packageName}}-\"), \".x86_64.rpm\")}]}"
       ]
     },
     "deb2404-test": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -407,6 +407,24 @@
     },
     {
       "matchPackageNames": [
+        "datacenter-gpu-manager-4-core",
+        "datacenter-gpu-manager-4-proprietary",
+        "dcgm-exporter"
+      ],
+      "groupName": "nvidia-dcgm",
+      "assignees": [
+        "djsly",
+        "ganeshkumarashok",
+        "surajssd"
+      ],
+      "reviewers": [
+        "djsly",
+        "ganeshkumarashok",
+        "surajssd"
+      ]
+    },
+    {
+      "matchPackageNames": [
         "oss/kubernetes-csi/**"
       ],
       "groupName": "csi",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -683,13 +683,13 @@
     },
     {
       "customType": "regex",
-      "description": "auto update Nvidia DCGM packages for OS AzureLinux 3.0 in components.json",
+      "description": "auto update Nvidia packages for OS AzureLinux 3.0 in components.json",
       "managerFilePatterns": [
         "/parts/common/components.json/"
       ],
       "matchStringsStrategy": "any",
       "matchStrings": [
-        "\"renovateTag\":\\s*\"name=(?<packageName>datacenter-gpu-manager-4-core|datacenter-gpu-manager-4-proprietary), repository=nvidia, os=azurelinux, release=3\\.0\",\\s*\"latestVersion\":\\s*\"(?<currentValue>[^\"]+)\"(?:[^}]*\"previousLatestVersion\":\\s*\"(?<depType>[^\"]+)\")?"
+        "\"renovateTag\":\\s*\"name=(?<packageName>[^,]+), repository=nvidia, os=azurelinux, release=3\\.0\",\\s*\"latestVersion\":\\s*\"(?<currentValue>[^\"]+)\"(?:[^}]*\"previousLatestVersion\":\\s*\"(?<depType>[^\"]+)\")?"
       ],
       "datasourceTemplate": "custom.nvidia-rpm-azl3",
       "versioningTemplate": "deb",

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1998,7 +1998,7 @@
           "DEFAULT/v3.0": {
             "versionsV2": [
               {
-                "renovateTag": "RPM_registry=https://developer.download.nvidia.com/compute/cuda/repos/azl3/x86_64/repodata, name=datacenter-gpu-manager-4-core, repository=nvidia, os=azurelinux, release=3.0",
+                "renovateTag": "name=datacenter-gpu-manager-4-core, repository=nvidia, os=azurelinux, release=3.0",
                 "latestVersion": "1:4.5.2-1"
               }
             ]
@@ -2032,7 +2032,7 @@
           "DEFAULT/v3.0": {
             "versionsV2": [
               {
-                "renovateTag": "RPM_registry=https://developer.download.nvidia.com/compute/cuda/repos/azl3/x86_64/repodata, name=datacenter-gpu-manager-4-proprietary, repository=nvidia, os=azurelinux, release=3.0",
+                "renovateTag": "name=datacenter-gpu-manager-4-proprietary, repository=nvidia, os=azurelinux, release=3.0",
                 "latestVersion": "1:4.5.2-1"
               }
             ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes Renovate skipping Azure Linux 3.0 version bumps for DCGM packages (`datacenter-gpu-manager-4-core` and `datacenter-gpu-manager-4-proprietary`). Three issues were identified and resolved:

1. **Missing DCGM AzureLinux regex manager**: When DCGM packages were originally added in #7063, only Ubuntu 22.04 and 24.04 Renovate managers were created. The Azure Linux 3.0 entries in `components.json` had a `renovateTag` with `RPM_registry=...` prefix and a `repository=nvidia` field that didn't match the generic AzureLinux 3.0 RPM regex (which expected `name=` immediately followed by `, os=azurelinux`). This PR adds a dedicated custom regex manager pointing to a new `nvidia-rpm-azl3` custom datasource that scrapes the [NVIDIA AzL3 HTML directory listing](https://developer.download.nvidia.com/compute/cuda/repos/azl3/x86_64/) for available RPM versions.

2. **Wrong `renovateTag` format in `components.json`**: The DCGM AzureLinux entries included an `RPM_registry=` prefix referencing the `/repodata` path, but NVIDIA's repo doesn't use standard RPM repodata XML — it's an HTML directory listing. The `RPM_registry=` prefix is removed since the registry URL is now hardcoded in the `nvidia-rpm-azl3` custom datasource's `defaultRegistryUrlTemplate`.

3. **Python-style named groups in `extractVersion` regexes**: Two pre-existing `extractVersion` entries (for `oss/binaries/kubernetes/*` and `oss/v2/kubernetes/*-sysext`) used Python-style `(?P<version>...)` named groups instead of JavaScript/RE2-style `(?<version>...)`. Renovate's regex engine (RE2 via `uhop/node-re2`) does not support `(?P<...>)` syntax, causing `config-validation` errors that **aborted the entire lookup phase** (`lookup: 0ms`), preventing version updates for all packages — not just DCGM.

### Changes

- **`.github/renovate.json`**:
  - Add `nvidia-rpm-azl3` custom datasource with `format: "html"` and a JSONata transform that filters RPM filenames, excludes `debuginfo` variants, and prepends the `1:` epoch prefix
  - Add dedicated custom regex manager for DCGM AzureLinux 3.0 packages using `datasourceTemplate: "custom.nvidia-rpm-azl3"` and `versioningTemplate: "deb"` (to handle epoch-prefixed versions)
  - Fix `extractVersion` on line 528: `(?P<version>...)` → `(?<version>...)`
  - Fix `extractVersion` on line 538: `(?P<version>...)` → `(?<version>...)`
- **`parts/common/components.json`**:
  - Remove `RPM_registry=https://developer.download.nvidia.com/compute/cuda/repos/azl3/x86_64/repodata, ` prefix from `renovateTag` for `datacenter-gpu-manager-4-core` AzureLinux 3.0 entry
  - Remove same prefix from `datacenter-gpu-manager-4-proprietary` AzureLinux 3.0 entry

### Verification

Tested locally with `LOG_LEVEL=debug npx renovate --platform=local --dry-run=lookup`:
- Extract phase successfully matches both DCGM AzureLinux packages
- Lookup phase completes (no longer aborted by `config-validation`)
- `nvidia-rpm-azl3` datasource fetches the NVIDIA HTML directory and resolves versions correctly

**Which issue(s) this PR fixes**:

Inspired by: https://github.com/Azure/AgentBaker/pull/8221#pullrequestreview-4047137476 and https://github.com/Azure/AgentBaker/pull/8220#pullrequestreview-4047138044