### PR TITLE
fix: fix azure cni case where route table doesnt exist

### DIFF
--- a/e2e/aks_model.go
+++ b/e2e/aks_model.go
@@ -310,27 +310,17 @@ func addFirewallRules(
 		return err
 	}
 
-	// Find the AKS-managed route table currently associated with the subnet.
-	// We add firewall routes directly to this table so that both pod routes
-	// (managed by cloud-provider-azure) and firewall routes coexist. Creating
-	// a separate route table and swapping the subnet association disconnects
-	// the pod routes and breaks kubenet networking.
+	// For kubenet, the AKS-managed route table must stay attached so that pod
+	// routes (managed by cloud-provider-azure) and firewall routes coexist.
+	// For Azure CNI variants, the subnet may not have any route table, so we
+	// create and associate a dedicated one before adding the firewall routes.
 	aksSubnetResp, err := config.Azure.Subnet.Get(ctx, rg, vnet.name, "aks-subnet", nil)
 	if err != nil {
 		return fmt.Errorf("failed to get AKS subnet: %w", err)
 	}
-	if aksSubnetResp.Properties == nil || aksSubnetResp.Properties.RouteTable == nil || aksSubnetResp.Properties.RouteTable.ID == nil {
-		return fmt.Errorf("AKS subnet has no route table associated")
-	}
-
-	aksRTID := *aksSubnetResp.Properties.RouteTable.ID
-	parsedRT, err := arm.ParseResourceID(aksRTID)
+	aksRTName, err := ensureFirewallRouteTable(ctx, clusterModel, vnet.name, aksSubnetResp.Subnet)
 	if err != nil {
-		return fmt.Errorf("failed to parse AKS route table resource ID %q: %w", aksRTID, err)
-	}
-	aksRTName := parsedRT.Name
-	if aksRTName == "" {
-		return fmt.Errorf("parsed empty route table name from resource ID %q", aksRTID)
+		return err
 	}
 
 	// Create AzureFirewallSubnet - this subnet name is required by Azure Firewall
