### PR TITLE
fix(e2e): validate secure TLS bootstrapping token fallback purely through kubelet logs

### DIFF
--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -44,18 +44,10 @@ func ValidateTLSBootstrapping(ctx context.Context, s *Scenario) {
 }
 
 func validateTLSBootstrappingLinux(ctx context.Context, s *Scenario) {
-	if s.KubeletConfigFileEnabled() {
-		ValidateFileHasContent(ctx, s, "/etc/default/kubeletconfig.json", "\"rotateCertificates\": true")
-	} else {
-		ValidateFileHasContent(ctx, s, "/etc/default/kubelet", "--rotate-certificates=true")
-	}
-	ValidateDirectoryContent(ctx, s, "/var/lib/kubelet", []string{"kubeconfig"})
-	ValidateDirectoryContent(ctx, s, "/var/lib/kubelet/pki", []string{"kubelet-client-current.pem"})
 	kubeletLogs := execScriptOnVMForScenarioValidateExitCode(ctx, s, "sudo journalctl -u kubelet", 0, "could not retrieve kubelet logs with journalctl").stdout
 	switch {
 	case s.SecureTLSBootstrappingEnabled() && s.Tags.BootstrapTokenFallback:
 		s.T.Logf("will validate bootstrapping mode: secure TLS bootstrapping failure with bootstrap token fallback")
-		ValidateSystemdUnitIsNotRunning(ctx, s, "secure-tls-bootstrap")
 		require.True(
 			s.T,
 			!strings.Contains(kubeletLogs, "unable to validate bootstrap credentials") && strings.Contains(kubeletLogs, "kubelet bootstrap token credential is valid"),
@@ -80,6 +72,13 @@ func validateTLSBootstrappingLinux(ctx context.Context, s *Scenario) {
 			"expected to have successfully validated bootstrap token credential before kubelet startup, but did not",
 		)
 	}
+	if s.KubeletConfigFileEnabled() {
+		ValidateFileHasContent(ctx, s, "/etc/default/kubeletconfig.json", "\"rotateCertificates\": true")
+	} else {
+		ValidateFileHasContent(ctx, s, "/etc/default/kubelet", "--rotate-certificates=true")
+	}
+	ValidateDirectoryContent(ctx, s, "/var/lib/kubelet", []string{"kubeconfig"})
+	ValidateDirectoryContent(ctx, s, "/var/lib/kubelet/pki", []string{"kubelet-client-current.pem"})
 }
 
 func validateTLSBootstrappingWindows(ctx context.Context, s *Scenario) {


### PR DESCRIPTION

<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
validate secure TLS bootstrapping token fallback purely through kubelet logs - it seems that in rare cases before we validate that the secure-tls-bootstrap service is not in a running state by the time the node joins the cluster within bootstrap token fallback scenarios, kubelet could have restarted at least once due to some transient issue. Because of the restart, the secure-tls-bootstrap service will be restarted as well _after_ the kubelet has already bootstrapped a client credential for itself using the bootstrap token fallback as expected. Because the client credential exists at the time secure-tls-bootstrap.service is restarted, the service will actually converge on a succeeded and running state, since the bootstrap client itself is idempotent and will successfully exit early if it finds a valid client credential (kubeconfig) already on disk. This ends up breaking the current validation logic, that assumes secure-tls-bootstrap.service will never be in a running state by the time the node joins the cluster in bootstrap token fallback scenarios.

The validation has been changed such that we don't explicitly check on the status of secure-tls-bootstrap.service, and instead solely rely on kubelet logs to ensure the correct behavior was observed - this will take into account any transient kubelet/secure-tls-bootstrap service restarts during provisioning

example repro logs from the kubelet:
```
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 systemd[1]: Starting kubelet.service - Kubelet...
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[5426]: Primary NIC IP: 10.224.0.53
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[5426]: Insert IMDS restriction rule to mangle table: false
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[5426]: Enable IMDS restriction: false
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[5426]: Checking whether IMDS restriction rule exists in mangle table...
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[5426]: IMDS restriction rule does not exist in mangle table, no need to delete
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[5426]: Checking whether IMDS restriction rule exists in filter table...
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[5426]: IMDS restriction rule does not exist in filter table, no need to delete
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 ebtables[5444]: Bridge table: nat
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 ebtables[5444]: Bridge chain: PREROUTING, entries: 0, policy: ACCEPT
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 ebtables[5444]: Bridge chain: OUTPUT, entries: 0, policy: ACCEPT
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 ebtables[5444]: Bridge chain: POSTROUTING, entries: 0, policy: ACCEPT
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[5446]: Chain PREROUTING (policy ACCEPT)
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[5446]: target     prot opt source               destination
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[5446]: Chain INPUT (policy ACCEPT)
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[5446]: target     prot opt source               destination
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[5446]: Chain OUTPUT (policy ACCEPT)
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[5446]: target     prot opt source               destination
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[5446]: Chain POSTROUTING (policy ACCEPT)
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[5446]: target     prot opt source               destination
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[5448]: will validate kubelet bootstrap credentials
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[5448]: will check credential validity against apiserver url: https://abe2e-kubenet-v4-17g79p14.hcp.westus.azmk8s.io:443
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[5448]: (retry=0) received valid HTTP status code from apiserver: 200
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[5448]: kubelet bootstrap token credential is valid
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 systemd[1]: Started kubelet.service - Kubelet.
Apr 20 11:18:42 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 (kubelet)[5528]: kubelet.service: Referenced but unset environment variable evaluates to an empty string: KUBELET_CONFIG_FILE_FLAGS, KUBELET_CONTAINER_RUNTIME_FLAG
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --enable-server has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --volume-plugin-dir has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --runtime-request-timeout has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --container-runtime-endpoint has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --cgroup-driver has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --address has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --anonymous-auth has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --authentication-token-webhook has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --authorization-mode has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --cgroups-per-qos has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --client-ca-file has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --cluster-dns has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --cluster-domain has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --enforce-node-allocatable has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --event-qps has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --eviction-hard has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --feature-gates has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --image-gc-high-threshold has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --image-gc-low-threshold has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --kube-reserved has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --max-pods has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --node-status-update-frequency has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --pod-manifest-path has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --pod-max-pids has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --protect-kernel-defaults has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --read-only-port has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --resolv-conf has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --rotate-certificates has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --rotate-server-certificates has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --streaming-connection-idle-timeout has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: Flag --tls-cipher-suites has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032670    5528 flags.go:64] FLAG: --address="0.0.0.0"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032717    5528 flags.go:64] FLAG: --allowed-unsafe-sysctls="[]"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032730    5528 flags.go:64] FLAG: --anonymous-auth="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032737    5528 flags.go:64] FLAG: --application-metrics-count-limit="100"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032744    5528 flags.go:64] FLAG: --authentication-token-webhook="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032748    5528 flags.go:64] FLAG: --authentication-token-webhook-cache-ttl="2m0s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032759    5528 flags.go:64] FLAG: --authorization-mode="Webhook"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032767    5528 flags.go:64] FLAG: --authorization-webhook-cache-authorized-ttl="5m0s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032772    5528 flags.go:64] FLAG: --authorization-webhook-cache-unauthorized-ttl="30s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032776    5528 flags.go:64] FLAG: --boot-id-file="/proc/sys/kernel/random/boot_id"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032781    5528 flags.go:64] FLAG: --bootstrap-kubeconfig="/var/lib/kubelet/bootstrap-kubeconfig"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032787    5528 flags.go:64] FLAG: --cert-dir="/var/lib/kubelet/pki"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032793    5528 flags.go:64] FLAG: --cgroup-driver="systemd"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032803    5528 flags.go:64] FLAG: --cgroup-root=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032810    5528 flags.go:64] FLAG: --cgroups-per-qos="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032814    5528 flags.go:64] FLAG: --client-ca-file="/etc/kubernetes/certs/ca.crt"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032819    5528 flags.go:64] FLAG: --cloud-config=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032824    5528 flags.go:64] FLAG: --cloud-provider="external"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032828    5528 flags.go:64] FLAG: --cluster-dns="[10.0.0.10]"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032841    5528 flags.go:64] FLAG: --cluster-domain="cluster.local"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032845    5528 flags.go:64] FLAG: --config=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032849    5528 flags.go:64] FLAG: --config-dir=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032853    5528 flags.go:64] FLAG: --container-hints="/etc/cadvisor/container_hints.json"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032863    5528 flags.go:64] FLAG: --container-log-max-files="5"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032873    5528 flags.go:64] FLAG: --container-log-max-size="10Mi"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032878    5528 flags.go:64] FLAG: --container-runtime-endpoint="unix:///run/containerd/containerd.sock"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032883    5528 flags.go:64] FLAG: --containerd="/run/containerd/containerd.sock"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032887    5528 flags.go:64] FLAG: --containerd-namespace="k8s.io"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032891    5528 flags.go:64] FLAG: --contention-profiling="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032896    5528 flags.go:64] FLAG: --cpu-cfs-quota="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032900    5528 flags.go:64] FLAG: --cpu-cfs-quota-period="100ms"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032908    5528 flags.go:64] FLAG: --cpu-manager-policy="none"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032912    5528 flags.go:64] FLAG: --cpu-manager-policy-options=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032919    5528 flags.go:64] FLAG: --cpu-manager-reconcile-period="10s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032928    5528 flags.go:64] FLAG: --enable-controller-attach-detach="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032933    5528 flags.go:64] FLAG: --enable-debugging-handlers="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032936    5528 flags.go:64] FLAG: --enable-load-reader="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032940    5528 flags.go:64] FLAG: --enable-server="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032945    5528 flags.go:64] FLAG: --enforce-node-allocatable="[pods]"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032956    5528 flags.go:64] FLAG: --event-burst="100"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032960    5528 flags.go:64] FLAG: --event-qps="0"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032964    5528 flags.go:64] FLAG: --event-storage-age-limit="default=0"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032969    5528 flags.go:64] FLAG: --event-storage-event-limit="default=0"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032973    5528 flags.go:64] FLAG: --eviction-hard="memory.available<750Mi,nodefs.available<10%,nodefs.inodesFree<5%"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032985    5528 flags.go:64] FLAG: --eviction-max-pod-grace-period="0"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.032989    5528 flags.go:64] FLAG: --eviction-minimum-reclaim=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033005    5528 flags.go:64] FLAG: --eviction-pressure-transition-period="5m0s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033010    5528 flags.go:64] FLAG: --eviction-soft=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033014    5528 flags.go:64] FLAG: --eviction-soft-grace-period=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033019    5528 flags.go:64] FLAG: --exit-on-lock-contention="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033023    5528 flags.go:64] FLAG: --experimental-allocatable-ignore-eviction="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033027    5528 flags.go:64] FLAG: --experimental-mounter-path=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033031    5528 flags.go:64] FLAG: --fail-cgroupv1="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033035    5528 flags.go:64] FLAG: --fail-swap-on="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033043    5528 flags.go:64] FLAG: --feature-gates="RotateKubeletServerCertificate=true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033052    5528 flags.go:64] FLAG: --file-check-frequency="20s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033056    5528 flags.go:64] FLAG: --global-housekeeping-interval="1m0s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033061    5528 flags.go:64] FLAG: --hairpin-mode="promiscuous-bridge"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033064    5528 flags.go:64] FLAG: --healthz-bind-address="127.0.0.1"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033069    5528 flags.go:64] FLAG: --healthz-port="10248"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033073    5528 flags.go:64] FLAG: --help="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033077    5528 flags.go:64] FLAG: --hostname-override=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033086    5528 flags.go:64] FLAG: --housekeeping-interval="10s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033090    5528 flags.go:64] FLAG: --http-check-frequency="20s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033094    5528 flags.go:64] FLAG: --image-credential-provider-bin-dir=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033098    5528 flags.go:64] FLAG: --image-credential-provider-config=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033102    5528 flags.go:64] FLAG: --image-gc-high-threshold="85"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033112    5528 flags.go:64] FLAG: --image-gc-low-threshold="80"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033116    5528 flags.go:64] FLAG: --image-service-endpoint=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033122    5528 flags.go:64] FLAG: --kernel-memcg-notification="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033126    5528 flags.go:64] FLAG: --kube-api-burst="100"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033134    5528 flags.go:64] FLAG: --kube-api-content-type="application/vnd.kubernetes.protobuf"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033139    5528 flags.go:64] FLAG: --kube-api-qps="50"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033143    5528 flags.go:64] FLAG: --kube-reserved="cpu=100m,memory=1638Mi"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033150    5528 flags.go:64] FLAG: --kube-reserved-cgroup=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033154    5528 flags.go:64] FLAG: --kubeconfig="/var/lib/kubelet/kubeconfig"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033158    5528 flags.go:64] FLAG: --kubelet-cgroups=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033162    5528 flags.go:64] FLAG: --local-storage-capacity-isolation="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033170    5528 flags.go:64] FLAG: --lock-file=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033173    5528 flags.go:64] FLAG: --log-cadvisor-usage="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033178    5528 flags.go:64] FLAG: --log-flush-frequency="5s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033182    5528 flags.go:64] FLAG: --log-json-info-buffer-size="0"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033191    5528 flags.go:64] FLAG: --log-json-split-stream="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033195    5528 flags.go:64] FLAG: --log-text-info-buffer-size="0"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033199    5528 flags.go:64] FLAG: --log-text-split-stream="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033204    5528 flags.go:64] FLAG: --logging-format="text"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033208    5528 flags.go:64] FLAG: --machine-id-file="/etc/machine-id,/var/lib/dbus/machine-id"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033217    5528 flags.go:64] FLAG: --make-iptables-util-chains="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033221    5528 flags.go:64] FLAG: --manifest-url=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033225    5528 flags.go:64] FLAG: --manifest-url-header=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033232    5528 flags.go:64] FLAG: --max-open-files="1000000"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033238    5528 flags.go:64] FLAG: --max-pods="110"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033242    5528 flags.go:64] FLAG: --maximum-dead-containers="-1"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033246    5528 flags.go:64] FLAG: --maximum-dead-containers-per-container="1"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033249    5528 flags.go:64] FLAG: --memory-manager-policy="None"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033257    5528 flags.go:64] FLAG: --minimum-container-ttl-duration="0s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033261    5528 flags.go:64] FLAG: --minimum-image-ttl-duration="2m0s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033265    5528 flags.go:64] FLAG: --node-ip="10.224.0.53"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033269    5528 flags.go:64] FLAG: --node-labels="agentpool=nodepool2,kubernetes.azure.com/agentpool=nodepool2,kubernetes.azure.com/cluster=test-cluster,kubernetes.azure.com/kubelet-serving-ca=cluster,kubernetes.azure.com/localdns-exporter=enabled,kubernetes.azure.com/mode=system,kubernetes.azure.com/node-image-version=AKSUbuntu-2404gen2containerd-2025.06.02"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033292    5528 flags.go:64] FLAG: --node-status-max-images="50"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033303    5528 flags.go:64] FLAG: --node-status-update-frequency="10s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033308    5528 flags.go:64] FLAG: --oom-score-adj="-999"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033312    5528 flags.go:64] FLAG: --pod-cidr=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033316    5528 flags.go:64] FLAG: --pod-infra-container-image="registry.k8s.io/pause:3.10"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033320    5528 flags.go:64] FLAG: --pod-manifest-path="/etc/kubernetes/manifests"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033325    5528 flags.go:64] FLAG: --pod-max-pids="-1"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033329    5528 flags.go:64] FLAG: --pods-per-core="0"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033337    5528 flags.go:64] FLAG: --port="10250"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033341    5528 flags.go:64] FLAG: --protect-kernel-defaults="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033344    5528 flags.go:64] FLAG: --provider-id=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033348    5528 flags.go:64] FLAG: --qos-reserved=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033353    5528 flags.go:64] FLAG: --read-only-port="0"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033356    5528 flags.go:64] FLAG: --register-node="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033360    5528 flags.go:64] FLAG: --register-schedulable="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033364    5528 flags.go:64] FLAG: --register-with-taints=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033372    5528 flags.go:64] FLAG: --registry-burst="10"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033530    5528 flags.go:64] FLAG: --registry-qps="5"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033537    5528 flags.go:64] FLAG: --reserved-cpus=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033542    5528 flags.go:64] FLAG: --reserved-memory=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033602    5528 flags.go:64] FLAG: --resolv-conf="/run/systemd/resolve/resolv.conf"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033607    5528 flags.go:64] FLAG: --root-dir="/var/lib/kubelet"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033611    5528 flags.go:64] FLAG: --rotate-certificates="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033616    5528 flags.go:64] FLAG: --rotate-server-certificates="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033624    5528 flags.go:64] FLAG: --runonce="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033628    5528 flags.go:64] FLAG: --runtime-cgroups="/system.slice/containerd.service"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033632    5528 flags.go:64] FLAG: --runtime-request-timeout="15m0s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033637    5528 flags.go:64] FLAG: --seccomp-default="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033641    5528 flags.go:64] FLAG: --serialize-image-pulls="true"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033646    5528 flags.go:64] FLAG: --storage-driver-buffer-duration="1m0s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033651    5528 flags.go:64] FLAG: --storage-driver-db="cadvisor"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033655    5528 flags.go:64] FLAG: --storage-driver-host="localhost:8086"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033660    5528 flags.go:64] FLAG: --storage-driver-password="root"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033668    5528 flags.go:64] FLAG: --storage-driver-secure="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033681    5528 flags.go:64] FLAG: --storage-driver-table="stats"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033685    5528 flags.go:64] FLAG: --storage-driver-user="root"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033691    5528 flags.go:64] FLAG: --streaming-connection-idle-timeout="4h0m0s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033696    5528 flags.go:64] FLAG: --sync-frequency="1m0s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033699    5528 flags.go:64] FLAG: --system-cgroups=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033708    5528 flags.go:64] FLAG: --system-reserved=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033713    5528 flags.go:64] FLAG: --system-reserved-cgroup=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033716    5528 flags.go:64] FLAG: --tls-cert-file=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033723    5528 flags.go:64] FLAG: --tls-cipher-suites="[TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256]"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033737    5528 flags.go:64] FLAG: --tls-min-version=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033742    5528 flags.go:64] FLAG: --tls-private-key-file=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033746    5528 flags.go:64] FLAG: --topology-manager-policy="none"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033750    5528 flags.go:64] FLAG: --topology-manager-policy-options=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033754    5528 flags.go:64] FLAG: --topology-manager-scope="container"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033758    5528 flags.go:64] FLAG: --v="2"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033764    5528 flags.go:64] FLAG: --version="false"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033775    5528 flags.go:64] FLAG: --vmodule=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033782    5528 flags.go:64] FLAG: --volume-plugin-dir="/etc/kubernetes/volumeplugins"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.033787    5528 flags.go:64] FLAG: --volume-stats-agg-period="1m0s"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.034031    5528 feature_gate.go:385] feature gates: {map[RotateKubeletServerCertificate:true]}
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.034141    5528 server.go:1172] "Use of insecure cipher detected." cipher="TLS_RSA_WITH_AES_256_GCM_SHA384"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.034153    5528 server.go:1172] "Use of insecure cipher detected." cipher="TLS_RSA_WITH_AES_128_GCM_SHA256"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.041908    5528 server.go:530] "Kubelet version" kubeletVersion="v1.33.6"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.041935    5528 server.go:532] "Golang settings" GOGC="" GOMAXPROCS="" GOTRACEBACK=""
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.041970    5528 feature_gate.go:385] feature gates: {map[RotateKubeletServerCertificate:true]}
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.042044    5528 feature_gate.go:385] feature gates: {map[RotateKubeletServerCertificate:true]}
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.042180    5528 server.go:956] "Client rotation is on, will bootstrap in background"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.042990    5528 bootstrap.go:101] "Use the bootstrap credentials to request a cert, and set kubeconfig to point to the certificate dir"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.043189    5528 server.go:1013] "Starting client certificate rotation"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.043989    5528 dynamic_cafile_content.go:123] "Loaded a new CA Bundle and Verifier" name="client-ca-bundle::/etc/kubernetes/certs/ca.crt"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.046335    5528 certificate_manager.go:422] "Certificate rotation is enabled" logger="kubernetes.io/kube-apiserver-client-kubelet"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.046555    5528 certificate_manager.go:566] "Rotating certificates" logger="kubernetes.io/kube-apiserver-client-kubelet"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.051698    5528 dynamic_cafile_content.go:161] "Starting controller" name="client-ca-bundle::/etc/kubernetes/certs/ca.crt"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.109817    5528 reflector.go:430] "Caches populated" logger="kubernetes.io/kube-apiserver-client-kubelet" type="*v1.CertificateSigningRequest" reflector="k8s.io/client-go/tools/watch/informerwatcher.go:162"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.114703    5528 csr.go:274] "Certificate signing request is approved, waiting to be issued" logger="kubernetes.io/kube-apiserver-client-kubelet" csr="csr-847m8"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: I0420 11:18:43.147151    5528 csr.go:270] "Certificate signing request is issued" logger="kubernetes.io/kube-apiserver-client-kubelet" csr="csr-847m8"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 kubelet[5528]: E0420 11:18:43.414552    5528 run.go:72] "command failed" err="failed to run Kubelet: validate service connection: validate CRI v1 runtime API for endpoint \"unix:///run/containerd/containerd.sock\": rpc error: code = Unavailable desc = server is not initialized yet: unavailable"
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 systemd[1]: kubelet.service: Main process exited, code=exited, status=1/FAILURE
Apr 20 11:18:43 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 systemd[1]: kubelet.service: Failed with result 'exit-code'.
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 systemd[1]: kubelet.service: Scheduled restart job, restart counter is at 1.
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 systemd[1]: Starting kubelet.service - Kubelet...
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[6139]: Primary NIC IP: 10.224.0.53
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[6139]: Insert IMDS restriction rule to mangle table: false
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[6139]: Enable IMDS restriction: false
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[6139]: Checking whether IMDS restriction rule exists in mangle table...
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[6139]: IMDS restriction rule does not exist in mangle table, no need to delete
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[6139]: Checking whether IMDS restriction rule exists in filter table...
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[6139]: IMDS restriction rule does not exist in filter table, no need to delete
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 ebtables[6156]: Bridge table: nat
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 ebtables[6156]: Bridge chain: PREROUTING, entries: 0, policy: ACCEPT
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 ebtables[6156]: Bridge chain: OUTPUT, entries: 0, policy: ACCEPT
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 ebtables[6156]: Bridge chain: POSTROUTING, entries: 0, policy: ACCEPT
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[6158]: Chain PREROUTING (policy ACCEPT)
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[6158]: target     prot opt source               destination
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[6158]: Chain INPUT (policy ACCEPT)
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[6158]: target     prot opt source               destination
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[6158]: Chain OUTPUT (policy ACCEPT)
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[6158]: target     prot opt source               destination
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[6158]: Chain POSTROUTING (policy ACCEPT)
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 iptables[6158]: target     prot opt source               destination
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 bash[6160]: client credential already exists within kubeconfig: /var/lib/kubelet/kubeconfig, no need to validate bootstrap credentials
Apr 20 11:18:45 bmzu-2026-04-20-azurelinuxv3securetlsbootstrappingbootstr000000 systemd[1]: Started kubelet.service - Kubelet.
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
