### PR TITLE
fix: use the script file directly instead of bash -c

### DIFF
--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -274,6 +274,7 @@ stages:
     variables:
       VHD_BUILD_ID: $(Build.BuildId)
       ENABLE_SCRIPTLESS_NBC_CSE_CMD: true
+      DISABLE_SCRIPTLESS_COMPILATION: true
       TAGS_TO_SKIP: gpu=true,os=windows,scriptless=true
     jobs:
       - template: ./templates/e2e-template.yaml

--- a/aks-node-controller/app.go
+++ b/aks-node-controller/app.go
@@ -164,6 +164,24 @@ func buildCmdFromProvisionConfig(ctx context.Context, path string) (*exec.Cmd, e
 	return parser.BuildCSECmd(ctx, config)
 }
 
+func buildCmdFromNBCCmd(ctx context.Context, path string) (*exec.Cmd, error) {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("read NBC command file %s: %w", path, err)
+	}
+	if !fileInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("NBC command file %s must be a regular file", path)
+	}
+
+	scriptPath := filepath.Clean(path)
+	slog.Info("Using NBC command for scriptless phase 2", "NBCCmdFile", scriptPath)
+
+	// #nosec G204 -- scriptPath is validated as a file path and passed after "--" so bash treats it as a script, not an option or shell input.
+	cmd := exec.CommandContext(ctx, "/bin/bash", "--", scriptPath)
+	cmd.Env = os.Environ()
+	return cmd, nil
+}
+
 func (a *App) Provision(ctx context.Context, flags ProvisionFlags) (*ProvisionResult, error) {
 	provisionResult := &ProvisionResult{}
 
@@ -179,17 +197,13 @@ func (a *App) Provision(ctx context.Context, flags ProvisionFlags) (*ProvisionRe
 	}
 
 	if flags.NBCCmd != "" {
-		nbcCmdContent, err := os.ReadFile(flags.NBCCmd)
+		var err error
+		cmd, err = buildCmdFromNBCCmd(ctx, flags.NBCCmd)
 		if err != nil {
 			provisionResult.ExitCode = strconv.Itoa(240)
-			provisionResult.Error = fmt.Sprintf("read NBC command file %s: %v", flags.NBCCmd, err)
-			return provisionResult, errors.New(provisionResult.Error)
+			provisionResult.Error = err.Error()
+			return provisionResult, err
 		}
-		nbcScript := strings.TrimSpace(string(nbcCmdContent))
-		slog.Info("Using NBC command for scriptless phase 2", "NBCCmdFile", flags.NBCCmd)
-		nbcCMD := exec.CommandContext(ctx, "/bin/bash", "-c", nbcScript)
-		nbcCMD.Env = os.Environ()
-		cmd = nbcCMD
 	}
 
 	var stdoutBuf, stderrBuf bytes.Buffer

--- a/aks-node-controller/app_test.go
+++ b/aks-node-controller/app_test.go
@@ -128,6 +128,60 @@ func TestApp_Provision(t *testing.T) {
 		_, err := tt.App.Provision(context.Background(), ProvisionFlags{ProvisionConfig: "parser/testdata/test_aksnodeconfig.json"})
 		assert.Error(t, err)
 	})
+
+	t.Run("nbc cmd is executed by passing the script path to bash", func(t *testing.T) {
+		scriptPath := filepath.Join(t.TempDir(), "test_nbccmd.sh")
+		require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/bash\necho success running nbc_cmd.sh\n"), 0o600))
+
+		var gotCmd *exec.Cmd
+		tt := NewTestApp(t, TestAppConfig{
+			RunFunc: func(cmd *exec.Cmd) error {
+				gotCmd = cmd
+				return cmdRunner(cmd)
+			},
+		})
+
+		result, err := tt.App.Provision(context.Background(), ProvisionFlags{NBCCmd: scriptPath})
+		require.NoError(t, err)
+		require.NotNil(t, gotCmd)
+		assert.Equal(t, "/bin/bash", gotCmd.Path)
+		assert.Equal(t, []string{"/bin/bash", "--", scriptPath}, gotCmd.Args)
+		assert.Equal(t, "0", result.ExitCode)
+		assert.Contains(t, result.Output, "success running nbc_cmd.sh")
+	})
+
+	t.Run("nbc cmd is always passed as a script path, even when it starts with a dash", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+		scriptPath := "-test_nbccmd.sh"
+		require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/bash\necho success running dashed nbc_cmd.sh\n"), 0o600))
+
+		var gotCmd *exec.Cmd
+		tt := NewTestApp(t, TestAppConfig{
+			RunFunc: func(cmd *exec.Cmd) error {
+				gotCmd = cmd
+				return cmdRunner(cmd)
+			},
+		})
+
+		result, err := tt.App.Provision(context.Background(), ProvisionFlags{NBCCmd: scriptPath})
+		require.NoError(t, err)
+		require.NotNil(t, gotCmd)
+		assert.Equal(t, []string{"/bin/bash", "--", scriptPath}, gotCmd.Args)
+		assert.Equal(t, "0", result.ExitCode)
+		assert.Contains(t, result.Output, "success running dashed nbc_cmd.sh")
+	})
+
+	t.Run("nbc cmd file read errors are wrapped", func(t *testing.T) {
+		tt := NewTestApp(t, TestAppConfig{})
+		scriptPath := filepath.Join(t.TempDir(), "missing.sh")
+
+		result, err := tt.App.Provision(context.Background(), ProvisionFlags{NBCCmd: scriptPath})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+		assert.Equal(t, "240", result.ExitCode)
+		assert.Contains(t, result.Error, "read NBC command file "+scriptPath)
+	})
 }
 
 func TestApp_Provision_DryRun(t *testing.T) {


### PR DESCRIPTION
Followup PR to use the script file directly to avoid expanding shell scripts