### PR TITLE
fix: skip setup_golang.sh on hosts without apt-get

### DIFF
--- a/hack/setup_golang.sh
+++ b/hack/setup_golang.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -euxo pipefail
 
+# This script installs Microsoft's Go distribution via apt-get (Ubuntu).
+# On hosts without apt-get (e.g. Azure Linux build agents), the build environment
+# is expected to provide Go through its own package manager, so just verify that
+# `go` is on PATH and exit.
+if ! command -v apt-get >/dev/null 2>&1; then
+    echo "apt-get not found; skipping Ubuntu-specific Go setup."
+    if ! command -v go >/dev/null 2>&1; then
+        echo "ERROR: 'go' is not on PATH; the build environment must install Go before invoking setup_golang.sh." >&2
+        exit 1
+    fi
+    echo "Using Go provided by the build environment:"
+    go version
+    exit 0
+fi
+
 purge_go() {
     sudo apt-get purge golang*
     sudo apt-get update


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:


### What

Make `hack/setup_golang.sh` a no-op when `apt-get` is unavailable, instead of failing with `apt-get: command not found`. If Go is missing on PATH, fail with a clear error message.

### Why

The `setup-golang` make target unconditionally calls this script. This causes an issue if running AgentBaker on non-Ubuntu hosts (e.g. the AKS image-build pipeline's Azure Linux 1ES pool, where Go is provided via `tdnf`).

## Behavior

| Host | Before | After |
|---|---|---|
| Ubuntu (apt-get) | Installs/updates `msft-golang` | Unchanged |
| Non-Ubuntu (no apt-get) | Fails: `apt-get: command not found` | Logs notice + `go version`, exits 0 |
| Non-Ubuntu, Go missing | Fails: `apt-get: command not found` | Fails with explicit error: `'go' is not on PATH` |

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
