### PR TITLE
chore(vhdbuilder): build ACL VHDs using marketplace images

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -862,6 +862,10 @@ stages:
           - bash: |
               echo '##vso[task.setvariable variable=OS_SKU]AzureContainerLinux'
               echo '##vso[task.setvariable variable=OS_VERSION]acl'
+              echo '##vso[task.setvariable variable=IMG_PUBLISHER]MicrosoftCBLMariner'
+              echo '##vso[task.setvariable variable=IMG_OFFER]azure-linux-3'
+              echo '##vso[task.setvariable variable=IMG_SKU]azure-linux-3-acl'
+              echo '##vso[task.setvariable variable=IMG_VERSION]3.20260506.01'
               echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
               echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ds_v5'
               echo '##vso[task.setvariable variable=FEATURE_FLAGS]None'
@@ -869,9 +873,6 @@ stages:
               echo '##vso[task.setvariable variable=ENABLE_FIPS]false'
               echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]True'
               echo '##vso[task.setvariable variable=ENABLE_CGROUPV2]True'
-              echo '##vso[task.setvariable variable=SIG_SOURCE_GALLERY_UNIQUE_NAME]b3e01d89-bd55-414f-bbb4-cdfeb2628caa-ACL'
-              echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_NAME]acl'
-              echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_VERSION]3.0.20260401'
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
@@ -886,6 +887,10 @@ stages:
           - bash: |
               echo '##vso[task.setvariable variable=OS_SKU]AzureContainerLinux'
               echo '##vso[task.setvariable variable=OS_VERSION]acl'
+              echo '##vso[task.setvariable variable=IMG_PUBLISHER]MicrosoftCBLMariner'
+              echo '##vso[task.setvariable variable=IMG_OFFER]azure-linux-3'
+              echo '##vso[task.setvariable variable=IMG_SKU]azure-linux-3-arm64-gen2-acl'
+              echo '##vso[task.setvariable variable=IMG_VERSION]3.20260506.01'
               echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
               echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16pds_v6'
               echo '##vso[task.setvariable variable=FEATURE_FLAGS]None'
@@ -893,9 +898,6 @@ stages:
               echo '##vso[task.setvariable variable=ENABLE_FIPS]false'
               echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]True'
               echo '##vso[task.setvariable variable=ENABLE_CGROUPV2]True'
-              echo '##vso[task.setvariable variable=SIG_SOURCE_GALLERY_UNIQUE_NAME]b3e01d89-bd55-414f-bbb4-cdfeb2628caa-ACL'
-              echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_NAME]acl-arm64'
-              echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_VERSION]3.0.20260401'
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -209,6 +209,10 @@ stages:
         - bash: |
             echo '##vso[task.setvariable variable=OS_SKU]AzureContainerLinux'
             echo '##vso[task.setvariable variable=OS_VERSION]acl'
+            echo '##vso[task.setvariable variable=IMG_PUBLISHER]MicrosoftCBLMariner'
+            echo '##vso[task.setvariable variable=IMG_OFFER]azure-linux-3'
+            echo '##vso[task.setvariable variable=IMG_SKU]azure-linux-3-acl'
+            echo '##vso[task.setvariable variable=IMG_VERSION]3.20260506.01'
             echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
             echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ds_v5'
             echo '##vso[task.setvariable variable=FEATURE_FLAGS]None'
@@ -216,9 +220,6 @@ stages:
             echo '##vso[task.setvariable variable=ENABLE_FIPS]false'
             echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]True'
             echo '##vso[task.setvariable variable=ENABLE_CGROUPV2]True'
-            echo '##vso[task.setvariable variable=SIG_SOURCE_GALLERY_UNIQUE_NAME]b3e01d89-bd55-414f-bbb4-cdfeb2628caa-ACL'
-            echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_NAME]acl'
-            echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_VERSION]3.0.20260401'
           displayName: Setup Build Variables
         - template: ./templates/.builder-release-template.yaml
           parameters:
@@ -230,6 +231,10 @@ stages:
         - bash: |
             echo '##vso[task.setvariable variable=OS_SKU]AzureContainerLinux'
             echo '##vso[task.setvariable variable=OS_VERSION]acl'
+            echo '##vso[task.setvariable variable=IMG_PUBLISHER]MicrosoftCBLMariner'
+            echo '##vso[task.setvariable variable=IMG_OFFER]azure-linux-3'
+            echo '##vso[task.setvariable variable=IMG_SKU]azure-linux-3-arm64-gen2-acl'
+            echo '##vso[task.setvariable variable=IMG_VERSION]3.20260506.01'
             echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
             echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16pds_v6'
             echo '##vso[task.setvariable variable=FEATURE_FLAGS]None'
@@ -237,9 +242,6 @@ stages:
             echo '##vso[task.setvariable variable=ENABLE_FIPS]false'
             echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]True'
             echo '##vso[task.setvariable variable=ENABLE_CGROUPV2]True'
