### PR TITLE
test(e2e): add ANC hotfix binary selection E2E test

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -642,20 +642,19 @@ func Test_Ubuntu2204_ScriptlessCSECmd_Hotfix(t *testing.T) {
 	})
 }
 
-// Test_Ubuntu2204_ANCHotfix_WrongBaseVersion tests that the ANC hotfix download is
-// skipped when the hotfix version targets a different VHD base (YYYYMM.DD).
-// The VHD-baked ANC has a real version (e.g. 202604.27.0), and the hotfix JSON
-// requests a version with a completely different base (202501.01.1).
-// shouldUpgradeToHotfix returns false → no download → no hotfix binary → VHD binary used.
-func Test_Ubuntu2204_ANCHotfix_WrongBaseVersion(t *testing.T) {
+// Test_Ubuntu2204_ANCHotfix_VersionSkip tests that the ANC hotfix download is
+// gracefully skipped when version comparison fails. On E2E VHDs, the ANC binary
+// has Version="dev" which can't be parsed as semver, so shouldUpgradeToHotfix
+// returns an error and ANC skips the download. The wrapper then falls back to
+// the VHD-baked binary and provision succeeds.
+func Test_Ubuntu2204_ANCHotfix_VersionSkip(t *testing.T) {
 	RunScenario(t, &Scenario{
-		Description: "tests that ANC hotfix download is skipped when hotfix version targets a different VHD base",
+		Description: "tests that ANC hotfix download is gracefully skipped on version parse failure",
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
 			CustomDataWriteFiles: []CustomDataWriteFile{
 				{
-					// Hotfix JSON with a base version that doesn't match any current VHD
 					Path:    "/opt/azure/containers/aks-node-controller-hotfix.json",
 					Content: `{"version":"202501.01.1"}`,
 				},
@@ -664,12 +663,14 @@ func Test_Ubuntu2204_ANCHotfix_WrongBaseVersion(t *testing.T) {
 				nbc.EnableScriptlessCSECmd = true
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				// Wrapper should have found the hotfix config and attempted download-hotfix
+				// Wrapper found the hotfix config and ran download-hotfix
+				ValidateJournalctlOutput(ctx, s, "aks-node-controller", "Found ANC hotfix config")
+				// ANC could not parse version → skipped download
 				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log",
-					"ANC version not targeted by hotfix")
-				// No hotfix binary should exist — download was skipped
+					"failed to compare versions, skipping hotfix download")
+				// No hotfix binary was downloaded
 				ValidateFileDoesNotExist(ctx, s, "/opt/azure/containers/aks-node-controller-hotfix")
-				// Wrapper should have fallen back to the VHD-baked binary
+				// Wrapper fell back to VHD-baked binary
 				ValidateJournalctlOutput(ctx, s, "aks-node-controller", "Using VHD-baked binary")
 			},
 		},
@@ -688,8 +689,8 @@ func Test_Ubuntu2204_ANCHotfix_BinarySelection(t *testing.T) {
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
 			CustomDataWriteFiles: []CustomDataWriteFile{
 				{
-					// Hotfix JSON — version doesn't matter here because download-hotfix
-					// will be skipped (wrong base) but the pre-seeded binary will be found.
+					// Hotfix JSON — triggers download-hotfix (which will be skipped due to
+					// dev version), but the pre-seeded binary below will still be found.
 					Path:    "/opt/azure/containers/aks-node-controller-hotfix.json",
 					Content: `{"version":"202501.01.1"}`,
 				},
@@ -706,9 +707,11 @@ func Test_Ubuntu2204_ANCHotfix_BinarySelection(t *testing.T) {
 				nbc.EnableScriptlessCSECmd = true
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				// Wrapper should have selected the hotfix binary
+				// Wrapper found the pre-seeded hotfix binary and selected it
 				ValidateJournalctlOutput(ctx, s, "aks-node-controller", "Using hotfix binary")
-				// The stub delegates to real ANC, so provision should succeed
+				// The stub delegates to real ANC, so provision should succeed.
+				// "aks-node-controller finished successfully." is logged by ANC's slog
+				// after the provision command completes.
 				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log",
 					"aks-node-controller finished successfully")
 			},
@@ -734,40 +737,9 @@ func Test_Ubuntu2204_ANCHotfix_NoHotfixJSON(t *testing.T) {
 				ValidateJournalctlOutput(ctx, s, "aks-node-controller", "Using VHD-baked binary")
 				// Hotfix binary should not exist
 				ValidateFileDoesNotExist(ctx, s, "/opt/azure/containers/aks-node-controller-hotfix")
-				// Provision should complete successfully
+				// Provision completed via VHD-baked ANC
 				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log",
 					"aks-node-controller finished successfully")
-			},
-		},
-	})
-}
-
-// Test_Ubuntu2204_ANCHotfix_BadVersion tests graceful handling when the hotfix
-// JSON contains an unparseable version string. ANC should log a warning and
-// skip the download, falling back to the VHD-baked binary.
-func Test_Ubuntu2204_ANCHotfix_BadVersion(t *testing.T) {
-	RunScenario(t, &Scenario{
-		Description: "tests that ANC gracefully handles an unparseable hotfix version",
-		Config: Config{
-			Cluster: ClusterKubenet,
-			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			CustomDataWriteFiles: []CustomDataWriteFile{
-				{
-					Path:    "/opt/azure/containers/aks-node-controller-hotfix.json",
-					Content: `{"version":"not-a-valid-version"}`,
-				},
-			},
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.EnableScriptlessCSECmd = true
-			},
-			Validator: func(ctx context.Context, s *Scenario) {
-				// ANC should warn about the unparseable version
-				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log",
-					"failed to compare versions, skipping hotfix download")
-				// No hotfix binary should exist
-				ValidateFileDoesNotExist(ctx, s, "/opt/azure/containers/aks-node-controller-hotfix")
-				// Wrapper falls back to VHD binary, provision succeeds
-				ValidateJournalctlOutput(ctx, s, "aks-node-controller", "Using VHD-baked binary")
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -642,6 +642,137 @@ func Test_Ubuntu2204_ScriptlessCSECmd_Hotfix(t *testing.T) {
 	})
 }
 
+// Test_Ubuntu2204_ANCHotfix_WrongBaseVersion tests that the ANC hotfix download is
+// skipped when the hotfix version targets a different VHD base (YYYYMM.DD).
+// The VHD-baked ANC has a real version (e.g. 202604.27.0), and the hotfix JSON
+// requests a version with a completely different base (202501.01.1).
+// shouldUpgradeToHotfix returns false → no download → no hotfix binary → VHD binary used.
+func Test_Ubuntu2204_ANCHotfix_WrongBaseVersion(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "tests that ANC hotfix download is skipped when hotfix version targets a different VHD base",
+		Config: Config{
+			Cluster: ClusterKubenet,
+			VHD:     config.VHDUbuntu2204Gen2Containerd,
+			CustomDataWriteFiles: []CustomDataWriteFile{
+				{
+					// Hotfix JSON with a base version that doesn't match any current VHD
+					Path:    "/opt/azure/containers/aks-node-controller-hotfix.json",
+					Content: `{"version":"202501.01.1"}`,
+				},
+			},
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.EnableScriptlessCSECmd = true
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				// Wrapper should have found the hotfix config and attempted download-hotfix
+				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log",
+					"ANC version not targeted by hotfix")
+				// No hotfix binary should exist — download was skipped
+				ValidateFileDoesNotExist(ctx, s, "/opt/azure/containers/aks-node-controller-hotfix")
+				// Wrapper should have fallen back to the VHD-baked binary
+				ValidateJournalctlOutput(ctx, s, "aks-node-controller", "Using VHD-baked binary")
+			},
+		},
+	})
+}
+
+// Test_Ubuntu2204_ANCHotfix_BinarySelection tests that the wrapper script correctly
+// selects a pre-existing hotfix binary over the VHD-baked binary. This validates the
+// wrapper's binary selection logic without requiring an actual PMC download.
+// A stub script at the hotfix binary path delegates to the real ANC binary.
+func Test_Ubuntu2204_ANCHotfix_BinarySelection(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "tests that the wrapper selects a pre-seeded hotfix binary and provision succeeds",
+		Config: Config{
+			Cluster: ClusterKubenet,
+			VHD:     config.VHDUbuntu2204Gen2Containerd,
+			CustomDataWriteFiles: []CustomDataWriteFile{
+				{
+					// Hotfix JSON — version doesn't matter here because download-hotfix
+					// will be skipped (wrong base) but the pre-seeded binary will be found.
+					Path:    "/opt/azure/containers/aks-node-controller-hotfix.json",
+					Content: `{"version":"202501.01.1"}`,
+				},
+				{
+					// Pre-seed the hotfix binary path with a stub script that delegates
+					// to the real VHD-baked ANC binary. This simulates a successful
+					// hotfix download without needing PMC.
+					Path:        "/opt/azure/containers/aks-node-controller-hotfix",
+					Permissions: "0755",
+					Content:     "#!/bin/bash\nexec /opt/azure/containers/aks-node-controller \"$@\"",
+				},
+			},
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.EnableScriptlessCSECmd = true
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				// Wrapper should have selected the hotfix binary
+				ValidateJournalctlOutput(ctx, s, "aks-node-controller", "Using hotfix binary")
+				// The stub delegates to real ANC, so provision should succeed
+				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log",
+					"aks-node-controller finished successfully")
+			},
+		},
+	})
+}
+
+// Test_Ubuntu2204_ANCHotfix_NoHotfixJSON tests the normal path where no hotfix
+// JSON config exists. The wrapper should skip the download-hotfix step entirely
+// and use the VHD-baked binary.
+func Test_Ubuntu2204_ANCHotfix_NoHotfixJSON(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "tests that provision succeeds normally when no ANC hotfix JSON is present",
+		Config: Config{
+			Cluster:           ClusterKubenet,
+			VHD:               config.VHDUbuntu2204Gen2Containerd,
+			SkipScriptlessNBC: true,
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.EnableScriptlessCSECmd = true
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				// No hotfix config → wrapper skips download-hotfix entirely
+				ValidateJournalctlOutput(ctx, s, "aks-node-controller", "Using VHD-baked binary")
+				// Hotfix binary should not exist
+				ValidateFileDoesNotExist(ctx, s, "/opt/azure/containers/aks-node-controller-hotfix")
+				// Provision should complete successfully
+				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log",
+					"aks-node-controller finished successfully")
+			},
+		},
+	})
+}
+
+// Test_Ubuntu2204_ANCHotfix_BadVersion tests graceful handling when the hotfix
+// JSON contains an unparseable version string. ANC should log a warning and
+// skip the download, falling back to the VHD-baked binary.
+func Test_Ubuntu2204_ANCHotfix_BadVersion(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "tests that ANC gracefully handles an unparseable hotfix version",
+		Config: Config{
+			Cluster: ClusterKubenet,
+			VHD:     config.VHDUbuntu2204Gen2Containerd,
+			CustomDataWriteFiles: []CustomDataWriteFile{
+				{
+					Path:    "/opt/azure/containers/aks-node-controller-hotfix.json",
+					Content: `{"version":"not-a-valid-version"}`,
+				},
+			},
+			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.EnableScriptlessCSECmd = true
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				// ANC should warn about the unparseable version
+				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log",
+					"failed to compare versions, skipping hotfix download")
+				// No hotfix binary should exist
+				ValidateFileDoesNotExist(ctx, s, "/opt/azure/containers/aks-node-controller-hotfix")
+				// Wrapper falls back to VHD binary, provision succeeds
+				ValidateJournalctlOutput(ctx, s, "aks-node-controller", "Using VHD-baked binary")
+			},
+		},
+	})
+}
+
 // Returns config for the 'gpu' E2E scenario
 func Test_Ubuntu2204(t *testing.T) {
 	RunScenario(t, &Scenario{

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -642,57 +642,30 @@ func Test_Ubuntu2204_ScriptlessCSECmd_Hotfix(t *testing.T) {
 	})
 }
 
-// Test_Ubuntu2204_ANCHotfix_VersionSkip tests that the ANC hotfix download is
-// gracefully skipped when version comparison fails. On E2E VHDs, the ANC binary
-// has Version="dev" which can't be parsed as semver, so shouldUpgradeToHotfix
-// returns an error and ANC skips the download. The wrapper then falls back to
-// the VHD-baked binary and provision succeeds.
-func Test_Ubuntu2204_ANCHotfix_VersionSkip(t *testing.T) {
-	RunScenario(t, &Scenario{
-		Description: "tests that ANC hotfix download is gracefully skipped on version parse failure",
-		Config: Config{
-			Cluster: ClusterKubenet,
-			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			CustomDataWriteFiles: []CustomDataWriteFile{
-				{
-					Path:    "/opt/azure/containers/aks-node-controller-hotfix.json",
-					Content: `{"version":"202501.01.1"}`,
-				},
-			},
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.EnableScriptlessCSECmd = true
-			},
-			Validator: func(ctx context.Context, s *Scenario) {
-				// Wrapper found the hotfix config and ran download-hotfix
-				ValidateJournalctlOutput(ctx, s, "aks-node-controller", "Found ANC hotfix config")
-				// ANC could not parse version → skipped download
-				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log",
-					"failed to compare versions, skipping hotfix download")
-				// No hotfix binary was downloaded
-				ValidateFileDoesNotExist(ctx, s, "/opt/azure/containers/aks-node-controller-hotfix")
-				// Wrapper fell back to VHD-baked binary
-				ValidateJournalctlOutput(ctx, s, "aks-node-controller", "Using VHD-baked binary")
-			},
-		},
-	})
-}
-
 // Test_Ubuntu2204_ANCHotfix_BinarySelection tests that the wrapper script correctly
 // selects a pre-existing hotfix binary over the VHD-baked binary. This validates the
 // wrapper's binary selection logic without requiring an actual PMC download.
 // A stub script at the hotfix binary path delegates to the real ANC binary.
