### PR TITLE
fix: add backward-compatible shims for hotfix overlay on older VHDs

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -35,6 +35,9 @@ if ! command -v checkServiceHealth >/dev/null 2>&1; then
         local service=$1
         local state
         state=$(systemctl show -p ActiveState --value "$service" 2>/dev/null) || true
+        if [ "$state" = "active" ]; then
+            return 0
+        fi
         if [ "$state" = "failed" ]; then
             echo "$service is in a failed state"
             return 1

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -24,6 +24,41 @@ done
 source "${CSE_HELPERS_FILEPATH}"
 source "${CSE_DISTRO_HELPERS_FILEPATH}"
 
+# Backward-compatible shims: when a hotfixed cse_main.sh (provision.sh) is delivered
+# to a node running an older VHD, functions added after the VHD was built will be
+# missing from the VHD's cse_helpers.sh. Define minimal fallbacks here so that the
+# hotfixed script doesn't fail with "command not found".
+# These shims are no-ops or safe defaults and are only used when the real function
+# is absent; if the VHD already defines them, these are skipped.
+if ! command -v checkServiceHealth >/dev/null 2>&1; then
+    checkServiceHealth() {
+        local service=$1
+        local state
+        state=$(systemctl show -p ActiveState --value "$service" 2>/dev/null) || true
+        if [ "$state" = "failed" ]; then
+            echo "$service is in a failed state"
+            return 1
+        fi
+    }
+fi
+if ! command -v isACL >/dev/null 2>&1; then
+    isACL() { return 1; }
+fi
+if ! command -v isAmdAmaEnabledNode >/dev/null 2>&1; then
+    isAmdAmaEnabledNode() { return 1; }
+fi
+if ! command -v should_enable_managed_gpu_experience >/dev/null 2>&1; then
+    should_enable_managed_gpu_experience() { echo ""; }
+fi
+if ! command -v fetch_and_cache_imds_instance_metadata >/dev/null 2>&1; then
+    fetch_and_cache_imds_instance_metadata() { true; }
+fi
+if ! command -v waitForContainerdReady >/dev/null 2>&1; then
+    waitForContainerdReady() {
+        retrycmd_if_failure 120 0.1 1 bash -c 'ctr version >/dev/null 2>&1'
+    }
+fi
+
 # Setup logs for upload to host
 LOG_DIR=/var/log/azure/aks
 mkdir -p ${LOG_DIR}

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -24,12 +24,12 @@ done
 source "${CSE_HELPERS_FILEPATH}"
 source "${CSE_DISTRO_HELPERS_FILEPATH}"
 
-# Backward-compatible shims: when a hotfixed cse_main.sh (provision.sh) is delivered
-# to a node running an older VHD, functions added after the VHD was built will be
-# missing from the VHD's cse_helpers.sh. Define minimal fallbacks here so that the
-# hotfixed script doesn't fail with "command not found".
-# These shims are no-ops or safe defaults and are only used when the real function
-# is absent; if the VHD already defines them, these are skipped.
+# ---- BEGIN BACKWARD-COMPAT SHIMS ----
+# When a hotfixed cse_main.sh (provision.sh) is delivered to a node running an
+# older VHD, functions added after the VHD was built will be missing from the
+# VHD's cse_helpers.sh. These minimal fallbacks prevent "command not found" errors.
+# Each shim is guarded by `command -v` so it's skipped when the real function exists.
+# Remove this block when the minimum supported VHD is >= v20260413.
 if ! command -v checkServiceHealth >/dev/null 2>&1; then
     checkServiceHealth() {
         local service=$1
@@ -61,6 +61,7 @@ if ! command -v waitForContainerdReady >/dev/null 2>&1; then
         retrycmd_if_failure 120 0.1 1 bash -c 'ctr version >/dev/null 2>&1'
     }
 fi
+# ---- END BACKWARD-COMPAT SHIMS ----
 
 # Setup logs for upload to host
 LOG_DIR=/var/log/azure/aks


### PR DESCRIPTION
## Summary

When the RP master deploys agentbakersvc v0.20260424.1 in scriptless hotfix mode, the hotfixed `provision.sh` (= `cse_main.sh`) is written to the node via cloud-init, but the node's VHD still has the old `cse_helpers.sh` baked in from build time. Functions added to helpers after the VHD was built (e.g., `checkServiceHealth` from PR #8105) are missing, causing:

```
provision.sh: line 400: checkServiceHealth: command not found
+ exit 4
```

This affects all VHDs older than v0.20260413.0 (Oct 2025 – March 2026 VHDs) when served by the hotfixed agentbakersvc.

## Root Cause

Forward-compatibility breakage: the hotfix overlay only replaces `provision.sh`, not `cse_helpers.sh`. Any function added to helpers after the VHD was built will be missing at runtime.

## Changes

Added backward-compatible shims in `cse_main.sh` immediately after sourcing helpers. Each shim uses `command -v` to check if the function exists — if it does (newer VHD), the shim is skipped; if missing (older VHD), a minimal fallback is defined:

| Function | Shim behavior |
|----------|--------------|
| `checkServiceHealth` | Checks systemd ActiveState, returns 1 on failed |
| `isACL` | Returns false (no ACL on older VHDs) |
| `isAmdAmaEnabledNode` | Returns false (safe default) |
| `should_enable_managed_gpu_experience` | Returns empty string |
| `fetch_and_cache_imds_instance_metadata` | No-op (older code doesn't use IMDS cache) |
| `waitForContainerdReady` | Retry loop with `ctr version` |

## Testing

- Verified that shims are only activated when the function is missing (`command -v` guard)
- Verified function diff between v0.20251029.0 and main to identify all missing functions
- Pre-existing shellcheck warnings in `make generate` are not from this change

## Related

- AB#37833513
- RP PR: https://dev.azure.com/msazure/CloudNativeCompute/_git/aks-rp/pullrequest/15593832
- Root cause commit: PR #8105 (added `checkServiceHealth` to `cse_helpers.sh`)