### PR TITLE
fix(e2e): gunzip nbc-cmd source in CustomDataWithNBCCmdHack for Flatcar/ACL

### DIFF
--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -213,6 +213,30 @@ func CustomDataWithNBCCmdHack(s *Scenario, customData, binaryURL string) (string
 							source, _ := contents["source"].(string)
 							// source is "data:;base64,<base64data>"
 							nbcCmdContent, _ = strings.CutPrefix(source, "data:;base64,")
+							// As of PR #8357, baker.go's flatcarTemplate marks the file with
+							// `compression: gzip`, so the base64 payload decodes to gzip bytes
+							// rather than plaintext shell. Ignition would normally gunzip it,
+							// but here we re-emit via cloud-config `!!binary`, which only
+							// base64-decodes. We must gunzip ourselves and re-base64 the
+							// plaintext, otherwise the resulting nbc-cmd-hack.sh contains raw
+							// gzip bytes and CSE exec fails with "cannot execute binary file"
+							// (exit 126).
+							if compression, _ := contents["compression"].(string); compression == "gzip" {
+								gzBytes, err := base64.StdEncoding.DecodeString(nbcCmdContent)
+								if err != nil {
+									return "", fmt.Errorf("failed to base64-decode gzipped nbc-cmd source: %w", err)
+								}
+								gzReader, err := gzip.NewReader(bytes.NewReader(gzBytes))
+								if err != nil {
+									return "", fmt.Errorf("failed to create gzip reader for nbc-cmd source: %w", err)
+								}
+								plain, err := io.ReadAll(gzReader)
+								_ = gzReader.Close()
+								if err != nil {
+									return "", fmt.Errorf("failed to gunzip nbc-cmd source: %w", err)
+								}
+								nbcCmdContent = base64.StdEncoding.EncodeToString(plain)
+							}
 						}
 					}
 				}


### PR DESCRIPTION
## Summary

PR #8357 added `compression: gzip` to the flatcar ignition entry for `aks-node-controller-nbc-cmd.sh`. The base64 payload now decodes to gzip bytes — Ignition gunzips at write time on real nodes, so production is fine.

The e2e helper `CustomDataWithNBCCmdHack` (in `e2e/vmss.go`) reuses the same base64 source from the ignition config but re-emits it through cloud-config `!!binary`, which only base64-decodes. As a result the renamed `nbc-cmd-hack.sh` ended up containing raw gzip bytes, and CSE failed with `cannot execute binary file` (exit 126) on every Flatcar/ACL scriptless-NBC scenario (e.g. `Test_AzureLinuxV3_ACL_GPUA100/scriptless_nbc`).

This PR detects the `compression: gzip` hint and gunzips the payload before re-encoding it for `!!binary`.

## Failure signature

```
/opt/azure/containers/aks-node-controller-nbc-cmd-hack.sh: cannot execute binary file
exit 126
```

Observed in main-branch build [161132296](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=161132296) on all ACL_GPU* scriptless_nbc scenarios after #8357 merged.

## Test plan
- [ ] Re-run GPU E2E pipeline against this branch and confirm `*ACL_GPU*/scriptless_nbc` scenarios get past CSE
- [ ] Confirm Ubuntu boothook scriptless_nbc scenarios remain green (unchanged path — boothookTemplate already does `base64 -d | gzip -d` itself)