### PR TITLE
feat: pass cse cmd generated from nbc to node controller

### DIFF
--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -250,18 +250,30 @@ stages:
     condition: and(succeeded(), ne(variables.SKIP_E2E_TESTS, 'true'))
     variables:
       VHD_BUILD_ID: $(Build.BuildId)
-      DISABLE_SCRIPTLESS_COMPILATION: true
+      TAGS_TO_SKIP: gpu=true,os=windows,scriptless=true
     jobs:
       - template: ./templates/e2e-template.yaml
         parameters:
           IgnoreScenariosWithMissingVhd: true
 
-  - stage: scriptless_cse_cmd_e2e
+  - stage: scriptless_e2e
     dependsOn: build
     condition: and(succeeded(), ne(variables.SKIP_E2E_TESTS, 'true'))
     variables:
       VHD_BUILD_ID: $(Build.BuildId)
-      ENABLE_SCRIPTLESS_CSE_CMD: true
+      DISABLE_SCRIPTLESS_COMPILATION: true
+      TAGS_TO_RUN: scriptless=true
+    jobs:
+      - template: ./templates/e2e-template.yaml
+        parameters:
+          IgnoreScenariosWithMissingVhd: true
+
+  - stage: scriptless_nbc_cse_cmd_e2e
+    dependsOn: build
+    condition: and(succeeded(), ne(variables.SKIP_E2E_TESTS, 'true'))
+    variables:
+      VHD_BUILD_ID: $(Build.BuildId)
+      ENABLE_SCRIPTLESS_NBC_CSE_CMD: true
       TAGS_TO_SKIP: gpu=true,os=windows,scriptless=true
     jobs:
       - template: ./templates/e2e-template.yaml