-            echo '##vso[task.setvariable variable=SIG_SOURCE_GALLERY_UNIQUE_NAME]b3e01d89-bd55-414f-bbb4-cdfeb2628caa-ACL'
-            echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_NAME]acl-arm64'
-            echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_VERSION]3.0.20260401'
           displayName: Setup Build Variables
         - template: ./templates/.builder-release-template.yaml
           parameters:

--- a/spec/vhdbuilder/packer/ensure_sig_image_name_linux_spec.sh
+++ b/spec/vhdbuilder/packer/ensure_sig_image_name_linux_spec.sh
@@ -212,6 +212,65 @@ Describe 'ensure_sig_image_name_linux function'
     End
   End
 
+  Describe 'IMG_OFFER azure-linux-3 with OS_SKU AzureContainerLinux (ACL) scenarios'
+    # ACL shares the azure-linux-3 marketplace offer but its destination SIG image
+    # definitions (aclgen2TL, aclgen2arm64TL) intentionally have no AzureLinux prefix.
+    It 'should NOT add AzureLinux prefix when OS_SKU is AzureContainerLinux (gen2 TL)'
+      SIG_IMAGE_NAME=""
+      SKU_NAME="aclgen2TL"
+      IMG_OFFER="azure-linux-3"
+      OS_SKU="AzureContainerLinux"
+      When call ensure_sig_image_name_linux
+      The status should be success
+      The variable SIG_IMAGE_NAME should eq "aclgen2TL"
+	  The output should be present
+    End
+
+    It 'should NOT add AzureLinux prefix when OS_SKU is AzureContainerLinux (arm64 gen2 TL)'
+      SIG_IMAGE_NAME=""
+      SKU_NAME="aclgen2arm64TL"
+      IMG_OFFER="azure-linux-3"
+      OS_SKU="AzureContainerLinux"
+      When call ensure_sig_image_name_linux
+      The status should be success
+      The variable SIG_IMAGE_NAME should eq "aclgen2arm64TL"
+	  The output should be present
+    End
+
+    It 'should handle case-insensitive OS_SKU azurecontainerlinux (lowercase)'
+      SIG_IMAGE_NAME=""
+      SKU_NAME="aclgen2TL"
+      IMG_OFFER="azure-linux-3"
+      OS_SKU="azurecontainerlinux"
+      When call ensure_sig_image_name_linux
+      The status should be success
+      The variable SIG_IMAGE_NAME should eq "aclgen2TL"
+	  The output should be present
+    End
+
+    It 'should handle case-insensitive OS_SKU AzureContainerLinux (uppercase)'
+      SIG_IMAGE_NAME=""
+      SKU_NAME="aclgen2TL"
+      IMG_OFFER="azure-linux-3"
+      OS_SKU="AZURECONTAINERLINUX"
+      When call ensure_sig_image_name_linux
+      The status should be success
+      The variable SIG_IMAGE_NAME should eq "aclgen2TL"
+	  The output should be present
+    End
+
+    It 'should still add AzureLinux prefix when OS_SKU is AzureLinux (regression guard)'
+      SIG_IMAGE_NAME=""
+      SKU_NAME="test-sku"
+      IMG_OFFER="azure-linux-3"
+      OS_SKU="AzureLinux"
+      When call ensure_sig_image_name_linux
+      The status should be success
+      The variable SIG_IMAGE_NAME should eq "AzureLinuxtest-sku"
+	  The output should be present
+    End
+  End
+
   Describe 'OS_SKU azurelinuxosguard scenarios'
     It 'should add AzureLinuxOSGuard prefix when OS_SKU is azurelinuxosguard'
       SIG_IMAGE_NAME=""

