### PR TITLE
test: re-enable Windows Cilium Networking e2e test

### DIFF
--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -326,7 +326,6 @@ func Test_Windows2025Gen2(t *testing.T) {
 }
 
 func Test_Windows2025Gen2_WindowsCiliumNetworking(t *testing.T) {
-	t.Skip("Awaiting the network team’s release of the new WCN package to be included in the VHD before re-enabling this test.")
 	RunScenario(t, &Scenario{
 		Description: "Windows Server 2025 Gen2 with Windows Cilium Networking (WCN) enabled",
 		Config: Config{


### PR DESCRIPTION
Re-enables the `Test_Windows2025Gen2_WindowsCiliumNetworking` e2e test, now that the WCN package is available in the VHD.