### PR TITLE
fix(e2e): add gotestsum --rerun-fails to retry flaky e2e test failures

### DIFF
--- a/.pipelines/scripts/e2e_run.sh
+++ b/.pipelines/scripts/e2e_run.sh
@@ -96,9 +96,11 @@ chmod +x bin/gotestsum
 rm -f "$temp_file"
 
 # gotestsum configure to only show logs for failed tests, json file for detailed logs
+# --rerun-fails=1 reruns only failed tests once to handle transient/flaky failures
+# (e.g., systemd bookkeeping races, temporary network blips)
 # Run the tests! Yey!
 test_exit_code=0
-./bin/gotestsum --format testdox --junitfile "${BUILD_SRC_DIR}/e2e/report.xml" --jsonfile "${BUILD_SRC_DIR}/e2e/test-log.json" -- -parallel 150 -timeout "${E2E_GO_TEST_TIMEOUT}" || test_exit_code=$?
+./bin/gotestsum --format testdox --rerun-fails=1 --junitfile "${BUILD_SRC_DIR}/e2e/report.xml" --jsonfile "${BUILD_SRC_DIR}/e2e/test-log.json" -- -parallel 150 -timeout "${E2E_GO_TEST_TIMEOUT}" || test_exit_code=$?
 
 # Upload test results as Azure DevOps artifacts
 echo "##vso[artifact.upload containerfolder=test-results;artifactname=e2e-test-log]${BUILD_SRC_DIR}/e2e/test-log.json"


### PR DESCRIPTION
## What
Add automatic retry for failed e2e tests using gotestsum `--rerun-fails=1`.

## Why
E2e tests have no retry mechanism today. When a transient infrastructure issue causes a single test to fail (e.g., a cloud-init temp mount entering failed systemd state), the entire pipeline fails and requires manual re-run.

The VHD build pipelines already have `retryCountOnTaskFailure: 3`, but the e2e pipeline has nothing — no ADO-level retry and no Go-level retry.

### Example flaky failure (Build 160089239)
```
DONE 160 tests, 68 skipped, 1 failure in 528.088s
```
One test failed due to a transient `run-cloud\x2dinit-tmp-tmpde1rbvp9.mount` systemd unit entering failed state. All 159 other tests passed. A retry would have likely passed.

## Changes
- Added `--rerun-fails=1` to the gotestsum command in `.pipelines/scripts/e2e_run.sh`
- Only **failed tests** are rerun (not the entire suite), so overhead is minimal
- If the test passes on retry, the suite passes — consistent with how gotestsum handles flaky tests

## Risk
🟢 **Low** — gotestsum `--rerun-fails` is a well-established feature. It only reruns failed tests, does not affect passing tests, and the JUnit report correctly reflects the final outcome.