### PR TITLE
fix: update inspektor gadget v0.51.0 compatibility

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1771,7 +1771,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=ig, repository=production, os=ubuntu, release=24.04",
-                "latestVersion": "0.49.1-ubuntu24.04u2"
+                "latestVersion": "0.51.0-ubuntu24.04u4"
               }
             ]
           },
@@ -1779,7 +1779,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=ig, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "0.49.1-ubuntu22.04u2"
+                "latestVersion": "0.51.0-ubuntu22.04u4"
               }
             ]
           },
@@ -1787,7 +1787,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=ig, repository=production, os=ubuntu, release=20.04",
-                "latestVersion": "0.49.1-ubuntu20.04u2"
+                "latestVersion": "0.51.0-ubuntu20.04u4"
               }
             ]
           }
@@ -1797,7 +1797,7 @@
             "versionsV2": [
               {
                 "renovateTag": "RPM_registry=https://packages.microsoft.com/azurelinux/3.0/prod/cloud-native/x86_64/repodata, name=ig, os=azurelinux, release=3.0",
-                "latestVersion": "0.49.1-1.azl3"
+                "latestVersion": "0.51.0-4.azl3"
               }
             ]
           }

--- a/spec/vhdbuilder/packer/install_ig_spec.sh
+++ b/spec/vhdbuilder/packer/install_ig_spec.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+Describe 'ig_extract_upstream_version function'
+  Include './vhdbuilder/packer/install-ig.sh'
+
+  It 'returns the upstream version on success'
+    When call ig_extract_upstream_version "0.51.0-4.azl3"
+    The status should be success
+    The output should eq "0.51.0"
+    The stderr should eq ""
+  End
+
+  It 'writes parse failures to stderr'
+    When run ig_extract_upstream_version "not-a-version"
+    The status should equal 1
+    The output should eq ""
+    The stderr should include "[ig] Could not parse upstream version from 'not-a-version'"
+  End
+End

--- a/spec/vhdbuilder/packer/install_ig_spec.sh
+++ b/spec/vhdbuilder/packer/install_ig_spec.sh
@@ -17,3 +17,18 @@ Describe 'ig_extract_upstream_version function'
     The stderr should include "[ig] Could not parse upstream version from 'not-a-version'"
   End
 End
+
+Describe 'ig_validate_version_compatibility function'
+  Include './vhdbuilder/packer/install-ig.sh'
+
+  It 'writes version mismatches to stderr'
+    OS="AZURELINUX"
+    AZURELINUX_OS_NAME="AZURELINUX"
+    IG_VERSION="0.51.1-4.azl3"
+
+    When run ig_validate_version_compatibility
+    The status should equal 1
+    The output should eq ""
+    The stderr should include "[ig] ig (0.51.1-4.azl3) and ig-gadgets (0.51.0-1.azl3) must share upstream version, found 0.51.1 vs 0.51.0"
+  End
+End

--- a/spec/vhdbuilder/packer/test/linux_vhd_content_test_helpers_spec.sh
+++ b/spec/vhdbuilder/packer/test/linux_vhd_content_test_helpers_spec.sh
@@ -199,3 +199,37 @@ EOF
     End
   End
 End
+
+Describe 'Inspektor Gadget version helper functions'
+  BeforeAll "eval \"\$(sed -n '/^extractIgUpstreamVersion()/,/^}/p;/^igPackageVersionsShareUpstreamVersion()/,/^}/p' './vhdbuilder/packer/test/linux-vhd-content-test.sh')\""
+
+  Describe 'extractIgUpstreamVersion'
+    It 'extracts the upstream version from an Ubuntu package version'
+      When call extractIgUpstreamVersion "0.51.0-ubuntu24.04u4"
+      The output should equal "0.51.0"
+    End
+
+    It 'extracts the upstream version from an Azure Linux package version'
+      When call extractIgUpstreamVersion "0.51.0-4.azl3"
+      The output should equal "0.51.0"
+    End
+
+    It 'fails for an unparsable package version'
+      When call extractIgUpstreamVersion "not-a-version"
+      The status should equal 1
+      The output should equal ""
+    End
+  End
+
+  Describe 'igPackageVersionsShareUpstreamVersion'
+    It 'accepts matching upstream versions with different distro revisions'
+      When call igPackageVersionsShareUpstreamVersion "0.51.0-4.azl3" "0.51.0-1.azl3"
+      The status should equal 0
+    End
+
+    It 'rejects different upstream versions'
+      When call igPackageVersionsShareUpstreamVersion "0.51.1-1.azl3" "0.51.0-1.azl3"
+      The status should equal 1
+    End
+  End
+End

--- a/vhdbuilder/packer/install-ig.sh
+++ b/vhdbuilder/packer/install-ig.sh
@@ -48,7 +48,7 @@ ig_extract_upstream_version() {
         return 0
     fi
 
-    echo "[ig] Could not parse upstream version from '${version}'"
+    echo "[ig] Could not parse upstream version from '${version}'" >&2
     return 1
 }
 

