### PR TITLE
feat: version-scoped scripts hotfix via staging

### DIFF
--- a/aks-node-controller/app.go
+++ b/aks-node-controller/app.go
@@ -34,6 +34,8 @@ type App struct {
 	aptSourcesDir string
 	// nodeCustomDataPath overrides the default nodecustomdata path for testing.
 	nodeCustomDataPath string
+	// scriptHotfixManifestPath overrides the default script hotfix manifest location for testing.
+	scriptHotfixManifestPath string
 }
 
 // provision.json values are emitted as strings by the shell jq invocation.
@@ -237,6 +239,13 @@ func (a *App) getNodeCustomDataPath() string {
 	return defaultNodeCustomDataPath
 }
 
+func (a *App) getScriptHotfixManifestPath() string {
+	if a.scriptHotfixManifestPath != "" {
+		return a.scriptHotfixManifestPath
+	}
+	return defaultScriptHotfixManifestPath
+}
+
 func (a *App) Provision(ctx context.Context, flags ProvisionFlags) (*ProvisionResult, error) {
 	provisionResult := &ProvisionResult{}
 
@@ -253,6 +262,12 @@ func (a *App) Provision(ctx context.Context, flags ProvisionFlags) (*ProvisionRe
 
 	if flags.NBCCmd != "" {
 		if err := applyNodeCustomData(a.getNodeCustomDataPath()); err != nil {
+			provisionResult.ExitCode = strconv.Itoa(240)
+			provisionResult.Error = err.Error()
+			return provisionResult, err
+		}
+
+		if err := applyScriptHotfix(a.getScriptHotfixManifestPath(), Version); err != nil {
 			provisionResult.ExitCode = strconv.Itoa(240)
 			provisionResult.Error = err.Error()
 			return provisionResult, err

--- a/aks-node-controller/nodecustomdata.go
+++ b/aks-node-controller/nodecustomdata.go
@@ -4,19 +4,24 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"gopkg.in/yaml.v3"
 )
 
 const (
-	defaultNodeCustomDataPath = "/opt/azure/containers/nodecustomdata.yml"
-	encodingGZIP              = "gzip"
-	encodingBase64            = "base64"
+	defaultNodeCustomDataPath         = "/opt/azure/containers/nodecustomdata.yml"
+	defaultScriptHotfixManifestPath   = "/opt/azure/hotfix/scripts/manifest.json"
+	encodingGZIP                      = "gzip"
+	encodingBase64                    = "base64"
 )
 
 type nodeCustomDataWriteFile struct {
@@ -29,6 +34,19 @@ type nodeCustomDataWriteFile struct {
 
 type nodeCustomData struct {
 	WriteFiles []nodeCustomDataWriteFile `yaml:"write_files"`
+}
+
+// scriptHotfixManifest describes version-scoped script hotfix files staged by cloud-init.
+// ANC reads this manifest, checks the target version against its own VHD version,
+// and copies staged files to their real destinations only when the version matches.
+type scriptHotfixManifest struct {
+	TargetVersion string              `json:"targetVersion"`
+	Files         []scriptHotfixFile  `json:"files"`
+}
+
+type scriptHotfixFile struct {
+	Staging     string `json:"staging"`
+	Destination string `json:"destination"`
 }
 
 func applyNodeCustomData(path string) error {
@@ -112,4 +130,116 @@ func decodeNodeCustomDataWriteFileContent(file nodeCustomDataWriteFile) ([]byte,
 	default:
 		return nil, fmt.Errorf("unsupported encoding %q", file.Encoding)
 	}
+}
+
+// applyScriptHotfix reads the script hotfix manifest, checks if the target version
+// matches the current ANC/VHD version (same YYYYMM.DD base), and copies staged
+// hotfix scripts to their real destinations. Returns nil if no manifest exists.
+func applyScriptHotfix(manifestPath, currentVersion string) error {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			slog.Info("no script hotfix manifest found, skipping", "path", manifestPath)
+			return nil
+		}
+		return fmt.Errorf("read script hotfix manifest %s: %w", manifestPath, err)
+	}
+
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return nil
+	}
+
+	var manifest scriptHotfixManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return fmt.Errorf("parse script hotfix manifest %s: %w", manifestPath, err)
+	}
+
+	if manifest.TargetVersion == "" || len(manifest.Files) == 0 {
+		slog.Info("script hotfix manifest is empty, skipping", "path", manifestPath)
+		return nil
+	}
+
+	shouldApply, err := isScriptHotfixTargeted(currentVersion, manifest.TargetVersion)
+	if err != nil {
+		slog.Warn("failed to compare versions for script hotfix, skipping",
+			"current", currentVersion, "target", manifest.TargetVersion, "error", err)
+		return nil
+	}
+	if !shouldApply {
+		slog.Info("script hotfix not targeted for this VHD, skipping",
+			"current", currentVersion, "target", manifest.TargetVersion)
+		return nil
+	}
+
+	slog.Info("applying script hotfix",
+		"current", currentVersion, "target", manifest.TargetVersion, "fileCount", len(manifest.Files))
+
+	for _, f := range manifest.Files {
+		if err := copyHotfixFile(f.Staging, f.Destination); err != nil {
+			return fmt.Errorf("apply script hotfix %s → %s: %w", f.Staging, f.Destination, err)
+		}
+		slog.Info("applied script hotfix file", "staging", f.Staging, "destination", f.Destination)
+	}
+
+	return nil
+}
+
+// isScriptHotfixTargeted returns true when the current ANC/VHD version matches the
+// hotfix target version's YYYYMM.DD base (any patch). This allows a hotfix targeting
+// "202604.27.0" to apply on nodes running "202604.27.0" or "202604.27.1" (ANC-hotfixed).
+func isScriptHotfixTargeted(current, target string) (bool, error) {
+	cv, err := semver.NewVersion(strings.TrimSpace(current))
+	if err != nil {
+		return false, fmt.Errorf("parsing current version %q: %w", current, err)
+	}
+	tv, err := semver.NewVersion(strings.TrimSpace(target))
+	if err != nil {
+		return false, fmt.Errorf("parsing target version %q: %w", target, err)
+	}
+	return cv.Major() == tv.Major() && cv.Minor() == tv.Minor(), nil
+}
+
+// copyHotfixFile copies a staged hotfix file to its destination, preserving the
+// source file's permissions. Uses atomic write (temp + rename) for safety.
+func copyHotfixFile(src, dst string) error {
+	srcData, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("reading staged file %s: %w", src, err)
+	}
+
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat staged file %s: %w", src, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("create parent directory for %s: %w", dst, err)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".script-hotfix-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file for %s: %w", dst, err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(srcData); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("writing temp file %s: %w", tmpPath, err)
+	}
+	if err := tmp.Chmod(srcInfo.Mode()); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("chmod temp file %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("closing temp file %s: %w", tmpPath, err)
+	}
+
+	if err := os.Rename(tmpPath, dst); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("renaming %s to %s: %w", tmpPath, dst, err)
+	}
+	return nil
 }

