### PR TITLE
feat: implement budget timeout for apt_get_install

### DIFF
--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
@@ -58,20 +58,23 @@ _apt_get_install() {
     shift && shift && shift && shift
     local packages=("${@}")
 
+    local hasBudget=false
+    if [ "${maxBudget}" -gt 0 ]; then
+        hasBudget=true
+    fi
+
     local opStartTime
     opStartTime=$(date +%s)
 
     for i in $(seq 1 $retries); do
-        # CSE timeout guard — only during real CSE runs
-        if [ -n "${CSE_STARTTIME_SECONDS:-}" ]; then
-            if ! check_cse_timeout; then
-                echo "CSE timeout approaching, exiting apt_get_install early." >&2
-                return 2
-            fi
+        # CSE timeout guard
+        if ! check_cse_timeout; then
+            echo "CSE timeout approaching, exiting apt_get_install early." >&2
+            return 2
         fi
 
         # Per-operation budget check
-        if [ "${maxBudget}" -gt 0 ]; then
+        if [ "$hasBudget" = true ]; then
             local opElapsed
             opElapsed=$(( $(date +%s) - opStartTime ))
             if [ "$opElapsed" -ge "$maxBudget" ]; then
@@ -86,17 +89,19 @@ _apt_get_install() {
 
         # Cap per-attempt timeout to the remaining budget so a single attempt
         # cannot overrun the operation window.
-        local aptTimeout=""
-        if [ "${maxBudget}" -gt 0 ]; then
+        local install_ok=false
+        if [ "$hasBudget" = true ]; then
             local remaining=$(( maxBudget - ( $(date +%s) - opStartTime ) ))
             if [ "$remaining" -lt 1 ]; then
                 echo "apt_get_install budget of ${maxBudget}s exceeded, exiting early." >&2
                 return 2
             fi
-            aptTimeout="timeout $remaining"
+            timeout "$remaining" apt-get install ${apt_opts} -o Dpkg::Options::="--force-confold" --no-install-recommends "${packages[@]}" && install_ok=true
+        else
+            apt-get install ${apt_opts} -o Dpkg::Options::="--force-confold" --no-install-recommends "${packages[@]}" && install_ok=true
         fi
 
-        if ${aptTimeout} apt-get install ${apt_opts} -o Dpkg::Options::="--force-confold" --no-install-recommends "${packages[@]}"; then
+        if [ "$install_ok" = true ]; then
             echo "Executed apt-get install \"${packages[*]}\" $i times"
             wait_for_apt_locks
             DEBIAN_FRONTEND=noninteractive apt-get clean
@@ -108,11 +113,11 @@ _apt_get_install() {
             return 1
         else
             # Check budget/CSE again before sleeping
-            if [ -n "${CSE_STARTTIME_SECONDS:-}" ] && ! check_cse_timeout; then
+            if ! check_cse_timeout; then
                 echo "CSE timeout approaching, exiting apt_get_install early." >&2
                 return 2
             fi
-            if [ "${maxBudget}" -gt 0 ]; then
+            if [ "$hasBudget" = true ]; then
                 local postElapsed=$(( $(date +%s) - opStartTime ))
                 if [ "$postElapsed" -ge "$maxBudget" ]; then
                     echo "apt_get_install budget of ${maxBudget}s exceeded after ${postElapsed}s, exiting early." >&2

--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
@@ -54,15 +54,50 @@ _apt_get_install() {
     local retries=$1
     local wait_sleep=$2
     local apt_opts=$3
-    shift && shift && shift
+    local maxBudget=${4:-0}
+    shift && shift && shift && shift
+    local packages=("${@}")
+
+    local opStartTime
+    opStartTime=$(date +%s)
 
     for i in $(seq 1 $retries); do
+        # CSE timeout guard — only during real CSE runs
+        if [ -n "${CSE_STARTTIME_SECONDS:-}" ]; then
+            if ! check_cse_timeout; then
+                echo "CSE timeout approaching, exiting apt_get_install early." >&2
+                return 2
+            fi
+        fi
+
+        # Per-operation budget check
+        if [ "${maxBudget}" -gt 0 ]; then
+            local opElapsed
+            opElapsed=$(( $(date +%s) - opStartTime ))
+            if [ "$opElapsed" -ge "$maxBudget" ]; then
+                echo "apt_get_install budget of ${maxBudget}s exceeded after ${opElapsed}s, exiting early." >&2
+                return 2
+            fi
+        fi
+
         wait_for_apt_locks
         export DEBIAN_FRONTEND=noninteractive
         dpkg --configure -a --force-confdef
 
-        if apt-get install ${apt_opts} -o Dpkg::Options::="--force-confold" --no-install-recommends "${@}"; then
-            echo "Executed apt-get install \"${packages[@]}\" $i times"
+        # Cap per-attempt timeout to the remaining budget so a single attempt
+        # cannot overrun the operation window.
+        local aptTimeout=""
+        if [ "${maxBudget}" -gt 0 ]; then
+            local remaining=$(( maxBudget - ( $(date +%s) - opStartTime ) ))
+            if [ "$remaining" -lt 1 ]; then
+                echo "apt_get_install budget of ${maxBudget}s exceeded, exiting early." >&2
+                return 2
+            fi
+            aptTimeout="timeout $remaining"
+        fi
+
+        if ${aptTimeout} apt-get install ${apt_opts} -o Dpkg::Options::="--force-confold" --no-install-recommends "${packages[@]}"; then
+            echo "Executed apt-get install \"${packages[*]}\" $i times"
             wait_for_apt_locks
             DEBIAN_FRONTEND=noninteractive apt-get clean
             wait_for_apt_locks
@@ -72,14 +107,31 @@ _apt_get_install() {
         if [ $i -eq $retries ]; then
             return 1
         else
+            # Check budget/CSE again before sleeping
+            if [ -n "${CSE_STARTTIME_SECONDS:-}" ] && ! check_cse_timeout; then
+                echo "CSE timeout approaching, exiting apt_get_install early." >&2
+                return 2
+            fi
+            if [ "${maxBudget}" -gt 0 ]; then
+                local postElapsed=$(( $(date +%s) - opStartTime ))
+                if [ "$postElapsed" -ge "$maxBudget" ]; then
+                    echo "apt_get_install budget of ${maxBudget}s exceeded after ${postElapsed}s, exiting early." >&2
+                    return 2
+                fi
+            fi
             sleep $wait_sleep
             apt_get_update
         fi
     done
 }
 apt_get_install() {
-    retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
-    _apt_get_install $retries $wait_sleep "-y" "$@"
+    local retries=$1; local wait_sleep=$2; local timeout=$3; shift && shift && shift
+    # Only apply per-operation budget during real CSE runs; during VHD build use no cap.
+    local maxBudget=0
+    if [ -n "${CSE_STARTTIME_SECONDS:-}" ]; then
+        maxBudget=$timeout
+    fi
+    _apt_get_install "$retries" "$wait_sleep" "-y" "$maxBudget" "$@"
 }
 apt_get_purge() {
     retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
@@ -168,7 +220,8 @@ apt_get_install_from_local_repo() {
     # Install package from local repo using core installation function
     local retries=10
     local wait_sleep=5
-    if ! _apt_get_install $retries $wait_sleep "${opts}" "${package_name}"; then
+    # maxBudget=0: no per-operation time cap for local repo installs (no network download involved)
+    if ! _apt_get_install $retries $wait_sleep "${opts}" 0 "${package_name}"; then
         echo "Failed to install ${package_name} from local repo"
         rm -f "${tmp_list}"
         rmdir "${tmp_dir}"

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh
@@ -85,6 +85,7 @@ Describe 'apt_get_install budget timeout'
             When call _apt_get_install 1 0 "-y" 0 fake-package
             The status should eq 0
             The stdout should include 'Executed apt-get install "fake-package"'
+            The stderr should include "Warning: CSE_STARTTIME_SECONDS environment variable is not set."
         End
     End
 
@@ -117,6 +118,7 @@ Describe 'apt_get_install budget timeout'
             When call apt_get_install 1 0 60 fake-package
             The status should eq 0
             The stdout should include 'Executed apt-get install "fake-package"'
+            The stderr should include "Warning: CSE_STARTTIME_SECONDS environment variable is not set."
         End
     End
 End

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+Describe 'apt_get_install budget timeout'
+    apt_install_precheck() {
+        CSE_STARTTIME_SECONDS=$(date +%s)
+    }
+    BeforeEach apt_install_precheck
+
+    Include "./parts/linux/cloud-init/artifacts/cse_helpers.sh"
+    Include "./parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh"
+
+    Describe '_apt_get_install with budget'
+        # Mock apt-related commands and timeout to isolate budget logic
+        wait_for_apt_locks() { :; }
+        dpkg() { :; }
+        apt_get_update() { :; }
+        # Pass-through timeout mock: skip the timeout value, run the rest
+        timeout() { shift; "$@"; }
+        apt-get() {
+            # Simulate install failure by default so retries are exercised
+            if [ "$1" = "install" ]; then
+                return 1
+            fi
+            # apt-get clean, etc.
+            return 0
+        }
+
+        It "returns 0 when install succeeds within budget"
+            apt-get() {
+                if [ "$1" = "install" ]; then
+                    return 0
+                fi
+                return 0
+            }
+            When call _apt_get_install 3 1 "-y" 60 fake-package
+            The status should eq 0
+            The stdout should include 'Executed apt-get install "fake-package"'
+        End
+
+        It "logs all package names when installing multiple packages"
+            apt-get() {
+                if [ "$1" = "install" ]; then
+                    return 0
+                fi
+                return 0
+            }
+            When call _apt_get_install 1 0 "-y" 0 pkg-one pkg-two pkg-three
+            The status should eq 0
+            The stdout should include 'Executed apt-get install "pkg-one pkg-two pkg-three"'
+        End
+
+        It "returns 1 when install fails and retries exhausted (no budget)"
+            When call _apt_get_install 2 0 "-y" 0 fake-package
+            The status should eq 1
+        End
+
+        It "returns 2 when per-operation budget is exceeded"
+            # Mock timeout to sleep so elapsed time exceeds the 1s budget
+            timeout() {
+                sleep 2
+                return 1
+            }
+            When call _apt_get_install 5 0 "-y" 1 fake-package
+            The status should eq 2
+            The stderr should include "apt_get_install budget of 1s exceeded"
+        End
+
+        It "returns 2 when CSE timeout is already exceeded before first attempt"
+            CSE_STARTTIME_SECONDS=$(( $(date +%s) - 800 ))
+            When call _apt_get_install 3 1 "-y" 600 fake-package
+            The status should eq 2
+            The stderr should include "CSE timeout approaching"
+        End
+
+        It "does not apply budget when CSE_STARTTIME_SECONDS is unset"
+            unset CSE_STARTTIME_SECONDS
+            apt-get() {
+                if [ "$1" = "install" ]; then
+                    return 0
+                fi
+                return 0
+            }
+            # maxBudget=1 but since CSE_STARTTIME_SECONDS is unset, budget is ignored by apt_get_install wrapper
+            # Here we test _apt_get_install directly with budget=0 (what the wrapper passes when unset)
+            When call _apt_get_install 1 0 "-y" 0 fake-package
+            The status should eq 0
+            The stdout should include 'Executed apt-get install "fake-package"'
+        End
+    End
+
+    Describe 'apt_get_install wrapper'
+        wait_for_apt_locks() { :; }
+        dpkg() { :; }
+        apt_get_update() { :; }
+        timeout() { shift; "$@"; }
+        apt-get() {
+            if [ "$1" = "install" ]; then
+                return 0
+            fi
+            return 0
+        }
+
+        It "passes timeout as budget during CSE run"
+            CSE_STARTTIME_SECONDS=$(date +%s)
+            When call apt_get_install 1 0 60 fake-package
+            The status should eq 0
+            The stdout should include 'Executed apt-get install "fake-package"'
+        End
+
+        It "does not apply budget during VHD build (CSE_STARTTIME_SECONDS unset)"
+            unset CSE_STARTTIME_SECONDS
+            # Override timeout mock to fail if called — proves budget was not applied
+            timeout() {
+                echo "ERROR: timeout should not be called during VHD build" >&2
+                return 1
+            }
+            When call apt_get_install 1 0 60 fake-package
+            The status should eq 0
+            The stdout should include 'Executed apt-get install "fake-package"'
+        End
+    End
+End


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
The 3rd argument 'timeout' in apt_get_install was accepted but never used. Following the pattern from PR #8230, this change makes it work as a per-operation wall-clock budget:

- _apt_get_install: new maxBudget parameter (default 0). When > 0, tracks elapsed time and exits with code 2 if budget exceeded. Each apt-get install attempt is wrapped with 'timeout' capped to remaining budget. CSE timeout guards (check_cse_timeout) are added before each attempt, gated on CSE_STARTTIME_SECONDS to avoid noise during VHD build.

- apt_get_install: passes the timeout value as maxBudget only during real CSE runs (CSE_STARTTIME_SECONDS set). VHD build callers are unaffected.

- apt_get_install_from_local_repo: passes explicit 0 budget to _apt_get_install to maintain existing behavior.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