--- a/vhdbuilder/packer/install-ig.sh
+++ b/vhdbuilder/packer/install-ig.sh
@@ -65,7 +65,7 @@ ig_validate_version_compatibility() {
     ig_gadgets_upstream=$(ig_extract_upstream_version "${ig_gadgets_version}") || return 1
 
     if [[ "${ig_upstream}" != "${ig_gadgets_upstream}" ]]; then
-        echo "[ig] ig (${IG_VERSION}) and ig-gadgets (${ig_gadgets_version}) must share upstream version, found ${ig_upstream} vs ${ig_gadgets_upstream}"
+        echo "[ig] ig (${IG_VERSION}) and ig-gadgets (${ig_gadgets_version}) must share upstream version, found ${ig_upstream} vs ${ig_gadgets_upstream}" >&2
         return 1
     fi
 }

--- a/vhdbuilder/packer/install-ig.sh
+++ b/vhdbuilder/packer/install-ig.sh
@@ -12,16 +12,15 @@ IG_SKIP_FILE="/etc/ig.d/skip_vhd_ig"
 # Debs are only published to the 20.04 repo on PMC; the 20.04 deb is compatible
 # with 22.04 and 24.04. Maintainers: ebpf-tools within Azure org on GitHub.
 #
-# Dependency constraints differ by OS (defined in the ig-gadgets Dalec spec):
-#   Ubuntu (deb-based): ig >= <gadgets_version>  — ig can be newer than gadgets
-#   AzureLinux (azl3):  ig == <gadgets_version>  — ig must match gadgets exactly
-# This means on AzureLinux, ig and ig-gadgets MUST be bumped together or the
-# RPM install will fail with "conflicting requests".
+# ig and ig-gadgets must share the same upstream IG version (X.Y.Z), but their
+# distro/package revisions can differ. The PMC feeds typically publish multiple
+# ig revisions per OS while ig-gadgets is published once per upstream release.
+# Example: ig 0.51.0-4.azl3 is compatible with ig-gadgets 0.51.0-1.azl3.
 # Since ig-gadgets is NOT in components.json (no Renovate coverage), its version
