### PR TITLE
e2e: increase Azure SDK retry tolerance for gallery throttling

### DIFF
--- a/e2e/config/azure.go
+++ b/e2e/config/azure.go
@@ -690,16 +690,24 @@ func (a *AzureClient) EnsureSIGImageVersion(ctx context.Context, image *Image, l
 
 func DefaultRetryOpts() policy.RetryOptions {
 	return policy.RetryOptions{
-		MaxRetries: 3,
-		RetryDelay: time.Second * 5,
+		// Use generous retry settings to survive Azure Compute Gallery throttling.
+		// Gallery APIs return HTTP 429 (ResourceCollectionRequestsThrottled) with
+		// "try after 120 seconds" when rate-limited. With 3 parallel E2E jobs hitting
+		// the same gallery, this is common. The Azure SDK uses exponential backoff
+		// (RetryDelay * 2^attempt) so with a 10s base and 6 retries we get:
+		// 10 + 20 + 40 + 80 + 160(→180) + 180 = ~510s total retry window, well past
+		// the 120s cooldown period.
+		MaxRetries:    6,
+		RetryDelay:    10 * time.Second,
+		MaxRetryDelay: 3 * time.Minute,
 		StatusCodes: []int{
 			http.StatusRequestTimeout,      // 408
-			http.StatusTooManyRequests,     // 429
-			http.StatusInternalServerError, // 500
-			http.StatusBadGateway,          // 502
-			http.StatusServiceUnavailable,  // 503
-			http.StatusGatewayTimeout,      // 504
-			http.StatusNotFound,            // 404
+			http.StatusTooManyRequests,      // 429
+			http.StatusInternalServerError,  // 500
+			http.StatusBadGateway,           // 502
+			http.StatusServiceUnavailable,   // 503
+			http.StatusGatewayTimeout,       // 504
+			http.StatusNotFound,             // 404
 		},
 	}
 }


### PR DESCRIPTION
## Problem

The 3 parallel E2E jobs (`e2e`, `scriptless_e2e`, `nbc_cse_cmd_e2e`) all hit the same Azure Compute Gallery APIs concurrently during VHD resolution. This frequently triggers `ResourceCollectionRequestsThrottled` (HTTP 429) with a 120-second cooldown window.

### Root Cause

The previous retry settings (`MaxRetries=3`, `RetryDelay=5s`) produced a total retry window of ~35 seconds (5s + 10s + 20s with exponential backoff). Since the Azure Compute Gallery throttle requires a 120-second cooldown, all retries exhausted well before the throttle lifted, causing consistent failures for whichever VHD image was last in the request sequence.

This has been a recurring source of E2E flakiness — e.g., build [160427675](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=160427675) had 4 test failures all from a single throttled `2404gen2containerd` lookup, all sharing tracking ID `185f63eb-6101-45b1-8789-0c01e637900a`.

### Fix

Increase retry settings to survive 120s+ throttle cooldowns:
- `MaxRetries`: 3 → 6
- `RetryDelay`: 5s → 10s  
- `MaxRetryDelay`: (unset) → 3 minutes

With exponential backoff (10 + 20 + 40 + 80 + 160→180 + 180 = ~510s total retry window), the SDK will easily span the 120s cooldown period.

### Impact

- Only affects E2E test infrastructure (no production code changes)
- Reduces false-positive E2E failures from gallery throttling
- May slightly increase individual test duration when throttled (retries wait longer), but prevents outright failures