### PR TITLE
fix: do not retry not found errors from azure

### DIFF
--- a/e2e/config/azure.go
+++ b/e2e/config/azure.go
@@ -702,12 +702,11 @@ func DefaultRetryOpts() policy.RetryOptions {
 		MaxRetryDelay: 3 * time.Minute,
 		StatusCodes: []int{
 			http.StatusRequestTimeout,      // 408
-			http.StatusTooManyRequests,      // 429
-			http.StatusInternalServerError,  // 500
-			http.StatusBadGateway,           // 502
-			http.StatusServiceUnavailable,   // 503
-			http.StatusGatewayTimeout,       // 504
-			http.StatusNotFound,             // 404
+			http.StatusTooManyRequests,     // 429
+			http.StatusInternalServerError, // 500
+			http.StatusBadGateway,          // 502
+			http.StatusServiceUnavailable,  // 503
+			http.StatusGatewayTimeout,      // 504
 		},
 	}
 }


### PR DESCRIPTION
Simple change to not retry NotFound errors from azure which makes no sense.