### PR TITLE
fix: disable prefetch optimization for azurecontainerlinux since it break first time boot

### DIFF
--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -168,6 +168,13 @@ steps:
         echo "##vso[task.setvariable variable=PREFETCH_COMPATIBLE]False"
         exit 0
       fi
+
+      if [ "${OS_SKU}" = "AzureContainerLinux" ]; then
+        echo "OS SKU is AzureContainerLinux - VHD is not compatible with prefetch optimization"
+        echo "##vso[task.setvariable variable=PREFETCH_COMPATIBLE]False"
+        exit 0
+      fi
+
       if [ "${ARCHITECTURE,,}" = "arm64" ]; then
         if [ "${ENABLE_TRUSTED_LAUNCH,,}" = "true" ]; then
           echo "arm64 with trusted launch - VHD is incompatible with prefetch optimization"


### PR DESCRIPTION
issue is that we do this in post provisioning in ACL
 
`sudo touch /boot/flatcar/first_boot`
 
which is obviously critical to tell ignition that you need to execute CustomData which downloads the files <- critical for scriptless since thats the things needed for running the provisioner
 
This works in E2E since the images are not prefetch optimized.
 
https://github.com/Azure/AgentBaker/blob/01bb1b0e8e9425a79e4d801ee0b29b679152ed3a/vhdbuilder/prefetch/templates/optimize.json#L21
we skip arm64 images because it doesn't support it. So this works fine in staging/prod images
 
https://github.com/Azure/AgentBaker/blob/01bb1b0e8e9425a79e4d801ee0b29b679152ed3a/.pipelines/templates/.builder-release-template.yaml#L173 
this conveniently deletes the first_boot because VM boots up and never restored.
 
so we either need to skip prefetch optimization or restore this somehow, i just chose to disable prefetch optimization for now
 