--- a/aks-node-controller/nodecustomdata_test.go
+++ b/aks-node-controller/nodecustomdata_test.go
@@ -79,3 +79,146 @@ write_files:
 	require.NoError(t, err)
 	assert.Equal(t, "0", result.ExitCode)
 }
+
+func TestApplyScriptHotfix_VersionMatch(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create staging directory and a staged script
+	stagingDir := filepath.Join(tempDir, "hotfix", "scripts")
+	require.NoError(t, os.MkdirAll(stagingDir, 0o755))
+
+	stagingPath := filepath.Join(stagingDir, "provision_installs.sh")
+	require.NoError(t, os.WriteFile(stagingPath, []byte("#!/bin/bash\n# hotfixed script"), 0o744))
+
+	destPath := filepath.Join(tempDir, "dest", "provision_installs.sh")
+
+	manifest := fmt.Sprintf(`{"targetVersion":"202604.27.0","files":[{"staging":"%s","destination":"%s"}]}`,
+		stagingPath, destPath)
+	manifestPath := filepath.Join(stagingDir, "manifest.json")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0o644))
+
+	// Current version matches target base (same YYYYMM.DD)
+	err := applyScriptHotfix(manifestPath, "202604.27.0")
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, "#!/bin/bash\n# hotfixed script", string(content))
+}
+
+func TestApplyScriptHotfix_VersionMatch_HigherPatch(t *testing.T) {
+	tempDir := t.TempDir()
+
+	stagingDir := filepath.Join(tempDir, "hotfix", "scripts")
+	require.NoError(t, os.MkdirAll(stagingDir, 0o755))
+
+	stagingPath := filepath.Join(stagingDir, "provision_installs.sh")
+	require.NoError(t, os.WriteFile(stagingPath, []byte("#!/bin/bash\n# hotfixed"), 0o744))
+
+	destPath := filepath.Join(tempDir, "dest", "provision_installs.sh")
+
+	manifest := fmt.Sprintf(`{"targetVersion":"202604.27.0","files":[{"staging":"%s","destination":"%s"}]}`,
+		stagingPath, destPath)
+	manifestPath := filepath.Join(stagingDir, "manifest.json")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0o644))
+
+	// Node has ANC-hotfixed version (patch 1) but same base — should still apply
+	err := applyScriptHotfix(manifestPath, "202604.27.1")
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, "#!/bin/bash\n# hotfixed", string(content))
+}
+
+func TestApplyScriptHotfix_VersionMismatch(t *testing.T) {
+	tempDir := t.TempDir()
+
+	stagingDir := filepath.Join(tempDir, "hotfix", "scripts")
+	require.NoError(t, os.MkdirAll(stagingDir, 0o755))
+
+	stagingPath := filepath.Join(stagingDir, "provision_installs.sh")
+	require.NoError(t, os.WriteFile(stagingPath, []byte("#!/bin/bash\n# hotfixed"), 0o744))
+
+	destPath := filepath.Join(tempDir, "dest", "provision_installs.sh")
+
+	manifest := fmt.Sprintf(`{"targetVersion":"202604.27.0","files":[{"staging":"%s","destination":"%s"}]}`,
+		stagingPath, destPath)
+	manifestPath := filepath.Join(stagingDir, "manifest.json")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0o644))
+
+	// Node is on a different VHD version — should NOT apply
+	err := applyScriptHotfix(manifestPath, "202602.19.0")
+	require.NoError(t, err)
+
+	// Destination should not exist
+	_, err = os.ReadFile(destPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestApplyScriptHotfix_NoManifest(t *testing.T) {
+	err := applyScriptHotfix("/nonexistent/path/manifest.json", "202604.27.0")
+	require.NoError(t, err)
+}
+
+func TestApplyScriptHotfix_EmptyManifest(t *testing.T) {
+	tempDir := t.TempDir()
+	manifestPath := filepath.Join(tempDir, "manifest.json")
+	require.NoError(t, os.WriteFile(manifestPath, []byte("{}"), 0o644))
+
+	err := applyScriptHotfix(manifestPath, "202604.27.0")
+	require.NoError(t, err)
+}
+
+func TestApplyScriptHotfix_DevVersion(t *testing.T) {
+	tempDir := t.TempDir()
+
+	stagingDir := filepath.Join(tempDir, "hotfix", "scripts")
+	require.NoError(t, os.MkdirAll(stagingDir, 0o755))
+
+	stagingPath := filepath.Join(stagingDir, "test.sh")
+	require.NoError(t, os.WriteFile(stagingPath, []byte("#!/bin/bash"), 0o744))
+
+	destPath := filepath.Join(tempDir, "dest", "test.sh")
+
+	manifest := fmt.Sprintf(`{"targetVersion":"202604.27.0","files":[{"staging":"%s","destination":"%s"}]}`,
+		stagingPath, destPath)
+	manifestPath := filepath.Join(stagingDir, "manifest.json")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0o644))
+
+	// Dev version can't be parsed — should skip gracefully
+	err := applyScriptHotfix(manifestPath, "dev")
+	require.NoError(t, err)
+
+	_, err = os.ReadFile(destPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestIsScriptHotfixTargeted(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  string
+		target   string
+		expected bool
+		wantErr  bool
+	}{
+		{"exact match", "202604.27.0", "202604.27.0", true, false},
+		{"same base higher patch", "202604.27.1", "202604.27.0", true, false},
+		{"same base lower patch", "202604.27.0", "202604.27.1", true, false},
+		{"different base", "202602.19.0", "202604.27.0", false, false},
+		{"different minor", "202604.24.0", "202604.27.0", false, false},
+		{"dev current", "dev", "202604.27.0", false, true},
+		{"dev target", "202604.27.0", "dev", false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isScriptHotfixTargeted(tt.current, tt.target)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, got)
+			}
+		})
+	}
+}

