### PR TITLE
fix: acl hostname seems to be set further down boot order, wait for hostname to converge

### DIFF
--- a/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -uo pipefail
 
+until [ "$(hostname)" = "$(cat /etc/hostname)" ]; do
+   sleep 1
+done
+
 BIN_PATH="${BIN_PATH:-/opt/azure/containers/aks-node-controller}"
 HOTFIX_BIN="${BIN_PATH}-hotfix"
 CONFIG_PATH="${CONFIG_PATH:-/opt/azure/containers/aks-node-controller-config.json}"


### PR DESCRIPTION
this was a hard one, seems like on acl the hostname coverges full 5seconds after provisioning is complete. Add a helper script to wait for hostname to converge, which is very fast on ubuntu.