-# must be updated manually here whenever ig is bumped for AzureLinux.
-# testInspektorGadgetAssets should catch this behavior if we're off.
-IG_GADGETS_DEB_VERSION="0.49.1-ubuntu20.04u1"
-IG_GADGETS_RPM_VERSION="0.49.1-1.azl3"
+# must still be updated manually here whenever ig moves to a new upstream
+# release. testInspektorGadgetAssets should catch any mismatch.
+IG_GADGETS_DEB_VERSION="0.51.0-ubuntu20.04u1"
+IG_GADGETS_RPM_VERSION="0.51.0-1.azl3"
 
 ig_detect_arch() {
     CPU_ARCH=$(getCPUArch)
@@ -39,6 +38,36 @@ ig_detect_arch() {
             return 1
             ;;
     esac
+}
+
+ig_extract_upstream_version() {
+    local version="${1:-}"
+
+    if [[ "${version}" =~ ^([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return 0
+    fi
+
+    echo "[ig] Could not parse upstream version from '${version}'"
+    return 1
+}
+
+ig_validate_version_compatibility() {
+    local ig_gadgets_version ig_upstream ig_gadgets_upstream
+
+    if [[ "${OS}" == "${AZURELINUX_OS_NAME}" ]]; then
+        ig_gadgets_version="${IG_GADGETS_RPM_VERSION}"
+    else
+        ig_gadgets_version="${IG_GADGETS_DEB_VERSION}"
+    fi
+
+    ig_upstream=$(ig_extract_upstream_version "${IG_VERSION}") || return 1
+    ig_gadgets_upstream=$(ig_extract_upstream_version "${ig_gadgets_version}") || return 1
+
+    if [[ "${ig_upstream}" != "${ig_gadgets_upstream}" ]]; then
+        echo "[ig] ig (${IG_VERSION}) and ig-gadgets (${ig_gadgets_version}) must share upstream version, found ${ig_upstream} vs ${ig_gadgets_upstream}"
+        return 1
+    fi
 }
 
 ig_download_file() {
@@ -156,6 +185,7 @@ installIG() {
     fi
 
     IG_VERSION="${version}"
+    ig_validate_version_compatibility || return 1
 
     IG_BUILD_ROOT="${download_dir}"
     if [[ -z "${IG_BUILD_ROOT}" || "${IG_BUILD_ROOT}" == "null" ]]; then

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -160,6 +160,30 @@ validateOrasOCIArtifact() {
   return 0
 }
 
+extractIgUpstreamVersion() {
+  local version="${1:-}"
+  local upstream_version
+
+  upstream_version=$(printf '%s\n' "$version" | sed -n 's/^\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*$/\1/p')
+  if [ -n "$upstream_version" ]; then
+    echo "$upstream_version"
+    return 0
+  fi
+
+  return 1
+}
+
+igPackageVersionsShareUpstreamVersion() {
+  local ig_ver="$1"
+  local ig_gadgets_ver="$2"
+  local ig_upstream ig_gadgets_upstream
+
+  ig_upstream=$(extractIgUpstreamVersion "$ig_ver") || return 1
+  ig_gadgets_upstream=$(extractIgUpstreamVersion "$ig_gadgets_ver") || return 1
+
+  [ "$ig_upstream" = "$ig_gadgets_upstream" ]
+}
+
 testAcrCredentialProviderInstalled() {
   local test="testAcrCredentialProviderInstalled"
   echo "$test:Start"
@@ -2142,44 +2166,27 @@ testInspektorGadgetAssets() {
     err $test "Tracking file is empty at $tracking_file - no gadgets were imported"
   fi
 
-  # Verify ig / ig-gadgets version dependency constraint (defined in ig-gadgets Dalec spec).
-  #   AzureLinux (azl3):  ig == ig-gadgets  — versions must match exactly
-  #   Ubuntu (deb-based): ig >= ig-gadgets  — ig can be newer than gadgets
-  # A mismatch on AzureLinux causes "conflicting requests" during RPM install,
-  # so catching it here prevents broken VHD builds from shipping.
+  # Verify ig / ig-gadgets compatibility by upstream IG version.
+  # Distro/package revisions can differ as long as both packages share the same
+  # X.Y.Z release (for example, ig 0.51.0-4.azl3 with ig-gadgets 0.51.0-1.azl3).
+  # Query the full package version and normalize it here so the test covers the
+  # supported revision skew explicitly instead of relying on package-manager
+  # formatting details.
+  local ig_ver ig_gadgets_ver
   if [ "$OS_SKU" = "AzureLinux" ]; then
-    local ig_ver ig_gadgets_ver
-    ig_ver=$(rpm -q --queryformat '%{VERSION}' ig 2>/dev/null || echo "")
-    ig_gadgets_ver=$(rpm -q --queryformat '%{VERSION}' ig-gadgets 2>/dev/null || echo "")
-
-    if [ -z "$ig_ver" ] || [ -z "$ig_gadgets_ver" ]; then
-      err $test "Could not query package versions: ig='${ig_ver}' ig-gadgets='${ig_gadgets_ver}'"
-    elif [ "$ig_ver" != "$ig_gadgets_ver" ]; then
-      err $test "AzureLinux requires ig == ig-gadgets (Dalec spec) but found ig=${ig_ver} ig-gadgets=${ig_gadgets_ver}"
-    else
-      echo "$test: AzureLinux ig/ig-gadgets version constraint satisfied (both ${ig_ver})"
-    fi
+    ig_ver=$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' ig 2>/dev/null || echo "")
+    ig_gadgets_ver=$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' ig-gadgets 2>/dev/null || echo "")
   else
-    local ig_ver ig_gadgets_ver ig_semver ig_gadgets_semver
     ig_ver=$(dpkg-query -W -f '${Version}' ig 2>/dev/null || echo "")
     ig_gadgets_ver=$(dpkg-query -W -f '${Version}' ig-gadgets 2>/dev/null || echo "")
+  fi
 
-    if [ -z "$ig_ver" ] || [ -z "$ig_gadgets_ver" ]; then
-      err $test "Could not query package versions: ig='${ig_ver}' ig-gadgets='${ig_gadgets_ver}'"
-    else
-      # Extract base semver (e.g. "0.49.1" from "0.49.1-ubuntu22.04u1")
-      ig_semver=$(echo "$ig_ver" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
-      ig_gadgets_semver=$(echo "$ig_gadgets_ver" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
-
-      # sort -V: smallest version first; ig_gadgets_semver must be <= ig_semver
-      local oldest
-      oldest=$(printf '%s\n%s\n' "$ig_semver" "$ig_gadgets_semver" | sort -V | head -n1)
-      if [ "$oldest" != "$ig_gadgets_semver" ]; then
-        err $test "Ubuntu requires ig >= ig-gadgets (Dalec spec) but found ig=${ig_semver} ig-gadgets=${ig_gadgets_semver}"
-      else
-        echo "$test: Ubuntu ig/ig-gadgets version constraint satisfied (ig=${ig_semver} ig-gadgets=${ig_gadgets_semver})"
-      fi
-    fi
+  if [ -z "$ig_ver" ] || [ -z "$ig_gadgets_ver" ]; then
+    err $test "Could not query package versions: ig='${ig_ver}' ig-gadgets='${ig_gadgets_ver}'"
+  elif ! igPackageVersionsShareUpstreamVersion "$ig_ver" "$ig_gadgets_ver"; then
+    err $test "ig and ig-gadgets must share upstream version but found ig=${ig_ver} ig-gadgets=${ig_gadgets_ver}"
+  else
+    echo "$test: ig/ig-gadgets upstream version compatibility satisfied (ig=${ig_ver} ig-gadgets=${ig_gadgets_ver})"
   fi
 
   echo "$test:Finish"


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:

- Update Inspektor Gadget to v0.51.0
- Stop treating `ig` and `ig-gadgets` revision suffixes as a compatibility requirement for every OS

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Supersedes #8045 (ig-gadgets v0.51.1 is not available yet)
