### PR TITLE
fix: add fips tests and downgrade 2004 containerd

### DIFF
--- a/e2e/config/vhd.go
+++ b/e2e/config/vhd.go
@@ -60,6 +60,17 @@ var (
 		Distro:  datamodel.AKSUbuntuContainerd2204Gen2,
 		Gallery: imageGalleryLinux,
 	}
+	VHDUbuntu2004FIPSContainerd = &Image{
+		Name:                "2004fipscontainerd",
+		OS:                  OSUbuntu,
+		Arch:                "amd64",
+		Distro:              datamodel.AKSUbuntuFipsContainerd2004,
+		Gallery:             imageGalleryLinux,
+		UnsupportedLocalDns: true,
+		// Secure TLS Bootstrapping isn't currently supported on FIPS-enabled VHDs
+		UnsupportedSecureTLSBootstrapping: true,
+		UnsupportedGen2:                   true,
+	}
 	VHDUbuntu2204FIPSContainerd = &Image{
 		Name:                "2204fipscontainerd",
 		OS:                  OSUbuntu,

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -686,6 +686,23 @@ func Test_Ubuntu2204FIPS(t *testing.T) {
 	})
 }
 
+func Test_Ubuntu2004FIPS(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "Tests that a node using the Ubuntu 2004 FIPS Gen1 VHD can be properly bootstrapped",
+		Config: Config{
+			Cluster: ClusterKubenet,
+			VHD:     config.VHDUbuntu2004FIPSContainerd,
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			},
+			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateSSHServiceEnabled(ctx, s)
+			},
+		},
+	})
+}
+
 func Test_Ubuntu2204Gen2FIPS(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using the Ubuntu 2204 FIPS Gen2 VHD can be properly bootstrapped",

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1137,7 +1137,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=moby-containerd, repository=production, os=ubuntu, release=20.04",
-                "latestVersion": "1.7.31-ubuntu20.04u1"
+                "latestVersion": "1.7.30-ubuntu20.04u3"
               }
             ]
           }

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -624,33 +624,18 @@ testLtsKernel() {
   if [[ "$os_sku" == "Ubuntu" && ${enable_fips,,} != "true" ]] ; then
     echo "OS is Ubuntu, FIPS is not enabled, check LTS kernel version"
     # Check the Ubuntu version and set the expected kernel version
-    # CVM builds use linux-image-azure-fde-lts-* (different flavor), skip exact pin check
-    local is_cvm=false
-    if grep -q "cvm" <<< "$FEATURE_FLAGS"; then
-      is_cvm=true
-    fi
-
-    if [ "$os_version" = "22.04" ] && [ "$is_cvm" = "false" ]; then
-      # Pinned to exact version to avoid regression in 5.15.0-1103-azure
-      expected_kernel="5.15.0-1102-azure"
-    elif [ "$os_version" = "22.04" ] || [ "$os_version" = "24.04" ]; then
-      expected_kernel=$([ "$os_version" = "22.04" ] && echo "5.15" || echo "6.8")
+    if [ "$os_version" = "22.04" ]; then
+      expected_kernel="5.15"
+    elif [ "$os_version" = "24.04" ]; then
+      expected_kernel="6.8"
     else
-      echo "LTS kernel not installed for: $os_version, skipping check"
-      echo "$test:Finish"
-      return
+      echo "LTS kernel not installed for: $os_version"
     fi
 
     kernel=$(uname -r)
     echo "Current kernel version: $kernel"
     # shellcheck disable=SC3010
-    if [ "$os_version" = "22.04" ] && [ "$is_cvm" = "false" ]; then
-      if [[ "$kernel" == "$expected_kernel" ]]; then
-        echo "Kernel version matches pinned version ($expected_kernel)."
-      else
-        err $test "Kernel version does not match pinned version. Expected exactly $expected_kernel, found $kernel."
-      fi
-    elif [[ "$kernel" == *"$expected_kernel"* ]]; then
+    if [[ "$kernel" == *"$expected_kernel"* ]]; then
       echo "Kernel version is as expected ($expected_kernel)."
     else
       err $test "Kernel version is not as expected. Expected $expected_kernel, found $kernel."


### PR DESCRIPTION
We have an issue where new containerd version causes this

```
time="2026-04-22T19:11:59.236557991Z" level=errormsg="CreateContainer within sandbox \"1502c6d3e0dcbb098ed7c4170bdddde8c663d5462d31390ddaa1e0e63bd011b4\" for &ContainerMetadata{Name:node-driver-registrar,Attempt:0,} failed"error="failed to create containerd container: load apparmor profile /tmp/cri-containerd.apparmor.d1155998574: parsererror(\"AppArmor parsererrorfor /tmp/cri-containerd.apparmor.d1155998574 in /tmp/cri-containerd.apparmor.d1155998574 at line 2: Could not open 'abi/3.0': No such file or directory\"): exit status 1"
```

Its because of this PR https://github.com/containerd/containerd/pull/12899