### PR TITLE
fix: reduce Windows SIG cleanup retention to 7d and remove name filters

### DIFF
--- a/.pipelines/scripts/windows-sub-cleanup.sh
+++ b/.pipelines/scripts/windows-sub-cleanup.sh
@@ -98,7 +98,7 @@ fi
 if [ -n "${AZURE_RESOURCE_GROUP_NAME}" ]; then
   gallery_list=$(az sig list -g ${AZURE_RESOURCE_GROUP_NAME} | jq -r '.[].name')
 
-  due_date=$(date +%F -d "90 days ago")
+  due_date=$(date +%F -d "7 days ago")
   for gallery in $gallery_list; do
     image_defs=$(az sig image-definition list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${gallery} | jq -r '.[] | select(.osType == "Windows").name')
     for image_definition in $image_defs; do

--- a/.pipelines/scripts/windows-sub-cleanup.sh
+++ b/.pipelines/scripts/windows-sub-cleanup.sh
@@ -94,7 +94,7 @@ if [ -n "${AZURE_RESOURCE_GROUP_NAME}" ]; then
   done
 fi
 
-# attemp to clean up old test Windows SIG image versions over 3 months ago
+# attempt to clean up old test Windows SIG image versions over 7 days ago
 if [ -n "${AZURE_RESOURCE_GROUP_NAME}" ]; then
   gallery_list=$(az sig list -g ${AZURE_RESOURCE_GROUP_NAME} | jq -r '.[].name')
 

--- a/vhdbuilder/packer/cleanup.sh
+++ b/vhdbuilder/packer/cleanup.sh
@@ -145,7 +145,7 @@ if [[ "${MODE}" == "linuxVhdMode" && -n "${AZURE_RESOURCE_GROUP_NAME}" && "${DRY
   managed_image_ids=""
   sig_version_ids=""
   # we limit deletions to 25 managed images to make sure the build doesn't take too long and can finish successfully
-  for image in $(az image list -g ${AZURE_RESOURCE_GROUP_NAME} | jq --arg dl $deadline '.[] | select(.name | test("Ubuntu*|CBLMariner*|V1*|V2*|2004*|2204*")) | select(.tags.now < $dl).name' | head -n 25 | tr -d '\"' || ""); do
+  for image in $(az image list -g ${AZURE_RESOURCE_GROUP_NAME} | jq --arg dl $deadline '.[] | select(.tags.now != null) | select(.tags.now < $dl).name' | head -n 25 | tr -d '\"' || ""); do
     managed_image_ids="${managed_image_ids} /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/images/${image}"
     sig_version_ids="${sig_version_ids} /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/galleries/${SIG_GALLERY_NAME}/images/${image%-*}/versions/${image#*-}"
     echo "Will delete managed image ${image} and associated SIG version from resource group ${AZURE_RESOURCE_GROUP_NAME}"
@@ -168,7 +168,7 @@ if [[ "${MODE}" == "linuxVhdMode" && -n "${AZURE_RESOURCE_GROUP_NAME}" && "${DRY
   old_sig_version_ids=""
   # we limit deletion to 15 SIG image versions per image definition
   set +x
-  for image_definition in $(az sig image-definition list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${SIG_GALLERY_NAME} | jq '.[] | select(.name | test("Ubuntu*|CBLMariner*|V1*|V2*|2004*|2204*|2404*")).name' | tr -d '\"' || ""); do
+  for image_definition in $(az sig image-definition list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${SIG_GALLERY_NAME} | jq '.[].name' | tr -d '\"' || ""); do
     for image_version in $(az sig image-version list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${SIG_GALLERY_NAME} -i ${image_definition} | jq --arg dl $deadline '.[] | select(.tags.now < $dl).name' | head -n 15 | tr -d '\"' || ""); do
       image_version_id="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/galleries/${SIG_GALLERY_NAME}/images/${image_definition}/versions/${image_version}"
 


### PR DESCRIPTION
## Problem

Windows VHD PR builds in `PackerSigGalleryEastUS` used **90-day retention** (vs 7 days for Linux). After the gallery merge (PR #6440), ~10,000 Windows image versions accumulated, hitting the Azure `GalleryImageVersion` subscription quota (10,000) in westus2 and **breaking all Windows PR builds** (build 162318414).

Linux cleanup also missed definitions not matching name filters (`flatcar*`, `aclgen2*`, `AzureLinux*`), leaving ~1,300 orphaned versions.

## Fix (3 lines changed)

1. **`windows-sub-cleanup.sh`**: `90 days ago` → `7 days ago` — align with Linux retention
2. **`cleanup.sh`**: Remove name-pattern filters (`Ubuntu*|CBLMariner*|...`) — clean ALL image definitions and managed images by age, not by name

## Impact

- Unblocks Windows PR builds immediately after backlog drains
- Existing cleanup scripts run per-build (Linux) and per-PR (Windows) — no schedule changes needed
- Protected resources: `2204Gen2` v`1.1704411049.2812` has `CanNotDelete` lock + `gc.skip=true` tag