### PR TITLE
fix: adjusting windows container image json url logic to reach build scripts

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release-windows.yaml
+++ b/.pipelines/.vsts-vhd-builder-release-windows.yaml
@@ -79,24 +79,6 @@ parameters:
 # Use variable group "ab-windows-ms-tenant" and link it to the pipeline "[TEST All VHDs] AKS Windows VHD Build - Msft Tenant"
 
 stages:
-  - stage: CheckUseContainerUrlsFromJson
-    jobs:
-      - job: SetURLToDefault
-        condition: eq(variables['useContainerUrlsFromJson'], 'True')
-        steps:
-          - script: echo "Setting Windows Container Image JSON URL to ${{ parameters.windowsContainerImageJsonUrl }}"
-            displayName: Set Windows Container Image JSON URL
-          - powershell: |
-              Write-Host "##vso[task.setvariable variable=windowsContainerImageJsonUrl]${{ parameters.windowsContainerImageJsonUrl }}"
-            displayName: Set pipeline variable windowsContainerImageJsonUrl
-      - job: SetURLToEmpty
-        condition: eq(variables['useContainerUrlsFromJson'], 'False')
-        steps:
-          - script: echo "Setting Windows Container Image JSON URL to an empty string"
-            displayName: Set Windows Container Image JSON URL to empty
-          - powershell: |
-              Write-Host "##vso[task.setvariable variable=windowsContainerImageJsonUrl;isOutput=true]''"
-            displayName: Set pipeline variable windowsContainerImageJsonUrl to empty
   - template: ./templates/.build-and-test-windows-vhds-template.yaml
     parameters:
       vhddebug: ${{ parameters.vhddebug }}
@@ -112,3 +94,7 @@ stages:
       installOpenSshServer: ${{ parameters.installOpenSshServer }}
       overrideBranch: ${{ parameters.overrideBranch }}
       useOverrides: ${{ parameters.useOverrides }}
+      ${{ if eq(parameters.useContainerUrlsFromJson, true) }}:
+        windowsContainerImageJsonUrl: ${{ parameters.windowsContainerImageJsonUrl }}
+      ${{ else }}:
+        windowsContainerImageJsonUrl: ""

