### PR TITLE
fix(e2e): drop hardcoded D2s_v3 system pool from MA35D scenarios

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1824,8 +1824,7 @@ func Test_AzureLinuxV3_MA35D(t *testing.T) {
 			},
 		},
 		// No MA35D GPU capacity in West US, so using East US
-		Location:         "eastus",
-		K8sSystemPoolSKU: "Standard_D2s_v3",
+		Location: "eastus",
 	})
 }
 
@@ -1854,8 +1853,7 @@ func Test_AzureLinuxV3_MA35D_Scriptless(t *testing.T) {
 			},
 		},
 		// No MA35D GPU capacity in West US, so using East US
-		Location:         "eastus",
-		K8sSystemPoolSKU: "Standard_D2s_v3",
+		Location: "eastus",
 	})
 }
 


### PR DESCRIPTION
## Summary
- Remove `K8sSystemPoolSKU: \"Standard_D2s_v3\"` from `Test_AzureLinuxV3_MA35D` and `Test_AzureLinuxV3_MA35D_Scriptless`
- Falls back to `config.DefaultVMSKU` (`Standard_D2ds_v5`) — same SKU every other scenario uses for the AKS system node pool
- The GPU SKU under test (`Standard_NM16ads_MA35D`) is unchanged

## Background
Both MA35D scenarios pin `Location: \"eastus\"` (the only region with MA35D capacity) and override the system node pool to the older v3 SKU. The override predates the v5 default and is no longer necessary.

The pinned SKU is currently subscription-restricted across **all** eastus availability zones for the AB e2e subscription (`8ecadfc9-...`), so AKS cluster creation 400s before the GPU node under test can even be provisioned. Observed in PR #8228 GPU E2E build [161380177](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=161380177):

```
RESPONSE 400: 400 Bad Request
ERROR CODE: BadRequest
{
  \"code\": \"BadRequest\",
  \"message\": \"The VM size of 'Standard_D2s_v3' is currently not available in your subscription in location 'eastus'. All availability zones are restricted for this SKU. Please try another VM size or deploy to a different location.\"
}
```

This caused 5 reported failures in that run (the parent + leaf subtests for both MA35D scenarios), which had nothing to do with the PR being tested.

## Why this fix
- `Standard_D2ds_v5` is the established default for all e2e system pools (`config/config.go: DefaultVMSKU`)
- If `D2ds_v5` were also restricted in eastus we'd see it across many GPU scenarios, not just MA35D — i.e. failure mode would be loud and broad, not silently misattributed to MA35D
- Smallest possible diff (2 lines per test)

## Test plan
- [ ] Agentbaker GPU E2E (the only pipeline that exercises MA35D)
- [ ] Confirm cluster `abe2e-kubenet-v4-*` in eastus comes up cleanly with v5 system pool
- [ ] Confirm `Test_AzureLinuxV3_MA35D` and `_Scriptless` reach the GPU validators