### PR TITLE
fix: remove leading newline from login banner files for CIS 1.6.2/1.6.3

### DIFF
--- a/parts/linux/cloud-init/artifacts/etc-issue
+++ b/parts/linux/cloud-init/artifacts/etc-issue
@@ -1,2 +1,1 @@
-
 Authorized uses only. All activity may be monitored and reported.

--- a/parts/linux/cloud-init/artifacts/etc-issue.net
+++ b/parts/linux/cloud-init/artifacts/etc-issue.net
@@ -1,2 +1,1 @@
-
 Authorized uses only. All activity may be monitored and reported.


### PR DESCRIPTION
## Summary

Fixes CIS benchmark regressions for rules **1.6.2** (local login warning banner) and **1.6.3** (remote login warning banner).

### Root Cause

The files `parts/linux/cloud-init/artifacts/etc-issue` and `parts/linux/cloud-init/artifacts/etc-issue.net` had a **leading newline character** before the banner text:

```
↵
Authorized uses only. All activity may be monitored and reported.
```

The CIS checks expect the file to start directly with the banner text — no leading whitespace or newlines. This caused both rules to flip from `pass` to `fail` in VHD CIS scanning (`vhdbuilder/packer/vhd-scanning.sh`).

### Evidence

Regression confirmed across **4 independent builds** spanning March 27 – April 13:
- Build [160274540](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=160274540) (Apr 13)
- Build [160247780](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=160247780) (Apr 12)
- Build [160054264](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=160054264) (Apr 8)
- Build [159603476](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=159603476) (Mar 27)

### Fix

Removed the leading empty line from both files so content starts immediately with the banner text. The banner content itself is unchanged.

### Note on CIS 6.1.4.1

ADO [#37518794](https://dev.azure.com/msazure/CloudNativeCompute/_workitems/edit/37518794) also tracks an intermittent regression for rule 6.1.4.1 (logfile permissions). That issue is timing-dependent during VHD build and will be investigated separately.

AB#37518794