### PR TITLE
fix: switch to use msft golang for building aks-node-controller

### DIFF
--- a/hack/setup_golang.sh
+++ b/hack/setup_golang.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euxo pipefail
+
+purge_go() {
+    sudo apt-get purge golang*
+    sudo apt-get update
+    sudo rm -rf /usr/local/go
+}
+
+setup_pmc() {
+    # see: https://github.com/microsoft/go/blob/microsoft/main/README.md#ubuntu
+    UBUNTU_RELEASE=$(sudo lsb_release -r -s 2>/dev/null || echo "")
+    curl -sSL -O https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb
+    sudo dpkg -i packages-microsoft-prod.deb
+    sudo apt-get update
+}
+
+# purge any existing go installation
+purge_go
+
+# setup access to packages.microsoft.com for the particular Ubuntu release
+setup_pmc
+
+# install make
+sudo apt-get -y install make
+
+# install msft-golang
+sudo apt-get -y install msft-golang
+
+# make sure go is accessible from the command line
+go version

--- a/packer.mk
+++ b/packer.mk
@@ -8,7 +8,7 @@ ifeq (${ARCHITECTURE},ARM64)
 endif
 GOHOSTARCH = $(shell go env GOHOSTARCH)
 
-build-packer: generate-prefetch-scripts build-image-fetcher build-aks-node-controller build-lister-binary
+build-packer: setup-golang generate-prefetch-scripts build-image-fetcher build-aks-node-controller build-lister-binary
 ifeq (${ARCHITECTURE},ARM64)
 	@echo "${MODE}: Building with Hyper-v generation 2 ARM64 VM"
 ifeq (${OS_SKU},Ubuntu)
@@ -85,7 +85,7 @@ endif
 	@packer build -timestamp-ui -var-file=vhdbuilder/packer/settings.json vhdbuilder/packer/windows/windows-vhd-builder-sig.json
 endif
 
-build-imagecustomizer: generate-prefetch-scripts build-image-fetcher build-aks-node-controller build-lister-binary
+build-imagecustomizer: setup-golang generate-prefetch-scripts build-image-fetcher build-aks-node-controller build-lister-binary
 	@./vhdbuilder/packer/imagecustomizer/scripts/build-imagecustomizer-image.sh
 
 az-login:
@@ -132,6 +132,10 @@ generate-prefetch-scripts:
 	@echo "${MODE}: Generating prefetch scripts"
 	@bash -c "pushd vhdbuilder/prefetch; go run cmd/main.go --components-path=../../parts/common/components.json --output-path=../packer/prefetch.sh || exit 1; popd"
 
+setup-golang:
+	@echo "Setting up Go environment"
+	@bash ./hack/setup_golang.sh
+
 build-aks-node-controller:
 	@echo "Building aks-node-controller binaries"
 	@bash -c "pushd aks-node-controller && \
@@ -139,20 +143,20 @@ build-aks-node-controller:
 	ANC_VERSION=\"$${IMAGE_VERSION:-$$(date +%Y%m.%d.0)}\"; \
 	ANC_LDFLAGS=\"-X main.Version=$${ANC_VERSION}\"; \
 	echo \"Stamping ANC version: $${ANC_VERSION}\"; \
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags \"$${ANC_LDFLAGS}\" -o bin/aks-node-controller-linux-amd64 && \
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags \"$${ANC_LDFLAGS}\" -o bin/aks-node-controller-linux-arm64 && \
+	GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags \"$${ANC_LDFLAGS}\" -o bin/aks-node-controller-linux-amd64 && \
+	GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags \"$${ANC_LDFLAGS}\" -o bin/aks-node-controller-linux-arm64 && \
 	popd"
 
 build-image-fetcher:
 	@echo "Building image-fetcher binaries"
 	@bash -c "pushd image-fetcher && \
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/image-fetcher-linux-amd64 && \
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/image-fetcher-linux-arm64 && \
+	GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/image-fetcher-linux-amd64 && \
+	GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/image-fetcher-linux-arm64 && \
 	popd"
 
 build-lister-binary:
 	@echo "Building lister binary for $(GOARCH)"
-	@bash -c "pushd vhdbuilder/lister && CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -o bin/lister main.go && popd"
+	@bash -c "pushd vhdbuilder/lister && GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -o bin/lister main.go && popd"
 
 generate-flatcar-customdata: vhdbuilder/packer/flatcar-customdata.json
 vhdbuilder/packer/flatcar-customdata.json: vhdbuilder/packer/flatcar-customdata.yaml | hack/tools/bin/butane


### PR DESCRIPTION
switch to msft golang to build aks-node-controller