--- a/vhdbuilder/packer/produce-packer-settings-functions.sh
+++ b/vhdbuilder/packer/produce-packer-settings-functions.sh
@@ -73,31 +73,31 @@ function ensure_sig_image_name_linux() {
 
 function download_windows_json_artifact() {
 	filename=$(basename "$WINDOWS_CONTAINERIMAGE_JSON_URL")
-	echo "Downloading $filename from wcct storage account using AzCopy with Managed Identity Auth"
+	echo "Downloading $filename from wcct storage account using Azure CLI auth"
 
 	# The JSON blob is formatted where each build image name is mapped to its corresponding image URL.
 	# For details on the expected format and how to manually retrieve the JSON blob,
 	# see: [WINDOWS-CONTAINERIMAGE-JSON.MD](vhdbuilder/packer/WINDOWS-CONTAINERIMAGE-JSON.MD)
-	if azcopy copy "${WINDOWS_CONTAINERIMAGE_JSON_URL}" "${BUILD_ARTIFACTSTAGINGDIRECTORY}/"; then
+
+	# Parse storage account, container, and blob path from the URL
+	# URL format: https://<account>.blob.core.windows.net/<container>/<blob_path>
+	local storage_account container blob_path
+	storage_account=$(echo "$WINDOWS_CONTAINERIMAGE_JSON_URL" | sed -n 's|https://\([^.]*\)\.blob\.core\.windows\.net/.*|\1|p')
+	container=$(echo "$WINDOWS_CONTAINERIMAGE_JSON_URL" | sed -n 's|https://[^/]*/\([^/]*\)/.*|\1|p')
+	blob_path=$(echo "$WINDOWS_CONTAINERIMAGE_JSON_URL" | sed -n 's|https://[^/]*/[^/]*/\(.*\)|\1|p')
+
+	echo "Storage account: $storage_account, Container: $container, Blob: $blob_path"
+
+	if az storage blob download \
+		--account-name "$storage_account" \
+		--container-name "$container" \
+		--name "$blob_path" \
+		--file "${BUILD_ARTIFACTSTAGINGDIRECTORY}/$filename" \
+		--auth-mode login; then
 		echo "Successfully downloaded the latest artifact: $filename"
 	else
-		# loop through azcopy log files
-		for f in "${AZCOPY_LOG_LOCATION}"/*.log; do
-			echo "Azcopy log file: $f"
-			# upload the log file as an attachment to vso
-			set +x
-			echo "##vso[build.uploadlog]$f"
-			set -x
-			# check if the log file contains any errors
-			if grep -q '"level":"Error"' "$f"; then
-				echo "log file $f contains errors"
-				set +x
-				echo "##vso[task.logissue type=error]Azcopy log file $f contains errors"
-				set -x
-				# print the log file
-				cat "$f"
-			fi
-		done
+		echo "##vso[task.logissue type=error]Failed to download $filename from storage account $storage_account"
+		echo "Error: az storage blob download failed for ${WINDOWS_CONTAINERIMAGE_JSON_URL}"
 	fi
 
 	# Parse the json artifact to get the image urls

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -187,8 +187,8 @@ windows_private_packages_url=""
 # msi_resource_strings is an array that will be used to build VHD build vm
 # test pipelines may not set it
 msi_resource_strings=()
-if [ -n "${AZURE_MSI_RESOURCE_STRING}" ] && { [ -n "${PRIVATE_PACKAGES_URL}" ] || [ -n "${WINDOWS_PRIVATE_PACKAGES_URL}" ] || [ -n "${WINDOWS_BASE_IMAGE_URL}" ]; }; then
-	echo "AZURE_MSI_RESOURCE_STRING is set and at least one of PRIVATE_PACKAGES_URL, WINDOWS_PRIVATE_PACKAGES_URL, or WINDOWS_BASE_IMAGE_URL is set. Assigning UAMI to Packer VM for VHD Build."
+if [ -n "${AZURE_MSI_RESOURCE_STRING}" ] && { [ -n "${PRIVATE_PACKAGES_URL}" ] || [ -n "${WINDOWS_PRIVATE_PACKAGES_URL}" ] || [ -n "${WINDOWS_BASE_IMAGE_URL}" ] || [ -n "${WINDOWS_CONTAINERIMAGE_JSON_URL}" ]; }; then
+	echo "AZURE_MSI_RESOURCE_STRING is set and at least one of PRIVATE_PACKAGES_URL, WINDOWS_PRIVATE_PACKAGES_URL, WINDOWS_BASE_IMAGE_URL, or WINDOWS_CONTAINERIMAGE_JSON_URL is set. Assigning UAMI to Packer VM for VHD Build."
 	msi_resource_strings+=(${AZURE_MSI_RESOURCE_STRING})
 else
 	echo "AZURE_MSI_RESOURCE_STRING or PRIVATE_PACKAGES_URL/WINDOWS_PRIVATE_PACKAGES_URL/WINDOWS_BASE_IMAGE_URL is not set. Skipping UAMI assignment to Packer VM for VHD Build."


### PR DESCRIPTION
** What does this PR fix:

  When running the Windows VHD release pipeline with useContainerUrlsFromJson=True and a valid JSON URL, the build
  always falls back to windows_settings.json defaults. Additionally, when the JSON path does work, the Packer build VM
  gets a 403 when downloading container images (servercore.tar, nanoserver.tar) from wcctagentbakerstorage.

  Root Causes

   1. Pipeline parameter was not flowing through templates — The CheckUseContainerUrlsFromJson stage used 
  ##vso[task.setvariable] to set a runtime variable, but downstream templates reference ${{ 
  parameters.windowsContainerImageJsonUrl }} (a compile-time expression). Runtime variables don't propagate across 
  stages to compile-time parameter references.
   2. UAMI not attached to Packer VM — The condition for attaching the managed identity to the Packer build VM only 
  checked WINDOWS_BASE_IMAGE_URL, which isn't set until after the JSON is downloaded and parsed. When using the JSON 
  flow, the VM had no identity attached → azcopy
    403.
   3. azcopy auth inside ADO agent — Replaced azcopy copy (which required MSI) with az storage blob download 
  --auth-mode login for the JSON artifact download on the ADO agent, using the existing Azure CLI session from the 
  AzureCLI@2 task.

  Changes

   - .pipelines/.vsts-vhd-builder-release-windows.yaml — Removed broken CheckUseContainerUrlsFromJson stage. Replaced 
  with compile-time ${{ if }} conditional that passes the JSON URL or empty string based on the 
  useContainerUrlsFromJson parameter. The toggle behavior is preserved.
   - vhdbuilder/packer/produce-packer-settings-functions.sh — Replaced azcopy copy with az storage blob download 
  --auth-mode login in download_windows_json_artifact() for compliance (uses CLI auth instead of MSI on the ADO 
  agent).
   - vhdbuilder/packer/produce-packer-settings.sh — Added WINDOWS_CONTAINERIMAGE_JSON_URL to the UAMI attachment 
  condition so the Packer build VM gets the managed identity when using the JSON flow.

  Testing

   - [ ]  Run release pipeline with useContainerUrlsFromJson=True and a valid JSON URL
   - [ ]  Verify JSON is downloaded and image URLs are parsed correctly
   - [ ]  Verify Packer VM can download container base images from wcctagentbakerstorage
   - [ ]  Run release pipeline with useContainerUrlsFromJson=False and verify fallback to defaults