### PR TITLE
test: make Windows log extraction best-effort in cleanup

### DIFF
--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -867,6 +867,7 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 		s.T.Logf("no VMSS instances found")
 		return
 	}
+
 	instanceID := *page.Value[0].InstanceID
 	blobPrefix := s.Runtime.VMSSName
 	blobUrl := config.Config.BlobStorageAccountURL() + "/" + config.Config.BlobContainer + "/" + blobPrefix
@@ -918,11 +919,17 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 		},
 		nil,
 	)
-	require.NoError(s.T, err, "failed to initiate run command on VMSS instance %s", instanceID)
+	if err != nil {
+		s.T.Logf("failed to initiate run command on VMSS instance %s: %s", instanceID, err)
+		return
+	}
 
 	// Poll the result until the operation is completed
 	runCommandResp, err := pollerResp.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
-	require.NoError(s.T, err, "failed to poll run command on VMSS instance %s", instanceID)
+	if err != nil {
+		s.T.Logf("failed to poll run command on VMSS instance %s: %s", instanceID, err)
+		return
+	}
 
 	respJSON, _ := json.MarshalIndent(runCommandResp, "", "  ")
 	s.T.Logf("run command executed successfully:\n%s", respJSON)


### PR DESCRIPTION
## Problem

`extractLogsFromVMWindows` used `require.NoError` for RunCommand operations during test cleanup. When a test fails and the VM is deallocated or never provisioned, RunCommand returns errors (409 Conflict, OSProvisioningTimedOut) that register as **additional test failures**, inflating the failure count and obscuring the real root cause.

Example: [build 162224450](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=162224450) reported 3 failures for `Test_Windows2022_VHDCaching`, but only 1 was the actual failure (Stage 2 VM provisioning timeout). The other 2 were cleanup trying to RunCommand on deallocated/unprovisioned VMs.

## Fix

Replace `require.NoError` with `Logf` + `return` in `extractLogsFromVMWindows`, matching the existing Linux log extraction pattern (`vmss.go:692-694`) which already handles errors gracefully.

## Impact

- Log collection failures during cleanup no longer fail the test
- Real test failures are no longer obscured by cleanup noise
- No behavior change for successful log collection paths