### PR TITLE
fix: use oras from AZL3 MCR image instead of imagecustomizer

### DIFF
--- a/vhdbuilder/packer/imagecustomizer/scripts/build-imagecustomizer-image.sh
+++ b/vhdbuilder/packer/imagecustomizer/scripts/build-imagecustomizer-image.sh
@@ -51,8 +51,8 @@ if [ ! -f "$BUILD_DIR/$CONFIG/image.vhdx" ]; then
         --interactive \
         --privileged=true \
         -v "$BUILD_DIR:/container/build" \
-        $IMG_CUSTOMIZER_CONTAINER:$IMG_CUSTOMIZER_VERSION \
-        oras pull $BASE_IMAGE_ORAS -o /container/build/$CONFIG
+        mcr.microsoft.com/azurelinux/base/core:3.0 \
+        sh -c "tdnf install -y oras && oras pull $BASE_IMAGE_ORAS -o /container/build/$CONFIG"
 else
     echo "Base image already exists, skipping pull."
 fi


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
Oras within the imagecustomizer container is no longer able to pull from MCR, blocking base image fetching for OS Guard builds. This PR switches to the latest AZL 3.0 container and explicitly installs oras there to do the base image fetch. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