--- a/vhdbuilder/packer/produce-packer-settings-functions.sh
+++ b/vhdbuilder/packer/produce-packer-settings-functions.sh
@@ -57,8 +57,11 @@ function ensure_sig_image_name_linux() {
 			else
 				SIG_IMAGE_NAME="CBLMariner${SIG_IMAGE_NAME}"
 			fi
-		elif [ "${IMG_OFFER,,}" = "azure-linux-3" ]; then
-			# for Azure Linux 3.0, only use AzureLinux prefix
+		elif [ "${IMG_OFFER,,}" = "azure-linux-3" ] && [ "${OS_SKU,,}" != "azurecontainerlinux" ]; then
+			# for Azure Linux 3.0, only use AzureLinux prefix.
+			# AzureContainerLinux (ACL) shares the azure-linux-3 marketplace offer but its destination
+			# SIG image definitions (e.g. aclgen2TL, aclgen2arm64TL) intentionally have no AzureLinux prefix,
+			# so it falls through to the no-prefix branch below.
 			SIG_IMAGE_NAME="AzureLinux${SIG_IMAGE_NAME}"
 		elif [ "${OS_SKU,,}" = "azurelinuxosguard" ]; then
 			SIG_IMAGE_NAME="AzureLinuxOSGuard${SIG_IMAGE_NAME}"

--- a/vhdbuilder/packer/vhd-image-builder-acl-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-acl-arm64.json
@@ -19,10 +19,10 @@
     "container_runtime": "{{env `CONTAINER_RUNTIME`}}",
     "captured_sig_version": "{{env `CAPTURED_SIG_VERSION`}}",
     "enable_fips": "{{env `ENABLE_FIPS`}}",
-    "img_sku": "",
-    "sig_source_gallery_unique_name": "{{env `SIG_SOURCE_GALLERY_UNIQUE_NAME`}}",
-    "sig_source_image_name": "{{env `SIG_SOURCE_IMAGE_NAME`}}",
-    "sig_source_image_version": "{{env `SIG_SOURCE_IMAGE_VERSION`}}",
+    "img_publisher": "{{env `IMG_PUBLISHER`}}",
+    "img_offer": "{{env `IMG_OFFER`}}",
+    "img_sku": "{{env `IMG_SKU`}}",
+    "img_version": "{{env `IMG_VERSION`}}",
     "vnet_resource_group_name": "{{env `VNET_RESOURCE_GROUP_NAME`}}",
     "vnet_name": "{{env `VNET_NAME`}}",
     "subnet_name": "{{env `SUBNET_NAME`}}",
@@ -41,9 +41,10 @@
       "ssh_read_write_timeout": "5m",
       "os_type": "Linux",
       "os_disk_size_gb": 60,
-      "shared_image_gallery": {
-        "direct_shared_gallery_image_id": "/SharedGalleries/{{user `sig_source_gallery_unique_name`}}/Images/{{user `sig_source_image_name`}}/Versions/{{user `sig_source_image_version`}}"
-      },
+      "image_publisher": "{{user `img_publisher`}}",
+      "image_offer": "{{user `img_offer`}}",
+      "image_sku": "{{user `img_sku`}}",
+      "image_version": "{{user `img_version`}}",
       "azure_tags": {
         "buildDefinitionName": "{{user `build_definition_name`}}",
         "buildNumber": "{{user `build_number`}}",

--- a/vhdbuilder/packer/vhd-image-builder-acl.json
+++ b/vhdbuilder/packer/vhd-image-builder-acl.json
@@ -19,10 +19,10 @@
     "container_runtime": "{{env `CONTAINER_RUNTIME`}}",
     "captured_sig_version": "{{env `CAPTURED_SIG_VERSION`}}",
     "enable_fips": "{{env `ENABLE_FIPS`}}",
-    "img_sku": "",
-    "sig_source_gallery_unique_name": "{{env `SIG_SOURCE_GALLERY_UNIQUE_NAME`}}",
-    "sig_source_image_name": "{{env `SIG_SOURCE_IMAGE_NAME`}}",
-    "sig_source_image_version": "{{env `SIG_SOURCE_IMAGE_VERSION`}}",
+    "img_publisher": "{{env `IMG_PUBLISHER`}}",
+    "img_offer": "{{env `IMG_OFFER`}}",
+    "img_sku": "{{env `IMG_SKU`}}",
+    "img_version": "{{env `IMG_VERSION`}}",
     "vnet_resource_group_name": "{{env `VNET_RESOURCE_GROUP_NAME`}}",
     "vnet_name": "{{env `VNET_NAME`}}",
     "subnet_name": "{{env `SUBNET_NAME`}}",
@@ -41,9 +41,10 @@
       "ssh_read_write_timeout": "5m",
       "os_type": "Linux",
       "os_disk_size_gb": 60,
-      "shared_image_gallery": {
-        "direct_shared_gallery_image_id": "/SharedGalleries/{{user `sig_source_gallery_unique_name`}}/Images/{{user `sig_source_image_name`}}/Versions/{{user `sig_source_image_version`}}"
-      },
+      "image_publisher": "{{user `img_publisher`}}",
+      "image_offer": "{{user `img_offer`}}",
+      "image_sku": "{{user `img_sku`}}",
+      "image_version": "{{user `img_version`}}",
       "azure_tags": {
         "buildDefinitionName": "{{user `build_definition_name`}}",
         "buildNumber": "{{user `build_number`}}",


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:

Switch ACL VHD builds from a direct-shared SIG source to the public Azure Linux 3 marketplace images:
- x64: `MicrosoftCBLMariner/azure-linux-3/azure-linux-3-acl`
- arm64: `MicrosoftCBLMariner/azure-linux-3/azure-linux-3-arm64-gen2-acl`

- Pipelines: replace `SIG_SOURCE_*` vars with `IMG_PUBLISHER/OFFER/SKU/VERSION` in release and PR builders.
- Packer: `vhd-image-builder-acl{,-arm64}.json` use `image_publisher/offer/sku/version` instead of `shared_image_gallery.direct_shared_gallery_image_id`.
- `ensure_sig_image_name_linux`: skip the `AzureLinux` prefix when `OS_SKU=AzureContainerLinux` (ACL shares the `azure-linux-3` offer but its destination SIG defs `aclgen2TL`/`aclgen2arm64TL` are unprefixed). Adds ShellSpec coverage + regression guard.


[[TEST All VHDs] AKS Linux VHD Build - Msft Tenant](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=163649984&view=results) - succeeded

[E2Ev2 AKS RP Customized Image Validation](https://dev.azure.com/msazure/CloudNativeCompute/_build/results?buildId=163662604&view=results) - succeeded

**Which issue(s) this PR fixes**:

Fixes #
