### PR TITLE
feat(e2e): add HTTPS_PROXY + private DNS test scenario

### DIFF
--- a/e2e/aks_model.go
+++ b/e2e/aks_model.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/Azure/agentbaker/e2e/config"
 	"github.com/Azure/agentbaker/e2e/toolkit"
@@ -19,6 +20,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // getLatestGAKubernetesVersion returns the highest GA Kubernetes version for the given location.
@@ -890,6 +892,11 @@ func createPrivateZone(ctx context.Context, nodeResourceGroup, privateZoneName s
 		nil,
 	)
 	if err != nil {
+		// 409 means another operation is in progress — wait and re-fetch
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode == 409 {
+			return waitForPrivateZone(ctx, nodeResourceGroup, privateZoneName)
+		}
 		return nil, fmt.Errorf("failed to create private dns zone in BeginCreateOrUpdate: %w", err)
 	}
 	resp, err := poller.PollUntilDone(ctx, nil)
@@ -899,6 +906,23 @@ func createPrivateZone(ctx context.Context, nodeResourceGroup, privateZoneName s
 
 	toolkit.Logf(ctx, "Private DNS Zone created or updated with ID: %s", *resp.ID)
 	return &resp.PrivateZone, nil
+}
+
+func waitForPrivateZone(ctx context.Context, nodeResourceGroup, privateZoneName string) (*armprivatedns.PrivateZone, error) {
+	defer toolkit.LogStepCtxf(ctx, "waiting for private DNS zone %s (409 conflict)", privateZoneName)()
+	var zone *armprivatedns.PrivateZone
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		resp, err := config.Azure.PrivateZonesClient.Get(ctx, nodeResourceGroup, privateZoneName, nil)
+		if err != nil {
+			return false, nil
+		}
+		zone = &resp.PrivateZone
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("waiting for private dns zone %q: %w", privateZoneName, err)
+	}
+	return zone, nil
 }
 
 func createPrivateDNSLink(ctx context.Context, vnet VNet, nodeResourceGroup, privateZoneName string) error {
@@ -938,6 +962,15 @@ func createPrivateDNSLink(ctx context.Context, vnet VNet, nodeResourceGroup, pri
 		nil,
 	)
 	if err != nil {
+		// 409 means another operation is in progress — link is being created by another run
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode == 409 {
+			toolkit.Logf(ctx, "Virtual network link creation conflict (409), waiting for completion")
+			return wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+				_, err := config.Azure.VirutalNetworkLinksClient.Get(ctx, nodeResourceGroup, privateZoneName, networkLinkName, nil)
+				return err == nil, nil
+			})
+		}
 		return fmt.Errorf("failed to create virtual network link in BeginCreateOrUpdate: %w", err)
 	}
 	resp, err := poller.PollUntilDone(ctx, nil)

--- a/e2e/aks_model.go
+++ b/e2e/aks_model.go
@@ -914,7 +914,11 @@ func waitForPrivateZone(ctx context.Context, nodeResourceGroup, privateZoneName 
 	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		resp, err := config.Azure.PrivateZonesClient.Get(ctx, nodeResourceGroup, privateZoneName, nil)
 		if err != nil {
-			return false, nil
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && respErr.StatusCode == 404 {
+				return false, nil // zone doesn't exist yet
+			}
+			return false, err
 		}
 		zone = &resp.PrivateZone
 		return true, nil
@@ -968,7 +972,14 @@ func createPrivateDNSLink(ctx context.Context, vnet VNet, nodeResourceGroup, pri
 			toolkit.Logf(ctx, "Virtual network link creation conflict (409), waiting for completion")
 			return wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 				_, err := config.Azure.VirutalNetworkLinksClient.Get(ctx, nodeResourceGroup, privateZoneName, networkLinkName, nil)
-				return err == nil, nil
+				if err != nil {
+					var respErr *azcore.ResponseError
+					if errors.As(err, &respErr) && respErr.StatusCode == 404 {
+						return false, nil // link doesn't exist yet
+					}
+					return false, err
+				}
+				return true, nil
 			})
 		}
 		return fmt.Errorf("failed to create virtual network link in BeginCreateOrUpdate: %w", err)

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/netip"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +44,7 @@ type Cluster struct {
 	SubnetID        string
 	ClusterParams   *ClusterParams
 	Bastion         *Bastion
+	ProxyURL        string
 }
 
 // Returns true if the cluster is configured with Azure CNI
@@ -107,7 +110,21 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 	needACR := isNetworkIsolated || attachPrivateAcr
 	acrNonAnon := dag.Run2(g, kube, identity, addACR(cluster, needACR, true))
 	acrAnon := dag.Run2(g, kube, identity, addACR(cluster, needACR, false))
-	dag.Run1(g, kube, ensureDebugDaemonsets(cluster, isNetworkIsolated), append([]dag.Dep{acrNonAnon, acrAnon}, networkDeps...)...)
+	debugDeps := append([]dag.Dep{acrNonAnon, acrAnon}, networkDeps...)
+	proxyURL := dag.Go1(g, kube, func(ctx context.Context, k *Kubeclient) (string, error) {
+		if err := k.EnsureDebugDaemonsets(ctx, isNetworkIsolated, config.GetPrivateACRName(true, *cluster.Location)); err != nil {
+			return "", err
+		}
+		if isNetworkIsolated {
+			return "", nil
+		}
+		return k.GetProxyURL(ctx)
+	}, debugDeps...)
+	if !isNetworkIsolated {
+		dag.Run(g, func(ctx context.Context) error {
+			return setupPrivateDNSForAPIServer(ctx, cluster)
+		})
+	}
 	extract := dag.Go1(g, kube, extractClusterParams(cluster))
 
 	if err := g.Wait(); err != nil {
@@ -120,6 +137,7 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 		SubnetID:        subnet.MustGet(),
 		ClusterParams:   extract.MustGet(),
 		Bastion:         bastion.MustGet(),
+		ProxyURL:        proxyURL.MustGet(),
 	}, nil
 }
 
@@ -129,12 +147,6 @@ func addACR(cluster *armcontainerservice.ManagedCluster, needACR, isNonAnonymous
 			return nil
 		}
 		return addPrivateAzureContainerRegistry(ctx, cluster, k, id, isNonAnonymousPull)
-	}
-}
-
-func ensureDebugDaemonsets(cluster *armcontainerservice.ManagedCluster, isNetworkIsolated bool) func(context.Context, *Kubeclient) error {
-	return func(ctx context.Context, k *Kubeclient) error {
-		return k.EnsureDebugDaemonsets(ctx, isNetworkIsolated, config.GetPrivateACRName(true, *cluster.Location))
 	}
 }
 
@@ -405,25 +417,35 @@ func createNewAKSClusterWithRetry(ctx context.Context, cluster *armcontainerserv
 			return createdCluster, nil
 		}
 
-		// Check if the error is a 409 Conflict
-		var respErr *azcore.ResponseError
-		if errors.As(err, &respErr) && respErr.StatusCode == 409 {
+		if isRetryableClusterError(err) {
 			lastErr = err
-			toolkit.Logf(ctx, "Attempt %d failed with 409 Conflict: %v. Retrying in %v...", attempt+1, err, retryInterval)
+			toolkit.Logf(ctx, "Attempt %d failed with retryable error: %v. Retrying in %v...", attempt+1, err, retryInterval)
 
 			select {
 			case <-time.After(retryInterval):
-				// Continue to next iteration
 			case <-ctx.Done():
 				return nil, fmt.Errorf("context canceled while retrying cluster creation: %w", ctx.Err())
 			}
 		} else {
-			// If it's not a 409 error, return immediately
 			return nil, fmt.Errorf("failed to create cluster: %w", err)
 		}
 	}
 
