### PR TITLE
fix: ensure VHD build garbage collection script always runs to completion

### DIFF
--- a/vhdbuilder/scripts/gc.sh
+++ b/vhdbuilder/scripts/gc.sh
@@ -54,7 +54,9 @@ function delete_group() {
         return 0
     fi
 
-    az group delete -g $group --yes --no-wait || return $?
+    if ! az group delete -g $group --yes --no-wait; then
+        echo "failed to delete resource group: ${group}, continuing..."
+    fi
 }
 
 main "$@"


### PR DESCRIPTION


<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:

ensure periodic VHD build garbage collection script always runs to completion - this should reduce the frequency of QuotaExceeded errors observed within the VHD build check-in pipeline

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
