### PR TITLE
fix: run SSH pubkey auth config in background to avoid scriptless boot race

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -99,10 +99,18 @@ function basePrep {
     # Configure SSH pubkey auth in background — not critical for provisioning and
     # the SSH service may not be ready yet in scriptless mode (ANC starts early).
     (
-        # Wait for SSH service: "ssh" on Ubuntu, "sshd" on AzureLinux
-        systemctl is-active --quiet ssh.service || systemctl is-active --quiet sshd.service || \
-            systemctl start ssh.service 2>/dev/null || systemctl start sshd.service 2>/dev/null || true
-        logs_to_events "AKS.CSE.configureSSHPubkeyAuth" configureSSHPubkeyAuth "${DISABLE_PUBKEY_AUTH}"
+        # Wait for /run/sshd to be created by the SSH service (ssh on Ubuntu, sshd on AzureLinux)
+        SSH_WAIT_SECONDS=0
+        while [ ! -d /run/sshd ] && [ "$SSH_WAIT_SECONDS" -lt 30 ]; do
+            sleep 1
+            SSH_WAIT_SECONDS=$((SSH_WAIT_SECONDS + 1))
+        done
+        if [ ! -d /run/sshd ]; then
+            echo "AKS.CSE.configureSSHPubkeyAuth.background: timed out after ${SSH_WAIT_SECONDS}s waiting for /run/sshd"
+            return
+        fi
+        echo "AKS.CSE.configureSSHPubkeyAuth.background: waited ${SSH_WAIT_SECONDS}s for /run/sshd"
+        logs_to_events "AKS.CSE.configureSSHPubkeyAuth.background" configureSSHPubkeyAuth "${DISABLE_PUBKEY_AUTH}"
     ) &
 
     if [ "${DISABLE_SSH}" = "true" ]; then

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -96,8 +96,14 @@ function basePrep {
 
     logs_to_events "AKS.CSE.installSecureTLSBootstrapClient" installSecureTLSBootstrapClient
 
-    logs_to_events "AKS.CSE.configureSSHPubkeyAuth" configureSSHPubkeyAuth "${DISABLE_PUBKEY_AUTH}"
-
+    # Configure SSH pubkey auth in background — not critical for provisioning and
+    # the SSH service may not be ready yet in scriptless mode (ANC starts early).
+    (
+        # Wait for SSH service: "ssh" on Ubuntu, "sshd" on AzureLinux
+        systemctl is-active --quiet ssh.service || systemctl is-active --quiet sshd.service || \
+            systemctl start ssh.service 2>/dev/null || systemctl start sshd.service 2>/dev/null || true
+        logs_to_events "AKS.CSE.configureSSHPubkeyAuth" configureSSHPubkeyAuth "${DISABLE_PUBKEY_AUTH}"
+    ) &
 
     if [ "${DISABLE_SSH}" = "true" ]; then
         disableSSH || exit $ERR_DISABLE_SSH


### PR DESCRIPTION
## Problem

In scriptless mode, `aks-node-controller.service` starts at `basic.target` (after network only), which is **before** `sshd.service` reaches active state. `configureSSHPubkeyAuth` calls `sshd -t` for config validation, which requires `/run/sshd` to exist — a directory created by sshd's `RuntimeDirectory=sshd`.

This causes **exit code 178** (`ERR_SSHD_CONFIG_FAIL`) in all `scriptless_nbc` E2E tests. The failure is new as of May 1 — a boot timing race that became consistently losable after recent changes sped up early CSE execution.

Non-scriptless tests are unaffected because the VM extension runs after `multi-user.target` when sshd is already active.

## Fix

Only `configureSSHPubkeyAuth` needs `/run/sshd` (it calls `sshd -t`). It is not critical for node provisioning — nothing downstream depends on it. Move it to a background subshell that waits for `sshd.service` before configuring.

`disableSSH` remains **synchronous and fatal** — it is security-critical (customer explicitly requests SSH disabled) and does not depend on `/run/sshd` (it just calls `systemctlDisableAndStop sshd`).

## Testing

- Fixes exit 178 in `scriptless_nbc` subtests (22/25 failures in build 162533733)
- Non-scriptless path: SSH config still happens, just no longer blocks provisioning
- `DISABLE_SSH=true` behavior unchanged — still fails CSE if it cannot disable SSH