-	return nil, fmt.Errorf("failed to create cluster after %d attempts due to persistent 409 Conflict: %w", maxRetries, lastErr)
+	return nil, fmt.Errorf("failed to create cluster after %d attempts: %w", maxRetries, lastErr)
+}
+
+// isRetryableClusterError returns true for transient cluster creation errors
+// that can be resolved by retrying, such as 409 Conflict (concurrent operations)
+// and NotFound during managed identity reconciliation (stale references after cluster deletion).
+func isRetryableClusterError(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	if respErr.StatusCode == 409 {
+		return true
+	}
+	return respErr.ErrorCode == "NotFound" && strings.Contains(err.Error(), "Reconcile managed identity credential failed")
 }
 
 func ensureMaintenanceConfiguration(ctx context.Context, cluster *armcontainerservice.ManagedCluster) error {
@@ -804,4 +826,71 @@ func ensureResourceGroup(ctx context.Context, location string) (armresources.Res
 		return armresources.ResourceGroup{}, fmt.Errorf("creating or updating RG %q: %w", resourceGroupName, err)
 	}
 	return rg.ResourceGroup, nil
+}
+
+// setupPrivateDNSForAPIServer creates a private DNS zone for the API server FQDN
+// linked to the cluster VNet with an A record pointing to the current public IP.
+// Simulates a customer environment with minimal private DNS entries.
+func setupPrivateDNSForAPIServer(ctx context.Context, cluster *armcontainerservice.ManagedCluster) error {
+	defer toolkit.LogStepCtx(ctx, "setting up private DNS for API server")()
+
+	fqdn := *cluster.Properties.Fqdn
+	nodeRG := *cluster.Properties.NodeResourceGroup
+
+	ips, err := net.LookupHost(fqdn)
+	if err != nil {
+		return fmt.Errorf("resolving API server FQDN %q: %w", fqdn, err)
+	}
+
+	var aRecords []*armprivatedns.ARecord
+	for _, ip := range ips {
+		if parsed := net.ParseIP(ip); parsed != nil && parsed.To4() != nil {
+			aRecords = append(aRecords, &armprivatedns.ARecord{IPv4Address: to.Ptr(ip)})
+		}
+	}
+	if len(aRecords) == 0 {
+		return fmt.Errorf("no IPv4 addresses for %q", fqdn)
+	}
+
+	zoneName := fqdn
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		_, err := createPrivateZone(ctx, nodeRG, zoneName)
+		if err != nil {
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && respErr.StatusCode == 409 {
+				return false, nil // concurrent operation, retry
+			}
+			return false, err
+		}
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("creating private zone %q: %w", zoneName, err)
+	}
+
+	vnet, err := getClusterVNet(ctx, nodeRG)
+	if err != nil {
+		return fmt.Errorf("getting cluster VNet: %w", err)
+	}
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		err := createPrivateDNSLink(ctx, vnet, nodeRG, zoneName)
+		if err != nil {
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && respErr.StatusCode == 409 {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("linking private zone to VNet: %w", err)
+	}
+
+	_, err = config.Azure.RecordSetClient.CreateOrUpdate(ctx, nodeRG, zoneName, armprivatedns.RecordTypeA, "@",
+		armprivatedns.RecordSet{Properties: &armprivatedns.RecordSetProperties{TTL: to.Ptr[int64](300), ARecords: aRecords}}, nil)
+	if err != nil {
+		return fmt.Errorf("creating A record in zone %q: %w", zoneName, err)
+	}
+
+	toolkit.Logf(ctx, "private DNS zone %q → %v", zoneName, ips)
+	return nil
 }

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -852,45 +852,25 @@ func setupPrivateDNSForAPIServer(ctx context.Context, cluster *armcontainerservi
 		return fmt.Errorf("no IPv4 addresses for %q", fqdn)
 	}
 
