### PR TITLE
fix: skip setup_golang.sh on hosts without apt-get

### DIFF
--- a/hack/setup_golang.sh
+++ b/hack/setup_golang.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -euxo pipefail
 
+# This script installs Microsoft's Go distribution via apt-get on Ubuntu hosts.
+# On hosts without apt-get (e.g. Azure Linux build agents), assume Go is already
+# provided by the build environment and skip the Ubuntu-specific setup.
+if ! command -v apt-get >/dev/null 2>&1; then
+    echo "apt-get not found; skipping Ubuntu-specific Go setup."
+    echo "Assuming Go is provided by the build environment:"
+    go version
+    exit 0
+fi
+
 purge_go() {
     sudo apt-get purge golang*
     sudo apt-get update


### PR DESCRIPTION
## What

Make `hack/setup_golang.sh` a no-op when `apt-get` is unavailable, instead of failing with `apt-get: command not found`.

## Why

[#8324](https://github.com/Azure/AgentBaker/pull/8324) added a `setup-golang` make target that unconditionally calls this script. This does not work when running AgentBaker on non-Ubuntu hosts.