### PR TITLE
fix: azurelinuxv3MA35D scenario fix

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1842,7 +1842,7 @@ func Test_AzureLinuxV3_MA35D(t *testing.T) {
 		},
 		// No MA35D GPU capacity in West US, so using East US
 		Location:         "eastus",
-		K8sSystemPoolSKU: "Standard_D2s_v3",
+		K8sSystemPoolSKU: "",
 	})
 }
 
@@ -1872,7 +1872,7 @@ func Test_AzureLinuxV3_MA35D_Scriptless(t *testing.T) {
 		},
 		// No MA35D GPU capacity in West US, so using East US
 		Location:         "eastus",
-		K8sSystemPoolSKU: "Standard_D2s_v3",
+		K8sSystemPoolSKU: "",
 	})
 }
 

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1842,7 +1842,7 @@ func Test_AzureLinuxV3_MA35D(t *testing.T) {
 		},
 		// No MA35D GPU capacity in West US, so using East US
 		Location:         "eastus",
-		K8sSystemPoolSKU: "",
+		K8sSystemPoolSKU: config.Config.DefaultVMSKU,
 	})
 }
 
@@ -1872,7 +1872,7 @@ func Test_AzureLinuxV3_MA35D_Scriptless(t *testing.T) {
 		},
 		// No MA35D GPU capacity in West US, so using East US
 		Location:         "eastus",
-		K8sSystemPoolSKU: "",
+		K8sSystemPoolSKU: config.Config.DefaultVMSKU,
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the vm sku for the k8s system pool for MA35 tests so they do not run into quota errors.

**Which issue(s) this PR fixes**:

Tests failing due to system pool quota issues.

*Automatically closes linked issue when PR is merged.