### PR TITLE
fix: enable hairpin mode for ubuntu 24.04 with kubenet bridge plugin

### DIFF
--- a/aks-node-controller/parser/helper.go
+++ b/aks-node-controller/parser/helper.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -39,6 +40,8 @@ import (
 var (
 	//go:embed templates/kubenet-cni.json.gtpl
 	kubenetTemplateContent []byte
+	//go:embed templates/kubenet-cni-hairpin.json.gtpl
+	kubenetTemplateHairpinContent []byte
 	//go:embed  templates/containerd.toml.gtpl
 	containerdConfigTemplateText string
 	//nolint:gochecknoglobals
@@ -144,8 +147,36 @@ func getStringifiedStringArray(arr []string, delimiter string) string {
 }
 
 // getKubenetTemplate returns the base64 encoded Kubenet template.
+// On Ubuntu 24.04+ (kernel 6.8+), promiscuous mode no longer implicitly enables
+// hairpin forwarding in the bridge. Use explicit hairpinMode for those nodes.
 func getKubenetTemplate() string {
+	if needsExplicitHairpinMode() {
+		return base64.StdEncoding.EncodeToString(kubenetTemplateHairpinContent)
+	}
 	return base64.StdEncoding.EncodeToString(kubenetTemplateContent)
+}
+
+// needsExplicitHairpinMode checks /etc/os-release to determine if the node is
+// running Ubuntu 24.04+, where kernel 6.8+ requires explicit BR_HAIRPIN_MODE.
+func needsExplicitHairpinMode() bool {
+	data, err := os.ReadFile("/etc/os-release")
+	if err != nil {
+		return false
+	}
+	var id, versionID string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "ID=") {
+			id = strings.Trim(strings.TrimPrefix(line, "ID="), `"`)
+		} else if strings.HasPrefix(line, "VERSION_ID=") {
+			versionID = strings.Trim(strings.TrimPrefix(line, "VERSION_ID="), `"`)
+		}
+	}
+	if strings.ToLower(id) != "ubuntu" {
+		return false
+	}
+	// Compare VERSION_ID >= "24.04" lexicographically (works for Ubuntu version format)
+	return versionID >= "24.04"
 }
 
 // getContainerdConfigBase64 returns the base64 encoded containerd config depending on whether the node is with GPU or not.

