### PR TITLE
Revert "chore(deps): update dependency moby-containerd to v1.7.31-ubuntu20.04u1 (#8382)"

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1137,7 +1137,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=moby-containerd, repository=production, os=ubuntu, release=20.04",
-                "latestVersion": "1.7.31-ubuntu20.04u1"
+                "latestVersion": "1.7.30-ubuntu20.04u4"
               }
             ]
           }


### PR DESCRIPTION
## Summary
- Reverts #8382 / commit a9c4971edf761d541876c7efbe0590c96a56e5f7
- Restores Ubuntu 20.04 moby-containerd from 1.7.31-ubuntu20.04u1 back to 1.7.30-ubuntu20.04u4

## Validation
- make generate