+//
+// Note: In the EnableScriptlessCSECmd (non-NBC) path, the wrapper runs at boot and
+// performs binary selection, but exits before provisioning because no config/nbc-cmd
+// file exists at that point. Provisioning happens later via CSE → provision.sh.
+// This test validates the wrapper's selection logic; node readiness (implicit in
+// RunScenario) confirms provisioning succeeded via the CSE path.
 func Test_Ubuntu2204_ANCHotfix_BinarySelection(t *testing.T) {
 	RunScenario(t, &Scenario{
-		Description: "tests that the wrapper selects a pre-seeded hotfix binary and provision succeeds",
+		Description: "tests that the wrapper selects a pre-seeded hotfix binary",
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
 			CustomDataWriteFiles: []CustomDataWriteFile{
 				{
-					// Hotfix JSON — triggers download-hotfix (which will be skipped due to
-					// dev version), but the pre-seeded binary below will still be found.
+					// Hotfix JSON — triggers download-hotfix, but a real hotfix install
+					// should be skipped because this intentionally old version will not
+					// target the VHD base version. The pre-seeded binary below will still
+					// be found and selected by the wrapper.
 					Path:    "/opt/azure/containers/aks-node-controller-hotfix.json",
-					Content: `{"version":"202501.01.1"}`,
+					Content: `{"version":"200001.01.1"}`,
 				},
 				{
 					// Pre-seed the hotfix binary path with a stub script that delegates
@@ -708,38 +681,10 @@ func Test_Ubuntu2204_ANCHotfix_BinarySelection(t *testing.T) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				// Wrapper found the pre-seeded hotfix binary and selected it
-				ValidateJournalctlOutput(ctx, s, "aks-node-controller", "Using hotfix binary")
-				// The stub delegates to real ANC, so provision should succeed.
-				// "aks-node-controller finished successfully." is logged by ANC's slog
-				// after the provision command completes.
+				ValidateJournalctlOutput(ctx, s, "aks-node-controller.service", "Using hotfix binary")
+				// download-hotfix was triggered by the hotfix JSON
 				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log",
-					"aks-node-controller finished successfully")
-			},
-		},
-	})
-}
-
-// Test_Ubuntu2204_ANCHotfix_NoHotfixJSON tests the normal path where no hotfix
-// JSON config exists. The wrapper should skip the download-hotfix step entirely
-// and use the VHD-baked binary.
-func Test_Ubuntu2204_ANCHotfix_NoHotfixJSON(t *testing.T) {
-	RunScenario(t, &Scenario{
-		Description: "tests that provision succeeds normally when no ANC hotfix JSON is present",
-		Config: Config{
-			Cluster:           ClusterKubenet,
-			VHD:               config.VHDUbuntu2204Gen2Containerd,
-			SkipScriptlessNBC: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.EnableScriptlessCSECmd = true
-			},
-			Validator: func(ctx context.Context, s *Scenario) {
-				// No hotfix config → wrapper skips download-hotfix entirely
-				ValidateJournalctlOutput(ctx, s, "aks-node-controller", "Using VHD-baked binary")
-				// Hotfix binary should not exist
-				ValidateFileDoesNotExist(ctx, s, "/opt/azure/containers/aks-node-controller-hotfix")
-				// Provision completed via VHD-baked ANC
-				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log",
-					"aks-node-controller finished successfully")
+					"aks-node-controller hotfix download finished")
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Add `Test_Ubuntu2204_ANCHotfix_BinarySelection` which validates that the aks-node-controller wrapper script correctly selects a pre-seeded hotfix binary over the VHD-baked binary.

## How it works

The test pre-seeds two files via cloud-init `CustomDataWriteFiles`:
1. **Hotfix JSON** (`/opt/azure/containers/aks-node-controller-hotfix.json`) — triggers the download-hotfix phase
2. **Stub binary** (`/opt/azure/containers/aks-node-controller-hotfix`) — a shell script that delegates to the real VHD-baked ANC binary, simulating a successful hotfix download without requiring PMC access to make the test self-contained.

## What it validates

- Wrapper detects the pre-seeded hotfix binary and selects it ("Using hotfix binary")
- The download-hotfix phase runs when hotfix JSON is present
- Node provisions successfully via the CSE path (implicit in RunScenario/node readiness)

## Notes

- Uses `EnableScriptlessCSECmd` (non-NBC) path where the wrapper runs at boot for binary selection but exits before provisioning (no config/nbc-cmd file exists). Provisioning happens later via CSE -> provision.sh.
- Does not require a real hotfix package on PMC — the stub script approach makes the test hermetic and self-contained.