### PR TITLE
fix: check file exists before sourcing

### DIFF
--- a/parts/windows/kuberneteswindowssetup.ps1
+++ b/parts/windows/kuberneteswindowssetup.ps1
@@ -311,7 +311,12 @@ if (-not (Test-Path "C:\AzureData\windows\azurecnifunc.ps1")) {
 . c:\AzureData\windows\kubeletfunc.ps1
 . c:\AzureData\windows\kubernetesfunc.ps1
 . c:\AzureData\windows\nvidiagpudriverfunc.ps1
-. c:\AzureData\windows\securetlsbootstrapfunc.ps1
+
+if (Test-Path -Path 'c:\AzureData\windows\securetlsbootstrapfunc.ps1') {
+    . c:\AzureData\windows\securetlsbootstrapfunc.ps1
+} else {
+    Write-Log "Windows Secure TLS Bootstrap function script not found, skipping dot-source"
+}
 
 if (Test-Path -Path 'c:\AzureData\windows\windowsciliumnetworkingfunc.ps1') {
     . c:\AzureData\windows\windowsciliumnetworkingfunc.ps1


### PR DESCRIPTION

Check that the windows secure bootstrap file exists before sourcing it.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
