### PR TITLE
chore(deps): bump `dcgm-exporter` to build v6

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -2049,7 +2049,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=dcgm-exporter, repository=production, os=ubuntu, release=24.04",
-                "latestVersion": "4.8.1-ubuntu24.04u5"
+                "latestVersion": "4.8.1-ubuntu24.04u6"
               }
             ]
           },
@@ -2057,7 +2057,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=dcgm-exporter, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "4.8.1-ubuntu22.04u5"
+                "latestVersion": "4.8.1-ubuntu22.04u6"
               }
             ]
           }
@@ -2067,7 +2067,7 @@
             "versionsV2": [
               {
                 "renovateTag": "RPM_registry=https://packages.microsoft.com/azurelinux/3.0/prod/cloud-native/x86_64/repodata, name=dcgm-exporter, os=azurelinux, release=3.0",
-                "latestVersion": "4.8.1-5.azl3"
+                "latestVersion": "4.8.1-6.azl3"
               }
             ]
           }


### PR DESCRIPTION
- Ubuntu 24.04: `4.8.1-ubuntu24.04u5` → `4.8.1-ubuntu24.04u6`
- Ubuntu 22.04: `4.8.1-ubuntu22.04u5` → `4.8.1-ubuntu22.04u6`
- Azure Linux 3.0: `4.8.1-5.azl3` → `4.8.1-6.azl3`

---

This PR overrides the changes in https://github.com/Azure/AgentBaker/pull/8354. https://github.com/Azure/AgentBaker/pull/8354 tries to update the dependencies of DCGM exporter making it incompatible, the pipeline `Validate Components / dcgm-compatibility` check fails on #8354.