### PR TITLE
feat: implement rendering nodecustomdata in aks-node-controller to support hotfixing scripts

### DIFF
--- a/aks-node-controller/app.go
+++ b/aks-node-controller/app.go
@@ -32,6 +32,8 @@ type App struct {
 	hotfixVersionPath string
 	// aptSourcesDir overrides the default APT sources directory for testing.
 	aptSourcesDir string
+	// nodeCustomDataPath overrides the default nodecustomdata path for testing.
+	nodeCustomDataPath string
 }
 
 // commandMetadata holds all metadata for a command in one place.
@@ -220,6 +222,13 @@ func buildCmdFromNBCCmd(ctx context.Context, path string) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
+func (a *App) getNodeCustomDataPath() string {
+	if a.nodeCustomDataPath != "" {
+		return a.nodeCustomDataPath
+	}
+	return defaultNodeCustomDataPath
+}
+
 func (a *App) Provision(ctx context.Context, flags ProvisionFlags) (*ProvisionResult, error) {
 	provisionResult := &ProvisionResult{}
 
@@ -235,6 +244,12 @@ func (a *App) Provision(ctx context.Context, flags ProvisionFlags) (*ProvisionRe
 	}
 
 	if flags.NBCCmd != "" {
+		if err := applyNodeCustomData(a.getNodeCustomDataPath()); err != nil {
+			provisionResult.ExitCode = strconv.Itoa(240)
+			provisionResult.Error = err.Error()
+			return provisionResult, err
+		}
+
 		var err error
 		cmd, err = buildCmdFromNBCCmd(ctx, flags.NBCCmd)
 		if err != nil {

--- a/aks-node-controller/nodecustomdata.go
+++ b/aks-node-controller/nodecustomdata.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	defaultNodeCustomDataPath = "/opt/azure/containers/nodecustomdata.yml"
+	encodingGZIP              = "gzip"
+	encodingBase64            = "base64"
+)
+
+type nodeCustomDataWriteFile struct {
+	Path        string `yaml:"path"`
+	Permissions string `yaml:"permissions"`
+	Encoding    string `yaml:"encoding,omitempty"`
+	Owner       string `yaml:"owner"`
+	Content     string `yaml:"content"`
+}
+
+type nodeCustomData struct {
+	WriteFiles []nodeCustomDataWriteFile `yaml:"write_files"`
+}
+
+func applyNodeCustomData(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read nodecustomdata %s: %w", path, err)
+	}
+
+	var customData nodeCustomData
+	if err := yaml.Unmarshal(data, &customData); err != nil {
+		return fmt.Errorf("unmarshal nodecustomdata %s: %w", path, err)
+	}
+
+	for _, file := range customData.WriteFiles {
+		if err := applyNodeCustomDataWriteFile(file); err != nil {
+			return fmt.Errorf("apply nodecustomdata write file %s: %w", file.Path, err)
+		}
+	}
+
+	return nil
+}
+
+func applyNodeCustomDataWriteFile(file nodeCustomDataWriteFile) error {
+	if file.Path == "" {
+		return fmt.Errorf("path is required")
+	}
+	if file.Owner != "" && file.Owner != "root" {
+		return fmt.Errorf("unsupported owner %q", file.Owner)
+	}
+
+	mode := os.FileMode(0o644)
+	if file.Permissions != "" {
+		parsedMode, err := strconv.ParseUint(file.Permissions, 8, 32)
+		if err != nil {
+			return fmt.Errorf("parse permissions: %w", err)
+		}
+		mode = os.FileMode(parsedMode)
+	}
+
+	contents, err := decodeNodeCustomDataWriteFileContent(file)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(file.Path), 0o755); err != nil {
+		return fmt.Errorf("create parent directory: %w", err)
+	}
+
+	if err := os.WriteFile(file.Path, contents, mode); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	return nil
+}
+
+func decodeNodeCustomDataWriteFileContent(file nodeCustomDataWriteFile) ([]byte, error) {
+	switch file.Encoding {
+	case "":
+		return []byte(file.Content), nil
+	case encodingGZIP:
+		reader, err := gzip.NewReader(bytes.NewReader([]byte(file.Content)))
+		if err != nil {
+			return nil, fmt.Errorf("create gzip reader: %w", err)
+		}
+		defer reader.Close()
+
+		decoded, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, fmt.Errorf("read gzip content: %w", err)
+		}
+		return decoded, nil
+	case encodingBase64:
+		decoded, err := base64.StdEncoding.DecodeString(file.Content)
+		if err != nil {
+			return nil, fmt.Errorf("decode base64 content: %w", err)
+		}
+		return decoded, nil
+	default:
+		return nil, fmt.Errorf("unsupported encoding %q", file.Encoding)
+	}
+}

