### PR TITLE
fix: adjust Renovate configuration limits and rebase behavior

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,15 +6,16 @@
   "enabledManagers": [
     "custom.regex"
   ],
-  "prConcurrentLimit": 50,
-  "prHourlyLimit": 50,
-  "branchConcurrentLimit": 50,
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
+  "branchConcurrentLimit": 0,
+  "commitHourlyLimit": 5,
   "separateMinorPatch": true,
   "recreateWhen": "never",
   "labels": [
     "renovate"
   ],
-  "rebaseWhen": "automerging",
+  "rebaseWhen": "conflicted",
   "logLevelRemap": [
     {
       "matchMessage": "/^Custom manager fetcher/",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
     "custom.regex"
   ],
   "prConcurrentLimit": 0,
-  "prHourlyLimit": 0,
+  "prHourlyLimit": 10,
   "branchConcurrentLimit": 0,
   "commitHourlyLimit": 5,
   "separateMinorPatch": true,


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
adjust Renovate configuration limits and rebase behavior so that it won't drain the check-in tests resources

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