--- a/aks-node-controller/app.go
+++ b/aks-node-controller/app.go
@@ -83,6 +83,7 @@ func cmdRunnerDryRun(cmd *exec.Cmd) error {
 
 type ProvisionFlags struct {
 	ProvisionConfig string
+	NBCCmd          string
 }
 
 type ProvisionStatusFiles struct {
@@ -130,13 +131,10 @@ func (a *App) run(ctx context.Context, args []string) error {
 	return err
 }
 
-func (a *App) Provision(ctx context.Context, flags ProvisionFlags) (*ProvisionResult, error) {
-	provisionResult := &ProvisionResult{}
-	inputJSON, err := os.ReadFile(flags.ProvisionConfig)
+func buildCmdFromProvisionConfig(ctx context.Context, path string) (*exec.Cmd, error) {
+	inputJSON, err := os.ReadFile(path)
 	if err != nil {
-		provisionResult.ExitCode = strconv.Itoa(240)
-		provisionResult.Error = fmt.Sprintf("open provision file %s: %v", flags.ProvisionConfig, err)
-		return provisionResult, errors.New(provisionResult.Error)
+		return nil, fmt.Errorf("open provision file %s: %w", path, err)
 	}
 
 	config, err := nodeconfigutils.UnmarshalConfigurationV1(inputJSON)
@@ -156,25 +154,48 @@ func (a *App) Provision(ctx context.Context, flags ProvisionFlags) (*ProvisionRe
 	// TODO: "v0" were a mistake. We are not going to have different logic maintaining both v0 and v1
 	// Disallow "v0" after some time (allow some time to update consumers)
 	if config.Version != "v0" && config.Version != "v1" {
-		provisionResult.ExitCode = strconv.Itoa(240)
-		provisionResult.Error = fmt.Sprintf("unsupported version: %s", config.Version)
-		return provisionResult, errors.New(provisionResult.Error)
+		return nil, fmt.Errorf("unsupported version: %s", config.Version)
 	}
 
 	if config.Version == "v0" {
 		slog.Error("v0 version is deprecated, please use v1 instead")
 	}
 
-	cmd, err := parser.BuildCSECmd(ctx, config)
-	if err != nil {
-		provisionResult.ExitCode = strconv.Itoa(240)
-		provisionResult.Error = fmt.Sprintf("build CSE command: %v", err)
-		return provisionResult, errors.New(provisionResult.Error)
+	return parser.BuildCSECmd(ctx, config)
+}
+
+func (a *App) Provision(ctx context.Context, flags ProvisionFlags) (*ProvisionResult, error) {
+	provisionResult := &ProvisionResult{}
+
+	var cmd *exec.Cmd
+	if flags.ProvisionConfig != "" {
+		var err error
+		cmd, err = buildCmdFromProvisionConfig(ctx, flags.ProvisionConfig)
+		if err != nil {
+			provisionResult.ExitCode = strconv.Itoa(240)
+			provisionResult.Error = err.Error()
+			return provisionResult, err
+		}
 	}
+
+	if flags.NBCCmd != "" {
+		nbcCmdContent, err := os.ReadFile(flags.NBCCmd)
+		if err != nil {
+			provisionResult.ExitCode = strconv.Itoa(240)
+			provisionResult.Error = fmt.Sprintf("read NBC command file %s: %v", flags.NBCCmd, err)
+			return provisionResult, errors.New(provisionResult.Error)
+		}
+		nbcScript := strings.TrimSpace(string(nbcCmdContent))
+		slog.Info("Using NBC command for scriptless phase 2", "NBCCmdFile", flags.NBCCmd)
+		nbcCMD := exec.CommandContext(ctx, "/bin/bash", "-c", nbcScript)
+		nbcCMD.Env = os.Environ()
+		cmd = nbcCMD
+	}
+
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = io.MultiWriter(os.Stdout, &stdoutBuf)
 	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
-	err = a.cmdRun(cmd)
+	err := a.cmdRun(cmd)
 	exitCode := -1
 	if cmd.ProcessState != nil {
 		exitCode = cmd.ProcessState.ExitCode()
@@ -207,21 +228,23 @@ func (a *App) runProvision(ctx context.Context, args []string) (*ProvisionResult
 
 	fs := flag.NewFlagSet("provision", flag.ContinueOnError)
 	provisionConfig := fs.String("provision-config", "", "path to the provision config file")
+	nbcCMD := fs.String("nbc-cmd", "", "path to the NBC command file")
 	dryRun := fs.Bool("dry-run", false, "print the command that would be run without executing it")
 	if parseErr := fs.Parse(args); parseErr != nil {
 		provisionResult.ExitCode = strconv.Itoa(240)
 		provisionResult.Error = fmt.Sprintf("parse args: %v", parseErr)
 		return provisionResult, errors.New(provisionResult.Error)
 	}
-	if *provisionConfig == "" {
+
+	if *provisionConfig == "" && *nbcCMD == "" {
 		provisionResult.ExitCode = strconv.Itoa(240)
-		provisionResult.Error = "--provision-config is required"
+		provisionResult.Error = "--provision-config or --nbc-cmd is required"
 		return provisionResult, errors.New(provisionResult.Error)
 	}
 	if *dryRun {
 		a.cmdRun = cmdRunnerDryRun
 	}
-	return a.Provision(ctx, ProvisionFlags{ProvisionConfig: *provisionConfig})
+	return a.Provision(ctx, ProvisionFlags{ProvisionConfig: *provisionConfig, NBCCmd: *nbcCMD})
 }
 
 // writeCompleteFileOnError writes the provision.complete sentinel if err is non-nil,

--- a/aks-node-controller/app_test.go
+++ b/aks-node-controller/app_test.go
@@ -83,6 +83,18 @@ func TestApp_Run(t *testing.T) {
 		assert.Contains(t, events[1].Message, "Completed")
 	})
 
+	t.Run("provision command with provision-config and nbc-cmd flag", func(t *testing.T) {
+		tt := NewTestApp(t, TestAppConfig{})
+		params := []string{"aks-node-controller", "provision", "--nbc-cmd=parser/testdata/test_nbccmd.sh"}
+		exitCode := tt.App.Run(context.Background(), params)
+		assert.Equal(t, 0, exitCode)
+
+		events := tt.eventLogger.Events()
+		assert.Len(t, events, 2)
+		assert.Contains(t, events[0].Message, "Starting")
+		assert.Contains(t, events[1].Message, "Completed")
+	})
+
 	t.Run("provision command with command runner error", func(t *testing.T) {
 		tt := NewTestApp(t, TestAppConfig{
 			RunFunc: func(*exec.Cmd) error { return &testExitError{Code: 666} },

--- a/aks-node-controller/parser/testdata/test_nbccmd.sh
+++ b/aks-node-controller/parser/testdata/test_nbccmd.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "success running nbc_cmd.sh"

--- a/aks-node-controller/pkg/nodeconfigutils/utils.go
+++ b/aks-node-controller/pkg/nodeconfigutils/utils.go
@@ -14,6 +14,8 @@ import (
 const (
 	CSE = "/opt/azure/containers/aks-node-controller provision-wait"
 
+	AKSNodeConfigFilePath = "/opt/azure/containers/aks-node-controller-config.json"
+
 	boothookTemplate = `#cloud-boothook
 #!/bin/bash
 set -euo pipefail
@@ -22,10 +24,10 @@ logger -t aks-boothook "boothook start $(date -Ins)"
 
 mkdir -p /opt/azure/containers
 
-cat <<'EOF' | base64 -d >/opt/azure/containers/aks-node-controller-config.json
-%s
+cat <<'EOF' | base64 -d >%[1]s
+%[2]s
 EOF
-chmod 0644 /opt/azure/containers/aks-node-controller-config.json
+chmod 0600 %[1]s
 
 logger -t aks-boothook "launching aks-node-controller service $(date -Ins)"
 systemctl start --no-block aks-node-controller.service
@@ -41,7 +43,7 @@ runcmd:
      "storage": {
        "files": [{
          "path": "/opt/azure/containers/aks-node-controller-config.json",
-         "mode": 420,
+         "mode": 384,
          "contents": { "source": "data:;base64,%s" }
        }]
      }
@@ -59,7 +61,7 @@ func CustomData(cfg *aksnodeconfigv1.Configuration) (string, error) {
 	}
 
 	encodedAksNodeConfigJSON := base64.StdEncoding.EncodeToString(aksNodeConfigJSON)
-	boothook := fmt.Sprintf(boothookTemplate, encodedAksNodeConfigJSON)
+	boothook := fmt.Sprintf(boothookTemplate, AKSNodeConfigFilePath, encodedAksNodeConfigJSON)
 
 	var customData bytes.Buffer
 	writer := multipart.NewWriter(&customData)

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -63,7 +63,8 @@ type Configuration struct {
 	DisableScriptLessCompilation           bool          `env:"DISABLE_SCRIPTLESS_COMPILATION"`
 	E2ELoggingDir                          string        `env:"LOGGING_DIR" envDefault:"scenario-logs"`
 	EnableSecureTLSBootstrapping           bool          `env:"ENABLE_SECURE_TLS_BOOTSTRAPPING" envDefault:"true"`
-	EnableScriptlessCSECmd                 bool          `env:"ENABLE_SCRIPTLESS_CSE_CMD" envDefault:"false"`
+	EnableScriptlessCSECmd                 bool          `env:"ENABLE_SCRIPTLESS_CSE_CMD" envDefault:"true"`
+	EnableScriptlessNBCCSECmd              bool          `env:"ENABLE_SCRIPTLESS_NBC_CSE_CMD" envDefault:"false"`
 	ExtendedTests                          string        `env:"EXTENDED_TESTS" envDefault:""`
 	GalleryNameLinux                       string        `env:"GALLERY_NAME" envDefault:"PackerSigGalleryEastUS"`
 	GalleryNameWindows                     string        `env:"GALLERY_NAME" envDefault:"PackerSigGalleryEastUS"`

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -75,6 +75,9 @@ func Test_Flatcar_CustomCATrust(t *testing.T) {
 func Test_Flatcar_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using a Flatcar and the self-contained installer can be properly bootstrapped",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDFlatcarGen2,
@@ -248,6 +251,9 @@ func Test_ACL_ARM64(t *testing.T) {
 func Test_ACL_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using ACL and the self-contained installer can be properly bootstrapped",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDACLGen2TL,
@@ -412,7 +418,8 @@ func runScenarioACLGPUScriptless(t *testing.T, vmSize string, location string) {
 		Description: fmt.Sprintf("Tests that a GPU-enabled node with VM size %s using an ACL VHD and scriptless CSE can be properly bootstrapped", vmSize),
 		Location:    location,
 		Tags: Tags{
-			GPU: true,
+			GPU:        true,
+			Scriptless: true,
 		},
 		Config: Config{
 			Cluster: ClusterKubenet,
@@ -526,6 +533,9 @@ func Test_AzureLinuxV3_ChronyRestarts(t *testing.T) {
 func Test_Ubuntu2204_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that a new ubuntu 2204 node using self contained installer can be properly bootstrapped",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
@@ -541,6 +551,9 @@ func Test_Ubuntu2204_Scriptless(t *testing.T) {
 func Test_Ubuntu2204_Failure_Scriptless(t *testing.T) {
 	err := RunScenario(t, &Scenario{
 		Description: "tests that a new ubuntu 2204 node using self contained installer can be properly bootstrapped",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
@@ -565,6 +578,9 @@ func Test_Ubuntu2204_Failure_Scriptless(t *testing.T) {
 func Test_Ubuntu2204_Early_Failure_Scriptless(t *testing.T) {
 	err := RunScenario(t, &Scenario{
 		Description: "tests that a new ubuntu 2204 node using self contained installer can be properly bootstrapped",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
@@ -587,6 +603,9 @@ func Test_Ubuntu2204_Early_Failure_Scriptless(t *testing.T) {
 func Test_Ubuntu2404_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "testing that a new ubuntu 2404 node using self contained installer can be properly bootstrapped",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404Gen2Containerd,
@@ -604,6 +623,9 @@ func Test_Ubuntu2404_Scriptless(t *testing.T) {
 // It injects a unique marker into cloud-init write_files via BootstrapConfigMutator,
 // then verifies that marker landed on disk — proving cloud-init write_files delivery works.
 func Test_Ubuntu2204_ScriptlessCSECmd_Hotfix(t *testing.T) {
+	if config.Config.EnableScriptlessNBCCSECmd {
+		t.Skip("skipping test because its unsupported in nbc CSE cmd path")
+	}
 	const hotfixMarkerPath = "/opt/azure/containers/e2e-hotfix-marker.txt"
 	hotfixMarkerContent := fmt.Sprintf("HOTFIX_E2E_MARKER_%d", time.Now().UnixNano())
 
@@ -765,6 +787,9 @@ func Test_Ubuntu2204_EntraIDSSH(t *testing.T) {
 func Test_Ubuntu2204_EntraIDSSH_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using Ubuntu 2204 VHD with Entra ID SSH can be properly bootstrapped and SSH private key authentication is disabled",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
@@ -1044,6 +1069,7 @@ func Test_Ubuntu2204Gen2_Containerd_NetworkIsolatedCluster_NoneCached(t *testing
 					config.PrivateACRName(config.Config.DefaultLocation),
 					nbc.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion)
 				nbc.EnableScriptlessCSECmd = false
+				nbc.EnableScriptlessNBCCSECmd = false
 			},
 		},
 	})
@@ -1082,6 +1108,7 @@ func Test_Ubuntu2204Gen2_Containerd_NetworkIsolatedCluster_NonAnonymousNoneCache
 				nbc.KubeletConfig["--image-credential-provider-config"] = "/var/lib/kubelet/credential-provider-config.yaml"
 				nbc.KubeletConfig["--image-credential-provider-bin-dir"] = "/var/lib/kubelet/credential-provider"
 				nbc.EnableScriptlessCSECmd = false
+				nbc.EnableScriptlessNBCCSECmd = false
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateDirectoryContent(ctx, s, "/opt/azure", []string{"outbound-check-skipped"})
@@ -1123,6 +1150,7 @@ func Test_Ubuntu2204Gen2_Containerd_NetworkIsolatedCluster_NonAnonymousNoneCache
 				nbc.KubeletConfig["--image-credential-provider-config"] = "/var/lib/kubelet/credential-provider-config.yaml"
 				nbc.KubeletConfig["--image-credential-provider-bin-dir"] = "/var/lib/kubelet/credential-provider"
 				nbc.EnableScriptlessCSECmd = false
+				nbc.EnableScriptlessNBCCSECmd = false
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				if vmss.Tags == nil {
@@ -1202,6 +1230,9 @@ func Test_Ubuntu2204_ArtifactStreaming_ARM64(t *testing.T) {
 func Test_Ubuntu2204_ArtifactStreaming_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that a new ubuntu 2204 node using artifact streaming can be properly bootstrapped",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
@@ -1265,6 +1296,9 @@ func Test_AzureLinuxV3_ArtifactStreaming_Scriptless(t *testing.T) {
 func Test_Ubuntu2204_ArtifactStreaming_ARM64_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that a new ubuntu 2204 node using artifact streaming and ARM64 architecture can be properly bootstrapped",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Arm64Containerd,
@@ -1308,6 +1342,9 @@ func Test_Ubuntu2204_ChronyRestarts_Taints_And_Tolerations(t *testing.T) {
 func Test_Ubuntu2204_ChronyRestarts_Taints_And_Tolerations_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that the chrony service restarts if it is killed. Also tests taints and tolerations",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
@@ -1367,6 +1404,9 @@ func Test_Ubuntu2204_CustomCATrust(t *testing.T) {
 func Test_Ubuntu2204_CustomCATrust_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using the Ubuntu 2204 VHD can be properly bootstrapped and custom CA was correctly added",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
@@ -1434,6 +1474,9 @@ func Test_Ubuntu2204_CustomSysctls_Scriptless(t *testing.T) {
 	}
 	RunScenario(t, &Scenario{
 		Description: "tests that an ubuntu 2204 VHD can be properly bootstrapped when supplied custom node config that contains custom sysctl settings",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
@@ -1536,7 +1579,8 @@ func Test_Ubuntu2204_GPUA10_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests scriptless installer that a GPU-enabled node using the Ubuntu 2204 VHD with grid driver can be properly bootstrapped",
 		Tags: Tags{
-			GPU: true,
+			GPU:        true,
+			Scriptless: true,
 		},
 		Config: Config{
 			Cluster: ClusterKubenet,
@@ -1620,7 +1664,8 @@ func Test_Ubuntu2204_GPUNoDriver_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a GPU-enabled node using the Ubuntu 2204 VHD opting for skipping gpu driver installation can be properly bootstrapped",
 		Tags: Tags{
-			GPU: true,
+			GPU:        true,
+			Scriptless: true,
 		},
 		Config: Config{
 			Cluster: ClusterKubenet,
@@ -1657,6 +1702,7 @@ func Test_Ubuntu2204_PrivateKubePkg(t *testing.T) {
 				nbc.K8sComponents.LinuxPrivatePackageURL = "https://privatekube.blob.core.windows.net/kubernetes/v1.25.6-hotfix.20230612/binaries/v1.25.6-hotfix.20230612.tar.gz"
 				nbc.AgentPoolProfile.LocalDNSProfile = nil
 				nbc.EnableScriptlessCSECmd = false
+				nbc.EnableScriptlessNBCCSECmd = false
 			},
 		},
 	})
@@ -1691,6 +1737,9 @@ func Test_Ubuntu2204_ContainerdURL_IMDSRestrictionFilterTable_Scriptless(t *test
 	RunScenario(t, &Scenario{
 		Description: `tests that a node using the Ubuntu 2204 VHD with the ContainerdPackageURL override the provided URL and not the components.json containerd version,
 		              tests that the imds restriction filter table is properly set`,
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
@@ -1787,6 +1836,9 @@ func Test_Ubuntu2204_DisableKubeletServingCertificateRotationWithTags_CustomKube
 func Test_Ubuntu2204_DisableKubeletServingCertificateRotationWithTags_CustomKubeletConfig_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that a node on ubuntu 2204 bootstrapped with custom kubelet config and kubelet serving certificate rotation enabled will disable certificate rotation due to nodepool tags",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
@@ -1887,6 +1939,9 @@ func Test_AzureLinuxV3_MessageOfTheDay(t *testing.T) {
 func Test_AzureLinuxV3_MessageOfTheDay_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using a AzureLinuxV3 can be bootstrapped and message of the day is added to the node",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2,
@@ -1964,6 +2019,9 @@ func Test_AzureLinuxV3_MA35D_Scriptless(t *testing.T) {
 func Test_AzureLinuxV3LocalDns_Disabled_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using a AzureLinuxV3 can be bootstrapped with localdns disabled",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterAzureNetwork,
 			VHD:     config.VHDAzureLinuxV3Gen2,
@@ -2080,6 +2138,7 @@ func Test_AzureLinuxV3_KubeletCustomConfig_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Tags: Tags{
 			KubeletCustomConfig: true,
+			Scriptless:          true,
 		},
 		Description: "tests that a node on azure linux v3 bootstrapped with kubelet custom config for seccomp set to non default values",
 		Config: Config{
@@ -2181,7 +2240,8 @@ func Test_AzureLinuxV3_GPUAzureCNI_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "AzureLinux V3 (CgroupV2) gpu scenario on cluster configured with Azure CNI",
 		Tags: Tags{
-			GPU: true,
+			GPU:        true,
+			Scriptless: true,
 		},
 		Config: Config{
 			Cluster: ClusterAzureNetwork,
@@ -2765,6 +2825,9 @@ func Test_Ubuntu2204Gen2_ImagePullIdentityBinding_NetworkIsolated(t *testing.T) 
 func Test_Ubuntu2204Gen2_ImagePullIdentityBinding_Enabled_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that credential provider config includes identity binding when ServiceAccountImagePullProfile is enabled in scriptless mode",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterLatestKubernetesVersion,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
@@ -2810,6 +2873,9 @@ func Test_Ubuntu2204Gen2_ImagePullIdentityBinding_Enabled_Scriptless(t *testing.
 func Test_Ubuntu2204Gen2_ImagePullIdentityBinding_Disabled_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that credential provider config excludes identity binding when ServiceAccountImagePullProfile is disabled in scriptless mode",
+		Tags: Tags{
+			Scriptless: true,
+		},
 		Config: Config{
 			Cluster: ClusterLatestKubernetesVersion,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -130,6 +130,7 @@ func runScenarioWithPreProvision(t *testing.T, original *Scenario) {
 		firstStage.BootstrapConfigMutator = func(nbc *datamodel.NodeBootstrappingConfiguration) {
 			original.BootstrapConfigMutator(nbc)
 			nbc.PreProvisionOnly = true
+			nbc.EnableScriptlessNBCCSECmd = false
 		}
 	}
 	if original.AKSNodeConfigMutator != nil {
@@ -230,9 +231,6 @@ func runScenario(t testing.TB, s *Scenario) error {
 
 func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 	defer toolkit.LogStep(s.T, "preparing AKS node")()
-	if (s.BootstrapConfigMutator == nil) == (s.AKSNodeConfigMutator == nil) {
-		s.T.Fatalf("exactly one of BootstrapConfigMutator or AKSNodeConfigMutator must be set")
-	}
 
 	var err error
 	nbc, err := getBaseNBC(s.T, s.Runtime.Cluster, s.VHD)
@@ -240,6 +238,10 @@ func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 
 	if config.Config.EnableScriptlessCSECmd {
 		nbc.EnableScriptlessCSECmd = true
+	}
+	if config.Config.EnableScriptlessNBCCSECmd {
+		nbc.EnableScriptlessNBCCSECmd = true
+		nbc.EnableScriptlessCSECmd = false
 	}
 
 	if s.IsWindows() {

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -47,6 +47,7 @@ func ValidateCommonLinux(ctx context.Context, s *Scenario) {
 	ValidateKernelLogs(ctx, s)
 	ValidateWaagentLog(ctx, s)
 	ValidateScriptlessCSECmd(ctx, s)
+	ValidateScriptlessNBCCSECmd(ctx, s)
 	ValidateNodeExporter(ctx, s)
 
 	ValidateSysctlConfig(ctx, s, map[string]string{

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2004,6 +2004,19 @@ func ValidateScriptlessCSECmd(ctx context.Context, s *Scenario) {
 	}
 }
 
+// ValidateScriptlessNBCCSECmd checks if the node has scriptless NBCCSECmd correctly enabled
+func ValidateScriptlessNBCCSECmd(ctx context.Context, s *Scenario) {
+	nbc := s.Runtime.NBC
+	if nbc != nil && nbc.EnableScriptlessNBCCSECmd && !s.VHD.Flatcar {
+		fileNameToCheck := "/opt/azure/containers/aks-node-controller-nbc-cmd.sh"
+		if !config.Config.DisableScriptLessCompilation && !s.Tags.NetworkIsolated {
+			fileNameToCheck = "/opt/azure/containers/aks-node-controller-nbc-cmd-hack.sh"
+		}
+		ValidateFileExists(ctx, s, fileNameToCheck)
+		ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log", "Using NBC command for scriptless phase 2")
+	}
+}
+
 // ValidateRxBufferDefault validates rx buffer config using default values based on VM's CPU count
 func ValidateRxBufferDefault(ctx context.Context, s *Scenario) {
 	s.T.Helper()

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -97,18 +97,20 @@ set -euo pipefail
 
 mkdir -p /opt/azure/containers /opt/azure/bin
 
-cat <<'EOF' | base64 -d > /opt/azure/containers/aks-node-controller-config-hack.json
-%s
+cat <<'EOF' | base64 -d > %[1]s
+%[2]s
 EOF
-chmod 0755 /opt/azure/containers/aks-node-controller-config-hack.json
+chmod 0600 %[1]s
 
 cat <<'SCRIPT' > /opt/azure/bin/run-aks-node-controller-hack.sh
 #!/bin/bash
 set -euo pipefail
 mkdir -p /opt/azure/bin
-curl -fSL --retry 10 --retry-delay 2 "%s" -o /opt/azure/bin/aks-node-controller-hack
+curl -fSL --retry 10 --retry-delay 2 "%[3]s" -o /opt/azure/bin/aks-node-controller-hack
 chmod +x /opt/azure/bin/aks-node-controller-hack
-/opt/azure/bin/aks-node-controller-hack provision --provision-config=/opt/azure/containers/aks-node-controller-config-hack.json
+
+/opt/azure/bin/aks-node-controller-hack provision --provision-config=%[1]s
+
 SCRIPT
 chmod +x /opt/azure/bin/run-aks-node-controller-hack.sh
 
@@ -135,11 +137,11 @@ systemctl start --no-block aks-node-controller-hack.service
 		// https://github.com/flatcar/coreos-cloudinit/blob/main/Documentation/cloud-config.md#coreos-parameters
 		cloudConfigTemplate = `#cloud-config
 write_files:
-- path: /opt/azure/containers/aks-node-controller-config-hack.json
-  permissions: "0755"
+- path: %[1]s
+  permissions: "0600"
   owner: root
   content: !!binary |
-   %s
+   %[2]s
 - path: /opt/azure/bin/run-aks-node-controller-hack.sh
   permissions: "0755"
   owner: root
@@ -147,9 +149,9 @@ write_files:
     #!/bin/bash
     set -euo pipefail
     mkdir -p /opt/azure/bin
-    curl -fSL --retry 10 --retry-delay 2 "%s" -o /opt/azure/bin/aks-node-controller-hack
+    curl -fSL --retry 10 --retry-delay 2 "%[3]s" -o /opt/azure/bin/aks-node-controller-hack
     chmod +x /opt/azure/bin/aks-node-controller-hack
-    /opt/azure/bin/aks-node-controller-hack provision --provision-config=/opt/azure/containers/aks-node-controller-config-hack.json
+    /opt/azure/bin/aks-node-controller-hack provision --provision-config=%[1]s
 # Flatcar specific configuration. It supports only a subset of cloud-init features https://github.com/flatcar/coreos-cloudinit/blob/main/Documentation/cloud-config.md#coreos-parameters
 coreos:
   units:
@@ -173,7 +175,126 @@ coreos:
 		return "", fmt.Errorf("failed to marshal nbc, error: %w", err)
 	}
 	encodedAksNodeConfigJSON := base64.StdEncoding.EncodeToString(aksNodeConfigJSON)
-	customDataYAML := fmt.Sprintf(cloudConfigTemplate, encodedAksNodeConfigJSON, binaryURL)
+	configPath := "/opt/azure/containers/aks-node-controller-config-hack.json"
+
+	customDataYAML := fmt.Sprintf(cloudConfigTemplate, configPath, encodedAksNodeConfigJSON, binaryURL)
+	return base64.StdEncoding.EncodeToString([]byte(customDataYAML)), nil
+}
+
+// CustomDataWithNBCCmdHack is similar to baker.boothooktemplate, but it uses a hack to run new aks-node-controller binary.
+// Original aks-node-controller isn't run because it fails systemd check validating aks-node-controller-config.json exists
+// (check aks-node-controller.service for details).
+// with a coreos.units block to define and start the service instead.
+func CustomDataWithNBCCmdHack(s *Scenario, customData, binaryURL string) (string, error) {
+	decoded, err := base64.StdEncoding.DecodeString(customData)
+	require.NoError(s.T, err)
+
+	customData = strings.Replace(string(decoded), "aks-node-controller-nbc-cmd.sh", "aks-node-controller-nbc-cmd-hack.sh", -1)
+
+	if s.VHD.Flatcar {
+		// For Flatcar, customData is an ignition JSON config from baker.go's flatcarTemplate.
+		// Ignition's "enabled: true" only creates enable symlinks but does NOT start services,
+		// so we can't use ignition JSON to start the hack service reliably.
+		// Instead, convert to #cloud-config format with coreos.units "command: start",
+		// which coreos-cloudinit processes and explicitly starts the service.
+		var ignitionConfig map[string]interface{}
+		if err := json.Unmarshal([]byte(customData), &ignitionConfig); err != nil {
+			return "", fmt.Errorf("failed to parse ignition config: %w", err)
+		}
+
+		// Extract the nbc-cmd-hack.sh content from the ignition storage.files
+		var nbcCmdContent string
+		if storage, ok := ignitionConfig["storage"].(map[string]interface{}); ok {
+			if files, ok := storage["files"].([]interface{}); ok {
+				for _, f := range files {
+					file, _ := f.(map[string]interface{})
+					if file["path"] == "/opt/azure/containers/aks-node-controller-nbc-cmd-hack.sh" {
+						if contents, ok := file["contents"].(map[string]interface{}); ok {
+							source, _ := contents["source"].(string)
+							// source is "data:;base64,<base64data>"
+							nbcCmdContent, _ = strings.CutPrefix(source, "data:;base64,")
+						}
+					}
+				}
+			}
+		}
+		if nbcCmdContent == "" {
+			return "", fmt.Errorf("failed to extract nbc-cmd-hack.sh content from ignition config")
+		}
+
+		// Build a #cloud-config that writes both the nbc-cmd script and hack runner,
+		// then starts the hack service via coreos.units command: start
+		cloudConfig := fmt.Sprintf(`#cloud-config
+write_files:
+- path: /opt/azure/containers/aks-node-controller-nbc-cmd-hack.sh
+  permissions: "0600"
+  owner: root
+  content: !!binary |
+   %[1]s
+- path: /opt/azure/bin/run-aks-node-controller-hack.sh
+  permissions: "0755"
+  owner: root
+  content: |
+    #!/bin/bash
+    set -euo pipefail
+    mkdir -p /opt/azure/bin
+    curl -fSL --retry 10 --retry-delay 2 "%[2]s" -o /opt/azure/bin/aks-node-controller-hack
+    chmod +x /opt/azure/bin/aks-node-controller-hack
+    /opt/azure/bin/aks-node-controller-hack provision --nbc-cmd=/opt/azure/containers/aks-node-controller-nbc-cmd-hack.sh
+coreos:
+  units:
+    - name: aks-node-controller-hack.service
+      command: start
+      content: |
+        [Unit]
+        Description=Downloads and runs the AKS node controller hack
+        After=network-online.target
+        Wants=network-online.target
+        [Service]
+        Type=oneshot
+        ExecStart=/opt/azure/bin/run-aks-node-controller-hack.sh
+        [Install]
+        WantedBy=multi-user.target
+`, nbcCmdContent, binaryURL)
+
+		return base64.StdEncoding.EncodeToString([]byte(cloudConfig)), nil
+	}
+
+	cloudConfigTemplate := `%s
+
+mkdir -p /opt/azure/bin
+
+cat <<'SCRIPT' > /opt/azure/bin/run-aks-node-controller-hack.sh
+#!/bin/bash
+set -euo pipefail
+mkdir -p /opt/azure/bin
+curl -fSL --retry 10 --retry-delay 2 "%s" -o /opt/azure/bin/aks-node-controller-hack
+chmod +x /opt/azure/bin/aks-node-controller-hack
+
+/opt/azure/bin/aks-node-controller-hack provision --nbc-cmd=/opt/azure/containers/aks-node-controller-nbc-cmd-hack.sh
+
+SCRIPT
+chmod +x /opt/azure/bin/run-aks-node-controller-hack.sh
+
+cat <<'UNIT' > /etc/systemd/system/aks-node-controller-hack.service
+[Unit]
+Description=Downloads and runs the AKS node controller hack
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/azure/bin/run-aks-node-controller-hack.sh
+
+[Install]
+WantedBy=basic.target
+UNIT
+
+systemctl daemon-reload
+systemctl start --no-block aks-node-controller-hack.service
+`
+
+	customDataYAML := fmt.Sprintf(cloudConfigTemplate, customData, binaryURL)
 	return base64.StdEncoding.EncodeToString([]byte(customDataYAML)), nil
 }
 
@@ -183,6 +304,7 @@ func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachine
 	ab, err := agent.NewAgentBaker()
 	require.NoError(s.T, err)
 	var cse, customData string
+
 	if s.Runtime.AKSNodeConfig != nil {
 		cse = nodeconfigutils.CSE
 		customData = func() string {
@@ -209,6 +331,12 @@ func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachine
 		require.NoError(s.T, err)
 		cse = nodeBootstrapping.CSE
 		customData = nodeBootstrapping.CustomData
+		if s.Runtime.NBC.EnableScriptlessNBCCSECmd && !config.Config.DisableScriptLessCompilation && !s.Tags.NetworkIsolated {
+			binaryURL, err := CachedCompileAndUploadAKSNodeController(ctx, s.VHD.Arch)
+			require.NoError(s.T, err, "failed to compile and upload aks-node-controller binary")
+			customData, err = CustomDataWithNBCCmdHack(s, customData, binaryURL)
+			require.NoError(s.T, err, "failed to generate custom data with NBC cmd hack")
+		}
 		if len(s.Config.CustomDataWriteFiles) > 0 {
 			customData, err = injectWriteFilesEntriesToCustomData(customData, s.Config.CustomDataWriteFiles)
 			require.NoError(s.T, err, "failed to inject customData write_files entries")

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1114,7 +1114,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=moby-containerd, repository=test, os=ubuntu, release=24.04",
-                "latestVersion": "2.1.6-ubuntu24.04u1"
+                "latestVersion": "2.1.6-ubuntu24.04u2"
               }
             ]
           },
@@ -1122,7 +1122,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=moby-containerd, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "1.7.30-ubuntu22.04u2"
+                "latestVersion": "1.7.30-ubuntu22.04u3"
               }
             ]
           },
@@ -1130,7 +1130,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=moby-containerd, repository=production, os=ubuntu, release=20.04",
-                "latestVersion": "1.7.30-ubuntu20.04u2"
+                "latestVersion": "1.7.30-ubuntu20.04u3"
               }
             ]
           }

--- a/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
@@ -3,6 +3,7 @@ set -uo pipefail
 
 BIN_PATH="${BIN_PATH:-/opt/azure/containers/aks-node-controller}"
 CONFIG_PATH="${CONFIG_PATH:-/opt/azure/containers/aks-node-controller-config.json}"
+NBC_CMD_PATH="${NBC_CMD_PATH:-/opt/azure/containers/aks-node-controller-nbc-cmd.sh}"
 LOGGER_TAG="aks-node-controller-wrapper"
 
 log() {
@@ -15,8 +16,18 @@ log() {
 # this is to ensure that shellspec won't interpret any further lines below
 ${__SOURCED__:+return}
 
-log "Launching aks-node-controller with config ${CONFIG_PATH}"
-"$BIN_PATH" provision --provision-config="$CONFIG_PATH" &
+command=("$BIN_PATH" provision)
+if [ -f "$CONFIG_PATH" ]; then
+    log "Launching aks-node-controller with config ${CONFIG_PATH}"
+    command+=("--provision-config=$CONFIG_PATH")
+elif [ -f "$NBC_CMD_PATH" ]; then
+    log "Launching aks-node-controller with nbc cmd ${NBC_CMD_PATH}"
+    command+=("--nbc-cmd=$NBC_CMD_PATH")
+else
+    log "Gracefully exit aks-node-controller without provision config or nbc cmd"
+    exit 0
+fi
+"${command[@]}" &
 child_pid=$!
 log "Spawned aks-node-controller (pid ${child_pid})"
 

--- a/parts/linux/cloud-init/artifacts/aks-node-controller.service
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Parse contract and run csecmd
-ConditionPathExists=/opt/azure/containers/aks-node-controller-config.json
 After=network-online.target
 Wants=network-online.target
 

--- a/parts/linux/cloud-init/artifacts/cse_start.sh
+++ b/parts/linux/cloud-init/artifacts/cse_start.sh
@@ -30,10 +30,14 @@ SYSTEMD_SUMMARY=$(systemd-analyze || true)
 CSE_ENDTIME_FORMATTED=$(date +"%F %T.%3N")
 EVENTS_FILE_NAME=$(date +%s%3N)
 EXECUTION_DURATION=$(($(date +%s) - $(date -d "$CSE_STARTTIME" +%s)))
-SCRIPTLESS_MODE=false
+SCRIPTLESS_MODE="none"
 
 if [ -f "/opt/azure/containers/scriptless-cse-overrides.txt" ]; then
-    SCRIPTLESS_MODE=true
+    SCRIPTLESS_MODE="cse_cmd"
+fi
+
+if [ -f "/opt/azure/containers/aks-node-controller-nbc-cmd.sh" ]; then
+    SCRIPTLESS_MODE="nbc_cse_cmd"
 fi
 
 JSON_STRING=$( jq -n \
@@ -82,7 +86,7 @@ message_string=$( jq -n \
 --arg KUBELET_START_TIME_FORMATTED        "${KUBELET_START_TIME_FORMATTED}" \
  --arg KUBELET_READY_TIME_FORMATTED       "${KUBELET_READY_TIME_FORMATTED}" \
  --arg SCRIPTLESS_MODE                    "${SCRIPTLESS_MODE}" \
- '{ExitCode: $EXIT_CODE, E2E: $EXECUTION_DURATION, KernelStartTime: $KERNEL_STARTTIME_FORMATTED, CloudInitLocalStartTime: $CLOUDINITLOCAL_STARTTIME_FORMATTED, CloudInitStartTime: $CLOUDINIT_STARTTIME_FORMATTED, CloudFinalStartTime: $CLOUDINITFINAL_STARTTIME_FORMATTED, NetworkdStartTime: $NETWORKD_STARTTIME_FORMATTED, GuestAgentStartTime: $GUEST_AGENT_STARTTIME_FORMATTED, KubeletStartTime: $KUBELET_START_TIME_FORMATTED, KubeletReadyTime: $KUBELET_READY_TIME_FORMATTED, ScriptlessMode: $SCRIPTLESS_MODE } | tostring'
+ '{ExitCode: $EXIT_CODE, E2E: $EXECUTION_DURATION, KernelStartTime: $KERNEL_STARTTIME_FORMATTED, CloudInitLocalStartTime: $CLOUDINITLOCAL_STARTTIME_FORMATTED, CloudInitStartTime: $CLOUDINIT_STARTTIME_FORMATTED, CloudFinalStartTime: $CLOUDINITFINAL_STARTTIME_FORMATTED, NetworkdStartTime: $NETWORKD_STARTTIME_FORMATTED, GuestAgentStartTime: $GUEST_AGENT_STARTTIME_FORMATTED, KubeletStartTime: $KUBELET_START_TIME_FORMATTED, KubeletReadyTime: $KUBELET_READY_TIME_FORMATTED, ScriptlessMode: $SCRIPTLESS_MODE} | tostring'
 )
 # this clean up brings me no joy, but removing extra "\" and then removing quotes at the end of the string
 # allows parsing to happening without additional manipulation

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -43,6 +43,35 @@ func (t *TemplateGenerator) getNodeBootstrappingPayload(config *datamodel.NodeBo
 	return t.getLinuxNodeBootstrappingPayload(config)
 }
 
+const (
+	boothookTemplate = `#cloud-boothook
+#!/bin/bash
+set -euo pipefail
+
+logger -t aks-boothook "boothook start $(date -Ins)"
+
+mkdir -p /opt/azure/containers
+
+cat <<'EOF' | base64 -d >/opt/azure/containers/aks-node-controller-nbc-cmd.sh
+%s
+EOF
+chmod 0600 /opt/azure/containers/aks-node-controller-nbc-cmd.sh
+
+logger -t aks-boothook "launching aks-node-controller service $(date -Ins)"
+systemctl start --no-block aks-node-controller.service
+`
+	flatcarTemplate = `{
+     "ignition": { "version": "3.4.0" },
+     "storage": {
+       "files": [{
+         "path": "/opt/azure/containers/aks-node-controller-nbc-cmd.sh",
+         "mode": 384,
+         "contents": { "source": "data:;base64,%s" }
+       }]
+     }
+    }`
+)
+
 func (t *TemplateGenerator) getWindowsNodeBootstrappingPayload(config *datamodel.NodeBootstrappingConfiguration) string {
 	// this might seem strange that we're encoding the custom data to a JSON string and then extracting it, but without that serialisation and deserialisation
 	// lots of tests fail.
@@ -51,6 +80,19 @@ func (t *TemplateGenerator) getWindowsNodeBootstrappingPayload(config *datamodel
 }
 
 func (t *TemplateGenerator) getLinuxNodeBootstrappingPayload(config *datamodel.NodeBootstrappingConfiguration) string {
+	if config.EnableScriptlessNBCCSECmd {
+		config.DisableCustomData = true
+		nbcCMD := t.getLinuxNodeCSECommand(config)
+		encodedNBCCMD := base64.StdEncoding.EncodeToString([]byte(nbcCMD))
+		var customData string
+		if config.IsFlatcar() || config.IsACL() {
+			customData = fmt.Sprintf(flatcarTemplate, encodedNBCCMD)
+		} else {
+			customData = fmt.Sprintf(boothookTemplate, encodedNBCCMD)
+		}
+
+		return base64.StdEncoding.EncodeToString([]byte(customData))
+	}
 	// this might seem strange that we're encoding the custom data to a JSON string and then extracting it, but without that serialisation and deserialisation
 	// lots of tests fail.
 	var encoded string
@@ -288,6 +330,9 @@ func (t *TemplateGenerator) getWindowsNodeCustomDataJSONObject(config *datamodel
 func (t *TemplateGenerator) getNodeBootstrappingCmd(config *datamodel.NodeBootstrappingConfiguration) string {
 	if config.AgentPoolProfile.IsWindows() {
 		return t.getWindowsNodeCSECommand(config)
+	}
+	if config.EnableScriptlessNBCCSECmd {
+		return "/opt/azure/containers/aks-node-controller provision-wait"
 	}
 	return t.getLinuxNodeCSECommand(config)
 }

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -1797,6 +1797,10 @@ type NodeBootstrappingConfiguration struct {
 	// EnableScriptlessCSECmd uses the CSE command to run the CSE logic without replacing scripts on the node using custom data.
 	// When EnableScriptlessCSECmd is true, the rendered CSE commands are executed directly on the node.
 	EnableScriptlessCSECmd bool
+
+	// EnableScriptlessNBCCSECmd enables scriptless phase 2 in which the cse cmd generated from NBC is passed to
+	// AKS Node Controller and uses the NBC cmd to start provisioning.
+	EnableScriptlessNBCCSECmd bool
 }
 
 func (config *NodeBootstrappingConfiguration) IsAzureLinux() bool {

--- a/vhdbuilder/packer/imagecustomizer/azlosguard/azlosguard.yml
+++ b/vhdbuilder/packer/imagecustomizer/azlosguard/azlosguard.yml
@@ -67,6 +67,9 @@ os:
     - source: /AgentBaker/parts/linux/cloud-init/artifacts/aks-node-controller.service
       destination: /etc/systemd/system/aks-node-controller.service
       permissions: 600
+    - source: /AgentBaker/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
+      destination: /opt/azure/containers/aks-node-controller-wrapper.sh
+      permissions: 755
     # Fix systemd resolved caching
     - source: /AgentBaker/parts/linux/cloud-init/artifacts/resolv-uplink-override.service
       destination: /etc/systemd/system/resolv-uplink-override.service


### PR DESCRIPTION
## Summary
This change adds support for passing the CSE command generated from the node bootstrapping config directly into aks-node-controller for
scriptless phase 2 provisioning. It updates Linux bootstrapping/custom data generation and the node-controller startup path so provisioning
can run from either the existing config file or a generated NBC command script.

Also included

 - Adds wrapper/service changes and VHD image customization needed to launch aks-node-controller with --nbc-cmd
 - Records the new scriptless mode in cse_start.sh telemetry
 - Adds pipeline and e2e coverage for the new scriptless NBC CSE command flow, plus validation and opt-outs for scenarios that don’t support 
it