@@ -454,6 +444,58 @@ func addFirewallRules(
 
 	toolkit.Logf(ctx, "Successfully added firewall routes to AKS route table %q", aksRTName)
 	return nil
+}
+
+func ensureFirewallRouteTable(
+	ctx context.Context,
+	clusterModel *armcontainerservice.ManagedCluster,
+	vnetName string,
+	aksSubnet armnetwork.Subnet,
+) (string, error) {
+	if aksSubnet.Properties == nil {
+		return "", fmt.Errorf("AKS subnet has no properties")
+	}
+	if aksSubnet.Properties.RouteTable != nil && aksSubnet.Properties.RouteTable.ID != nil {
+		aksRTID := *aksSubnet.Properties.RouteTable.ID
+		parsedRT, err := arm.ParseResourceID(aksRTID)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse AKS route table resource ID %q: %w", aksRTID, err)
+		}
+		if parsedRT.Name == "" {
+			return "", fmt.Errorf("parsed empty route table name from resource ID %q", aksRTID)
+		}
+		return parsedRT.Name, nil
+	}
+
+	if clusterModel.Properties == nil || clusterModel.Properties.NetworkProfile == nil || clusterModel.Properties.NetworkProfile.NetworkPlugin == nil {
+		return "", fmt.Errorf("AKS subnet has no route table associated and cluster network plugin is unknown")
+	}
+	if *clusterModel.Properties.NetworkProfile.NetworkPlugin == armcontainerservice.NetworkPluginKubenet {
+		return "", fmt.Errorf("AKS subnet has no route table associated for kubenet cluster")
+	}
+
+	rg := *clusterModel.Properties.NodeResourceGroup
+	routeTableName := "abe2e-fw-rt"
+	toolkit.Logf(ctx, "AKS subnet has no route table; creating dedicated firewall route table %q", routeTableName)
+	poller, err := config.Azure.RouteTables.BeginCreateOrUpdate(ctx, rg, routeTableName, armnetwork.RouteTable{
+		Location: clusterModel.Location,
+	}, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to start creating firewall route table %q: %w", routeTableName, err)
+	}
+	routeTableResp, err := poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	if err != nil {
+		return "", fmt.Errorf("failed to create firewall route table %q: %w", routeTableName, err)
+	}
+
+	aksSubnet.Properties.RouteTable = &armnetwork.RouteTable{
+		ID: routeTableResp.ID,
+	}
+	if err := updateSubnet(ctx, clusterModel, aksSubnet, vnetName); err != nil {
+		return "", fmt.Errorf("failed to associate firewall route table %q with AKS subnet: %w", routeTableName, err)
+	}
+
+	return routeTableName, nil
 }
 
 func addPrivateAzureContainerRegistry(ctx context.Context, cluster *armcontainerservice.ManagedCluster, kube *Kubeclient, kubeletIdentity *armcontainerservice.UserAssignedIdentity, isNonAnonymousPull bool) error {

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -90,8 +90,9 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 	identity := dag.Go(g, func(ctx context.Context) (*armcontainerservice.UserAssignedIdentity, error) {
 		return getClusterKubeletIdentity(ctx, cluster)
 	})
-	// networkSetup adds firewall routes to the AKS route table or applies
-	// network-isolated NSG.  It must run after bastion (both mutate the
+	// networkSetup adds firewall routes to the existing AKS route table or
+	// creates/associates a dedicated one when Azure CNI has none, or applies
+	// the network-isolated NSG. It must run after bastion (both mutate the
 	// VNet) and before collectGarbageVMSS (which needs network setup done).
 	// collectGarbageVMSS also depends on kube to clean up stale K8s Node
 	// objects whose backing VMSS no longer exist.

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/agentbaker/e2e/config"
 	"github.com/Azure/agentbaker/e2e/toolkit"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/assert"
@@ -73,7 +74,7 @@ func ValidateCommonLinux(ctx context.Context, s *Scenario) {
 	}
 
 	// localdns is not supported on scriptless, privatekube and VHDUbuntu2204Gen2ContainerdNetworkIsolatedK8sNotCached.
-	if !s.VHD.UnsupportedLocalDns {
+	if !s.VHD.UnsupportedLocalDns && !config.Config.TestPreProvision && !s.VHDCaching {
 		ValidateLocalDNSService(ctx, s, "enabled")
 		ValidateLocalDNSResolution(ctx, s, "169.254.10.10")
 		ValidateLocalDNSExporterMetrics(ctx, s)


### PR DESCRIPTION
Keep @timmy-wright  happy


## Summary
 
 Handle AKS clusters whose subnet no longer has an associated route table during `addFirewallRules`.
 
 This keeps the existing kubenet behavior intact while allowing Azure CNI clusters to proceed when AKS does not attach a route table to `aks-subnet`.
 
 ## Problem
 
 `addFirewallRules` assumed the AKS subnet always had an associated route table and failed with:
 
 > `AKS subnet has no route table associated`
 
 That assumption is valid for kubenet, where AKS manages pod routes through a subnet route table, but it is no longer reliable for Azure CNI clusters.
 
 ## Changes
 
 - Keep the existing kubenet behavior:
   - require the AKS-managed route table to already exist
   - add firewall routes to that table in place
 - Add an Azure CNI fallback path:
   - detect when `aks-subnet` has no route table
   - create a dedicated firewall route table
   - associate it to the subnet
   - add the firewall routes to the new table
 - Update the orchestration comment in `prepareCluster` to document both paths
 
 ## Why this is safe
 
 - **Kubenet** still uses the existing AKS-managed route table, which preserves pod CIDR routes managed by cloud-provider-azure.
 - **Azure CNI** can now work even when AKS does not create or attach a route table to the subnet.
 - The change only affects the firewall setup path and does not change cluster creation behavior outside that flow.
 
