### PR TITLE
fix(e2e): allow transient cloud-init temp mount failures in systemd unit validator

### DIFF
--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -819,6 +819,14 @@ func ValidateNoFailedSystemdUnits(ctx context.Context, s *Scenario) {
 		// Ubuntu - do we even need it? it seems that it's coming from the base image
 		"fwupd-refresh.service": true,
 	}
+	// cloud-init creates temporary directories under /run/cloud-init/tmp/ during provisioning.
+	// systemd auto-generates transient .mount units for these (e.g., run-cloud\x2dinit-tmp-tmpXXXXX.mount).
+	// When cloud-init cleans up the temp directory, the mount unit enters a "failed" state.
+	// This is normal systemd behavior and the unit name contains a random suffix,
+	// so we use prefix matching instead of exact string matching.
+	unitFailureAllowPrefixes := []string{
+		"run-cloud\\x2dinit-tmp-",
+	}
 	if s.Tags.BootstrapTokenFallback {
 		// secure-tls-bootstrap.service is expected to fail within scenarios that test bootstrap token fall-back behavior
 		unitFailureAllowList["secure-tls-bootstrap.service"] = true
@@ -842,7 +850,15 @@ func ValidateNoFailedSystemdUnits(ctx context.Context, s *Scenario) {
 	result := execScriptOnVMForScenarioValidateExitCode(ctx, s, "systemctl list-units --failed --output json", 0, fmt.Sprintf("unable to list failed systemd units"))
 	assert.NoError(s.T, json.Unmarshal([]byte(result.stdout), &failedUnits), `unable to parse and unmarshal "systemctl list-units" command output`)
 	failedUnits = lo.Filter(failedUnits, func(unit systemdUnit, _ int) bool {
-		return !unitFailureAllowList[unit.Name]
+		if unitFailureAllowList[unit.Name] {
+			return false
+		}
+		for _, prefix := range unitFailureAllowPrefixes {
+			if strings.HasPrefix(unit.Name, prefix) {
+				return false
+			}
+		}
+		return true
 	})
 
 	if len(failedUnits) < 1 {

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -856,7 +856,7 @@ func ValidateNoFailedSystemdUnits(ctx context.Context, s *Scenario) {
 			return false
 		}
 		for _, prefix := range unitFailureAllowPrefixes {
-			if strings.HasPrefix(unit.Name, prefix) {
+			if strings.HasPrefix(unit.Name, prefix) && strings.HasSuffix(unit.Name, ".mount") {
 				return false
 			}
 		}

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -820,10 +820,12 @@ func ValidateNoFailedSystemdUnits(ctx context.Context, s *Scenario) {
 		"fwupd-refresh.service": true,
 	}
 	// cloud-init creates temporary directories under /run/cloud-init/tmp/ during provisioning.
-	// systemd auto-generates transient .mount units for these (e.g., run-cloud\x2dinit-tmp-tmpXXXXX.mount).
-	// When cloud-init cleans up the temp directory, the mount unit enters a "failed" state.
-	// This is normal systemd behavior and the unit name contains a random suffix,
-	// so we use prefix matching instead of exact string matching.
+	// systemd may auto-generate transient .mount units for these (for example,
+	// run-cloud\x2dinit-tmp-tmpXXXXX.mount). When cloud-init cleans up the temp
+	// directory, these ephemeral mount units may occasionally appear in a "failed"
+	// state due to transient/racy cleanup timing. This prefix-based allow rule is
+	// intentionally scoped to those cloud-init temp mounts, whose unit names contain
+	// random suffixes, so we use prefix matching instead of exact string matching.
 	unitFailureAllowPrefixes := []string{
 		"run-cloud\\x2dinit-tmp-",
 	}


### PR DESCRIPTION
## What

Fix flaky e2e test failure caused by transient cloud-init temporary mount units entering a failed systemd state.

## Why

### The Problem

The `ValidateNoFailedSystemdUnits` validator (introduced in [#7644](https://github.com/Azure/AgentBaker/pull/7644)) checks for any failed systemd unit after node provisioning. It uses an exact-string allow list to skip known-benign failures (e.g., `fwupd-refresh.service`, `systemd-sysupdate.service`).

During VM provisioning, cloud-init creates temporary directories under `/run/cloud-init/tmp/` (e.g., `/run/cloud-init/tmp/tmpde1rbvp9`). systemd auto-generates transient `.mount` units for these paths. When cloud-init cleans up the temp directory, the mount unit **sometimes** enters a "failed" state instead of cleanly deactivating — this is a race condition in systemd's internal bookkeeping, not a real provisioning failure.

The unit names follow the pattern `run-cloud\x2dinit-tmp-<random>.mount` (where `\x2d` is systemd's escape for the `-` in `cloud-init`). Because the suffix is randomly generated by Python's `tempfile` module on each boot, **these units can never match a static allow list entry**.

### Evidence from Pipeline Logs (Build 160089239)

**Failed VM (`m9nl-*`):**
- `run-cloud\x2dinit-tmp-tmpde1rbvp9.mount` entered "failed" state
- Unit journal log shows `-- No entries --` — the mount was so transient that journald captured nothing for it
- `syslog` has no mention of the unit — rsyslog started after the mount was already gone
- All real validations passed (node readiness, pod scheduling, wireserver blocking, network config, kernel checks)
- The test only failed at the final systemd unit health check

**Successful VM (`rd0c-*`) from the same pipeline run:**
```
run-cloud\x2dinit-tmp-tmpr9w26ksr.mount: Deactivated successfully.
run-cloud\x2dinit-tmp-tmpgn9b4daw.mount: Deactivated successfully.
```
Same mount units appeared but deactivated cleanly — confirming the outcome (failed vs deactivated) is a race condition, not a code issue.

### Failed Test
```
FAIL: Test_Ubuntu2204Gen2_Containerd_NetworkIsolatedCluster_NonAnonymousNoneCached_InstallPackage (513.30s)

🔴 FAIL: the following systemd units have unexpectedly entered a failed state:
  [run-cloud\x2dinit-tmp-tmpde1rbvp9.mount]

DONE 160 tests, 68 skipped, 1 failure in 528.088s
```

## Changes

- Added a `unitFailureAllowPrefixes` slice in `ValidateNoFailedSystemdUnits` (`e2e/validators.go`) alongside the existing exact-match `unitFailureAllowList` map
- Added prefix `run-cloud\x2dinit-tmp-` to match all transient cloud-init temp mount units regardless of their random suffix
- Updated the filter logic to check both exact matches (existing behavior) and prefix matches (new)
- No changes to the allow list for `.service` units — only transient `.mount` units with random names are affected
- The prefix-based approach is extensible: future transient units with random names can be added to `unitFailureAllowPrefixes` without changing the filter logic

## Testing

- Verified the code compiles cleanly (`go build ./...` from `e2e/`)
- Confirmed the prefix `run-cloud\x2dinit-tmp-` matches the exact naming pattern observed across multiple VMs in production logs