### PR TITLE
fix: conslidate use of masterminds semver across the codebase

### DIFF
--- a/aks-node-controller/go.mod
+++ b/aks-node-controller/go.mod
@@ -5,17 +5,17 @@ go 1.24.12
 require (
 	github.com/Azure/agentbaker v0.20240503.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1
-	github.com/blang/semver v3.5.1+incompatible
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/protobuf v1.36.6
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.38.2 // indirect
 	github.com/clarketm/json v1.17.1 // indirect
 	github.com/coreos/butane v0.25.1 // indirect
@@ -29,7 +29,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/vincent-petithory/dataurl v1.0.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/Azure/agentbaker => ../

--- a/aks-node-controller/go.sum
+++ b/aks-node-controller/go.sum
@@ -10,8 +10,6 @@ github.com/aws/aws-sdk-go-v2 v1.38.2 h1:QUkLO1aTW0yqW95pVzZS0LGFanL71hJ0a49w4TJL
 github.com/aws/aws-sdk-go-v2 v1.38.2/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df h1:GSoSVRLoBaFpOOds6QyY1L8AX7uoY+Ln3BHc22W40X0=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/clarketm/json v1.17.1 h1:U1IxjqJkJ7bRK4L6dyphmoO840P6bdhPdbbLySourqI=
 github.com/clarketm/json v1.17.1/go.mod h1:ynr2LRfb0fQU34l07csRNBTcivjySLLiY1YzQqKVfdo=
 github.com/coreos/butane v0.25.1 h1:Nm2WDRD7h3f6GUpazGlge1o417Z+eIC9bQlkpgVdNms=

--- a/aks-node-controller/helpers/utils.go
+++ b/aks-node-controller/helpers/utils.go
@@ -24,7 +24,7 @@ import (
 	aksnodeconfigv1 "github.com/Azure/agentbaker/aks-node-controller/pkg/gen/aksnodeconfig/v1"
 	"github.com/Azure/agentbaker/pkg/agent"
 	"github.com/Azure/agentbaker/pkg/agent/datamodel"
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 )
 
 const numInPair = 2
@@ -231,9 +231,15 @@ func ValidateAndSetLinuxKubeletFlags(kubeletFlags map[string]string, cs *datamod
 
 // IsKubernetesVersionGe returns true if actualVersion is greater than or equal to version.
 func IsKubernetesVersionGe(actualVersion, version string) bool {
-	v1, _ := semver.Make(actualVersion)
-	v2, _ := semver.Make(version)
-	return v1.GE(v2)
+	v1, err := semver.NewVersion(actualVersion)
+	if err != nil {
+		return false
+	}
+	v2, err := semver.NewVersion(version)
+	if err != nil {
+		return false
+	}
+	return v1.GreaterThanEqual(v2)
 }
 
 func strKeyValToMapBool(str string, strDelim string, pairDelim string) map[string]bool {

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v3 v3.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.2
-	github.com/blang/semver v3.5.1+incompatible
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/bramvdbogaerde/go-scp v1.6.0
 	github.com/caarlos0/env/v11 v11.3.1
 	github.com/coder/websocket v1.8.14
@@ -36,7 +36,6 @@ require (
 require (
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.38.2 // indirect
 	github.com/clarketm/json v1.17.1 // indirect
 	github.com/coreos/butane v0.25.1 // indirect
@@ -60,7 +59,6 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
-	github.com/Masterminds/semver v1.5.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -42,8 +42,6 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -52,8 +50,6 @@ github.com/aws/aws-sdk-go-v2 v1.38.2 h1:QUkLO1aTW0yqW95pVzZS0LGFanL71hJ0a49w4TJL
 github.com/aws/aws-sdk-go-v2 v1.38.2/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df h1:GSoSVRLoBaFpOOds6QyY1L8AX7uoY+Ln3BHc22W40X0=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bramvdbogaerde/go-scp v1.6.0 h1:lDh0lUuz1dbIhJqlKLwWT7tzIRONCp1Mtx3pgQVaLQo=
 github.com/bramvdbogaerde/go-scp v1.6.0/go.mod h1:on2aH5AxaFb2G0N5Vsdy6B0Ml7k9HuHSwfo1y0QzAbQ=
 github.com/caarlos0/env/v11 v11.3.1 h1:cArPWC15hWmEt+gWk7YBi7lEXTXCvpaSdCiZE2X5mCA=

--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/Azure/agentbaker/aks-node-controller/helpers"
 	aksnodeconfigv1 "github.com/Azure/agentbaker/aks-node-controller/pkg/gen/aksnodeconfig/v1"
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 
 	"github.com/Azure/agentbaker/e2e/config"
 	"github.com/Azure/agentbaker/e2e/toolkit"

--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Azure/agentbaker/e2e/components"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/Azure/agentbaker/e2e/config"

--- a/e2e/toolkit/k8s.go
+++ b/e2e/toolkit/k8s.go
@@ -1,7 +1,7 @@
 package toolkit
 
 import (
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 )
 
 func CheckK8sConstraint(kubernetesVersion string, constraintStr string) (bool, error) {

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 
@@ -1254,10 +1254,10 @@ func ValidateRuncVersion(ctx context.Context, s *Scenario, versions []string) {
 	require.Lenf(s.T, versions, 1, "Expected exactly one version for moby-runc but got %d", len(versions))
 	// check if versions[0] is great than or equal to 1.2.0
 	// check semantic version
-	semver, err := semver.ParseTolerant(versions[0])
+	parsedVersion, err := semver.NewVersion(versions[0])
 	require.NoError(s.T, err, "failed to parse semver from moby-runc version")
-	require.GreaterOrEqual(s.T, int(semver.Major), 1, "expected moby-runc major version to be at least 1, got %d", semver.Major)
-	require.GreaterOrEqual(s.T, int(semver.Minor), 2, "expected moby-runc minor version to be at least 2, got %d", semver.Minor)
+	require.GreaterOrEqual(s.T, int(parsedVersion.Major()), 1, "expected moby-runc major version to be at least 1, got %d", parsedVersion.Major())
+	require.GreaterOrEqual(s.T, int(parsedVersion.Minor()), 2, "expected moby-runc minor version to be at least 2, got %d", parsedVersion.Minor())
 	ValidateInstalledPackageVersion(ctx, s, "moby-runc", versions[0])
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.4.1
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/coreos/butane v0.25.1
 	github.com/google/go-cmp v0.7.0
 	github.com/gorilla/handlers v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/aws/aws-sdk-go-v2 v1.38.2 h1:QUkLO1aTW0yqW95pVzZS0LGFanL71hJ0a49w4TJL
 github.com/aws/aws-sdk-go-v2 v1.38.2/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df h1:GSoSVRLoBaFpOOds6QyY1L8AX7uoY+Ln3BHc22W40X0=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/clarketm/json v1.17.1 h1:U1IxjqJkJ7bRK4L6dyphmoO840P6bdhPdbbLySourqI=
 github.com/clarketm/json v1.17.1/go.mod h1:ynr2LRfb0fQU34l07csRNBTcivjySLLiY1YzQqKVfdo=
 github.com/coreos/butane v0.25.1 h1:Nm2WDRD7h3f6GUpazGlge1o417Z+eIC9bQlkpgVdNms=

--- a/pkg/agent/datamodel/versions.go
+++ b/pkg/agent/datamodel/versions.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 )
 
@@ -257,13 +257,19 @@ preReleases=true means that we include pre-release versions in the list.
 func GetVersionsGt(versions []string, version string, inclusive, preReleases bool) []string {
 	// Try to get latest version matching the release.
 	var ret []string
-	minVersion, _ := semver.Make(version)
+	minVersion, err := semver.NewVersion(version)
+	if err != nil {
+		return ret
+	}
 	for _, v := range versions {
-		sv, _ := semver.Make(v)
-		if !preReleases && len(sv.Pre) != 0 {
+		sv, err := semver.NewVersion(v)
+		if err != nil {
 			continue
 		}
-		if (inclusive && sv.GTE(minVersion)) || (!inclusive && sv.GT(minVersion)) {
+		if !preReleases && sv.Prerelease() != "" {
+			continue
+		}
+		if (inclusive && sv.GreaterThanEqual(minVersion)) || (!inclusive && sv.GreaterThan(minVersion)) {
 			ret = append(ret, v)
 		}
 	}
@@ -278,13 +284,19 @@ preReleases=true means that we include pre-release versions in the list.
 func GetVersionsLt(versions []string, version string, inclusive, preReleases bool) []string {
 	// Try to get latest version matching the release.
 	var ret []string
-	minVersion, _ := semver.Make(version)
+	minVersion, err := semver.NewVersion(version)
+	if err != nil {
+		return ret
+	}
 	for _, v := range versions {
-		sv, _ := semver.Make(v)
-		if !preReleases && len(sv.Pre) != 0 {
+		sv, err := semver.NewVersion(v)
+		if err != nil {
 			continue
 		}
-		if (inclusive && sv.LTE(minVersion)) || (!inclusive && sv.LT(minVersion)) {
+		if !preReleases && sv.Prerelease() != "" {
+			continue
+		}
+		if (inclusive && sv.LessThanEqual(minVersion)) || (!inclusive && sv.LessThan(minVersion)) {
 			ret = append(ret, v)
 		}
 	}
@@ -298,7 +310,7 @@ preReleases=true means that we include pre-release versions in the list.
 */
 func GetVersionsBetween(versions []string, versionMin, versionMax string, inclusive, preReleases bool) []string {
 	var ret []string
-	if minV, _ := semver.Make(versionMin); len(minV.Pre) != 0 {
+	if minV, err := semver.NewVersion(versionMin); err == nil && minV.Prerelease() != "" {
 		preReleases = true
 	}
 	greaterThan := GetVersionsGt(versions, versionMin, inclusive, preReleases)
@@ -320,6 +332,9 @@ func GetMinVersion(versions []string, preRelease bool) string {
 		return ""
 	}
 	semverVersions := getSortedSemverVersions(versions, preRelease)
+	if len(semverVersions) == 0 {
+		return ""
+	}
 	return semverVersions[0].String()
 }
 
@@ -330,18 +345,24 @@ func GetMaxVersion(versions []string, preRelease bool) string {
 		return ""
 	}
 	semverVersions := getSortedSemverVersions(versions, preRelease)
+	if len(semverVersions) == 0 {
+		return ""
+	}
 	return semverVersions[len(semverVersions)-1].String()
 }
 
-func getSortedSemverVersions(versions []string, preRelease bool) []semver.Version {
-	var semverVersions []semver.Version
+func getSortedSemverVersions(versions []string, preRelease bool) []*semver.Version {
+	var semverVersions []*semver.Version
 	for _, v := range versions {
-		sv, _ := semver.Make(v)
-		if len(sv.Pre) == 0 || preRelease {
+		sv, err := semver.NewVersion(v)
+		if err != nil {
+			continue
+		}
+		if sv.Prerelease() == "" || preRelease {
 			semverVersions = append(semverVersions, sv)
 		}
 	}
-	semver.Sort(semverVersions)
+	sort.Sort(semver.Collection(semverVersions))
 	return semverVersions
 }
 
@@ -402,11 +423,11 @@ func GetValidPatchVersion(orchType, orchVer string, isUpdate, hasWindows bool) s
 		hasWindows)
 
 	if version == "" {
-		sv, err := semver.Make(orchVer)
+		sv, err := semver.NewVersion(orchVer)
 		if err != nil {
 			return ""
 		}
-		sr := fmt.Sprintf("%d.%d", sv.Major, sv.Minor)
+		sr := fmt.Sprintf("%d.%d", sv.Major(), sv.Minor())
 
 		version = RationalizeReleaseAndVersion(
 			orchType,
@@ -452,8 +473,11 @@ func RationalizeReleaseAndVersion(orchType, orchRel, orchVer string, isUpdate, h
 	// Try to get latest version matching the release.
 	version = ""
 	for _, ver := range supportedVersions {
-		sv, _ := semver.Make(ver)
-		sr := fmt.Sprintf("%d.%d", sv.Major, sv.Minor)
+		sv, err := semver.NewVersion(ver)
+		if err != nil {
+			continue
+		}
+		sr := fmt.Sprintf("%d.%d", sv.Major(), sv.Minor())
 		if sr == orchRel && ver == orchVer {
 			version = ver
 			break
@@ -477,15 +501,15 @@ func IsValidMinVersion(orchType, orchRelease, orchVersion, minVersion string) (b
 			orchRelease,
 			orchVersion)
 	}
-	sv, err := semver.Make(version)
+	sv, err := semver.NewVersion(version)
 	if err != nil {
 		return false, errors.Errorf("could not validate version %s", version)
 	}
-	m, err := semver.Make(minVersion)
+	m, err := semver.NewVersion(minVersion)
 	if err != nil {
 		return false, errors.New("could not validate version")
 	}
-	if sv.LT(m) {
+	if sv.LessThan(m) {
 		return false, nil
 	}
 	return true, nil
@@ -493,9 +517,15 @@ func IsValidMinVersion(orchType, orchRelease, orchVersion, minVersion string) (b
 
 // IsKubernetesVersionGe returns true if actualVersion is greater than or equal to version.
 func IsKubernetesVersionGe(actualVersion, version string) bool {
-	v1, _ := semver.Make(actualVersion)
-	v2, _ := semver.Make(version)
-	return v1.GE(v2)
+	v1, err := semver.NewVersion(actualVersion)
+	if err != nil {
+		return false
+	}
+	v2, err := semver.NewVersion(version)
+	if err != nil {
+		return false
+	}
+	return v1.GreaterThanEqual(v2)
 }
 
 /*
@@ -506,17 +536,17 @@ func GetLatestPatchVersion(majorMinor string, versionsList []string) string {
 	// Try to get latest version matching the release.
 	var version string
 	for _, ver := range versionsList {
-		sv, err := semver.Make(ver)
+		sv, err := semver.NewVersion(ver)
 		if err != nil {
-			return ""
+			continue
 		}
-		sr := fmt.Sprintf("%d.%d", sv.Major, sv.Minor)
+		sr := fmt.Sprintf("%d.%d", sv.Major(), sv.Minor())
 		if sr == majorMinor {
 			if version == "" {
 				version = ver
 			} else {
-				current, _ := semver.Make(version)
-				if sv.GT(current) {
+				current, err := semver.NewVersion(version)
+				if err != nil || sv.GreaterThan(current) {
 					version = ver
 				}
 			}

--- a/pkg/agent/datamodel/versions_test.go
+++ b/pkg/agent/datamodel/versions_test.go
@@ -595,8 +595,16 @@ func Test_IsValidMinVersion(t *testing.T) {
 		}
 	})
 
-	t.Run("Minimum version is invalid", func(t *testing.T) {
+	t.Run("Minimum version accepts v prefix", func(t *testing.T) {
 		minVersion := "v1.15.0"
+		_, err := IsValidMinVersion(Kubernetes, orchestratorRelease, orchestratorVersion, minVersion)
+		if err != nil {
+			t.Errorf("version should be valid: %v", err)
+		}
+	})
+
+	t.Run("Minimum version is invalid", func(t *testing.T) {
+		minVersion := "invalid"
 		_, err := IsValidMinVersion(Kubernetes, orchestratorRelease, orchestratorVersion, minVersion)
 		if err == nil {
 			t.Errorf("version should be invalid: %v", err)

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Azure/agentbaker/parts"
 	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 )
 
 /*
@@ -343,9 +343,15 @@ func GetCloudTargetEnv(location string) string {
 
 // IsKubernetesVersionGe returns true if actualVersion is greater than or equal to version.
 func IsKubernetesVersionGe(actualVersion, version string) bool {
-	v1, _ := semver.Make(actualVersion)
-	v2, _ := semver.Make(version)
-	return v1.GE(v2)
+	v1, err := semver.NewVersion(actualVersion)
+	if err != nil {
+		return false
+	}
+	v2, err := semver.NewVersion(version)
+	if err != nil {
+		return false
+	}
+	return v1.GreaterThanEqual(v2)
 }
 
 func getCustomDataFromJSON(jsonStr string) string {


### PR DESCRIPTION
We seem to be using some old library for semver, consolidate use of masterminds semver across the codebase