### PR TITLE
fix: use compact JSON in ANC hotfix injection

### DIFF
--- a/hotfix/anc_hotfix_generate.py
+++ b/hotfix/anc_hotfix_generate.py
@@ -50,7 +50,7 @@ def read_hotfix_version():
 
 def build_hotfix_entry(version):
     """Build the write_files YAML lines for the hotfix JSON config."""
-    hotfix_json = json.dumps({"version": version})
+    hotfix_json = json.dumps({"version": version}, separators=(',', ':'))
     return [
         f"\n",
         f"{BEGIN_MARKER}\n",


### PR DESCRIPTION
## Summary

Uses compact JSON serialization (`separators=(',', ':')`) in `hotfix/anc_hotfix_generate.py` so the injected content matches the format of `hotfix/anc-hotfix-version.json` exactly.

**Before:** `{"version": "202504.27.0"}` (space after colon)
**After:** `{"version":"202504.27.0"}` (compact, matches source file)

This ensures idempotent regeneration — re-running the script produces identical output.

Follow-up to #8405.