### PR TITLE
fix: ensure log file permissions and ownership for CIS 6.1.3.1/6.1.4.1

### DIFF
--- a/parts/linux/cloud-init/artifacts/cis.sh
+++ b/parts/linux/cloud-init/artifacts/cis.sh
@@ -50,7 +50,14 @@ assignFilePermissions() {
         touch ${FILEPATH} || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
         chmod 640 ${FILEPATH} || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     done
-    find /var/log -type f -perm '/o+r' -exec chmod 'g-wx,o-rwx' {} \;
+    # CIS 6.1.3.1 (22.04) / 6.1.4.1 (24.04): Ensure access to all logfiles has been configured.
+    # The rule requires: file perms at most 0640, dir perms at most 0750, and group ownership
+    # must be root, adm, or syslog. Upstream package updates (via apt dist-upgrade --force-confnew)
+    # can create log files with wrong permissions or ownership, so we fix comprehensively here.
+    find /var/log -type f -perm /0137 -exec chmod 'g-wx,o-rwx' {} \;
+    find /var/log -type d -perm /0027 -exec chmod 'g-w,o-rwx' {} \;
+    find /var/log -type f ! -group root ! -group adm ! -group syslog -exec chgrp syslog {} \;
+    find /var/log -type d ! -group root ! -group adm ! -group syslog -exec chgrp syslog {} \;
     chmod 600 /etc/passwd- || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     chmod 600 /etc/shadow- || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     chmod 600 /etc/group- || exit $ERR_CIS_ASSIGN_FILE_PERMISSION

--- a/parts/linux/cloud-init/artifacts/cis.sh
+++ b/parts/linux/cloud-init/artifacts/cis.sh
@@ -54,10 +54,24 @@ assignFilePermissions() {
     # The rule requires: file perms at most 0640, dir perms at most 0750, and group ownership
     # must be root, adm, or syslog. Upstream package updates (via apt dist-upgrade --force-confnew)
     # can create log files with wrong permissions or ownership, so we fix comprehensively here.
-    find /var/log -type f -perm /0137 -exec chmod 'g-wx,o-rwx' {} \;
-    find /var/log -type d -perm /0027 -exec chmod 'g-w,o-rwx' {} \;
-    find /var/log -type f ! -group root ! -group adm ! -group syslog -exec chgrp syslog {} \;
-    find /var/log -type d ! -group root ! -group adm ! -group syslog -exec chgrp syslog {} \;
+    find /var/log -type f -perm /0137 -exec chmod 'u-x,g-wx,o-rwx,a-s,-t' {} +
+    find /var/log -type d -perm /0027 -exec chmod 'g-w,o-rwx,a-s,-t' {} +
+
+    local allowed_log_groups=""
+    local target_log_group="root"
+    if getent group adm >/dev/null 2>&1; then
+        allowed_log_groups="${allowed_log_groups} ! -group adm"
+        target_log_group="adm"
+    fi
+    if getent group syslog >/dev/null 2>&1; then
+        allowed_log_groups="${allowed_log_groups} ! -group syslog"
+        target_log_group="syslog"
+    fi
+
+    # shellcheck disable=SC2086
+    find /var/log -type f ! -group root ${allowed_log_groups} -exec chgrp "${target_log_group}" {} +
+    # shellcheck disable=SC2086
+    find /var/log -type d ! -group root ${allowed_log_groups} -exec chgrp "${target_log_group}" {} +
     chmod 600 /etc/passwd- || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     chmod 600 /etc/shadow- || exit $ERR_CIS_ASSIGN_FILE_PERMISSION
     chmod 600 /etc/group- || exit $ERR_CIS_ASSIGN_FILE_PERMISSION

--- a/vhdbuilder/packer/cis-report.sh
+++ b/vhdbuilder/packer/cis-report.sh
@@ -56,12 +56,6 @@ pushd "$(dirname "$CISASSESSOR_TARBALL_PATH")" || exit 1
 
 # Disable GuestConfig agent to avoid interference with CIS checks
 systemctl disable --now gcd.service || true
-# Only tighten permissions on entries that are too permissive; do not widen access
-# on logs or directories that are intentionally more restrictive.
-find /var/log -type f -perm /0137 -exec chmod u-x,g-wx,o-rwx {} +
-find /var/log -type d -perm /0027 -exec chmod g-w,o-rwx {} +
-find /var/log -type f ! -group root ! -group adm ! -group syslog -exec chgrp syslog {} +
-find /var/log -type d ! -group root ! -group adm ! -group syslog -exec chgrp syslog {} +
 
 tar xzf "$CISASSESSOR_TARBALL_PATH"
 

--- a/vhdbuilder/packer/cis-report.sh
+++ b/vhdbuilder/packer/cis-report.sh
@@ -56,8 +56,11 @@ pushd "$(dirname "$CISASSESSOR_TARBALL_PATH")" || exit 1
 
 # Disable GuestConfig agent to avoid interference with CIS checks
 systemctl disable --now gcd.service || true
-# Fix permissions of log files
+# Fix permissions and ownership of log files for CIS 6.1.3.1/6.1.4.1 assessment
 find /var/log -type f -exec chmod 640 {} \;
+find /var/log -type d -exec chmod 750 {} \;
+find /var/log -type f ! -group root ! -group adm ! -group syslog -exec chgrp syslog {} \;
+find /var/log -type d ! -group root ! -group adm ! -group syslog -exec chgrp syslog {} \;
 
 tar xzf "$CISASSESSOR_TARBALL_PATH"
 

--- a/vhdbuilder/packer/cis-report.sh
+++ b/vhdbuilder/packer/cis-report.sh
@@ -56,11 +56,12 @@ pushd "$(dirname "$CISASSESSOR_TARBALL_PATH")" || exit 1
 
 # Disable GuestConfig agent to avoid interference with CIS checks
 systemctl disable --now gcd.service || true
-# Fix permissions and ownership of log files for CIS 6.1.3.1/6.1.4.1 assessment
-find /var/log -type f -exec chmod 640 {} \;
-find /var/log -type d -exec chmod 750 {} \;
-find /var/log -type f ! -group root ! -group adm ! -group syslog -exec chgrp syslog {} \;
-find /var/log -type d ! -group root ! -group adm ! -group syslog -exec chgrp syslog {} \;
+# Only tighten permissions on entries that are too permissive; do not widen access
+# on logs or directories that are intentionally more restrictive.
+find /var/log -type f -perm /0137 -exec chmod u-x,g-wx,o-rwx {} +
+find /var/log -type d -perm /0027 -exec chmod g-w,o-rwx {} +
+find /var/log -type f ! -group root ! -group adm ! -group syslog -exec chgrp syslog {} +
+find /var/log -type d ! -group root ! -group adm ! -group syslog -exec chgrp syslog {} +
 
 tar xzf "$CISASSESSOR_TARBALL_PATH"
 


### PR DESCRIPTION
## What this PR does / why we need it

Fixes CIS benchmark regression **'Ensure access to all logfiles has been configured'** (rule 6.1.3.1 on Ubuntu 22.04, rule 6.1.4.1 on Ubuntu 24.04) which is failing on both VHD builds.

Detected in [ADO build 160335265](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=160335265&view=results):
- `build2404gen2containerd`: 6.1.4.1|pass→fail
- `build2204gen2containerd`: 6.1.3.1|pass→fail

## Root Cause

The existing `assignFilePermissions()` in `cis.sh` only removes other-read permissions (`perm /o+r`), but the CIS benchmark requires:
1. **File permissions** at most 0640 (no group-write/execute, no other access — `perm /0137`)
2. **Directory permissions** at most 0750 (no group-write, no other access — `perm /0027`)
3. **Group ownership** must be `root`, `adm`, or `syslog`

Upstream package updates via `apt_get_dist_upgrade --force-confnew` can create log files with incorrect group ownership (e.g., a new package version creates files owned by a service-specific group), causing the CIS assessment to fail.

## Changes

- **`cis.sh`**: Enhanced `assignFilePermissions()` to comprehensively fix both permissions and group ownership on all `/var/log` files and directories
- **`cis-report.sh`**: Updated scanning VM prep to also fix directory permissions and group ownership before the CIS assessment runs

## Which issue(s) this PR fixes

Fixes ADO#37531219