### PR TITLE
fix(e2e): prevent kubenet route table detachment and stale node accumulation

### DIFF
--- a/e2e/aks_model.go
+++ b/e2e/aks_model.go
@@ -302,21 +302,43 @@ func addFirewallRules(
 ) error {
 	location := *clusterModel.Location
 	defer toolkit.LogStepCtx(ctx, "adding firewall rules")()
-	routeTableName := "abe2e-fw-rt"
-	rtGetResp, err := config.Azure.RouteTables.Get(
-		ctx,
-		*clusterModel.Properties.NodeResourceGroup,
-		routeTableName,
-		nil,
-	)
-	if err == nil && len(rtGetResp.Properties.Subnets) != 0 {
-		// already associated with aks subnet
-		return nil
-	}
 
-	vnet, err := getClusterVNet(ctx, *clusterModel.Properties.NodeResourceGroup)
+	rg := *clusterModel.Properties.NodeResourceGroup
+	vnet, err := getClusterVNet(ctx, rg)
 	if err != nil {
 		return err
+	}
+
+	// Find the AKS-managed route table currently associated with the subnet.
+	// We add firewall routes directly to this table so that both pod routes
+	// (managed by cloud-provider-azure) and firewall routes coexist. Creating
+	// a separate route table and swapping the subnet association disconnects
+	// the pod routes and breaks kubenet networking.
+	aksSubnetResp, err := config.Azure.Subnet.Get(ctx, rg, vnet.name, "aks-subnet", nil)
+	if err != nil {
+		return fmt.Errorf("failed to get AKS subnet: %w", err)
+	}
+	if aksSubnetResp.Properties == nil || aksSubnetResp.Properties.RouteTable == nil || aksSubnetResp.Properties.RouteTable.ID == nil {
+		return fmt.Errorf("AKS subnet has no route table associated")
+	}
+
+	aksRTID := *aksSubnetResp.Properties.RouteTable.ID
+	idParts := strings.Split(aksRTID, "/")
+	aksRTName := idParts[len(idParts)-1]
+
+	// Check if firewall routes already exist in the AKS route table
+	aksRT, err := config.Azure.RouteTables.Get(ctx, rg, aksRTName, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get AKS route table %q: %w", aksRTName, err)
+	}
+
+	if aksRT.Properties != nil {
+		for _, route := range aksRT.Properties.Routes {
+			if route.Name != nil && *route.Name == "default-route-to-firewall" {
+				toolkit.Logf(ctx, "firewall routes already present in AKS route table %q", aksRTName)
+				return nil
+			}
+		}
 	}
 
 	// Create AzureFirewallSubnet - this subnet name is required by Azure Firewall
@@ -330,7 +352,7 @@ func addFirewallRules(
 	toolkit.Logf(ctx, "Creating subnet %s in VNet %s", firewallSubnetName, vnet.name)
 	subnetPoller, err := config.Azure.Subnet.BeginCreateOrUpdate(
 		ctx,
-		*clusterModel.Properties.NodeResourceGroup,
+		rg,
 		vnet.name,
 		firewallSubnetName,
 		firewallSubnetParams,
@@ -363,7 +385,7 @@ func addFirewallRules(
 	toolkit.Logf(ctx, "Creating public IP %s", publicIPName)
 	pipPoller, err := config.Azure.PublicIPAddresses.BeginCreateOrUpdate(
 		ctx,
-		*clusterModel.Properties.NodeResourceGroup,
+		rg,
 		publicIPName,
 		publicIPParams,
 		nil,
@@ -382,7 +404,7 @@ func addFirewallRules(
 
 	firewallName := "abe2e-fw"
 	firewall := getFirewall(ctx, location, firewallSubnetID, publicIPID)
-	fwPoller, err := config.Azure.AzureFirewall.BeginCreateOrUpdate(ctx, *clusterModel.Properties.NodeResourceGroup, firewallName, *firewall, nil)
+	fwPoller, err := config.Azure.AzureFirewall.BeginCreateOrUpdate(ctx, rg, firewallName, *firewall, nil)
 	if err != nil {
 		return fmt.Errorf("failed to start Firewall creation: %w", err)
 	}
@@ -404,85 +426,41 @@ func addFirewallRules(
 		return fmt.Errorf("failed to get firewall private IP address")
 	}
 
-	routeTableParams := armnetwork.RouteTable{
-		Location: to.Ptr(location),
-		Properties: &armnetwork.RouteTablePropertiesFormat{
-			Routes: []*armnetwork.Route{
-				// Allow internal VNet traffic to bypass the firewall
-				{
-					Name: to.Ptr("vnet-local"),
-					Properties: &armnetwork.RoutePropertiesFormat{
-						AddressPrefix: to.Ptr("10.224.0.0/16"), // AKS subnet CIDR
-						NextHopType:   to.Ptr(armnetwork.RouteNextHopTypeVnetLocal),
-					},
-				},
-				// Route all other traffic (internet-bound) through the firewall
-				{
-					Name: to.Ptr("default-route-to-firewall"),
-					Properties: &armnetwork.RoutePropertiesFormat{
-						AddressPrefix:    to.Ptr("0.0.0.0/0"),
-						NextHopType:      to.Ptr(armnetwork.RouteNextHopTypeVirtualAppliance),
-						NextHopIPAddress: to.Ptr(firewallPrivateIP),
-					},
-				},
+	// Add firewall routes to the existing AKS route table using individual
+	// route operations. This avoids replacing the entire table (which would
+	// race with cloud-provider-azure pod route updates) and preserves the
+	// subnet association so pod CIDR routes remain active.
+	firewallRoutes := []armnetwork.Route{
+		{
+			Name: to.Ptr("vnet-local"),
+			Properties: &armnetwork.RoutePropertiesFormat{
+				AddressPrefix: to.Ptr("10.224.0.0/16"),
+				NextHopType:   to.Ptr(armnetwork.RouteNextHopTypeVnetLocal),
 			},
-			DisableBgpRoutePropagation: to.Ptr(true),
+		},
+		{
+			Name: to.Ptr("default-route-to-firewall"),
+			Properties: &armnetwork.RoutePropertiesFormat{
+				AddressPrefix:    to.Ptr("0.0.0.0/0"),
+				NextHopType:      to.Ptr(armnetwork.RouteNextHopTypeVirtualAppliance),
+				NextHopIPAddress: to.Ptr(firewallPrivateIP),
+			},
 		},
 	}
 
-	toolkit.Logf(ctx, "Creating route table %s", routeTableName)
-	rtPoller, err := config.Azure.RouteTables.BeginCreateOrUpdate(
-		ctx,
-		*clusterModel.Properties.NodeResourceGroup,
-		routeTableName,
-		routeTableParams,
-		nil,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to start creating route table: %w", err)
+	for _, route := range firewallRoutes {
+		toolkit.Logf(ctx, "Adding route %q to AKS route table %q", *route.Name, aksRTName)
+		poller, err := config.Azure.Routes.BeginCreateOrUpdate(ctx, rg, aksRTName, *route.Name, route, nil)
+		if err != nil {
+			return fmt.Errorf("failed to start adding route %q: %w", *route.Name, err)
+		}
+		_, err = poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+		if err != nil {
+			return fmt.Errorf("failed to add route %q to AKS route table: %w", *route.Name, err)
+		}
 	}
 
-	rtResp, err := rtPoller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
-	if err != nil {
-		return fmt.Errorf("failed to create route table: %w", err)
-	}
-
-	toolkit.Logf(ctx, "Created route table with ID: %s", *rtResp.ID)
-
-	// Get the AKS subnet and associate it with the route table
-	aksSubnetResp, err := config.Azure.Subnet.Get(ctx, *clusterModel.Properties.NodeResourceGroup, vnet.name, "aks-subnet", nil)
-	if err != nil {
-		return fmt.Errorf("failed to get AKS subnet: %w", err)
-	}
-
-	// Update subnet to associate with route table
-	aksSubnet := aksSubnetResp.Subnet
-	if aksSubnet.Properties == nil {
-		aksSubnet.Properties = &armnetwork.SubnetPropertiesFormat{}
-	}
-	aksSubnet.Properties.RouteTable = &armnetwork.RouteTable{
-		ID: rtResp.ID,
-	}
-
-	toolkit.Logf(ctx, "Associating route table with AKS subnet")
-	subnetUpdatePoller, err := config.Azure.Subnet.BeginCreateOrUpdate(
-		ctx,
-		*clusterModel.Properties.NodeResourceGroup,
-		vnet.name,
-		"aks-subnet",
-		aksSubnet,
-		nil,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to start updating subnet with route table: %w", err)
-	}
-
-	_, err = subnetUpdatePoller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
-	if err != nil {
-		return fmt.Errorf("failed to associate route table with subnet: %w", err)
-	}
-
-	toolkit.Logf(ctx, "Successfully configured firewall and routing for AKS cluster")
+	toolkit.Logf(ctx, "Successfully added firewall routes to AKS route table %q", aksRTName)
 	return nil
 }
 

--- a/e2e/aks_model.go
+++ b/e2e/aks_model.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/agentbaker/e2e/toolkit"
 	"github.com/Azure/agentbaker/pkg/agent"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8"
@@ -323,22 +324,13 @@ func addFirewallRules(
 	}
 
 	aksRTID := *aksSubnetResp.Properties.RouteTable.ID
-	idParts := strings.Split(aksRTID, "/")
-	aksRTName := idParts[len(idParts)-1]
-
-	// Check if firewall routes already exist in the AKS route table
-	aksRT, err := config.Azure.RouteTables.Get(ctx, rg, aksRTName, nil)
+	parsedRT, err := arm.ParseResourceID(aksRTID)
 	if err != nil {
-		return fmt.Errorf("failed to get AKS route table %q: %w", aksRTName, err)
+		return fmt.Errorf("failed to parse AKS route table resource ID %q: %w", aksRTID, err)
 	}
-
-	if aksRT.Properties != nil {
-		for _, route := range aksRT.Properties.Routes {
-			if route.Name != nil && *route.Name == "default-route-to-firewall" {
-				toolkit.Logf(ctx, "firewall routes already present in AKS route table %q", aksRTName)
-				return nil
-			}
-		}
+	aksRTName := parsedRT.Name
+	if aksRTName == "" {
+		return fmt.Errorf("parsed empty route table name from resource ID %q", aksRTID)
 	}
 
 	// Create AzureFirewallSubnet - this subnet name is required by Azure Firewall

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -90,11 +90,11 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 	identity := dag.Go(g, func(ctx context.Context) (*armcontainerservice.UserAssignedIdentity, error) {
 		return getClusterKubeletIdentity(ctx, cluster)
 	})
-	// networkSetup associates a route table with aks-subnet (firewall or
-	// network-isolated NSG).  It must run after bastion (both mutate the
-	// VNet) and before collectGarbageVMSS (VMSS deletion triggers AKS
-	// cloud-controller route reconciliation that can race with the subnet
-	// association and leave the AKS pod route table detached).
+	// networkSetup adds firewall routes to the AKS route table or applies
+	// network-isolated NSG.  It must run after bastion (both mutate the
+	// VNet) and before collectGarbageVMSS (which needs network setup done).
+	// collectGarbageVMSS also depends on kube to clean up stale K8s Node
+	// objects whose backing VMSS no longer exist.
 	var networkDeps []dag.Dep
 	if !isNetworkIsolated {
 		networkDeps = append(networkDeps, dag.Run(g, func(ctx context.Context) error { return addFirewallRules(ctx, cluster) }, bastion))
@@ -102,7 +102,7 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 	if isNetworkIsolated {
 		networkDeps = append(networkDeps, dag.Run(g, func(ctx context.Context) error { return addNetworkIsolatedSettings(ctx, cluster) }, bastion))
 	}
-	dag.Run(g, func(ctx context.Context) error { return collectGarbageVMSS(ctx, cluster) }, networkDeps...)
+	dag.Run1(g, kube, func(ctx context.Context, k *Kubeclient) error { return collectGarbageVMSS(ctx, cluster, k) }, networkDeps...)
 	needACR := isNetworkIsolated || attachPrivateAcr
 	acrNonAnon := dag.Run2(g, kube, identity, addACR(cluster, needACR, true))
 	acrAnon := dag.Run2(g, kube, identity, addACR(cluster, needACR, false))
@@ -700,9 +700,12 @@ func getClusterVNet(ctx context.Context, mcResourceGroupName string) (VNet, erro
 	return VNet{}, fmt.Errorf("failed to find aks vnet")
 }
 
-func collectGarbageVMSS(ctx context.Context, cluster *armcontainerservice.ManagedCluster) error {
+func collectGarbageVMSS(ctx context.Context, cluster *armcontainerservice.ManagedCluster, kube *Kubeclient) error {
 	defer toolkit.LogStepCtx(ctx, "collecting garbage VMSS")()
 	rg := *cluster.Properties.NodeResourceGroup
+
+	// Build a set of all existing VMSS names while deleting old ones.
+	existingVMSS := map[string]struct{}{}
 	pager := config.Azure.VMSS.NewListPager(rg, nil)
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
@@ -710,6 +713,8 @@ func collectGarbageVMSS(ctx context.Context, cluster *armcontainerservice.Manage
 			return fmt.Errorf("failed to get next page of VMSS: %w", err)
 		}
 		for _, vmss := range page.Value {
+			existingVMSS[*vmss.Name] = struct{}{}
+
 			if _, ok := vmss.Tags["KEEP_VMSS"]; ok {
 				continue
 			}
@@ -735,7 +740,45 @@ func collectGarbageVMSS(ctx context.Context, cluster *armcontainerservice.Manage
 		}
 	}
 
+	collectGarbageNodes(ctx, kube, existingVMSS)
 	return nil
+}
+
+// collectGarbageNodes deletes Kubernetes Node objects whose backing VMSS no
+// longer exists. This prevents stale nodes from accumulating in the cluster
+// and overwhelming the cloud-provider-azure route controller with perpetual
+// "instance not found" failures.
+func collectGarbageNodes(ctx context.Context, kube *Kubeclient, existingVMSS map[string]struct{}) {
+	defer toolkit.LogStepCtx(ctx, "collecting garbage K8s nodes")()
+
+	nodes, err := kube.Typed.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		toolkit.Logf(ctx, "failed to list K8s nodes for garbage collection: %s", err)
+		return
+	}
+
+	for _, node := range nodes.Items {
+		// skip managed pool nodes (system nodepool)
+		if strings.HasPrefix(node.Name, "aks-") {
+			continue
+		}
+
+		// VMSS instance names are the VMSS name + 6-digit instance ID suffix
+		if len(node.Name) < 7 {
+			continue
+		}
+		vmssName := node.Name[:len(node.Name)-6]
+
+		if _, exists := existingVMSS[vmssName]; exists {
+			continue
+		}
+
+		if err := kube.Typed.CoreV1().Nodes().Delete(ctx, node.Name, metav1.DeleteOptions{}); err != nil {
+			toolkit.Logf(ctx, "failed to delete stale node %q: %s", node.Name, err)
+			continue
+		}
+		toolkit.Logf(ctx, "deleted stale K8s node %q (VMSS %q not found)", node.Name, vmssName)
+	}
 }
 
 func ensureResourceGroup(ctx context.Context, location string) (armresources.ResourceGroup, error) {

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -740,7 +740,9 @@ func collectGarbageVMSS(ctx context.Context, cluster *armcontainerservice.Manage
 		}
 	}
 
-	collectGarbageNodes(ctx, kube, existingVMSS)
+	if err := collectGarbageNodes(ctx, kube, existingVMSS); err != nil {
+		return fmt.Errorf("failed to collect garbage K8s nodes: %w", err)
+	}
 	return nil
 }
 
@@ -748,15 +750,15 @@ func collectGarbageVMSS(ctx context.Context, cluster *armcontainerservice.Manage
 // longer exists. This prevents stale nodes from accumulating in the cluster
 // and overwhelming the cloud-provider-azure route controller with perpetual
 // "instance not found" failures.
-func collectGarbageNodes(ctx context.Context, kube *Kubeclient, existingVMSS map[string]struct{}) {
+func collectGarbageNodes(ctx context.Context, kube *Kubeclient, existingVMSS map[string]struct{}) error {
 	defer toolkit.LogStepCtx(ctx, "collecting garbage K8s nodes")()
 
 	nodes, err := kube.Typed.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		toolkit.Logf(ctx, "failed to list K8s nodes for garbage collection: %s", err)
-		return
+		return fmt.Errorf("listing K8s nodes for garbage collection: %w", err)
 	}
 
+	var deleteErrors []error
 	for _, node := range nodes.Items {
 		// skip managed pool nodes (system nodepool)
 		if strings.HasPrefix(node.Name, "aks-") {
@@ -774,11 +776,16 @@ func collectGarbageNodes(ctx context.Context, kube *Kubeclient, existingVMSS map
 		}
 
 		if err := kube.Typed.CoreV1().Nodes().Delete(ctx, node.Name, metav1.DeleteOptions{}); err != nil {
-			toolkit.Logf(ctx, "failed to delete stale node %q: %s", node.Name, err)
+			deleteErrors = append(deleteErrors, fmt.Errorf("deleting stale node %q: %w", node.Name, err))
 			continue
 		}
 		toolkit.Logf(ctx, "deleted stale K8s node %q (VMSS %q not found)", node.Name, vmssName)
 	}
+
+	if len(deleteErrors) > 0 {
+		return fmt.Errorf("failed to delete %d stale nodes, first error: %w", len(deleteErrors), deleteErrors[0])
+	}
+	return nil
 }
 
 func ensureResourceGroup(ctx context.Context, location string) (armresources.ResourceGroup, error) {

--- a/e2e/config/azure.go
+++ b/e2e/config/azure.go
@@ -61,6 +61,7 @@ type AzureClient struct {
 	StorageAccounts           *armstorage.AccountsClient
 	Subnet                    *armnetwork.SubnetsClient
 	PublicIPAddresses         *armnetwork.PublicIPAddressesClient
+	Routes                    *armnetwork.RoutesClient
 	RouteTables               *armnetwork.RouteTablesClient
 	UserAssignedIdentities    *armmsi.UserAssignedIdentitiesClient
 	VMSS                      *armcompute.VirtualMachineScaleSetsClient
@@ -217,6 +218,11 @@ func NewAzureClient() (*AzureClient, error) {
 	cloud.RouteTables, err = armnetwork.NewRouteTablesClient(Config.SubscriptionID, credential, opts)
 	if err != nil {
 		return nil, fmt.Errorf("create route tables client: %w", err)
+	}
+
+	cloud.Routes, err = armnetwork.NewRoutesClient(Config.SubscriptionID, credential, opts)
+	if err != nil {
+		return nil, fmt.Errorf("create routes client: %w", err)
 	}
 
 	cloud.AKS, err = armcontainerservice.NewManagedClustersClient(Config.SubscriptionID, credential, opts)


### PR DESCRIPTION
## Problem

ALL 40 kubenet E2E tests have been failing consistently with `cni plugin not initialized` / nodes stuck in `Waiting for cloud routes`. Root cause investigation revealed a **compound failure** involving two independent bugs in the E2E infrastructure.

## Root Cause Analysis

### 1. Stale K8s Node Accumulation
`collectGarbageVMSS` deletes Azure VMSS instances but does NOT clean up the corresponding Kubernetes Node objects. Over multiple E2E runs, **99+ stale nodes** accumulated in the kubenet cluster. The cloud-provider-azure route controller perpetually retried `CreateRoute` for these ghost nodes, receiving `instance not found` errors (36+ observed in events). This **saturated the route controller**, starving new legitimate nodes of routes.

### 2. Disconnected Route Table
`addFirewallRules` created a separate `abe2e-fw-rt` route table (containing only firewall routes) and **swapped it onto the subnet**, disconnecting the AKS-managed `aks-agentpool-*-routetable` that holds pod CIDR routes. Cloud-provider-azure continued writing pod routes to the disconnected table — with no effect on actual traffic.

### Evidence
- **Azure Activity Logs**: ZERO subnet modifications during the entire test window. Only 1 route table write at 20:38 (after tests were already failing).
- **kubectl**: 99 Node objects in cluster, 36+ `FailedToCreateRoute` events with "instance not found"
- **Pass/fail correlation**: ALL 40 kubenet tests failed; "passing" tests were Azure CNI / network-isolated (different cluster)
- **Timeline**: 41 VMSS hit the kubenet cluster in a 22-second window from both Regular and Scriptless E2E pipelines

## Fix

### Fix 1: Stale Node Cleanup (`e2e/cluster.go`)
Added `collectGarbageNodes()` that:
- Lists all K8s nodes in the cluster
- Builds a set of active VMSS names
- Identifies nodes whose backing VMSS no longer exists (by deriving VMSS name from node name)
- Preserves system pool nodes (prefixed with `aks-`)
- Deletes stale nodes

Wired into the DAG via `dag.Run1` with kube dependency so it runs after VMSS GC.

### Fix 2: Preserve AKS Route Table (`e2e/aks_model.go`)
Rewrote `addFirewallRules()` to:
- Find the AKS-managed route table already associated with the subnet
- Add firewall routes (`vnet-local` + `default-route-to-firewall`) directly to that table
- Use individual `Routes` client operations to avoid TOCTOU races
- **Never** create a separate route table or change subnet association

### Supporting Change (`e2e/config/azure.go`)
Added `Routes *armnetwork.RoutesClient` for individual route operations.

## Live Cluster Remediation
- ✅ Re-associated `aks-agentpool-13663576-routetable` with `aks-subnet`
- ✅ Added `vnet-local` and `default-route-to-firewall` routes to AKS table
- ✅ Both pod CIDR routes and firewall routes now coexist

## Testing
- `go build ./...` passes
- Changes are E2E infrastructure only (no `parts/` or `pkg/` changes, no `make generate` needed)
- Full E2E validation will occur on next pipeline run