-	zoneName := fqdn
-	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		_, err := createPrivateZone(ctx, nodeRG, zoneName)
-		if err != nil {
-			var respErr *azcore.ResponseError
-			if errors.As(err, &respErr) && respErr.StatusCode == 409 {
-				return false, nil // concurrent operation, retry
-			}
-			return false, err
-		}
-		return true, nil
-	}); err != nil {
-		return fmt.Errorf("creating private zone %q: %w", zoneName, err)
+	// createPrivateZone and createPrivateDNSLink handle 409 conflicts internally
+	if _, err := createPrivateZone(ctx, nodeRG, fqdn); err != nil {
+		return fmt.Errorf("creating private zone %q: %w", fqdn, err)
 	}
 
 	vnet, err := getClusterVNet(ctx, nodeRG)
 	if err != nil {
 		return fmt.Errorf("getting cluster VNet: %w", err)
 	}
-	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		err := createPrivateDNSLink(ctx, vnet, nodeRG, zoneName)
-		if err != nil {
-			var respErr *azcore.ResponseError
-			if errors.As(err, &respErr) && respErr.StatusCode == 409 {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, nil
-	}); err != nil {
+	if err := createPrivateDNSLink(ctx, vnet, nodeRG, fqdn); err != nil {
 		return fmt.Errorf("linking private zone to VNet: %w", err)
 	}
 
-	_, err = config.Azure.RecordSetClient.CreateOrUpdate(ctx, nodeRG, zoneName, armprivatedns.RecordTypeA, "@",
+	_, err = config.Azure.RecordSetClient.CreateOrUpdate(ctx, nodeRG, fqdn, armprivatedns.RecordTypeA, "@",
 		armprivatedns.RecordSet{Properties: &armprivatedns.RecordSetProperties{TTL: to.Ptr[int64](300), ARecords: aRecords}}, nil)
 	if err != nil {
-		return fmt.Errorf("creating A record in zone %q: %w", zoneName, err)
+		return fmt.Errorf("creating A record in zone %q: %w", fqdn, err)
 	}
 
-	toolkit.Logf(ctx, "private DNS zone %q → %v", zoneName, ips)
+	toolkit.Logf(ctx, "private DNS zone %q → %v", fqdn, ips)
 	return nil
 }

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -37,6 +37,8 @@ type Kubeclient struct {
 const (
 	hostNetworkDebugAppLabel = "debug-mariner-tolerated"
 	podNetworkDebugAppLabel  = "debugnonhost-mariner-tolerated"
+	proxyAppLabel            = "e2e-proxy"
+	proxyPort                = 8888
 )
 
 func getClusterKubeClient(ctx context.Context, cluster *armcontainerservice.ManagedCluster) (*Kubeclient, error) {
@@ -303,13 +305,25 @@ func (k *Kubeclient) EnsureDebugDaemonsets(ctx context.Context, isNetworkIsolate
 		return err
 	}
 
+	// proxy is not available on network-isolated clusters
+	if !isNetworkIsolated {
+		if err := k.ensureProxyConfigMap(ctx); err != nil {
+			return err
+		}
+		proxyDS := daemonsetProxy(ctx)
+		if err := k.CreateDaemonset(ctx, proxyDS); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
 func (k *Kubeclient) CreateDaemonset(ctx context.Context, ds *appsv1.DaemonSet) error {
 	desired := ds.DeepCopy()
 	_, err := controllerutil.CreateOrUpdate(ctx, k.Dynamic, ds, func() error {
-		ds = desired
+		ds.Spec = desired.Spec
+		ds.Labels = desired.Labels
 		return nil
 	})
 	if err != nil {
@@ -443,6 +457,181 @@ func daemonsetDebug(ctx context.Context, deploymentName, targetNodeLabel, privat
 			},
 		},
 	}
+}
+
+func (k *Kubeclient) ensureProxyConfigMap(ctx context.Context) error {
+	// Minimal HTTP forward proxy in Python. Handles both:
+	// - CONNECT tunneling for HTTPS (curl uses this when HTTPS_PROXY is set)
+	// - Plain HTTP forwarding (curl uses this when http_proxy is set)
+	proxyScript := `import socket,threading,select,sys,re
+
+def relay(client, remote):
+    sockets = [client, remote]
+    try:
+        while True:
+            readable, _, errored = select.select(sockets, [], sockets, 60)
+            if errored or not readable:
+                break
+            for s in readable:
+                data = s.recv(65536)
+                if not data:
+                    return
+                (remote if s is client else client).sendall(data)
+    finally:
+        remote.close()
+
+def handle_connect(client, host, port):
+    try:
+        remote = socket.create_connection((host, int(port)), timeout=30)
+    except Exception as e:
+        client.sendall(f"HTTP/1.1 502 Bad Gateway\r\n\r\n{e}".encode())
+        return
+    client.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+    relay(client, remote)
+
+def handle_http(client, data, host, port):
+    try:
+        remote = socket.create_connection((host, int(port)), timeout=30)
+    except Exception as e:
+        client.sendall(f"HTTP/1.1 502 Bad Gateway\r\n\r\n{e}".encode())
+        return
+    # rewrite absolute URL to relative for the origin server
+    lines = data.split(b"\r\n")
+    parts = lines[0].split(b" ", 2)
+    if len(parts) == 3:
+        url = parts[1].decode()
+        m = re.match(r"https?://[^/]+(/.*)$", url)
+        if m:
+            parts[1] = m.group(1).encode()
+            lines[0] = b" ".join(parts)
+            data = b"\r\n".join(lines)
+    remote.sendall(data)
+    relay(client, remote)
+
+def handle(client):
+    try:
+        data = client.recv(65536)
+        if not data:
+            return
+        line = data.split(b"\r\n")[0]
+        parts = line.split(b" ", 2)
+        if len(parts) < 2:
+            return
+        method, target = parts[0], parts[1]
+        if method == b"CONNECT":
+            hp = target.decode().split(":")
+            handle_connect(client, hp[0], hp[1] if len(hp) > 1 else "443")
+        else:
+            # plain HTTP proxy: target is absolute URL like http://host:port/path
+            url = target.decode()
+            m = re.match(r"https?://([^/:]+)(?::(\d+))?", url)
+            if m:
+                handle_http(client, data, m.group(1), m.group(2) or "80")
+            else:
+                client.sendall(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+    finally:
+        client.close()
+
+srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+srv.bind(("0.0.0.0", ` + fmt.Sprintf("%d", proxyPort) + `))
+srv.listen(128)
+sys.stdout.write("proxy listening on port ` + fmt.Sprintf("%d", proxyPort) + `\n")
+sys.stdout.flush()
+while True:
+    c, _ = srv.accept()
+    threading.Thread(target=handle, args=(c,), daemon=True).start()
+`
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-proxy-config", Namespace: "default"},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, k.Dynamic, cm, func() error {
+		cm.Data = map[string]string{"proxy.py": proxyScript}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("ensuring proxy configmap: %w", err)
+	}
+	return nil
+}
+
+func daemonsetProxy(ctx context.Context) *appsv1.DaemonSet {
+	image := "mcr.microsoft.com/cbl-mariner/base/python:3"
+	toolkit.Logf(ctx, "Creating proxy daemonset %s with image %s", proxyAppLabel, image)
+
+	return &appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{Kind: "DaemonSet", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      proxyAppLabel,
+			Namespace: "default",
+			Labels:    map[string]string{"app": proxyAppLabel},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": proxyAppLabel},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": proxyAppLabel}},
+				Spec: corev1.PodSpec{
+					HostNetwork: true,
+					NodeSelector: map[string]string{
+						"kubernetes.azure.com/agentpool": "nodepool1",
+					},
+					Tolerations: []corev1.Toleration{
+						{Operator: corev1.TolerationOpExists},
+					},
+					Containers: []corev1.Container{{
+						Name:    "proxy",
+						Image:   image,
+						Command: []string{"python3", "/opt/proxy/proxy.py"},
+						Ports:   []corev1.ContainerPort{{ContainerPort: int32(proxyPort), HostPort: int32(proxyPort)}},
+						VolumeMounts: []corev1.VolumeMount{
+							{Name: "proxy-script", MountPath: "/opt/proxy", ReadOnly: true},
+						},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "proxy-script",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "e2e-proxy-config"},
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+// GetProxyURL returns the proxy URL after verifying the proxy pod is ready
+// on at least one system pool node.
+func (k *Kubeclient) GetProxyURL(ctx context.Context) (string, error) {
+	var proxyURL string
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		pods, err := k.Typed.CoreV1().Pods("default").List(ctx, metav1.ListOptions{
+			LabelSelector: "app=" + proxyAppLabel,
+		})
+		if err != nil {
+			return false, fmt.Errorf("listing proxy pods: %w", err)
+		}
+		if len(pods.Items) == 0 {
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			for _, c := range pod.Status.Conditions {
+				if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue && pod.Status.HostIP != "" {
+					proxyURL = fmt.Sprintf("http://%s:%d", pod.Status.HostIP, proxyPort)
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("waiting for proxy pod to be ready: %w", err)
+	}
+	return proxyURL, nil
 }
 
 func getClusterSubnetID(ctx context.Context, cluster *armcontainerservice.ManagedCluster) (string, error) {

--- a/e2e/scenario_cse_perf_test.go
+++ b/e2e/scenario_cse_perf_test.go
@@ -198,7 +198,7 @@ func Test_Ubuntu2204_CSE_CachedPerformance(t *testing.T) {
 			VHD:                      config.VHDUbuntu2204Gen2Containerd,
 			SkipScriptlessNBC:        true,
 			EagerCSETimingExtraction: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				// Disable scriptless CSE so traditional CSE scripts run and emit timing events
 				nbc.EnableScriptlessCSECmd = false
 				// The default 1.30 only has tarballs, not .deb files, so it would never
@@ -234,7 +234,7 @@ func Test_Ubuntu2204_CSE_FullInstallPerformance(t *testing.T) {
 			VHD:                      config.VHDUbuntu2204Gen2Containerd,
 			SkipScriptlessNBC:        true,
 			EagerCSETimingExtraction: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.EnableScriptlessCSECmd = false
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
@@ -261,7 +261,7 @@ func Test_Ubuntu2404_CSE_CachedPerformance(t *testing.T) {
 			VHD:                      config.VHDUbuntu2404Gen2Containerd,
 			SkipScriptlessNBC:        true,
 			EagerCSETimingExtraction: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				// Disable scriptless CSE so traditional CSE scripts run and emit timing events
 				nbc.EnableScriptlessCSECmd = false
 				nbc.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = "1.34.4"
@@ -290,7 +290,7 @@ func Test_Ubuntu2404_CSE_FullInstallPerformance(t *testing.T) {
 			VHD:                      config.VHDUbuntu2404Gen2Containerd,
 			SkipScriptlessNBC:        true,
 			EagerCSETimingExtraction: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.EnableScriptlessCSECmd = false
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
@@ -317,7 +317,7 @@ func Test_AzureLinuxV3_CSE_CachedPerformance(t *testing.T) {
 			VHD:                      config.VHDAzureLinuxV3Gen2,
 			SkipScriptlessNBC:        true,
 			EagerCSETimingExtraction: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.EnableScriptlessCSECmd = false
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -336,7 +336,7 @@ func Test_AzureLinuxV3_CSE_FullInstallPerformance(t *testing.T) {
 			VHD:                      config.VHDAzureLinuxV3Gen2,
 			SkipScriptlessNBC:        true,
 			EagerCSETimingExtraction: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.EnableScriptlessCSECmd = false
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {

--- a/e2e/scenario_gpu_daemonset_test.go
+++ b/e2e/scenario_gpu_daemonset_test.go
@@ -39,7 +39,7 @@ func Test_Ubuntu2204_NvidiaDevicePlugin_Daemonset(t *testing.T) {
 			Cluster:           ClusterKubenet,
 			VHD:               config.VHDUbuntu2204Gen2Containerd,
 			SkipScriptlessNBC: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_NV6ads_A10_v5"
 				nbc.ConfigGPUDriverIfNeeded = true
 				// Don't enable the managed GPU experience - we'll deploy the device plugin as a DaemonSet instead.

--- a/e2e/scenario_gpu_managed_experience_test.go
+++ b/e2e/scenario_gpu_managed_experience_test.go
@@ -193,7 +193,7 @@ func Test_DCGM_Exporter_Compatibility(t *testing.T) {
 				Config: Config{
 					Cluster:                ClusterKubenet,
 					VHD:                    tc.vhd,
-					BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {},
+					BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {},
 
 					// We are only validating if the package versions are compatible, and for that we need an environment like
 					// Ubuntu or Az Linux, and nothing else. This test doesn't care about any other validation.
@@ -244,7 +244,7 @@ func Test_Ubuntu2404_NvidiaDevicePluginRunning(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_NV6ads_A10_v5"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = true
@@ -322,7 +322,7 @@ func Test_Ubuntu2204_NvidiaDevicePluginRunning(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_NV6ads_A10_v5"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = true
@@ -399,7 +399,7 @@ func Test_AzureLinux3_NvidiaDevicePluginRunning(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_NC6s_v3"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = true
@@ -476,7 +476,7 @@ func Test_Ubuntu2404_NvidiaDevicePluginRunning_MIG(t *testing.T) {
 			VHD:                   config.VHDUbuntu2404Gen2Containerd,
 			SkipScriptlessNBC:     true,
 			WaitForSSHAfterReboot: 5 * time.Minute,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_NC24ads_A100_v4"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = true
@@ -553,7 +553,7 @@ func Test_Ubuntu2204_NvidiaDevicePluginRunning_WithoutVMSSTag(t *testing.T) {
 			Cluster:           ClusterKubenet,
 			VHD:               config.VHDUbuntu2204Gen2Containerd,
 			SkipScriptlessNBC: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_NV6ads_A10_v5"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = true
@@ -669,7 +669,7 @@ func Test_Ubuntu2404_NvidiaDevicePluginRunning_MIG_Mixed(t *testing.T) {
 			Cluster:               ClusterKubenet,
 			VHD:                   config.VHDUbuntu2404Gen2Containerd,
 			WaitForSSHAfterReboot: 5 * time.Minute,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_NC24ads_A100_v4"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = true

--- a/e2e/scenario_localdns_hosts_test.go
+++ b/e2e/scenario_localdns_hosts_test.go
@@ -37,7 +37,7 @@ func Test_LocalDNSHostsPlugin(t *testing.T) {
 				Config: Config{
 					Cluster: ClusterKubenet,
 					VHD:     tt.vhd,
-					BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+					BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 						nbc.AgentPoolProfile.LocalDNSProfile.EnableHostsPlugin = true
 					},
 					VMConfigMutator: tt.vmConfigMutator,
@@ -75,7 +75,7 @@ func Test_LocalDNSHostsPlugin_Scriptless(t *testing.T) {
 					Cluster:         ClusterKubenet,
 					VHD:             tt.vhd,
 					VMConfigMutator: tt.vmConfigMutator,
-					AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+					AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 						config.LocalDnsProfile.EnableHostsPlugin = true
 					},
 				},

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -23,7 +23,7 @@ func Test_AzureLinux3OSGuard(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinux3OSGuard,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.LocalDNSProfile = nil
 			},
 			Validator: func(ctx context.Context, s *Scenario) {},
@@ -40,7 +40,7 @@ func Test_Flatcar(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDFlatcarGen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.CustomCATrustConfig = &datamodel.CustomCATrustConfig{
 					CustomCATrustCerts: []string{
 						encodedTestCert,
@@ -70,7 +70,7 @@ func Test_Flatcar_Scriptless(t *testing.T) {
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log", "aks-node-controller finished successfully")
 			},
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 			},
 		},
 	})
@@ -82,7 +82,7 @@ func Test_Flatcar_ARM64(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDFlatcarGen2Arm64,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_D2pds_V5"
 				nbc.IsARM64 = true
 			},
@@ -101,7 +101,7 @@ func Test_AzureLinuxV3_ARM64(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2Arm64,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_D2pds_V5"
 				nbc.IsARM64 = true
 			},
@@ -120,7 +120,7 @@ func Test_Flatcar_AzureCNI(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterAzureNetwork,
 			VHD:     config.VHDFlatcarGen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
 				nbc.AgentPoolProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
 			},
@@ -139,7 +139,7 @@ func Test_Ubuntu2204_AzureCNI(t *testing.T) {
 		Config: Config{
 			Cluster: clusterAzureOverlayNetwork,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
 				nbc.AgentPoolProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
 			},
@@ -158,7 +158,7 @@ func Test_Flatcar_AzureCNI_ChronyRestarts_Scriptless(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterAzureNetwork,
 			VHD:     config.VHDFlatcarGen2,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.NetworkConfig.NetworkPlugin = aksnodeconfigv1.NetworkPlugin_NETWORK_PLUGIN_AZURE
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -179,7 +179,7 @@ func Test_Flatcar_SecureTLSBootstrapping_BootstrapToken_Fallback(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDFlatcarGen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.SecureTLSBootstrappingConfig = &datamodel.SecureTLSBootstrappingConfig{
 					Enabled:                true,
 					Deadline:               (10 * time.Second).String(),
@@ -196,7 +196,7 @@ func Test_ACL(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDACLGen2TL,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.CustomCATrustConfig = &datamodel.CustomCATrustConfig{
 					CustomCATrustCerts: []string{
 						encodedTestCert,
@@ -225,7 +225,7 @@ func Test_ACL_ARM64(t *testing.T) {
 			VHD:     config.VHDACLArm64Gen2TL,
 			// v6 (Cobalt 100) only supports NVMe disk controllers, not ResourceDisk
 			UseNVMe: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				// Ampere Altra (v5) doesn't support TrustedLaunch; Cobalt 100 (v6) does
 				nbc.AgentPoolProfile.VMSize = "Standard_D2pds_v6"
 				nbc.IsARM64 = true
@@ -258,7 +258,7 @@ func Test_ACL_Scriptless(t *testing.T) {
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log", "aks-node-controller finished successfully")
 			},
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 			},
 		},
 	})
@@ -273,7 +273,7 @@ func Test_ACL_AzureCNI(t *testing.T) {
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				vmss.Properties = addTrustedLaunchToVMSS(vmss.Properties)
 			},
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
 				nbc.AgentPoolProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
 			},
@@ -298,7 +298,7 @@ func Test_ACL_SecureTLSBootstrapping_BootstrapToken_Fallback(t *testing.T) {
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				vmss.Properties = addTrustedLaunchToVMSS(vmss.Properties)
 			},
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.SecureTLSBootstrappingConfig = &datamodel.SecureTLSBootstrappingConfig{
 					Enabled:                true,
 					Deadline:               (10 * time.Second).String(),
@@ -321,7 +321,7 @@ func Test_ACL_AzureCNI_ChronyRestarts_Scriptless(t *testing.T) {
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				vmss.Properties = addTrustedLaunchToVMSS(vmss.Properties)
 			},
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.NetworkConfig.NetworkPlugin = aksnodeconfigv1.NetworkPlugin_NETWORK_PLUGIN_AZURE
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -342,7 +342,7 @@ func Test_ACL_DisableSSH(t *testing.T) {
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				vmss.Properties = addTrustedLaunchToVMSS(vmss.Properties)
 			},
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.SSHStatus = datamodel.SSHOff
 			},
 			SkipSSHConnectivityValidation: true, // Skip SSH connectivity validation since SSH is down
@@ -378,7 +378,7 @@ func runScenarioACLGPU(t *testing.T, vmSize string, location string) {
 			Cluster:           ClusterKubenet,
 			VHD:               config.VHDACLGen2TL,
 			SkipScriptlessNBC: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = vmSize
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
@@ -408,7 +408,7 @@ func runScenarioACLGRID(t *testing.T, vmSize string) {
 			Cluster:           ClusterKubenet,
 			VHD:               config.VHDACLGen2TL,
 			SkipScriptlessNBC: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = vmSize
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
@@ -438,7 +438,7 @@ func Test_AzureLinuxV3_SecureTLSBootstrapping_BootstrapToken_Fallback(t *testing
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.SecureTLSBootstrappingConfig = &datamodel.SecureTLSBootstrappingConfig{
 					Enabled:                true,
 					Deadline:               (10 * time.Second).String(),
@@ -458,7 +458,7 @@ func Test_AzureLinuxV3_AzureCNI(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterAzureNetwork,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
 				nbc.AgentPoolProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
 			},
@@ -472,7 +472,7 @@ func Test_AzureLinuxV3(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.MessageOfTheDay = "Zm9vYmFyDQo=" // base64 for foobar
 				nbc.CustomCATrustConfig = &datamodel.CustomCATrustConfig{
 					CustomCATrustCerts: []string{
@@ -527,7 +527,7 @@ func Test_Ubuntu2204_Scriptless(t *testing.T) {
 				ValidateUlimitSettings(ctx, s, customContainerdUlimits)
 				ValidateSysctlConfig(ctx, s, customSysctls)
 			},
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.KubeletConfig.KubeletFlags["--register-with-taints"] = registerWithTaints
 				config.CustomCaCerts = []string{encodedTestCert}
 				customLinuxOsConfig := &aksnodeconfigv1.CustomLinuxOsConfig{
@@ -561,7 +561,7 @@ func Test_Ubuntu2204_Failure_Scriptless(t *testing.T) {
 				ValidateFileExists(ctx, s, "/opt/azure/containers/provision.complete")
 				ValidateFileExists(ctx, s, "/var/log/azure/aks/provision.json")
 			},
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				// Intentionally causing a failure here
 				//config.Version = "v200"
 				config.BootstrappingConfig = nil
@@ -585,7 +585,7 @@ func Test_Ubuntu2204_Early_Failure_Scriptless(t *testing.T) {
 				ValidateFileExists(ctx, s, "/opt/azure/containers/provision.complete")
 				ValidateFileExists(ctx, s, "/var/log/azure/aks/provision.json")
 			},
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				// Intentionally causing a failure here
 				config.Version = "VeryBadVersion"
 			},
@@ -606,7 +606,7 @@ func Test_Ubuntu2404_Scriptless(t *testing.T) {
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log", "aks-node-controller finished successfully")
 			},
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 			},
 		},
 	})
@@ -629,7 +629,7 @@ func Test_Ubuntu2204_ScriptlessCSECmd_Hotfix(t *testing.T) {
 				Path:    hotfixMarkerPath,
 				Content: hotfixMarkerContent,
 			}},
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.EnableScriptlessCSECmd = true
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -677,7 +677,7 @@ func Test_Ubuntu2204_ANCHotfix_BinarySelection(t *testing.T) {
 					Content:     "#!/bin/bash\nexec /opt/azure/containers/aks-node-controller \"$@\"",
 				},
 			},
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.EnableScriptlessCSECmd = true
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -701,7 +701,7 @@ func Test_Ubuntu2204(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				// Check that we don't leak these secrets if they're
 				// set (which they mostly aren't in these scenarios).
 				nbc.ContainerService.Properties.CertificateProfile.ClientPrivateKey = "client cert private key"
@@ -732,7 +732,7 @@ func Test_Ubuntu2204FIPS(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204FIPSContainerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				vmss.Properties.AdditionalCapabilities = &armcompute.AdditionalCapabilities{
@@ -757,7 +757,7 @@ func Test_Ubuntu2004FIPS(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2004FIPSContainerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 			},
@@ -779,7 +779,7 @@ func Test_Ubuntu2204Gen2FIPS(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2FIPSContainerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				vmss.Properties.AdditionalCapabilities = &armcompute.AdditionalCapabilities{
@@ -807,7 +807,7 @@ func Test_Ubuntu2204Gen2FIPSTL(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2FIPSTLContainerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				vmss.Properties = addTrustedLaunchToVMSS(vmss.Properties)
@@ -833,7 +833,7 @@ func Test_Ubuntu2204_EntraIDSSH(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				// Enable Entra ID SSH authentication
 				nbc.SSHStatus = datamodel.EntraIDSSH
 			},
@@ -861,7 +861,7 @@ func Test_Ubuntu2204_EntraIDSSH_Scriptless(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.DisablePubkeyAuth = to.Ptr(true)
 			},
 			SkipSSHConnectivityValidation: true, // Skip SSH connectivity validation since Entra ID SSH disables private key authentication
@@ -885,7 +885,7 @@ func Test_AzureLinuxV3_DisableSSH(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.SSHStatus = datamodel.SSHOff
 			},
 			SkipSSHConnectivityValidation: true, // Skip SSH connectivity validation since SSH is down
@@ -904,7 +904,7 @@ func Test_Ubuntu2204_DisableSSH(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.SSHStatus = datamodel.SSHOff
 			},
 			SkipSSHConnectivityValidation: true, // Skip SSH connectivity validation since SSH is down
@@ -923,7 +923,7 @@ func Test_Flatcar_DisableSSH(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDFlatcarGen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.SSHStatus = datamodel.SSHOff
 			},
 			SkipSSHConnectivityValidation: true, // Skip SSH connectivity validation since SSH is down
@@ -946,7 +946,7 @@ func Test_Flatcar_NetworkIsolatedCluster_NonAnonymousACR(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterAzureNetworkIsolated,
 			VHD:     config.VHDFlatcarGen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.OutboundType = datamodel.OutboundTypeBlock
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
@@ -982,7 +982,7 @@ func Test_ACL_NetworkIsolatedCluster_NonAnonymousACR(t *testing.T) {
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				vmss.Properties = addTrustedLaunchToVMSS(vmss.Properties)
 			},
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.OutboundType = datamodel.OutboundTypeBlock
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
@@ -1015,7 +1015,7 @@ func Test_AzureLinuxV3_NetworkIsolatedCluster_NonAnonymousACR(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterAzureNetworkIsolated,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.OutboundType = datamodel.OutboundTypeBlock
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
@@ -1049,7 +1049,7 @@ func Test_AzureLinuxV3_NetworkIsolated_Package_Install(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterAzureNetworkIsolated,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.OutboundType = datamodel.OutboundTypeNone
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
@@ -1089,7 +1089,7 @@ func Test_Ubuntu2204_NetworkIsolatedCluster_NonAnonymousACR(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterAzureNetworkIsolated,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.OutboundType = datamodel.OutboundTypeBlock
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
@@ -1122,7 +1122,7 @@ func Test_Ubuntu2204Gen2_Containerd_NetworkIsolatedCluster_NoneCached(t *testing
 		Config: Config{
 			Cluster: ClusterAzureNetworkIsolated,
 			VHD:     config.VHDUbuntu2204Gen2ContainerdNetworkIsolatedK8sNotCached,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.OutboundType = datamodel.OutboundTypeBlock
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
@@ -1154,7 +1154,7 @@ func Test_Ubuntu2204Gen2_Containerd_NetworkIsolatedCluster_NonAnonymousNoneCache
 		Config: Config{
 			Cluster: ClusterAzureNetworkIsolated,
 			VHD:     config.VHDUbuntu2204Gen2ContainerdNetworkIsolatedK8sNotCached,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.OutboundType = datamodel.OutboundTypeBlock
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
@@ -1192,13 +1192,40 @@ func Test_Ubuntu2204Gen2_Containerd_NetworkIsolatedCluster_NonAnonymousNoneCache
 	})
 }
 
+// Test_Ubuntu2204_HTTPSProxy_PrivateDNS validates that node provisioning succeeds when
+// HTTPS_PROXY is set and the API server FQDN resolves via a private DNS zone.
+// Regression coverage for IcM 603699115 / ADO#31707996.
+func Test_Ubuntu2204_HTTPSProxy_PrivateDNS(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "Tests that a node with HTTPS_PROXY and private DNS for API server bootstraps successfully",
+		Config: Config{
+			Cluster: ClusterAzureNetwork,
+			VHD:     config.VHDUbuntu2204Gen2Containerd,
+			BootstrapConfigMutator: func(cluster *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.HTTPProxyConfig = &datamodel.HTTPProxyConfig{
+					HTTPSProxy: to.Ptr(cluster.ProxyURL),
+					NoProxy: &[]string{
+						"localhost",
+						"127.0.0.1",
+						"168.63.129.16",
+						"169.254.169.254",
+						"10.0.0.0/8",
+						"172.16.0.0/12",
+						cluster.ClusterParams.FQDN,
+					},
+				}
+			},
+		},
+	})
+}
+
 func Test_Ubuntu2204ARM64(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that an Ubuntu 2204 Node using ARM64 architecture can be properly bootstrapped",
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Arm64Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_D2pds_V5"
 				nbc.IsARM64 = true
 			},
@@ -1215,7 +1242,7 @@ func Test_Ubuntu2204_ArtifactStreaming(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.EnableArtifactStreaming = true
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -1235,7 +1262,7 @@ func Test_Ubuntu2204_ArtifactStreaming_ARM64(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Arm64Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.EnableArtifactStreaming = true
 				nbc.AgentPoolProfile.VMSize = "Standard_D2pds_V5"
 				nbc.IsARM64 = true
@@ -1263,7 +1290,7 @@ func Test_Ubuntu2204_ArtifactStreaming_Scriptless(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.EnableArtifactStreaming = true
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -1283,7 +1310,7 @@ func Test_AzureLinuxV3_ArtifactStreaming(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.EnableArtifactStreaming = true
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -1306,7 +1333,7 @@ func Test_AzureLinuxV3_ArtifactStreaming_Scriptless(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.EnableArtifactStreaming = true
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -1329,7 +1356,7 @@ func Test_Ubuntu2204_ArtifactStreaming_ARM64_Scriptless(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Arm64Containerd,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.EnableArtifactStreaming = true
 				config.VmSize = "Standard_D2pds_V5"
 			},
@@ -1353,7 +1380,7 @@ func Test_Ubuntu2404_ArtifactStreaming_ARM64(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404ArmContainerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.EnableArtifactStreaming = true
 				nbc.AgentPoolProfile.VMSize = "Standard_D2pds_V5"
 				nbc.IsARM64 = true
@@ -1381,7 +1408,7 @@ func Test_Ubuntu2404_ArtifactStreaming_ARM64_Scriptless(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404ArmContainerd,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.EnableArtifactStreaming = true
 				config.VmSize = "Standard_D2pds_V5"
 			},
@@ -1405,7 +1432,7 @@ func Test_Ubuntu2204_ArtifactStreaming_TrustedLaunch(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2TLContainerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.EnableArtifactStreaming = true
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
@@ -1431,7 +1458,7 @@ func Test_Ubuntu2204_ArtifactStreaming_TrustedLaunch_Scriptless(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2TLContainerd,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.EnableArtifactStreaming = true
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
@@ -1454,7 +1481,7 @@ func Test_Ubuntu2204_ArtifactStreaming_FIPS(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2FIPSContainerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.EnableArtifactStreaming = true
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
@@ -1485,7 +1512,7 @@ func Test_Ubuntu2204_ArtifactStreaming_FIPS_Scriptless(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2FIPSContainerd,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.EnableArtifactStreaming = true
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
@@ -1517,7 +1544,7 @@ func Test_Ubuntu2204_ArtifactStreaming_NetworkIsolatedCluster(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterAzureNetworkIsolated,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.EnableArtifactStreaming = true
 				nbc.OutboundType = datamodel.OutboundTypeBlock
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
@@ -1553,7 +1580,7 @@ func Test_Ubuntu2204_ChronyRestarts_Taints_And_Tolerations(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.KubeletConfig["--register-with-taints"] = "testkey1=value1:NoSchedule,testkey2=value2:NoSchedule"
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -1583,7 +1610,7 @@ func Test_Ubuntu2204_CustomSysctls(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				customLinuxConfig := &datamodel.CustomLinuxOSConfig{
 					Sysctls: &datamodel.SysctlConfig{
 						NetNetfilterNfConntrackMax:     to.Ptr(toolkit.StrToInt32(customSysctls["net.netfilter.nf_conntrack_max"])),
@@ -1630,7 +1657,7 @@ func runScenarioUbuntu2204GPU(t *testing.T, vmSize string, location string) {
 			Cluster:           ClusterKubenet,
 			VHD:               config.VHDUbuntu2204Gen2Containerd,
 			SkipScriptlessNBC: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = vmSize
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
@@ -1659,7 +1686,7 @@ func runScenarioUbuntuGRID(t *testing.T, vmSize string) {
 			Cluster:           ClusterKubenet,
 			VHD:               config.VHDUbuntu2204Gen2Containerd,
 			SkipScriptlessNBC: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = vmSize
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
@@ -1699,7 +1726,7 @@ func Test_Ubuntu2204_GPUA10_Scriptless(t *testing.T) {
 				ValidateKubeletHasNotStopped(ctx, s)
 				ValidateServicesDoNotRestartKubelet(ctx, s)
 			},
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.VmSize = "Standard_NV6ads_A10_v5"
 				config.GpuConfig.ConfigGpuDriver = true
 				config.GpuConfig.GpuDevicePlugin = false
@@ -1718,7 +1745,7 @@ func Test_Ubuntu2204_GPUGridDriver(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_NV6ads_A10_v5"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
@@ -1745,7 +1772,7 @@ func Test_Ubuntu2204_GPUNoDriver(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_NC6s_v3"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
@@ -1775,7 +1802,7 @@ func Test_Ubuntu2204_GPUNoDriver_Scriptless(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.VmSize = "Standard_NC6s_v3"
 				config.GpuConfig.ConfigGpuDriver = true
 				config.GpuConfig.GpuDevicePlugin = false
@@ -1802,7 +1829,7 @@ func Test_Ubuntu2204_PrivateKubePkg(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2ContainerdPrivateKubePkg,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = "1.25.6"
 				nbc.K8sComponents.LinuxPrivatePackageURL = "https://privatekube.blob.core.windows.net/kubernetes/v1.25.6-hotfix.20230612/binaries/v1.25.6-hotfix.20230612.tar.gz"
 				nbc.AgentPoolProfile.LocalDNSProfile = nil
@@ -1825,7 +1852,7 @@ func Test_Ubuntu2204_ContainerdURL_IMDSRestrictionFilterTable(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerdPackageURL = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/moby-containerd/moby-containerd_1.6.9+azure-ubuntu22.04u1_amd64.deb"
 				nbc.EnableIMDSRestriction = true
 				nbc.InsertIMDSRestrictionRuleToMangleTable = false
@@ -1848,7 +1875,7 @@ func Test_Ubuntu2204_ContainerdURL_IMDSRestrictionFilterTable_Scriptless(t *test
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.ContainerdConfig.ContainerdPackageUrl = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/moby-containerd/moby-containerd_1.6.9+azure-ubuntu22.04u1_amd64.deb"
 				config.ImdsRestrictionConfig = &aksnodeconfigv1.ImdsRestrictionConfig{
 					EnableImdsRestriction:                  true,
@@ -1868,7 +1895,7 @@ func Test_Ubuntu2204_ContainerdHasCurrentVersion(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateInstalledPackageVersion(ctx, s, "moby-containerd", components.GetExpectedPackageVersions("containerd", "ubuntu", "r2204")[0])
@@ -1883,7 +1910,7 @@ func Test_AzureLinux_Skip_Binary_Cleanup(t *testing.T) {
 		Config: Config{
 			Cluster:                ClusterKubenet,
 			VHD:                    config.VHDAzureLinuxV3Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {},
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				if vmss.Tags == nil {
 					vmss.Tags = map[string]*string{}
@@ -1903,7 +1930,7 @@ func Test_Ubuntu2204_DisableKubeletServingCertificateRotationWithTags(t *testing
 		Config: Config{
 			Cluster:                ClusterKubenet,
 			VHD:                    config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {},
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				if vmss.Tags == nil {
 					vmss.Tags = map[string]*string{}
@@ -1920,7 +1947,7 @@ func Test_Ubuntu2204_DisableKubeletServingCertificateRotationWithTags_CustomKube
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				// to force kubelet config file
 				customKubeletConfig := &datamodel.CustomKubeletConfig{
 					FailSwapOn:           to.Ptr(true),
@@ -1947,7 +1974,7 @@ func Test_Ubuntu2204_DisableKubeletServingCertificateRotationWithTags_CustomKube
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.KubeletConfig.EnableKubeletConfigFile = true
 				config.KubeletConfig.KubeletConfigFileConfig.FailSwapOn = to.Ptr(true)
 				config.KubeletConfig.KubeletConfigFileConfig.AllowedUnsafeSysctls = []string{"kernel.msg*", "net.ipv4.route.min_pmtu"}
@@ -1971,7 +1998,7 @@ func Test_Ubuntu2204_DisableKubeletServingCertificateRotationWithTags_AlreadyDis
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				if vmss.Tags == nil {
@@ -1989,7 +2016,7 @@ func Test_Ubuntu2204_DisableKubeletServingCertificateRotationWithTags_AlreadyDis
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				// to force kubelet config file
 				customKubeletConfig := &datamodel.CustomKubeletConfig{
 					FailSwapOn:           to.Ptr(true),
@@ -2017,7 +2044,7 @@ func Test_AzureLinuxV3_Scriptless(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.MessageOfTheDay = "Zm9vYmFyDQo=" // base64 for foobar
 				config.KubeletConfig.KubeletConfigFileConfig.SeccompDefault = true
 			},
@@ -2043,7 +2070,7 @@ func Test_AzureLinuxV3_MA35D(t *testing.T) {
 			Cluster:           ClusterKubenet,
 			VHD:               config.VHDAzureLinuxV3Gen2,
 			SkipScriptlessNBC: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.AgentPoolProfiles[0].VMSize = "Standard_NM16ads_MA35D"
 				nbc.AgentPoolProfile.VMSize = "Standard_NM16ads_MA35D"
 			},
@@ -2073,7 +2100,7 @@ func Test_AzureLinuxV3LocalDns_Disabled_Scriptless(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterAzureNetwork,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.LocalDnsProfile = &aksnodeconfigv1.LocalDnsProfile{
 					EnableLocalDns: false,
 				}
@@ -2104,7 +2131,7 @@ func Test_AzureLinuxV3_CustomSysctls(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				customLinuxConfig := &datamodel.CustomLinuxOSConfig{
 					Sysctls: &datamodel.SysctlConfig{
 						NetNetfilterNfConntrackMax:     to.Ptr(toolkit.StrToInt32(customSysctls["net.netfilter.nf_conntrack_max"])),
@@ -2136,7 +2163,7 @@ func Test_Ubuntu2204_KubeletCustomConfig(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-ubuntu-containerd-22.04-gen2"
 				nbc.AgentPoolProfile.Distro = "aks-ubuntu-containerd-22.04-gen2"
 				customKubeletConfig := &datamodel.CustomKubeletConfig{
@@ -2163,7 +2190,7 @@ func Test_AzureLinuxV3_KubeletCustomConfig(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.AgentPoolProfiles[0].Distro = "aks-azurelinux-v3-gen2"
 				nbc.AgentPoolProfile.Distro = "aks-azurelinux-v3-gen2"
 				customKubeletConfig := &datamodel.CustomKubeletConfig{
@@ -2192,7 +2219,7 @@ func Test_AzureLinuxV3_GPU(t *testing.T) {
 			Cluster:           ClusterKubenet,
 			VHD:               config.VHDAzureLinuxV3Gen2,
 			SkipScriptlessNBC: true,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_NC6s_v3"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
@@ -2216,7 +2243,7 @@ func Test_AzureLinuxV3_GPUA10(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_NV6ads_A10_v5"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
@@ -2245,7 +2272,7 @@ func Test_AzureLinuxV3_GPUAzureCNI(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterAzureNetwork,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
 				nbc.AgentPoolProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
 				nbc.AgentPoolProfile.VMSize = "Standard_NC6s_v3"
@@ -2272,7 +2299,7 @@ func Test_AzureLinuxV3_GPUAzureCNI_Scriptless(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterAzureNetwork,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.NetworkConfig.NetworkPlugin = aksnodeconfigv1.NetworkPlugin_NETWORK_PLUGIN_AZURE
 				config.VmSize = "Standard_NC6s_v3"
 				config.GpuConfig.ConfigGpuDriver = true
@@ -2297,7 +2324,7 @@ func Test_Ubuntu2204ARM64_KubeletCustomConfig(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Arm64Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.IsARM64 = true
 				nbc.AgentPoolProfile.Distro = "aks-ubuntu-arm64-containerd-22.04-gen2"
 				nbc.ContainerService.Properties.AgentPoolProfiles[0].VMSize = "Standard_D2pds_V5"
@@ -2331,7 +2358,7 @@ func Test_Ubuntu2404Gen2(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				containerdVersions := components.GetExpectedPackageVersions("containerd", "ubuntu", "r2404")
@@ -2356,7 +2383,7 @@ func Test_Ubuntu2404Gen2_McrChinaCloud_Scriptless(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404Gen2Containerd,
-			AKSNodeConfigMutator: func(config *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				if vmss.Tags == nil {
@@ -2380,7 +2407,7 @@ func Test_Ubuntu2404Gen2_McrChinaCloud(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				if vmss.Tags == nil {
@@ -2410,7 +2437,7 @@ func Test_Ubuntu2204_SecureTLSBootstrapping_BootstrapToken_Fallback(t *testing.T
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.SecureTLSBootstrappingConfig = &datamodel.SecureTLSBootstrappingConfig{
 					Enabled:                true,
 					Deadline:               (10 * time.Second).String(),
@@ -2430,7 +2457,7 @@ func Test_Ubuntu2404_SecureTLSBootstrapping_BootstrapToken_Fallback(t *testing.T
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.SecureTLSBootstrappingConfig = &datamodel.SecureTLSBootstrappingConfig{
 					Enabled:                true,
 					Deadline:               (10 * time.Second).String(),
@@ -2450,7 +2477,7 @@ func Test_Ubuntu2404Gen2_GPUNoDriver(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = "Standard_NC6s_v3"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
@@ -2481,7 +2508,7 @@ func Test_Ubuntu2404Gen1(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404Gen1Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				containerdVersions := components.GetExpectedPackageVersions("containerd", "ubuntu", "r2404")
@@ -2499,7 +2526,7 @@ func Test_Ubuntu2404ARM(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404ArmContainerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				vmss.SKU.Name = to.Ptr("Standard_D2pds_V5")
@@ -2520,7 +2547,7 @@ func Test_Random_VHD_With_Latest_Kubernetes_Version(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterLatestKubernetesVersion,
 			VHD:     config.GetRandomLinuxAMD64VHD(),
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 		},
 	})
@@ -2535,7 +2562,7 @@ func runScenarioUbuntu2404GRID(t *testing.T, vmSize string) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = vmSize
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
@@ -2566,7 +2593,7 @@ func Test_Ubuntu2404_NPD_Basic(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				extension, err := createVMExtensionLinuxAKSNode(t.Context(), vmss.Location)
@@ -2595,7 +2622,7 @@ func Test_AzureLinux3_PMC_Install(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.KubeletConfig["--image-credential-provider-config"] = "/var/lib/kubelet/credential-provider-config.yaml"
 				nbc.KubeletConfig["--image-credential-provider-bin-dir"] = "/var/lib/kubelet/credential-provider"
 			},
@@ -2617,7 +2644,7 @@ func Test_Ubuntu2204_PMC_Install(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				// Check that we don't leak these secrets if they're
 				// set (which they mostly aren't in these scenarios).
 				nbc.ContainerService.Properties.CertificateProfile.ClientPrivateKey = "client cert private key"
@@ -2646,7 +2673,7 @@ func Test_AzureLinux3OSGuard_PMC_Install(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinux3OSGuard,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.LocalDNSProfile = nil
 			},
 			Validator: func(ctx context.Context, s *Scenario) {},
@@ -2688,7 +2715,7 @@ func Test_Ubuntu2204Gen2_ImagePullIdentityBinding_Enabled(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterLatestKubernetesVersion,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				// Enforce Kubernetes 1.34.0 for ServiceAccountImagePullProfile testing
 				nbc.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = "1.34.0"
 				// Enable ServiceAccountImagePullProfile with test values
@@ -2724,7 +2751,7 @@ func Test_Ubuntu2204Gen2_ImagePullIdentityBinding_Disabled(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterLatestKubernetesVersion,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				// Enforce Kubernetes 1.34.0 for ServiceAccountImagePullProfile testing
 				nbc.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = "1.34.0"
 				// Explicitly disable ServiceAccountImagePullProfile
@@ -2755,7 +2782,7 @@ func Test_Ubuntu2204Gen2_ImagePullIdentityBinding_EnabledWithoutDefaultIDs(t *te
 		Config: Config{
 			Cluster: ClusterLatestKubernetesVersion,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				// Enforce Kubernetes 1.34.0 for ServiceAccountImagePullProfile testing
 				nbc.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = "1.34.0"
 				// Enable ServiceAccountImagePullProfile without default client/tenant IDs
@@ -2795,7 +2822,7 @@ func Test_Ubuntu2204Gen2_ImagePullIdentityBinding_NetworkIsolated(t *testing.T) 
 		Config: Config{
 			Cluster: ClusterAzureBootstrapProfileCache,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				// Enforce Kubernetes 1.34.0 for ServiceAccountImagePullProfile testing
 				nbc.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = "1.34.0"
 				// Enable ServiceAccountImagePullProfile with test values
@@ -2843,7 +2870,7 @@ func Test_Ubuntu2204Gen2_ImagePullIdentityBinding_Enabled_Scriptless(t *testing.
 		Config: Config{
 			Cluster: ClusterLatestKubernetesVersion,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			AKSNodeConfigMutator: func(aksConfig *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, aksConfig *aksnodeconfigv1.Configuration) {
 				// Enforce Kubernetes 1.34.0 for ServiceAccountImagePullProfile testing
 				aksConfig.KubernetesVersion = "1.34.0"
 				// Enable ServiceAccountImagePullProfile with test values
@@ -2891,7 +2918,7 @@ func Test_Ubuntu2204Gen2_ImagePullIdentityBinding_Disabled_Scriptless(t *testing
 		Config: Config{
 			Cluster: ClusterLatestKubernetesVersion,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			AKSNodeConfigMutator: func(aksConfig *aksnodeconfigv1.Configuration) {
+			AKSNodeConfigMutator: func(_ *Cluster, aksConfig *aksnodeconfigv1.Configuration) {
 				// Enforce Kubernetes 1.34.0 for ServiceAccountImagePullProfile testing
 				aksConfig.KubernetesVersion = "1.34.0"
 				// Disable ServiceAccountImagePullProfile

--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 )
 
-func EmptyBootstrapConfigMutator(configuration *datamodel.NodeBootstrappingConfiguration) {}
+func EmptyBootstrapConfigMutator(_ *Cluster, configuration *datamodel.NodeBootstrappingConfiguration) {}
 func EmptyVMConfigMutator(vmss *armcompute.VirtualMachineScaleSet)                        {}
 
-func DualStackConfigMutator(configuration *datamodel.NodeBootstrappingConfiguration) {
+func DualStackConfigMutator(_ *Cluster, configuration *datamodel.NodeBootstrappingConfiguration) {
 	properties := configuration.ContainerService.Properties
 	properties.FeatureFlags.EnableIPv6DualStack = true
 }
@@ -244,7 +244,7 @@ func Test_Windows23H2Gen2CachingRegression(t *testing.T) {
 			Cluster:         ClusterAzureNetwork,
 			VHD:             config.VHDWindows23H2Gen2,
 			VMConfigMutator: EmptyVMConfigMutator,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.WindowsProfile.CseScriptsPackageURL = "https://packages.aks.azure.com/aks/windows/cse/aks-windows-cse-scripts-v0.0.52.zip"
 				// Secure TLS Bootstrapping isn't supported on this CSE script package version
 				nbc.SecureTLSBootstrappingConfig.Enabled = false
@@ -263,7 +263,7 @@ func Test_Windows2022CachingRegression(t *testing.T) {
 			Cluster:         ClusterAzureNetwork,
 			VHD:             config.VHDWindows2022ContainerdGen2,
 			VMConfigMutator: EmptyVMConfigMutator,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.WindowsProfile.CseScriptsPackageURL = "https://packages.aks.azure.com/aks/windows/cse/aks-windows-cse-scripts-v0.0.52.zip"
 				// Secure TLS Bootstrapping isn't supported on this CSE script package version
 				nbc.SecureTLSBootstrappingConfig.Enabled = false
@@ -282,7 +282,7 @@ func Test_Windows2025(t *testing.T) {
 			Cluster:         ClusterAzureNetwork,
 			VHD:             config.VHDWindows2025,
 			VMConfigMutator: EmptyVMConfigMutator,
-			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, configuration *datamodel.NodeBootstrappingConfiguration) {
 				Windows2025BootstrapConfigMutator(t, configuration)
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -307,7 +307,7 @@ func Test_Windows2025Gen2(t *testing.T) {
 			Cluster:         ClusterAzureNetwork,
 			VHD:             config.VHDWindows2025Gen2,
 			VMConfigMutator: EmptyVMConfigMutator,
-			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, configuration *datamodel.NodeBootstrappingConfiguration) {
 				Windows2025BootstrapConfigMutator(t, configuration)
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -333,7 +333,7 @@ func Test_Windows2025Gen2_WindowsCiliumNetworking(t *testing.T) {
 			VHD:                   config.VHDWindows2025Gen2,
 			VMConfigMutator:       EmptyVMConfigMutator,
 			WaitForSSHAfterReboot: 5 * time.Minute,
-			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, configuration *datamodel.NodeBootstrappingConfiguration) {
 				Windows2025BootstrapConfigMutator(t, configuration)
 				if configuration.AgentPoolProfile.AgentPoolWindowsProfile == nil {
 					configuration.AgentPoolProfile.AgentPoolWindowsProfile = &datamodel.AgentPoolWindowsProfile{}
@@ -363,7 +363,7 @@ func Test_Windows2022_SecureTLSBootstrapping_BootstrapToken_Fallback(t *testing.
 			Cluster:         ClusterAzureNetwork,
 			VHD:             config.VHDWindows2022ContainerdGen2,
 			VMConfigMutator: EmptyVMConfigMutator,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.SecureTLSBootstrappingConfig = &datamodel.SecureTLSBootstrappingConfig{
 					Enabled:                true,
 					Deadline:               (10 * time.Second).String(),
@@ -447,7 +447,7 @@ func Test_Windows2022Gen2_k8s_133(t *testing.T) {
 			Cluster:         ClusterAzureNetwork,
 			VHD:             config.VHDWindows2022ContainerdGen2,
 			VMConfigMutator: EmptyVMConfigMutator,
-			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, configuration *datamodel.NodeBootstrappingConfiguration) {
 				// 2025 supported in 1.32+ .
 				configuration.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = "1.33.1"
 				configuration.K8sComponents.WindowsPackageURL = fmt.Sprintf("https://packages.aks.azure.com/kubernetes/v%s/windowszip/v%s-1int.zip", "1.33.1", "1.33.1")
@@ -473,7 +473,7 @@ func Test_Windows23H2_Cilium2(t *testing.T) {
 			Cluster:         ClusterCiliumNetwork,
 			VHD:             config.VHDWindows23H2Gen2,
 			VMConfigMutator: EmptyVMConfigMutator,
-			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, configuration *datamodel.NodeBootstrappingConfiguration) {
 				// cilium is only supported in 1.30 or greater.
 				configuration.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = "1.30.9"
 				configuration.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.EbpfDataplane = datamodel.EbpfDataplane_cilium
@@ -496,7 +496,7 @@ func Test_Windows23H2Gen2_WindowsCiliumNetworking(t *testing.T) {
 			Cluster:         ClusterAzureNetwork,
 			VHD:             config.VHDWindows23H2Gen2,
 			VMConfigMutator: EmptyVMConfigMutator,
-			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, configuration *datamodel.NodeBootstrappingConfiguration) {
 				if configuration.AgentPoolProfile.AgentPoolWindowsProfile == nil {
 					configuration.AgentPoolProfile.AgentPoolWindowsProfile = &datamodel.AgentPoolWindowsProfile{}
 				}
@@ -550,7 +550,7 @@ func Test_Windows2025Gen2_McrChinaCloud_Windows(t *testing.T) {
 			Cluster:         ClusterAzureNetwork,
 			VHD:             config.VHDWindows2025Gen2,
 			VMConfigMutator: EmptyVMConfigMutator,
-			BootstrapConfigMutator: func(configuration *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, configuration *datamodel.NodeBootstrappingConfiguration) {
 				Windows2025BootstrapConfigMutator(t, configuration)
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -585,7 +585,7 @@ func Test_NetworkIsolatedCluster_Windows_WithEgress(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterAzureBootstrapProfileCache,
 			VHD:     config.VHDWindows2025Gen2,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				Windows2025BootstrapConfigMutator(t, nbc)
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{
@@ -632,7 +632,7 @@ func Test_NetworkIsolatedCluster_Windows_OrasDownload(t *testing.T) {
 			Cluster:         ClusterAzureBootstrapProfileCache,
 			VHD:             config.VHDWindows2025Gen2,
 			VMConfigMutator: EmptyVMConfigMutator,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				Windows2025BootstrapConfigMutator(t, nbc)
 				nbc.ContainerService.Properties.SecurityProfile = &datamodel.SecurityProfile{
 					PrivateEgress: &datamodel.PrivateEgress{

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -147,15 +147,15 @@ func runScenarioWithPreProvision(t *testing.T, original *Scenario) {
 		}
 	}
 	if original.BootstrapConfigMutator != nil {
-		firstStage.BootstrapConfigMutator = func(nbc *datamodel.NodeBootstrappingConfiguration) {
-			original.BootstrapConfigMutator(nbc)
+		firstStage.BootstrapConfigMutator = func(cluster *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+			original.BootstrapConfigMutator(cluster, nbc)
 			nbc.PreProvisionOnly = true
 			nbc.EnableScriptlessNBCCSECmd = false
 		}
 	}
 	if original.AKSNodeConfigMutator != nil {
-		firstStage.AKSNodeConfigMutator = func(nodeconfig *aksnodeconfigv1.Configuration) {
-			original.AKSNodeConfigMutator(nodeconfig)
+		firstStage.AKSNodeConfigMutator = func(cluster *Cluster, nodeconfig *aksnodeconfigv1.Configuration) {
+			original.AKSNodeConfigMutator(cluster, nodeconfig)
 			nodeconfig.PreProvisionOnly = true
 		}
 	}
@@ -273,11 +273,11 @@ func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 
 	s.Runtime.NBC = nbc
 	if s.BootstrapConfigMutator != nil {
-		s.BootstrapConfigMutator(nbc)
+		s.BootstrapConfigMutator(s.Runtime.Cluster, nbc)
 	}
 	if s.AKSNodeConfigMutator != nil {
 		nodeconfig := nbcToAKSNodeConfigV1(nbc)
-		s.AKSNodeConfigMutator(nodeconfig)
+		s.AKSNodeConfigMutator(s.Runtime.Cluster, nodeconfig)
 		s.Runtime.AKSNodeConfig = nodeconfig
 		// AKSNodeConfig scenarios use aks-node-controller, not GetNodeBootstrapping.
 		// Clear NBC so validators that check NBC fields (e.g., ValidateScriptlessCSECmd)
@@ -838,7 +838,7 @@ func runScenarioGPUNPD(t *testing.T, vmSize, location, k8sSystemPoolSKU string) 
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404Gen2Containerd,
-			BootstrapConfigMutator: func(nbc *datamodel.NodeBootstrappingConfiguration) {
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.AgentPoolProfile.VMSize = vmSize
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableNvidia = true

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -168,10 +168,10 @@ type Config struct {
 	VHD *config.Image
 
 	// BootstrapConfigMutator is a function which mutates the base NodeBootstrappingConfig according to the scenario's requirements
-	BootstrapConfigMutator func(*datamodel.NodeBootstrappingConfiguration)
+	BootstrapConfigMutator func(*Cluster, *datamodel.NodeBootstrappingConfiguration)
 
 	// AKSNodeConfigMutator if defined then aks-node-controller will be used to provision nodes
-	AKSNodeConfigMutator func(*aksnodeconfigv1.Configuration)
+	AKSNodeConfigMutator func(*Cluster, *aksnodeconfigv1.Configuration)
 
 	// VMConfigMutator is a function which mutates the base VMSS model according to the scenario's requirements
 	VMConfigMutator func(*armcompute.VirtualMachineScaleSet)


### PR DESCRIPTION
## Summary

Add E2E test for node bootstrapping with HTTPS_PROXY configured and private DNS zone for the API server FQDN. Regression coverage for IcM 603699115 / ADO#31707996.

## Changes

### New test: `Test_Ubuntu2204_HTTPSProxy_PrivateDNS`
Validates that a node bootstraps successfully when `HTTPS_PROXY` is set and the API server FQDN resolves via a private DNS zone.

### Proxy infrastructure (all non-isolated clusters)
- Python-based HTTP CONNECT proxy deployed as DaemonSet on system pool (`mcr.microsoft.com/cbl-mariner/base/python:3`)
- Private DNS zone for API server FQDN linked to cluster VNet
- Both run in `prepareCluster` DAG, consistent across clusters

### Signature refactor
- `BootstrapConfigMutator` and `AKSNodeConfigMutator` now accept `*Cluster` as first parameter
- Enables scenarios to access cluster properties (e.g., `ProxyURL`)

### Bug fix
- `createNewAKSClusterWithRetry` now retries on managed identity reconciliation `NotFound` errors after cluster deletion

## Test Result
```
--- PASS: Test_Ubuntu2204_HTTPSProxy_PrivateDNS/default (251.99s)
PASS
```

Fixes: ADO#31707996