--- a/aks-node-controller/nodecustomdata_test.go
+++ b/aks-node-controller/nodecustomdata_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyNodeCustomData(t *testing.T) {
+	tempDir := t.TempDir()
+	plainPath := filepath.Join(tempDir, "plain.txt")
+	gzipPath := filepath.Join(tempDir, "gzip.txt")
+	renderedPath := filepath.Join(tempDir, "nodecustomdata.yml")
+
+	var gzipBuffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&gzipBuffer)
+	_, err := gzipWriter.Write([]byte("gzip-content"))
+	require.NoError(t, err)
+	require.NoError(t, gzipWriter.Close())
+
+	rendered := fmt.Sprintf(`#cloud-config
+write_files:
+- path: %s
+  permissions: "0600"
+  owner: root
+  content: |
+    plain-content
+- path: %s
+  permissions: "0644"
+  owner: root
+  encoding: gzip
+  content: !!binary |
+    %s
+`, plainPath, gzipPath, base64.StdEncoding.EncodeToString(gzipBuffer.Bytes()))
+	require.NoError(t, os.WriteFile(renderedPath, []byte(rendered), 0o600))
+
+	require.NoError(t, applyNodeCustomData(renderedPath))
+
+	plainContent, err := os.ReadFile(plainPath)
+	require.NoError(t, err)
+	assert.Equal(t, "plain-content\n", string(plainContent))
+
+	gzipContent, err := os.ReadFile(gzipPath)
+	require.NoError(t, err)
+	assert.Equal(t, "gzip-content", string(gzipContent))
+}
+
+func TestProvisionAppliesRenderedWriteFilesBeforeNBCCmd(t *testing.T) {
+	tempDir := t.TempDir()
+	markerPath := filepath.Join(tempDir, "marker.txt")
+	renderedPath := filepath.Join(tempDir, "nodecustomdata.yml")
+	scriptPath := filepath.Join(tempDir, "test_nbccmd.sh")
+
+	rendered := fmt.Sprintf(`#cloud-config
+write_files:
+- path: %s
+  permissions: "0644"
+  owner: root
+  content: |
+    rendered-marker
+`, markerPath)
+	require.NoError(t, os.WriteFile(renderedPath, []byte(rendered), 0o600))
+
+	script := fmt.Sprintf("#!/bin/bash\ngrep -qx 'rendered-marker' %s\n", markerPath)
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o700))
+
+	tt := NewTestApp(t, TestAppConfig{RunFunc: cmdRunner})
+	tt.App.nodeCustomDataPath = renderedPath
+
+	result, err := tt.App.Provision(context.Background(), ProvisionFlags{NBCCmd: scriptPath})
+	require.NoError(t, err)
+	assert.Equal(t, "0", result.ExitCode)
+}

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2018,7 +2018,7 @@ func ValidateNodeHasLabel(ctx context.Context, s *Scenario, labelKey, expectedVa
 // ValidateScriptlessCSECmd checks if the node has scriptless cmd correctly enabled
 func ValidateScriptlessCSECmd(ctx context.Context, s *Scenario) {
 	nbc := s.Runtime.NBC
-	if nbc != nil && nbc.EnableScriptlessCSECmd && s.VHD.SupportsScriptless() {
+	if nbc != nil && s.VHD.SupportsScriptless() && (nbc.EnableScriptlessCSECmd || nbc.EnableScriptlessNBCCSECmd) {
 		ValidateFileExists(ctx, s, "/opt/azure/containers/scriptless-cse-overrides.txt")
 	}
 }

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -341,7 +341,7 @@ func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachine
 			customData, err = injectWriteFilesEntriesToCustomData(customData, s.Config.CustomDataWriteFiles)
 			require.NoError(s.T, err, "failed to inject customData write_files entries")
 		}
-		if s.Runtime.NBC.EnableScriptlessCSECmd && s.VHD.SupportsScriptless() {
+		if s.Runtime.NBC.EnableScriptlessCSECmd && !s.Runtime.NBC.EnableScriptlessNBCCSECmd && s.VHD.SupportsScriptless() {
 			// Validate that the custom data doesn't contain any script content,
 			// which indicates that the scriptless CSE is working as intended
 			decodedCustomData, err := base64.StdEncoding.DecodeString(customData)

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -52,10 +52,15 @@ logger -t aks-boothook "boothook start $(date -Ins)"
 
 mkdir -p /opt/azure/containers
 
-cat <<'EOF' | base64 -d >/opt/azure/containers/aks-node-controller-nbc-cmd.sh
-%s
+cat <<'EOF' | base64 -d | gzip -d >%[1]s
+%[2]s
 EOF
-chmod 0600 /opt/azure/containers/aks-node-controller-nbc-cmd.sh
+chmod 0600 %[1]s
+
+cat <<'EOF' | base64 -d | gzip -d >%[3]s
+%[4]s
+EOF
+chmod 0600 %[3]s
 
 logger -t aks-boothook "launching aks-node-controller service $(date -Ins)"
 systemctl start --no-block aks-node-controller.service
@@ -64,12 +69,19 @@ systemctl start --no-block aks-node-controller.service
      "ignition": { "version": "3.4.0" },
      "storage": {
        "files": [{
-         "path": "/opt/azure/containers/aks-node-controller-nbc-cmd.sh",
-         "mode": 384,
-         "contents": { "source": "data:;base64,%s" }
+        "path": "/opt/azure/containers/aks-node-controller-nbc-cmd.sh",
+        "mode": 384,
+        "contents": { "compression": "gzip","source": "data:;base64,%s" }
+       },
+	   {
+        "path": "/opt/azure/containers/nodecustomdata.yml",
+        "mode": 384,
+        "contents": { "compression": "gzip","source": "data:;base64,%s" }
        }]
-     }
-    }`
+      }
+     }`
+	nodeCustomDataPath = "/opt/azure/containers/nodecustomdata.yml"
+	nbcCmdFilePath     = "/opt/azure/containers/aks-node-controller-nbc-cmd.sh"
 )
 
 func (t *TemplateGenerator) getWindowsNodeBootstrappingPayload(config *datamodel.NodeBootstrappingConfiguration) string {
@@ -82,13 +94,22 @@ func (t *TemplateGenerator) getWindowsNodeBootstrappingPayload(config *datamodel
 func (t *TemplateGenerator) getLinuxNodeBootstrappingPayload(config *datamodel.NodeBootstrappingConfiguration) string {
 	if config.EnableScriptlessNBCCSECmd {
 		config.DisableCustomData = true
+		config.EnableScriptlessCSECmd = true
 		nbcCMD := t.getLinuxNodeCSECommand(config)
-		encodedNBCCMD := base64.StdEncoding.EncodeToString([]byte(nbcCMD))
+		encodedNBCCMD := getBase64EncodedGzippedCustomScriptFromStr(nbcCMD)
+		nodeCustomData := getCustomDataFromJSON(t.getLinuxNodeCustomDataJSONObject(config))
+		encodedNodeCustomData := getBase64EncodedGzippedCustomScriptFromStr(nodeCustomData)
 		var customData string
 		if config.IsFlatcar() || config.IsACL() {
-			customData = fmt.Sprintf(flatcarTemplate, encodedNBCCMD)
+			customData = fmt.Sprintf(flatcarTemplate, encodedNBCCMD, encodedNodeCustomData)
 		} else {
-			customData = fmt.Sprintf(boothookTemplate, encodedNBCCMD)
+			customData = fmt.Sprintf(
+				boothookTemplate,
+				nodeCustomDataPath,
+				encodedNodeCustomData,
+				nbcCmdFilePath,
+				encodedNBCCMD,
+			)
 		}
 
 		return base64.StdEncoding.EncodeToString([]byte(customData))

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -1285,6 +1285,53 @@ var _ = Describe("getLinuxNodeCSECommand", func() {
 	})
 })
 
+var _ = Describe("getLinuxNodeBootstrappingPayload", func() {
+	It("should persist nodecustomdata in the scriptless NBC boothook", func() {
+		templateGenerator := InitializeTemplateGenerator()
+		agentPoolProfile := &datamodel.AgentPoolProfile{
+			Name:   "nodepool1",
+			OSType: datamodel.Linux,
+			Distro: datamodel.AKSUbuntuContainerd2204Gen2,
+		}
+		config := &datamodel.NodeBootstrappingConfiguration{
+			ContainerService: &datamodel.ContainerService{
+				Location: "eastus",
+				Properties: &datamodel.Properties{
+					OrchestratorProfile: &datamodel.OrchestratorProfile{
+						OrchestratorVersion: "1.29.0",
+						OrchestratorType:    datamodel.Kubernetes,
+						KubernetesConfig: &datamodel.KubernetesConfig{
+							ContainerRuntimeConfig: map[string]string{},
+						},
+					},
+					HostedMasterProfile: &datamodel.HostedMasterProfile{
+						FQDN: "test-cluster.hcp.eastus.azmk8s.io",
+					},
+					AgentPoolProfiles: []*datamodel.AgentPoolProfile{agentPoolProfile},
+				},
+			},
+			AgentPoolProfile:          agentPoolProfile,
+			CloudSpecConfig:           datamodel.AzurePublicCloudSpecForTest,
+			K8sComponents:             &datamodel.K8sComponents{},
+			KubeletConfig:             map[string]string{},
+			EnableScriptlessNBCCSECmd: true,
+		}
+
+		payload := templateGenerator.getLinuxNodeBootstrappingPayload(config)
+		decodedPayload, err := base64.StdEncoding.DecodeString(payload)
+		Expect(err).NotTo(HaveOccurred())
+
+		renderConfig := *config
+		renderConfig.EnableScriptlessCSECmd = true
+		nodeCustomData := getCustomDataFromJSON(templateGenerator.getLinuxNodeCustomDataJSONObject(&renderConfig))
+		encodedNodeCustomData := getBase64EncodedGzippedCustomScriptFromStr(nodeCustomData)
+
+		Expect(string(decodedPayload)).To(ContainSubstring(nodeCustomDataPath))
+		Expect(string(decodedPayload)).To(ContainSubstring(encodedNodeCustomData))
+		Expect(string(decodedPayload)).To(ContainSubstring(nbcCmdFilePath))
+	})
+})
+
 var _ = Describe("cloudInitToButane", func() {
 	checkForUnit := func(butane flatcar1_1.Config) {
 		Expect(butane.Systemd.Units).To(HaveLen(2))


### PR DESCRIPTION
## Summary

Restore nodecustomdata.yml hotfix behavior for the Linux scriptless NBC path.

When aks-node-controller was moved to start from cloud-boothook, the EnableScriptlessNBCCSECmd flow stopped going through the normal nodecustomdata.yml processing path. As a result, 
write_files overrides from nodecustomdata.yml no longer landed on disk before scriptless phase 2 ran, which removed the existing hotfix file replacement mechanism.

This change brings that behavior back by persisting a rendered nodecustomdata.yml artifact from the boothook path and having aks-node-controller apply its write_files entries before
executing the NBC phase-2 command.

## What changed

 - Updated the Linux EnableScriptlessNBCCSECmd boothook path in pkg/agent
  - still writes the NBC phase-2 command file
  - now also renders nodecustomdata.yml with EnableScriptlessCSECmd=true
  - persists that rendered content to /opt/azure/containers/nodecustomdata.yml
 - Added aks-node-controller logic to:
  - read /opt/azure/containers/nodecustomdata.yml if present
  - parse its write_files
  - write those files to their destination paths before running --nbc-cmd
 - Added simple test coverage for:
  - boothook containing the persisted nodecustomdata.yml artifact
  - applying write_files from nodecustomdata.yml
  - ensuring the files are applied before the NBC command executes

## Scope

 - This change is intentionally limited to the Linux boothook path.
 - Flatcar/ACL are unchanged for now.
 - The aks-node-controller helper only supports write_files; it does not try to emulate full cloud-init behavior such as bootcmd or runcmd.

## Why this approach

This keeps nodecustomdata.yml as the source of truth for hotfix-delivered file content instead of duplicating cloud-init rendering logic in the boothook itself. It also keeps the
file-application logic close to aks-node-controller, which is the component executing scriptless phase 2.