### PR TITLE
fix: use dpkg for local deb installs

### DIFF
--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
@@ -118,9 +118,12 @@ apt_get_dist_upgrade() {
   wait_for_apt_locks
 }
 installDebPackageFromFile() {
-    DEB_FILE=$1
+    export DEBIAN_FRONTEND=noninteractive
+    local DEB_FILE=$1
     wait_for_apt_locks
-    retrycmd_if_failure 10 5 600 apt-get -y -f install ${DEB_FILE} --allow-downgrades
+    retrycmd_if_failure 3 5 120 dpkg --force-confdef --force-confold -i "${DEB_FILE}" || {
+        retrycmd_if_failure 10 5 600 apt-get -y -f install "${DEB_FILE}" --allow-downgrades
+    }
     if [ "$?" -ne 0 ]; then
         return 1
     fi


### PR DESCRIPTION
Ubuntu CSE was staging kubelet and kubectl debs under /opt/.../downloads, but installDebPackageFromFile still used apt-get install on the local deb path. In practice apt continued consulting PMC, refetched the packages, and overlapped with the background apt-mark walinuxagent hold flow, which inflated the installKubeletKubectlFromPkg latency in Ubuntu 22.04.

Switch the fast path to a single noninteractive `dpkg --force-confdef --force-confold -i` of the staged deb so the hotfix uses the cached local artifact directly. Keep the existing apt-get -f install fallback unchanged so dependency repair behavior stays the same if dpkg fails.