### PR TITLE
fix: exclude beta/pre-release versions for containerd in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -99,6 +99,7 @@
       "matchUpdateTypes": [
         "patch"
       ],
+      "allowedVersions": "!/~(alpha|beta|rc)/",
       "automerge": true,
       "enabled": true,
       "groupName": "runc-containerd-ca_watcher",
@@ -119,6 +120,7 @@
       "matchUpdateTypes": [
         "minor"
       ],
+      "allowedVersions": "!/~(alpha|beta|rc)/",
       "automerge": false,
       "enabled": true,
       "groupName": "runc-containerd-minor",


### PR DESCRIPTION
## Problem

Renovate proposed a beta version of moby-containerd (2.3.0~beta.0-ubuntu24.04u1) in PR #8366. In Debian versioning, the tilde (~) prefix indicates a pre-release version, but our custom deb datasources do not automatically filter these out.

## Fix

Added `allowedVersions: "!/~(alpha|beta|rc)/"` to:
- **Patch rule** (automerge): moby-runc, moby-containerd, containerd2, aks/aks-node-ca-watcher, Azure/WALinuxAgent
- **Minor rule** (no automerge): moby-runc, moby-containerd, containerd2, Azure/WALinuxAgent

This regex rejects any version string containing ~alpha, ~beta, or ~rc, which are standard Debian pre-release indicators.