### PR TITLE
fix: skip kernel log validation for fips 2004 OS

### DIFF
--- a/e2e/config/vhd.go
+++ b/e2e/config/vhd.go
@@ -70,6 +70,7 @@ var (
 		// Secure TLS Bootstrapping isn't currently supported on FIPS-enabled VHDs
 		UnsupportedSecureTLSBootstrapping: true,
 		UnsupportedGen2:                   true,
+		SkipKernelLogValidation:           true,
 	}
 	VHDUbuntu2204FIPSContainerd = &Image{
 		Name:                "2204fipscontainerd",
@@ -304,6 +305,7 @@ type Image struct {
 	UnsupportedGen2                     bool
 	IgnoreFailedCgroupTelemetryServices bool
 	Flatcar                             bool
+	SkipKernelLogValidation             bool
 	// OSDiskSizeGB overrides the default OS disk size (50 GB) when set.
 	OSDiskSizeGB int32
 }

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2075,6 +2075,10 @@ func ValidateRxBufferDefault(ctx context.Context, s *Scenario) {
 func ValidateKernelLogs(ctx context.Context, s *Scenario) {
 	s.T.Helper()
 
+	if s.VHD != nil && s.VHD.SkipKernelLogValidation {
+		return
+	}
+
 	type categoryPattern struct {
 		pattern string
 		exclude string // optional pattern to exclude false positives


### PR DESCRIPTION
skip kernel log validation for 2004 FIPS VHD, i dont want to spend time validating since it already old