--- a/hack/hotfix_generate.py
+++ b/hack/hotfix_generate.py
@@ -12,12 +12,16 @@ Note: once we move to the final stage of scriptless, we no longer need to hotfix
 the scripts into the template and can remove this script entirely.
 """
 
+import json
 import subprocess
 import sys
 import re
 
 TEMPLATE = "parts/linux/cloud-init/nodecustomdata.yml"
 ARTIFACTS_DIR = "parts/linux/cloud-init/artifacts"
+SIG_VERSION_PATH = "pkg/agent/datamodel/linux_sig_version.json"
+HOTFIX_STAGING_DIR = "/opt/azure/hotfix/scripts"
+HOTFIX_MANIFEST_PATH = f"{HOTFIX_STAGING_DIR}/manifest.json"
 
 # Map from source file paths (relative to artifacts/) to the GetVariableProperty
 # keys used in nodecustomdata.yml. Only scripts that appear as write_files entries
@@ -98,6 +102,64 @@ VARKEY_TO_BLOCK_GROUP = {
     "provisionInstallsFlatcar": "install_distro",
     "provisionInstallsACL": "install_distro",
 }
+
+# Map from varkey to the real destination path on the node.
+# These must match the constants in pkg/agent/const.go.
+# For distro-variant scripts, all variants share the same destination path
+# (the distro-specific content is selected at template render time).
+VARKEY_TO_DEST_PATH = {
+    "provisionSource": "/opt/azure/containers/provision_source.sh",
+    "provisionSourceUbuntu": "/opt/azure/containers/provision_source_distro.sh",
+    "provisionSourceMariner": "/opt/azure/containers/provision_source_distro.sh",
+    "provisionSourceAzlOSGuard": "/opt/azure/containers/provision_source_distro.sh",
+    "provisionSourceFlatcar": "/opt/azure/containers/provision_source_distro.sh",
+    "provisionSourceACL": "/opt/azure/containers/provision_source_distro.sh",
+    "provisionInstalls": "/opt/azure/containers/provision_installs.sh",
+    "provisionInstallsUbuntu": "/opt/azure/containers/provision_installs_distro.sh",
+    "provisionInstallsMariner": "/opt/azure/containers/provision_installs_distro.sh",
+    "provisionInstallsAzlOSGuard": "/opt/azure/containers/provision_installs_distro.sh",
+    "provisionInstallsFlatcar": "/opt/azure/containers/provision_installs_distro.sh",
+    "provisionInstallsACL": "/opt/azure/containers/provision_installs_distro.sh",
+    "provisionConfigs": "/opt/azure/containers/provision_configs.sh",
+    "provisionScript": "/opt/azure/containers/provision.sh",
+    "provisionStartScript": "/opt/azure/containers/provision_start.sh",
+    "provisionRedactCloudConfig": "/opt/azure/containers/provision_redact_cloud_config.py",
+    "provisionSendLogs": "/opt/azure/containers/provision_send_logs.py",
+    "reconcilePrivateHostsScript": "/opt/azure/containers/reconcilePrivateHosts.sh",
+    "bindMountScript": "/opt/azure/containers/bind-mount.sh",
+    "migPartitionScript": "/opt/azure/containers/mig-partition.sh",
+    "dhcpv6ConfigurationScript": "/opt/azure/containers/enable-dhcpv6.sh",
+    "ensureIMDSRestrictionScript": "/opt/azure/containers/ensure_imds_restriction.sh",
+    "ensureNoDupEbtablesScript": "/opt/azure/containers/ensure-no-dup.sh",
+    "cloudInitStatusCheckScript": "/opt/azure/containers/cloud-init-status-check.sh",
+    "measureTLSBootstrappingLatencyScript": "/opt/azure/containers/measure-tls-bootstrapping-latency.sh",
+    "validateKubeletCredentialsScript": "/opt/azure/containers/validate-kubelet-credentials.sh",
+    "customSearchDomainsScript": "/opt/azure/containers/setup-custom-search-domains.sh",
+    "configureAzureNetworkScript": "/opt/azure-network/configure-azure-network.sh",
+    "initAKSCustomCloud": "/opt/azure/containers/init-aks-custom-cloud.sh",
+    "snapshotUpdateScript": "/opt/azure/containers/ubuntu-snapshot-update.sh",
+    "packageUpdateScriptMariner": "/opt/azure/containers/mariner-package-update.sh",
+    "kubeletSystemdService": "/etc/systemd/system/kubelet.service",
+    "reconcilePrivateHostsService": "/etc/systemd/system/reconcile-private-hosts.service",
+    "bindMountSystemdService": "/etc/systemd/system/bind-mount.service",
+    "dhcpv6SystemdService": "/etc/systemd/system/dhcpv6.service",
+    "migPartitionSystemdService": "/etc/systemd/system/mig-partition.service",
+    "secureTLSBootstrapService": "/etc/systemd/system/secure-tls-bootstrap.service",
+    "ensureNoDupEbtablesService": "/etc/systemd/system/ensure-no-dup.service",
+    "measureTLSBootstrappingLatencyService": "/etc/systemd/system/measure-tls-bootstrapping-latency.service",
+    "snapshotUpdateService": "/etc/systemd/system/snapshot-update.service",
+    "snapshotUpdateTimer": "/etc/systemd/system/snapshot-update.timer",
+    "packageUpdateServiceMariner": "/etc/systemd/system/snapshot-update.service",
+    "packageUpdateTimerMariner": "/etc/systemd/system/snapshot-update.timer",
+    "azureNetworkUdevRule": "/etc/udev/rules.d/99-azure-network.rules",
+    "componentManifestFile": "/opt/azure/manifest.json",
+}
+
+
+def read_target_version():
+    """Read the VHD image version from linux_sig_version.json."""
+    with open(SIG_VERSION_PATH) as f:
+        return json.load(f)["version"]
 
 
 def detect_changed_varkeys(base_ref):
@@ -222,8 +284,68 @@ def parse_write_files_blocks(traditional_lines):
     return blocks
 
 
+def rewrite_block_to_staging(block_lines, varkeys):
+    """Rewrite a write_files block to use staging paths instead of real destination paths.
+
+    For each '- path:' line, replace the path (which may be a Go template function call)
+    with a staging path under HOTFIX_STAGING_DIR. The staging filename is derived from
+    the destination path basename.
+
+    Returns (rewritten_lines, staging_to_dest_mapping) where the mapping is a list of
+    (staging_path, dest_path) tuples for the manifest.
+    """
+    rewritten = []
+    manifest_entries = []
+
+    # Collect unique destination paths from the varkeys in this block
+    dest_paths = set()
+    for vk in varkeys:
+        if vk in VARKEY_TO_DEST_PATH:
+            dest_paths.add(VARKEY_TO_DEST_PATH[vk])
+
+    for line in block_lines:
+        stripped = line.strip()
+        if stripped.startswith('- path:'):
+            # Extract the path value (may be a Go template expression or literal)
+            path_value = stripped[len('- path:'):].strip()
+
+            # Find which dest path this corresponds to by matching template functions
+            matched_dest = None
+            for vk in varkeys:
+                if vk in VARKEY_TO_DEST_PATH:
+                    dest = VARKEY_TO_DEST_PATH[vk]
+                    # Check if this path line could resolve to this dest
+                    # Template functions like {{GetCSEInstallScriptFilepath}} resolve to the dest
+                    basename = dest.rsplit('/', 1)[-1]
+                    staging = f"{HOTFIX_STAGING_DIR}/{basename}"
+                    if dest not in [e[1] for e in manifest_entries]:
+                        matched_dest = dest
+                        manifest_entries.append((staging, dest))
+                        break
+
+            if matched_dest:
+                basename = matched_dest.rsplit('/', 1)[-1]
+                staging_path = f"{HOTFIX_STAGING_DIR}/{basename}"
+                rewritten.append(f"- path: {staging_path}\n")
+            else:
+                rewritten.append(line)
+        else:
+            rewritten.append(line)
+
+    return rewritten, manifest_entries
+
+
 def inject_hotfix(target_varkeys):
-    """Extract matching write_files blocks from traditional section and inject into scriptless section."""
+    """Extract matching write_files blocks from traditional section and inject into scriptless section.
+
+    Scripts are written to staging paths under /opt/azure/hotfix/scripts/ along with a
+    manifest.json that maps staging paths to real destinations. ANC reads the manifest
+    at boot, checks the target version against its own VHD version, and copies files
+    only when the version matches.
+    """
+    target_version = read_target_version()
+    print(f"Target VHD version for hotfix: {target_version}", file=sys.stderr)
+
     with open(TEMPLATE, 'r') as f:
         content = f.read()
 
@@ -254,27 +376,53 @@ def inject_hotfix(target_varkeys):
     selected_blocks = []
     for varkeys, block_lines in blocks:
         if varkeys & target_varkeys:
-            selected_blocks.append(block_lines)
+            selected_blocks.append((varkeys, block_lines))
             print(f"  Selected block with varkeys: {varkeys}", file=sys.stderr)
 
     if not selected_blocks:
         print("No matching write_files blocks found for the target varkeys.", file=sys.stderr)
         return False
 
+    # Build staging blocks and manifest entries
+    all_manifest_entries = []
+    staged_blocks = []
+    for varkeys, block_lines in selected_blocks:
+        rewritten, entries = rewrite_block_to_staging(block_lines, varkeys)
+        staged_blocks.append(rewritten)
+        all_manifest_entries.extend(entries)
+
+    # Deduplicate manifest entries (distro variants share the same dest path)
+    seen_dests = set()
+    unique_entries = []
+    for staging, dest in all_manifest_entries:
+        if dest not in seen_dests:
+            seen_dests.add(dest)
+            unique_entries.append({"staging": staging, "destination": dest})
+
+    manifest = {"targetVersion": target_version, "files": unique_entries}
+    manifest_json = json.dumps(manifest, separators=(',', ':'))
+
     hotfix_lines = [
         "\n",
-        "# ---- hotfix: auto-generated by hotfix-generate GH Action ----\n",
+        f"# ---- hotfix: auto-generated by hotfix-generate GH Action (target={target_version}) ----\n",
+        f"- path: {HOTFIX_MANIFEST_PATH}\n",
+        '  permissions: "0644"\n',
+        "  owner: root\n",
+        f"  content: |\n",
+        f"    {manifest_json}\n",
+        "\n",
     ]
-    for block_lines in selected_blocks:
+    for block_lines in staged_blocks:
         hotfix_lines.extend(block_lines)
-    hotfix_lines.append("# ---- end hotfix ----\n")
+    hotfix_lines.append(f"# ---- end hotfix ----\n")
 
     final_lines = lines[:else_line] + hotfix_lines + lines[else_line:]
 
     with open(TEMPLATE, 'w') as f:
         f.writelines(final_lines)
 
-    print(f"\nInjected {len(selected_blocks)} write_files block(s) into EnableScriptlessCSECmd section", file=sys.stderr)
+    print(f"\nInjected {len(staged_blocks)} write_files block(s) to staging paths", file=sys.stderr)
+    print(f"Manifest: {manifest_json}", file=sys.stderr)
     print(f"Updated {TEMPLATE}", file=sys.stderr)
     return True
 


### PR DESCRIPTION
## Summary

Adds version-scoped scripts hotfix support so that script hotfixes only apply to the targeted VHD version, not all nodes unconditionally.

## Problem

The current scripts hotfix mechanism injects `write_files` entries at real destination paths (e.g. `/opt/azure/containers/provision_installs.sh`). ANC's `applyNodeCustomData()` writes them unconditionally, meaning a hotfix targeting VHD `202604.27.0` would also overwrite scripts on older VHDs where the logic may differ.

## Solution

**Staging approach**: Instead of writing hotfix scripts directly to their real paths, they are written to a staging directory (`/opt/azure/hotfix/scripts/`) along with a manifest (`manifest.json`) that contains the target VHD version and staging→destination path mappings.

ANC then:
1. Reads the manifest
2. Compares `targetVersion` against its own VHD version (set via ldflags)
3. Copies staged files to real paths **only** if the version base (YYYYMM.DD) matches
4. Skips gracefully for non-matching versions

### Changes

- **`aks-node-controller/nodecustomdata.go`**: Added `applyScriptHotfix()`, `isScriptHotfixTargeted()`, `copyHotfixFile()` and manifest structs
- **`aks-node-controller/app.go`**: Wired `applyScriptHotfix()` into `Provision()` after `applyNodeCustomData()`
- **`hack/hotfix_generate.py`**: Updated `inject_hotfix()` to generate staging paths + manifest; added `rewrite_block_to_staging()`, `read_target_version()`, `VARKEY_TO_DEST_PATH` mapping
- **`aks-node-controller/nodecustomdata_test.go`**: 7 new tests covering version match, mismatch, higher patch, no manifest, empty manifest, dev version, and `isScriptHotfixTargeted` table tests

### Compatibility

- **No RP changes required** — ANC knows its VHD version from ldflags
- **No manifest = no-op** — nodes without hotfix entries are unaffected
- **Backward safe** — older ANC versions ignore the staging directory
- **Forward safe** — new ANC on VHDs without hotfix just logs "no manifest found"
- **Automatic cleanup** — next weekly release from main has no hotfix markers