--- a/aks-node-controller/parser/helper_test.go
+++ b/aks-node-controller/parser/helper_test.go
@@ -505,13 +505,10 @@ oom_score = -999
 }
 
 func Test_getKubenetTemplate(t *testing.T) {
-	tests := []struct {
-		name string
-		want string
-	}{
-		{
-			name: "Kubenet template",
-			want: base64.StdEncoding.EncodeToString([]byte(`{
+	// getKubenetTemplate() selects the template based on OS detection at runtime.
+	// Validate that the returned template is one of the two valid variants.
+	got := getKubenetTemplate()
+	wantDefault := base64.StdEncoding.EncodeToString([]byte(`{
 	"cniVersion": "0.3.1",
 	"name": "kubenet",
 	"plugins": [{
@@ -535,16 +532,50 @@ func Test_getKubenetTemplate(t *testing.T) {
 		"externalSetMarkChain": "KUBE-MARK-MASQ"
 	}]
 }
-`)),
-		},
+`))
+	wantHairpin := base64.StdEncoding.EncodeToString([]byte(`{
+	"cniVersion": "0.3.1",
+	"name": "kubenet",
+	"plugins": [{
+		"type": "bridge",
+		"bridge": "cbr0",
+		"mtu": 1500,
+		"addIf": "eth0",
+		"isGateway": true,
+		"ipMasq": false,
+		"promiscMode": false,
+		"hairpinMode": true,
+		"ipam": {
+			"type": "host-local",
+			"ranges": [{{range $i, $range := .PodCIDRRanges}}{{if $i}}, {{end}}[{"subnet": "{{$range}}"}]{{end}}],
+			"routes": [{{range $i, $route := .Routes}}{{if $i}}, {{end}}{"dst": "{{$route}}"}{{end}}]
+		}
+	},
+	{
+		"type": "portmap",
+		"capabilities": {"portMappings": true},
+		"externalSetMarkChain": "KUBE-MARK-MASQ"
+	}]
+}
+`))
+	if got != wantDefault && got != wantHairpin {
+		t.Errorf("getKubenetTemplate() returned unexpected template: %v", got)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := getKubenetTemplate(); got != tt.want {
-				t.Errorf("getKubenetTemplate() = %v, want %v", got, tt.want)
-			}
-		})
+	if needsExplicitHairpinMode() {
+		if got != wantHairpin {
+			t.Errorf("getKubenetTemplate() on Ubuntu 24.04+ should return hairpin template, got default")
+		}
+	} else {
+		if got != wantDefault {
+			t.Errorf("getKubenetTemplate() on non-Ubuntu-24.04 should return default template, got hairpin")
+		}
 	}
+}
+
+func Test_needsExplicitHairpinMode(t *testing.T) {
+	// This is a runtime OS detection test; result depends on the build environment.
+	// Just verify it doesn't panic and returns a bool.
+	_ = needsExplicitHairpinMode()
 }
 
 func Test_getAzureEnvironmentFilepath(t *testing.T) {

--- a/aks-node-controller/parser/templates/kubenet-cni-hairpin.json.gtpl
+++ b/aks-node-controller/parser/templates/kubenet-cni-hairpin.json.gtpl
@@ -1,0 +1,24 @@
+{
+	"cniVersion": "0.3.1",
+	"name": "kubenet",
+	"plugins": [{
+		"type": "bridge",
+		"bridge": "cbr0",
+		"mtu": 1500,
+		"addIf": "eth0",
+		"isGateway": true,
+		"ipMasq": false,
+		"promiscMode": false,
+		"hairpinMode": true,
+		"ipam": {
+			"type": "host-local",
+			"ranges": [{{range $i, $range := .PodCIDRRanges}}{{if $i}}, {{end}}[{"subnet": "{{$range}}"}]{{end}}],
+			"routes": [{{range $i, $route := .Routes}}{{if $i}}, {{end}}{"dst": "{{$route}}"}{{end}}]
+		}
+	},
+	{
+		"type": "portmap",
+		"capabilities": {"portMappings": true},
+		"externalSetMarkChain": "KUBE-MARK-MASQ"
+	}]
+}

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -969,6 +969,11 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 			return ""
 		},
 		"GetKubenetTemplate": func() string {
+			// On Ubuntu 24.04+ (kernel 6.8+), promiscuous mode no longer implicitly
+			// enables hairpin forwarding in the bridge. Use explicit hairpinMode instead.
+			if profile.Is2404VHDDistro() {
+				return base64.StdEncoding.EncodeToString([]byte(kubenetCniTemplateHairpin))
+			}
 			return base64.StdEncoding.EncodeToString([]byte(kubenetCniTemplate))
 		},
 		"GetContainerdConfigContent": func() string {
@@ -1568,6 +1573,38 @@ const kubenetCniTemplate = `
     "ipMasq": false,
     "promiscMode": true,
     "hairpinMode": false,
+    "ipam": {
+        "type": "host-local",
+        "ranges": [{{range $i, $range := .PodCIDRRanges}}{{if $i}}, {{end}}[{"subnet": "{{$range}}"}]{{end}}],
+        "routes": [{{range $i, $route := .Routes}}{{if $i}}, {{end}}{"dst": "{{$route}}"}{{end}}]
+    }
+    },
+    {
+    "type": "portmap",
+    "capabilities": {"portMappings": true},
+    "externalSetMarkChain": "KUBE-MARK-MASQ"
+    }]
+}
+`
+
+// kubenetCniTemplateHairpin is the kubenet CNI template for Ubuntu 24.04+ (kernel 6.8+).
+// On kernel 6.8+, the bridge forwarding path strictly checks BR_HAIRPIN_MODE in should_deliver()
+// and promiscuous mode no longer implicitly enables hairpin forwarding. This template uses
+// explicit hairpinMode instead of promiscMode to fix service hairpin traffic
+// (pod -> own ClusterIP -> same pod).
+const kubenetCniTemplateHairpin = `
+{
+    "cniVersion": "0.3.1",
+    "name": "kubenet",
+    "plugins": [{
+    "type": "bridge",
+    "bridge": "cbr0",
+    "mtu": 1500,
+    "addIf": "eth0",
+    "isGateway": true,
+    "ipMasq": false,
+    "promiscMode": false,
+    "hairpinMode": true,
     "ipam": {
         "type": "host-local",
         "ranges": [{{range $i, $range := .PodCIDRRanges}}{{if $i}}, {{end}}[{"subnet": "{{$range}}"}]{{end}}],


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
This is the bug report: https://github.com/Azure/AKS/issues/5669#issuecomment-4335041448

We can repro the issue with kubenet + Ubuntu 24.04 (kernel 6.8), but couldn't repro for kubenet + azlinux3 (kernel 6.6) or other lower version of Ubuntu.

Why it worked before with hairpinmode off: when kube-proxy DNAT'd the ClusterIP to the same PodIP, kernels ≤ 6.6 would "promote" the bridged frame to the L3 path (ip_forward()), which ran nat POSTROUTING / KUBE-POSTROUTING, which SNAT'd src to 10.244.0.1 (cbr0's IP), then re-emitted the packet. By the time the frame returned to br_forward(), src MAC = host MAC (≠ veth peer MAC), so split-horizon no longer applied even without hairpin_mode.

Below investigation from AI, I don't have enough kernel knowledge to tell:
> There are two plausible mechanisms (both consistent with the dmesg data, hard to disambiguate without kernel source diving):
6.6 takes a different route earlier: After DNAT, instead of continuing through br_forward → should_deliver, the older code path notices the DNAT changed the dst and re-classifies the frame, sending it through ip_forward() → IPv4 POSTROUTING. POSTROUTING runs, MASQUERADE rewrites src → 10.244.0.1 (cbr0 IP), then the packet is re-sent as a fresh L3 packet, which on emit through cbr0 has src MAC = host MAC (different from veth_A's peer MAC) → hairpin no longer same-port → frame delivers.
6.6 treats DNAT'd frames as eligible to bypass split-horizon: The pre-rework br_nf_pre_routing_finish_bridge may have explicitly handled the DNAT-changed-dst case by skipping should_deliver's split-horizon check (or by re-injecting via L3).

Although it looks like it's kernel related, we still want to scope the fix to ubuntu only for now.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
