### PR TITLE
fix: wait for a bit longer for containerd to get ready, sometimes its slow

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -665,7 +665,7 @@ waitForContainerdReady() {
     local ret=0
 
     echo "Waiting for containerd to become ready..."
-    retrycmd_if_failure 60 0.1 1 bash -c 'ctr version >/dev/null 2>&1'
+    retrycmd_if_failure 120 0.1 1 bash -c 'ctr version >/dev/null 2>&1'
     ret=$?
     if [ "$ret" -ne 0 ]; then
         echo "containerd did not become ready"


### PR DESCRIPTION
Based on this https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=160809574&view=results containerd takes a long time for artifact streaming cases, double the time waited, but keep the step size the same.