### PR TITLE
fix: blacklist rxrpc/esp4/esp6 modules to mitigate DirtyFrag LPE

### DIFF
--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -117,6 +117,7 @@ func ValidateCommonLinux(ctx context.Context, s *Scenario) {
 
 	validateWireServerBlocked(ctx, s)
 	ValidateAlgifAeadMitigation(ctx, s)
+	ValidateDirtyFragMitigation(ctx, s)
 
 	// base NBC templates define a mock service principal profile that we can still use to test
 	// the correct bootstrapping logic: https://github.com/Azure/AgentBaker/blob/master/e2e/node_config.go#L438-L441

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -116,8 +116,7 @@ func ValidateCommonLinux(ctx context.Context, s *Scenario) {
 	_ = execScriptOnVMForScenarioValidateExitCode(ctx, s, "sudo curl http://168.63.129.16:32526/vmSettings", 0, "curl to wireserver failed")
 
 	validateWireServerBlocked(ctx, s)
-	ValidateAlgifAeadMitigation(ctx, s)
-	ValidateDirtyFragMitigation(ctx, s)
+	ValidateVulnerableKernelModulesDisabled(ctx, s)
 
 	// base NBC templates define a mock service principal profile that we can still use to test
 	// the correct bootstrapping logic: https://github.com/Azure/AgentBaker/blob/master/e2e/node_config.go#L438-L441

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2781,61 +2781,21 @@ func ValidateCollectWindowsLogsScript(ctx context.Context, s *Scenario) {
 		"collect-windows-logs.ps1 failed or did not produce a zip file")
 }
 
-// ValidateAlgifAeadMitigation verifies CVE-2026-31431 mitigation is active:
-// the algif_aead kernel module must be blocked via modprobe config, not loaded,
-// and modprobe must refuse to load it.
-func ValidateAlgifAeadMitigation(ctx context.Context, s *Scenario) {
-	s.T.Helper()
-
-	// Flatcar uses a different kernel module setup
-	if s.VHD.Flatcar {
-		s.T.Log("Skipping algif_aead validation: not applicable for Flatcar")
-		return
-	}
-
-	script := strings.Join([]string{
-		`# Check modprobe config blocks the module`,
-		`if ! grep -qs 'install algif_aead /bin/false' /etc/modprobe.d/*.conf 2>/dev/null; then`,
-		`  echo "FAIL: algif_aead disable rule not found in /etc/modprobe.d/*.conf"`,
-		`  exit 1`,
-		`fi`,
-		`echo "PASS: modprobe config blocks algif_aead"`,
-		``,
-		`# Check module is not loaded`,
-		`if grep -qE '^algif_aead ' /proc/modules 2>/dev/null; then`,
-		`  echo "FAIL: algif_aead module is loaded"`,
-		`  exit 1`,
-		`fi`,
-		`echo "PASS: algif_aead module is not loaded"`,
-		``,
-		`# Check modprobe refuses to load it`,
-		`if sudo modprobe algif_aead 2>/dev/null; then`,
-		`  echo "FAIL: modprobe algif_aead succeeded, should be blocked"`,
-		`  sudo rmmod algif_aead 2>/dev/null || true`,
-		`  exit 1`,
-		`fi`,
-		`echo "PASS: modprobe algif_aead correctly refused"`,
-	}, "\n")
-
-	execScriptOnVMForScenarioValidateExitCode(ctx, s, script, 0,
-		"CVE-2026-31431 (algif_aead) mitigation validation failed")
-}
-
-// ValidateDirtyFragMitigation verifies DirtyFrag LPE mitigation is active:
-// the esp4, esp6, and rxrpc kernel modules must be blocked via modprobe config,
-// not loaded, and modprobe must refuse to load them. The rxrpc path bypasses
-// AppArmor userns restrictions and was confirmed exploitable on Ubuntu 24.04.
-func ValidateDirtyFragMitigation(ctx context.Context, s *Scenario) {
+// ValidateVulnerableKernelModulesDisabled verifies that kernel modules with known
+// LPE vulnerabilities are blocked via modprobe config, not loaded, and cannot be loaded.
+// Covers: CVE-2026-31431 (algif_aead), DirtyFrag (esp4, esp6, rxrpc).
+// To add a new CVE mitigation, append the module name to the list below.
+func ValidateVulnerableKernelModulesDisabled(ctx context.Context, s *Scenario) {
 	s.T.Helper()
 
 	if s.VHD.Flatcar {
-		s.T.Log("Skipping DirtyFrag validation: not applicable for Flatcar")
+		s.T.Log("Skipping vulnerable kernel module validation: not applicable for Flatcar")
 		return
 	}
 
 	script := strings.Join([]string{
 		`failed=0`,
-		`for mod in esp4 esp6 rxrpc; do`,
+		`for mod in algif_aead esp4 esp6 rxrpc; do`,
 		`  if ! grep -qs "install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then`,
 		`    echo "FAIL: ${mod} disable rule not found in /etc/modprobe.d/*.conf"`,
 		`    failed=1`,
@@ -2860,5 +2820,5 @@ func ValidateDirtyFragMitigation(ctx context.Context, s *Scenario) {
 	}, "\n")
 
 	execScriptOnVMForScenarioValidateExitCode(ctx, s, script, 0,
-		"DirtyFrag (esp4/esp6/rxrpc) mitigation validation failed")
+		"Vulnerable kernel module mitigation validation failed (algif_aead/esp4/esp6/rxrpc)")
 }

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2796,7 +2796,7 @@ func ValidateVulnerableKernelModulesDisabled(ctx context.Context, s *Scenario) {
 	script := strings.Join([]string{
 		`failed=0`,
 		`for mod in algif_aead esp4 esp6 rxrpc; do`,
-		`  if ! grep -qs "install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then`,
+		`  if ! grep -qsE "^install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then`,
 		`    echo "FAIL: ${mod} disable rule not found in /etc/modprobe.d/*.conf"`,
 		`    failed=1`,
 		`  else`,

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2820,3 +2820,45 @@ func ValidateAlgifAeadMitigation(ctx context.Context, s *Scenario) {
 	execScriptOnVMForScenarioValidateExitCode(ctx, s, script, 0,
 		"CVE-2026-31431 (algif_aead) mitigation validation failed")
 }
+
+// ValidateDirtyFragMitigation verifies DirtyFrag LPE mitigation is active:
+// the esp4, esp6, and rxrpc kernel modules must be blocked via modprobe config,
+// not loaded, and modprobe must refuse to load them. The rxrpc path bypasses
+// AppArmor userns restrictions and was confirmed exploitable on Ubuntu 24.04.
+func ValidateDirtyFragMitigation(ctx context.Context, s *Scenario) {
+	s.T.Helper()
+
+	if s.VHD.Flatcar {
+		s.T.Log("Skipping DirtyFrag validation: not applicable for Flatcar")
+		return
+	}
+
+	script := strings.Join([]string{
+		`failed=0`,
+		`for mod in esp4 esp6 rxrpc; do`,
+		`  if ! grep -qs "install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then`,
+		`    echo "FAIL: ${mod} disable rule not found in /etc/modprobe.d/*.conf"`,
+		`    failed=1`,
+		`  else`,
+		`    echo "PASS: modprobe config blocks ${mod}"`,
+		`  fi`,
+		`  if grep -qE "^${mod} " /proc/modules 2>/dev/null; then`,
+		`    echo "FAIL: ${mod} module is loaded"`,
+		`    failed=1`,
+		`  else`,
+		`    echo "PASS: ${mod} module is not loaded"`,
+		`  fi`,
+		`  if sudo modprobe "${mod}" 2>/dev/null; then`,
+		`    echo "FAIL: modprobe ${mod} succeeded, should be blocked"`,
+		`    sudo modprobe -r "${mod}" 2>/dev/null || true`,
+		`    failed=1`,
+		`  else`,
+		`    echo "PASS: modprobe ${mod} correctly refused"`,
+		`  fi`,
+		`done`,
+		`exit $failed`,
+	}, "\n")
+
+	execScriptOnVMForScenarioValidateExitCode(ctx, s, script, 0,
+		"DirtyFrag (esp4/esp6/rxrpc) mitigation validation failed")
+}

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -861,53 +861,6 @@ configureNodeExporter() {
     echo "Node Exporter started successfully"
 }
 
-# Disable kernel modules with known LPE vulnerabilities.
-# Writes modprobe blacklist rules and unloads any already-loaded modules.
-# Applies to existing VHDs that don't yet have the fix baked into modprobe-CIS.conf.
-# Safe to run unconditionally — idempotent (overwrites with same content if already present).
-#
-# To add a new CVE mitigation, append to the MODULES array below.
-disableVulnerableKernelModules() {
-    # Each entry: "module_name:config_file:description"
-    local MODULES=(
-        "algif_aead:disable-algif_aead.conf:CVE-2026-31431 (Copy Fail)"
-        "esp4:disable-dirtyfrag.conf:DirtyFrag (xfrm-ESP page-cache write)"
-        "esp6:disable-dirtyfrag.conf:DirtyFrag (xfrm-ESP6 page-cache write)"
-        "rxrpc:disable-dirtyfrag.conf:DirtyFrag (RxRPC page-cache write, bypasses AppArmor userns)"
-    )
-
-    # Group modules by config file and write each file once
-    declare -A config_contents
-    for entry in "${MODULES[@]}"; do
-        local mod="${entry%%:*}"
-        local rest="${entry#*:}"
-        local conf="${rest%%:*}"
-        local desc="${rest#*:}"
-        config_contents["$conf"]+="# ${desc}
-install ${mod} /bin/false
-blacklist ${mod}
-"
-    done
-
-    for conf in "${!config_contents[@]}"; do
-        echo "${config_contents[$conf]}" > "/etc/modprobe.d/${conf}"
-    done
-
-    # Unload any already-loaded vulnerable modules
-    for entry in "${MODULES[@]}"; do
-        local mod="${entry%%:*}"
-        local desc="${entry#*:}"
-        desc="${desc#*:}"
-        if grep -q "^${mod} " /proc/modules 2>/dev/null; then
-            if modprobe -r "$mod" 2>/dev/null; then
-                echo "${desc}: successfully unloaded ${mod}"
-            else
-                echo "${desc}: failed to unload ${mod} (in use), reboot required for full mitigation"
-            fi
-        fi
-    done
-}
-
 ensureSysctl() {
     SYSCTL_CONFIG_FILE=/etc/sysctl.d/999-sysctl-aks.conf
     mkdir -p "$(dirname "${SYSCTL_CONFIG_FILE}")"

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -861,6 +861,53 @@ configureNodeExporter() {
     echo "Node Exporter started successfully"
 }
 
+# Disable kernel modules with known LPE vulnerabilities.
+# Writes modprobe blacklist rules and unloads any already-loaded modules.
+# Applies to existing VHDs that don't yet have the fix baked into modprobe-CIS.conf.
+# Safe to run unconditionally — idempotent (overwrites with same content if already present).
+#
+# To add a new CVE mitigation, append to the MODULES array below.
+disableVulnerableKernelModules() {
+    # Each entry: "module_name:config_file:description"
+    local MODULES=(
+        "algif_aead:disable-algif_aead.conf:CVE-2026-31431 (Copy Fail)"
+        "esp4:disable-dirtyfrag.conf:DirtyFrag (xfrm-ESP page-cache write)"
+        "esp6:disable-dirtyfrag.conf:DirtyFrag (xfrm-ESP6 page-cache write)"
+        "rxrpc:disable-dirtyfrag.conf:DirtyFrag (RxRPC page-cache write, bypasses AppArmor userns)"
+    )
+
+    # Group modules by config file and write each file once
+    declare -A config_contents
+    for entry in "${MODULES[@]}"; do
+        local mod="${entry%%:*}"
+        local rest="${entry#*:}"
+        local conf="${rest%%:*}"
+        local desc="${rest#*:}"
+        config_contents["$conf"]+="# ${desc}
+install ${mod} /bin/false
+blacklist ${mod}
+"
+    done
+
+    for conf in "${!config_contents[@]}"; do
+        echo "${config_contents[$conf]}" > "/etc/modprobe.d/${conf}"
+    done
+
+    # Unload any already-loaded vulnerable modules
+    for entry in "${MODULES[@]}"; do
+        local mod="${entry%%:*}"
+        local desc="${entry#*:}"
+        desc="${desc#*:}"
+        if grep -q "^${mod} " /proc/modules 2>/dev/null; then
+            if modprobe -r "$mod" 2>/dev/null; then
+                echo "${desc}: successfully unloaded ${mod}"
+            else
+                echo "${desc}: failed to unload ${mod} (in use), reboot required for full mitigation"
+            fi
+        fi
+    done
+}
+
 ensureSysctl() {
     SYSCTL_CONFIG_FILE=/etc/sysctl.d/999-sysctl-aks.conf
     mkdir -p "$(dirname "${SYSCTL_CONFIG_FILE}")"

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -50,6 +50,54 @@ get_ubuntu_release() {
     lsb_release -r -s 2>/dev/null || echo ""
 }
 
+# Disable kernel modules with known LPE vulnerabilities.
+# Writes modprobe blacklist rules and unloads any already-loaded modules.
+# Applies to existing VHDs that don't yet have the fix baked into modprobe-CIS.conf.
+# Safe to run unconditionally — idempotent (overwrites with same content if already present).
+# Defined in cse_main.sh (not sourced) to support scriptless provisioning.
+#
+# To add a new CVE mitigation, append to the MODULES array below.
+disableVulnerableKernelModules() {
+    # Each entry: "module_name:config_file:description"
+    local MODULES=(
+        "algif_aead:disable-algif_aead.conf:CVE-2026-31431 (Copy Fail)"
+        "esp4:disable-dirtyfrag.conf:DirtyFrag (xfrm-ESP page-cache write)"
+        "esp6:disable-dirtyfrag.conf:DirtyFrag (xfrm-ESP6 page-cache write)"
+        "rxrpc:disable-dirtyfrag.conf:DirtyFrag (RxRPC page-cache write, bypasses AppArmor userns)"
+    )
+
+    # Group modules by config file and write each file once
+    declare -A config_contents
+    for entry in "${MODULES[@]}"; do
+        local mod="${entry%%:*}"
+        local rest="${entry#*:}"
+        local conf="${rest%%:*}"
+        local desc="${rest#*:}"
+        config_contents["$conf"]+="# ${desc}
+install ${mod} /bin/false
+blacklist ${mod}
+"
+    done
+
+    for conf in "${!config_contents[@]}"; do
+        echo "${config_contents[$conf]}" > "/etc/modprobe.d/${conf}"
+    done
+
+    # Unload any already-loaded vulnerable modules
+    for entry in "${MODULES[@]}"; do
+        local mod="${entry%%:*}"
+        local desc="${entry#*:}"
+        desc="${desc#*:}"
+        if grep -q "^${mod} " /proc/modules 2>/dev/null; then
+            if modprobe -r "$mod" 2>/dev/null; then
+                echo "${desc}: successfully unloaded ${mod}"
+            else
+                echo "${desc}: failed to unload ${mod} (in use), reboot required for full mitigation"
+            fi
+        fi
+    done
+}
+
 # ====== BASE PREP: BASE IMAGE PREPARATION ======
 # This stage prepares the base VHD image with all necessary components and configurations.
 # IMPORTANT: This stage must NOT join the node to the cluster.
@@ -296,49 +344,6 @@ EOF
 
     # Disable kernel modules with known LPE vulnerabilities (CVE-2026-31431, DirtyFrag).
     # Applies to existing VHDs that don't yet have the modprobe-CIS.conf fix baked in.
-    # Defined inline in cse_main.sh (not sourced from cse_config.sh) to support scriptless provisioning.
-    # To add a new CVE mitigation, append to the MODULES array below.
-    disableVulnerableKernelModules() {
-        # Each entry: "module_name:config_file:description"
-        local MODULES=(
-            "algif_aead:disable-algif_aead.conf:CVE-2026-31431 (Copy Fail)"
-            "esp4:disable-dirtyfrag.conf:DirtyFrag (xfrm-ESP page-cache write)"
-            "esp6:disable-dirtyfrag.conf:DirtyFrag (xfrm-ESP6 page-cache write)"
-            "rxrpc:disable-dirtyfrag.conf:DirtyFrag (RxRPC page-cache write, bypasses AppArmor userns)"
-        )
-
-        # Group modules by config file and write each file once
-        declare -A config_contents
-        for entry in "${MODULES[@]}"; do
-            local mod="${entry%%:*}"
-            local rest="${entry#*:}"
-            local conf="${rest%%:*}"
-            local desc="${rest#*:}"
-            config_contents["$conf"]+="# ${desc}
-install ${mod} /bin/false
-blacklist ${mod}
-"
-        done
-
-        for conf in "${!config_contents[@]}"; do
-            echo "${config_contents[$conf]}" > "/etc/modprobe.d/${conf}"
-        done
-
-        # Unload any already-loaded vulnerable modules
-        for entry in "${MODULES[@]}"; do
-            local mod="${entry%%:*}"
-            local desc="${entry#*:}"
-            desc="${desc#*:}"
-            if grep -q "^${mod} " /proc/modules 2>/dev/null; then
-                if modprobe -r "$mod" 2>/dev/null; then
-                    echo "${desc}: successfully unloaded ${mod}"
-                else
-                    echo "${desc}: failed to unload ${mod} (in use), reboot required for full mitigation"
-                fi
-            fi
-        done
-    }
-
     if isUbuntu "$OS" || isMarinerOrAzureLinux "$OS"; then
         logs_to_events "AKS.CSE.disableVulnerableKernelModules" disableVulnerableKernelModules
     fi

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -50,52 +50,26 @@ get_ubuntu_release() {
     lsb_release -r -s 2>/dev/null || echo ""
 }
 
-# Disable kernel modules with known LPE vulnerabilities.
-# Writes modprobe blacklist rules and unloads any already-loaded modules.
+# Disable a single kernel module with a known LPE vulnerability.
+# Writes a modprobe blacklist rule and unloads the module if loaded.
 # Applies to existing VHDs that don't yet have the fix baked into modprobe-CIS.conf.
 # Safe to run unconditionally — idempotent (overwrites with same content if already present).
 # Defined in cse_main.sh (not sourced) to support scriptless provisioning.
 #
-# To add a new CVE mitigation, append to the MODULES array below.
-disableVulnerableKernelModules() {
-    # Each entry: "module_name:config_file:description"
-    local MODULES=(
-        "algif_aead:disable-algif_aead.conf:CVE-2026-31431 (Copy Fail)"
-        "esp4:disable-dirtyfrag.conf:DirtyFrag (xfrm-ESP page-cache write)"
-        "esp6:disable-dirtyfrag.conf:DirtyFrag (xfrm-ESP6 page-cache write)"
-        "rxrpc:disable-dirtyfrag.conf:DirtyFrag (RxRPC page-cache write, bypasses AppArmor userns)"
-    )
+# Usage: disableVulnerableKernelModule <module_name> <description>
+disableVulnerableKernelModule() {
+    local mod="$1"
+    local desc="$2"
 
-    # Group modules by config file and write each file once
-    declare -A config_contents
-    for entry in "${MODULES[@]}"; do
-        local mod="${entry%%:*}"
-        local rest="${entry#*:}"
-        local conf="${rest%%:*}"
-        local desc="${rest#*:}"
-        config_contents["$conf"]+="# ${desc}
-install ${mod} /bin/false
-blacklist ${mod}
-"
-    done
+    printf '# %s\ninstall %s /bin/false\nblacklist %s\n' "$desc" "$mod" "$mod" > "/etc/modprobe.d/disable-${mod}.conf"
 
-    for conf in "${!config_contents[@]}"; do
-        echo "${config_contents[$conf]}" > "/etc/modprobe.d/${conf}"
-    done
-
-    # Unload any already-loaded vulnerable modules
-    for entry in "${MODULES[@]}"; do
-        local mod="${entry%%:*}"
-        local desc="${entry#*:}"
-        desc="${desc#*:}"
-        if grep -q "^${mod} " /proc/modules 2>/dev/null; then
-            if modprobe -r "$mod" 2>/dev/null; then
-                echo "${desc}: successfully unloaded ${mod}"
-            else
-                echo "${desc}: failed to unload ${mod} (in use), reboot required for full mitigation"
-            fi
+    if grep -q "^${mod} " /proc/modules 2>/dev/null; then
+        if modprobe -r "$mod" 2>/dev/null; then
+            echo "${desc}: successfully unloaded ${mod}"
+        else
+            echo "${desc}: failed to unload ${mod} (in use), reboot required for full mitigation"
         fi
-    done
+    fi
 }
 
 # ====== BASE PREP: BASE IMAGE PREPARATION ======
@@ -344,8 +318,12 @@ EOF
 
     # Disable kernel modules with known LPE vulnerabilities (CVE-2026-31431, DirtyFrag).
     # Applies to existing VHDs that don't yet have the modprobe-CIS.conf fix baked in.
+    # To add a new CVE mitigation, add a disableVulnerableKernelModule call below.
     if isUbuntu "$OS" || isMarinerOrAzureLinux "$OS"; then
-        logs_to_events "AKS.CSE.disableVulnerableKernelModules" disableVulnerableKernelModules
+        disableVulnerableKernelModule "algif_aead" "CVE-2026-31431 (Copy Fail)"
+        disableVulnerableKernelModule "esp4" "DirtyFrag (xfrm-ESP page-cache write)"
+        disableVulnerableKernelModule "esp6" "DirtyFrag (xfrm-ESP6 page-cache write)"
+        disableVulnerableKernelModule "rxrpc" "DirtyFrag (RxRPC page-cache write, bypasses AppArmor userns)"
     fi
 
     if ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -316,12 +316,19 @@ EOF
     # Confirmed exploitable on Ubuntu 24.04 (kernel 6.8). No upstream patch exists yet.
     # Applies to existing VHDs that don't yet have the modprobe-CIS.conf fix baked in.
     if [ "$OS" = "$UBUNTU_OS_NAME" ] || isMarinerOrAzureLinux "$OS"; then
-        if ! grep -qs "install rxrpc /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then
+        local dirtyfrag_needs_update=false
+        for mod in esp4 esp6 rxrpc; do
+            if ! grep -qs "install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then
+                dirtyfrag_needs_update=true
+                break
+            fi
+        done
+        if [ "$dirtyfrag_needs_update" = "true" ]; then
             printf "install esp4 /bin/false\nblacklist esp4\ninstall esp6 /bin/false\nblacklist esp6\ninstall rxrpc /bin/false\nblacklist rxrpc\n" > /etc/modprobe.d/disable-dirtyfrag.conf
         fi
         for mod in rxrpc esp4 esp6; do
             if grep -q "^${mod} " /proc/modules 2>/dev/null; then
-                if rmmod "$mod" 2>/dev/null; then
+                if modprobe -r "$mod" 2>/dev/null; then
                     echo "DirtyFrag: successfully unloaded ${mod} module"
                 else
                     echo "DirtyFrag: failed to unload ${mod} (in use), reboot required for full mitigation"

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -296,6 +296,49 @@ EOF
 
     # Disable kernel modules with known LPE vulnerabilities (CVE-2026-31431, DirtyFrag).
     # Applies to existing VHDs that don't yet have the modprobe-CIS.conf fix baked in.
+    # Defined inline in cse_main.sh (not sourced from cse_config.sh) to support scriptless provisioning.
+    # To add a new CVE mitigation, append to the MODULES array below.
+    disableVulnerableKernelModules() {
+        # Each entry: "module_name:config_file:description"
+        local MODULES=(
+            "algif_aead:disable-algif_aead.conf:CVE-2026-31431 (Copy Fail)"
+            "esp4:disable-dirtyfrag.conf:DirtyFrag (xfrm-ESP page-cache write)"
+            "esp6:disable-dirtyfrag.conf:DirtyFrag (xfrm-ESP6 page-cache write)"
+            "rxrpc:disable-dirtyfrag.conf:DirtyFrag (RxRPC page-cache write, bypasses AppArmor userns)"
+        )
+
+        # Group modules by config file and write each file once
+        declare -A config_contents
+        for entry in "${MODULES[@]}"; do
+            local mod="${entry%%:*}"
+            local rest="${entry#*:}"
+            local conf="${rest%%:*}"
+            local desc="${rest#*:}"
+            config_contents["$conf"]+="# ${desc}
+install ${mod} /bin/false
+blacklist ${mod}
+"
+        done
+
+        for conf in "${!config_contents[@]}"; do
+            echo "${config_contents[$conf]}" > "/etc/modprobe.d/${conf}"
+        done
+
+        # Unload any already-loaded vulnerable modules
+        for entry in "${MODULES[@]}"; do
+            local mod="${entry%%:*}"
+            local desc="${entry#*:}"
+            desc="${desc#*:}"
+            if grep -q "^${mod} " /proc/modules 2>/dev/null; then
+                if modprobe -r "$mod" 2>/dev/null; then
+                    echo "${desc}: successfully unloaded ${mod}"
+                else
+                    echo "${desc}: failed to unload ${mod} (in use), reboot required for full mitigation"
+                fi
+            fi
+        done
+    }
+
     if isUbuntu "$OS" || isMarinerOrAzureLinux "$OS"; then
         logs_to_events "AKS.CSE.disableVulnerableKernelModules" disableVulnerableKernelModules
     fi

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -294,46 +294,10 @@ EOF
 
     logs_to_events "AKS.CSE.ensureSysctl" ensureSysctl || exit $ERR_SYSCTL_RELOAD
 
-    # CVE-2026-31431 (Copy Fail): Mitigate algif_aead LPE vulnerability.
-    # Affects Ubuntu 20.04/22.04/24.04 and AzureLinux 3.0 (kernel >=4.15).
+    # Disable kernel modules with known LPE vulnerabilities (CVE-2026-31431, DirtyFrag).
     # Applies to existing VHDs that don't yet have the modprobe-CIS.conf fix baked in.
-    # Safe to run unconditionally — idempotent if already mitigated.
-    if [ "$OS" = "$UBUNTU_OS_NAME" ] || isMarinerOrAzureLinux "$OS"; then
-        if ! grep -qs "algif_aead" /etc/modprobe.d/*.conf 2>/dev/null; then
-            printf "install algif_aead /bin/false\nblacklist algif_aead\n" > /etc/modprobe.d/disable-algif_aead.conf
-        fi
-        if grep -q '^algif_aead ' /proc/modules 2>/dev/null; then
-            if rmmod algif_aead 2>/dev/null; then
-                echo "CVE-2026-31431: successfully unloaded algif_aead module"
-            else
-                echo "CVE-2026-31431: failed to unload algif_aead (in use), reboot required for full mitigation"
-            fi
-        fi
-    fi
-
-    # DirtyFrag: Mitigate xfrm-ESP + RxRPC page-cache write LPE vulnerabilities.
-    # rxrpc path bypasses AppArmor userns restrictions — does NOT require user namespaces.
-    # Confirmed exploitable on Ubuntu 24.04 (kernel 6.8). No upstream patch exists yet.
-    # Applies to existing VHDs that don't yet have the modprobe-CIS.conf fix baked in.
-    # Safe to run unconditionally — idempotent, overwrites with same content if already present.
     if isUbuntu "$OS" || isMarinerOrAzureLinux "$OS"; then
-        cat > /etc/modprobe.d/disable-dirtyfrag.conf <<EOF
-install esp4 /bin/false
-blacklist esp4
-install esp6 /bin/false
-blacklist esp6
-install rxrpc /bin/false
-blacklist rxrpc
-EOF
-        for mod in rxrpc esp4 esp6; do
-            if grep -q "^${mod} " /proc/modules 2>/dev/null; then
-                if modprobe -r "$mod" 2>/dev/null; then
-                    echo "DirtyFrag: successfully unloaded ${mod} module"
-                else
-                    echo "DirtyFrag: failed to unload ${mod} (in use), reboot required for full mitigation"
-                fi
-            fi
-        done
+        logs_to_events "AKS.CSE.disableVulnerableKernelModules" disableVulnerableKernelModules
     fi
 
     if ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -311,6 +311,25 @@ EOF
         fi
     fi
 
+    # DirtyFrag: Mitigate xfrm-ESP + RxRPC page-cache write LPE vulnerabilities.
+    # rxrpc path bypasses AppArmor userns restrictions — does NOT require user namespaces.
+    # Confirmed exploitable on Ubuntu 24.04 (kernel 6.8). No upstream patch exists yet.
+    # Applies to existing VHDs that don't yet have the modprobe-CIS.conf fix baked in.
+    if [ "$OS" = "$UBUNTU_OS_NAME" ] || isMarinerOrAzureLinux "$OS"; then
+        if ! grep -qs "install rxrpc /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then
+            printf "install esp4 /bin/false\nblacklist esp4\ninstall esp6 /bin/false\nblacklist esp6\ninstall rxrpc /bin/false\nblacklist rxrpc\n" > /etc/modprobe.d/disable-dirtyfrag.conf
+        fi
+        for mod in rxrpc esp4 esp6; do
+            if grep -q "^${mod} " /proc/modules 2>/dev/null; then
+                if rmmod "$mod" 2>/dev/null; then
+                    echo "DirtyFrag: successfully unloaded ${mod} module"
+                else
+                    echo "DirtyFrag: failed to unload ${mod} (in use), reboot required for full mitigation"
+                fi
+            fi
+        done
+    fi
+
     if ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
         if [ "$OS" = "$UBUNTU_OS_NAME" ] || isMarinerOrAzureLinux "$OS"; then
             logs_to_events "AKS.CSE.ubuntuSnapshotUpdate" ensureSnapshotUpdate

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -315,17 +315,16 @@ EOF
     # rxrpc path bypasses AppArmor userns restrictions — does NOT require user namespaces.
     # Confirmed exploitable on Ubuntu 24.04 (kernel 6.8). No upstream patch exists yet.
     # Applies to existing VHDs that don't yet have the modprobe-CIS.conf fix baked in.
-    if [ "$OS" = "$UBUNTU_OS_NAME" ] || isMarinerOrAzureLinux "$OS"; then
-        local dirtyfrag_needs_update=false
-        for mod in esp4 esp6 rxrpc; do
-            if ! grep -qs "install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then
-                dirtyfrag_needs_update=true
-                break
-            fi
-        done
-        if [ "$dirtyfrag_needs_update" = "true" ]; then
-            printf "install esp4 /bin/false\nblacklist esp4\ninstall esp6 /bin/false\nblacklist esp6\ninstall rxrpc /bin/false\nblacklist rxrpc\n" > /etc/modprobe.d/disable-dirtyfrag.conf
-        fi
+    # Safe to run unconditionally — idempotent, overwrites with same content if already present.
+    if isUbuntu "$OS" || isMarinerOrAzureLinux "$OS"; then
+        cat > /etc/modprobe.d/disable-dirtyfrag.conf <<EOF
+install esp4 /bin/false
+blacklist esp4
+install esp6 /bin/false
+blacklist esp6
+install rxrpc /bin/false
+blacklist rxrpc
+EOF
         for mod in rxrpc esp4 esp6; do
             if grep -q "^${mod} " /proc/modules 2>/dev/null; then
                 if modprobe -r "$mod" 2>/dev/null; then

--- a/parts/linux/cloud-init/artifacts/modprobe-CIS.conf
+++ b/parts/linux/cloud-init/artifacts/modprobe-CIS.conf
@@ -31,8 +31,9 @@ install algif_aead /bin/false
 blacklist algif_aead
 # DirtyFrag / CopyFail2: Disable xfrm ESP and RxRPC modules to mitigate page-cache
 # write LPE vulnerabilities. rxrpc path bypasses AppArmor userns restrictions.
-# AKS workloads do not use IPsec ESP or AFS/RxRPC protocols.
-# See https://github.com/V4bel/dirtyfrag
+# AKS platform components do not require kernel IPsec ESP/XFRM or AFS/RxRPC.
+# Disabling these modules prevents workloads that rely on those protocols from working
+# on the node. See https://github.com/V4bel/dirtyfrag
 install esp4 /bin/false
 blacklist esp4
 install esp6 /bin/false

--- a/parts/linux/cloud-init/artifacts/modprobe-CIS.conf
+++ b/parts/linux/cloud-init/artifacts/modprobe-CIS.conf
@@ -29,3 +29,13 @@ blacklist usb-storage
 # until kernel fix is available. See https://ubuntu.com/blog/copy-fail-vulnerability-fixes-available
 install algif_aead /bin/false
 blacklist algif_aead
+# DirtyFrag / CopyFail2: Disable xfrm ESP and RxRPC modules to mitigate page-cache
+# write LPE vulnerabilities. rxrpc path bypasses AppArmor userns restrictions.
+# AKS workloads do not use IPsec ESP or AFS/RxRPC protocols.
+# See https://github.com/V4bel/dirtyfrag
+install esp4 /bin/false
+blacklist esp4
+install esp6 /bin/false
+blacklist esp6
+install rxrpc /bin/false
+blacklist rxrpc

--- a/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env shellspec
+
+# Unit tests for disableVulnerableKernelModules() in cse_main.sh
+# Verifies that the function creates correct modprobe blacklist configs
+# and attempts to unload loaded modules.
+
+Describe 'disableVulnerableKernelModules()'
+    MODPROBE_DIR=""
+
+    setup() {
+        MODPROBE_DIR="$(mktemp -d)"
+        # Override /etc/modprobe.d with our temp dir
+        # We redefine the function with the temp dir path
+        eval "$(sed -n '/^disableVulnerableKernelModules()/,/^}/p' parts/linux/cloud-init/artifacts/cse_main.sh | \
+            sed "s|/etc/modprobe.d|${MODPROBE_DIR}|g")"
+    }
+
+    cleanup() {
+        rm -rf "$MODPROBE_DIR"
+    }
+
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    # Mock grep for /proc/modules to simulate no modules loaded
+    grep() {
+        if [ "$2" = "/proc/modules" ]; then
+            return 1
+        fi
+        command grep "$@"
+    }
+
+    # Mock modprobe -r (should not be called since no modules are "loaded")
+    modprobe() {
+        echo "modprobe called with: $*"
+        return 0
+    }
+
+    It 'creates the algif_aead config file'
+        When run disableVulnerableKernelModules
+        Path config_file="${MODPROBE_DIR}/disable-algif_aead.conf"
+        The path config_file should be file
+        The contents of file config_file should include "install algif_aead /bin/false"
+        The contents of file config_file should include "blacklist algif_aead"
+    End
+
+    It 'creates the dirtyfrag config file with esp4/esp6/rxrpc'
+        When run disableVulnerableKernelModules
+        Path config_file="${MODPROBE_DIR}/disable-dirtyfrag.conf"
+        The path config_file should be file
+        The contents of file config_file should include "install esp4 /bin/false"
+        The contents of file config_file should include "blacklist esp4"
+        The contents of file config_file should include "install esp6 /bin/false"
+        The contents of file config_file should include "blacklist esp6"
+        The contents of file config_file should include "install rxrpc /bin/false"
+        The contents of file config_file should include "blacklist rxrpc"
+    End
+
+    It 'is idempotent — running twice produces same files'
+        run_twice() {
+            disableVulnerableKernelModules
+            disableVulnerableKernelModules
+        }
+        When run run_twice
+        Path algif="${MODPROBE_DIR}/disable-algif_aead.conf"
+        Path dirty="${MODPROBE_DIR}/disable-dirtyfrag.conf"
+        The path algif should be file
+        The path dirty should be file
+        # Only two config files should exist
+        The result of "ls ${MODPROBE_DIR}/*.conf | wc -l" should eq 2
+    End
+
+    It 'includes CVE descriptions as comments'
+        When run disableVulnerableKernelModules
+        Path algif="${MODPROBE_DIR}/disable-algif_aead.conf"
+        Path dirty="${MODPROBE_DIR}/disable-dirtyfrag.conf"
+        The contents of file algif should include "CVE-2026-31431"
+        The contents of file dirty should include "DirtyFrag"
+    End
+End

--- a/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
@@ -1,80 +1,73 @@
 #!/usr/bin/env shellspec
 
-# Unit tests for disableVulnerableKernelModules() in cse_main.sh
-# Verifies that the function creates correct modprobe blacklist configs
-# and attempts to unload loaded modules.
+# Unit tests for disableVulnerableKernelModule() in cse_main.sh
 
-Describe 'disableVulnerableKernelModules()'
+Describe 'disableVulnerableKernelModule()'
     MODPROBE_DIR=""
+    PROC_MODULES=""
 
     setup() {
         MODPROBE_DIR="$(mktemp -d)"
-        # Override /etc/modprobe.d with our temp dir
-        # We redefine the function with the temp dir path
-        eval "$(sed -n '/^disableVulnerableKernelModules()/,/^}/p' parts/linux/cloud-init/artifacts/cse_main.sh | \
-            sed "s|/etc/modprobe.d|${MODPROBE_DIR}|g")"
+        PROC_MODULES="$(mktemp)"
+        # Source only the function by extracting it
+        eval "$(sed -n '/^disableVulnerableKernelModule()/,/^}/p' parts/linux/cloud-init/artifacts/cse_main.sh | \
+            sed "s|/etc/modprobe.d|${MODPROBE_DIR}|g; s|/proc/modules|${PROC_MODULES}|g")"
     }
 
     cleanup() {
         rm -rf "$MODPROBE_DIR"
+        rm -f "$PROC_MODULES"
     }
 
     BeforeEach 'setup'
     AfterEach 'cleanup'
 
-    # Mock grep for /proc/modules to simulate no modules loaded
-    grep() {
-        if [ "$2" = "/proc/modules" ]; then
-            return 1
-        fi
-        command grep "$@"
-    }
+    # Mock modprobe -r
+    modprobe() { return 0; }
 
-    # Mock modprobe -r (should not be called since no modules are "loaded")
-    modprobe() {
-        echo "modprobe called with: $*"
-        return 0
-    }
-
-    It 'creates the algif_aead config file'
-        When run disableVulnerableKernelModules
-        Path config_file="${MODPROBE_DIR}/disable-algif_aead.conf"
-        The path config_file should be file
-        The contents of file config_file should include "install algif_aead /bin/false"
-        The contents of file config_file should include "blacklist algif_aead"
+    It 'creates a config file for a single module'
+        When call disableVulnerableKernelModule "algif_aead" "CVE-2026-31431 (Copy Fail)"
+        The file "${MODPROBE_DIR}/disable-algif_aead.conf" should be exist
+        The contents of file "${MODPROBE_DIR}/disable-algif_aead.conf" should include "install algif_aead /bin/false"
+        The contents of file "${MODPROBE_DIR}/disable-algif_aead.conf" should include "blacklist algif_aead"
+        The contents of file "${MODPROBE_DIR}/disable-algif_aead.conf" should include "CVE-2026-31431"
     End
 
-    It 'creates the dirtyfrag config file with esp4/esp6/rxrpc'
-        When run disableVulnerableKernelModules
-        Path config_file="${MODPROBE_DIR}/disable-dirtyfrag.conf"
-        The path config_file should be file
-        The contents of file config_file should include "install esp4 /bin/false"
-        The contents of file config_file should include "blacklist esp4"
-        The contents of file config_file should include "install esp6 /bin/false"
-        The contents of file config_file should include "blacklist esp6"
-        The contents of file config_file should include "install rxrpc /bin/false"
-        The contents of file config_file should include "blacklist rxrpc"
+    It 'creates separate config files per module'
+        When call disableVulnerableKernelModule "esp4" "DirtyFrag ESP4"
+        The file "${MODPROBE_DIR}/disable-esp4.conf" should be exist
+        The contents of file "${MODPROBE_DIR}/disable-esp4.conf" should include "install esp4 /bin/false"
+        The contents of file "${MODPROBE_DIR}/disable-esp4.conf" should include "blacklist esp4"
     End
 
-    It 'is idempotent — running twice produces same files'
-        run_twice() {
-            disableVulnerableKernelModules
-            disableVulnerableKernelModules
+    It 'is idempotent — running twice produces same content'
+        first_run() {
+            disableVulnerableKernelModule "rxrpc" "DirtyFrag RxRPC"
+            cat "${MODPROBE_DIR}/disable-rxrpc.conf"
         }
-        When run run_twice
-        Path algif="${MODPROBE_DIR}/disable-algif_aead.conf"
-        Path dirty="${MODPROBE_DIR}/disable-dirtyfrag.conf"
-        The path algif should be file
-        The path dirty should be file
-        # Only two config files should exist
-        The result of "ls ${MODPROBE_DIR}/*.conf | wc -l" should eq 2
+        second_run() {
+            disableVulnerableKernelModule "rxrpc" "DirtyFrag RxRPC"
+            cat "${MODPROBE_DIR}/disable-rxrpc.conf"
+        }
+        When call first_run
+        The output should eq "$(second_run)"
     End
 
-    It 'includes CVE descriptions as comments'
-        When run disableVulnerableKernelModules
-        Path algif="${MODPROBE_DIR}/disable-algif_aead.conf"
-        Path dirty="${MODPROBE_DIR}/disable-dirtyfrag.conf"
-        The contents of file algif should include "CVE-2026-31431"
-        The contents of file dirty should include "DirtyFrag"
+    It 'attempts to unload a loaded module'
+        loaded_test() {
+            echo "rxrpc 425984 0" > "$PROC_MODULES"
+            disableVulnerableKernelModule "rxrpc" "DirtyFrag RxRPC"
+        }
+        When call loaded_test
+        The output should include "successfully unloaded rxrpc"
+    End
+
+    It 'does not attempt unload when module is not loaded'
+        not_loaded_test() {
+            : > "$PROC_MODULES"
+            disableVulnerableKernelModule "rxrpc" "DirtyFrag RxRPC"
+        }
+        When call not_loaded_test
+        The output should not include "unloaded"
     End
 End

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1294,6 +1294,37 @@ testAlgifAeadDisabled() {
 
   echo "$test:Finish"
 }
+
+# DirtyFrag: Verify xfrm ESP and RxRPC kernel modules are disabled.
+# These modules are used in the DirtyFrag LPE exploit chain.
+# The rxrpc path bypasses AppArmor userns restrictions.
+testDirtyFragModulesDisabled() {
+  local test="testDirtyFragModulesDisabled"
+  echo "$test:Start"
+
+  local failed=0
+  for mod in esp4 esp6 rxrpc; do
+    if ! grep -qs "install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then
+      err "$test" "${mod} disable rule not found in /etc/modprobe.d/*.conf"
+      failed=1
+    else
+      echo "$test: modprobe config correctly blocks ${mod}"
+    fi
+
+    if grep -qE "^${mod} " /proc/modules 2>/dev/null; then
+      err "$test" "${mod} kernel module is loaded despite being disabled"
+      failed=1
+    else
+      echo "$test: ${mod} module is not loaded"
+    fi
+  done
+
+  if [ "$failed" -ne 0 ]; then
+    return 1
+  fi
+
+  echo "$test:Finish"
+}
 testPamDSettings() {
   local os_sku="${1}"
   local os_version="${2}"
@@ -2378,3 +2409,4 @@ testPackageDownloadURLFallbackLogic
 testFileOwnership $OS_SKU
 testDiskQueueServiceIsActive
 testAlgifAeadDisabled
+testDirtyFragModulesDisabled

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1271,7 +1271,7 @@ testVulnerableKernelModulesDisabled() {
 
   local failed=0
   for mod in algif_aead esp4 esp6 rxrpc; do
-    if ! grep -qs "install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then
+    if ! grep -qsE "^install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then
       err "$test" "${mod} disable rule not found in /etc/modprobe.d/*.conf"
       failed=1
     else
@@ -1287,7 +1287,7 @@ testVulnerableKernelModulesDisabled() {
 
     if modprobe "${mod}" 2>/dev/null; then
       err "$test" "modprobe ${mod} succeeded — module should be blocked"
-      rmmod "${mod}" 2>/dev/null || true
+      modprobe -r "${mod}" 2>/dev/null || true
       failed=1
     else
       echo "$test: modprobe ${mod} correctly refused to load"

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1262,49 +1262,15 @@ testNfsServerService() {
   echo "$test:Finish"
 }
 
-# CVE-2026-31431 (Copy Fail): Verify algif_aead kernel module is disabled.
-# The modprobe-CIS.conf should contain "install algif_aead /bin/false" which
-# prevents the module from loading. Verify the config is present, the module
-# is not loaded, and that attempting to load it fails.
-testAlgifAeadDisabled() {
-  local test="testAlgifAeadDisabled"
-  echo "$test:Start"
-
-  # Verify modprobe config blocks the module
-  if ! grep -qs "install algif_aead /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then
-    err "$test" "algif_aead disable rule not found in /etc/modprobe.d/*.conf"
-    return 1
-  fi
-  echo "$test: modprobe config correctly blocks algif_aead"
-
-  # Verify the module is not currently loaded
-  if grep -qE '^algif_aead ' /proc/modules 2>/dev/null; then
-    err "$test" "algif_aead kernel module is loaded despite being disabled"
-    return 1
-  fi
-  echo "$test: algif_aead module is not loaded"
-
-  # Verify that attempting to load the module fails
-  if modprobe algif_aead 2>/dev/null; then
-    err "$test" "modprobe algif_aead succeeded — module should be blocked"
-    rmmod algif_aead 2>/dev/null || true
-    return 1
-  fi
-  echo "$test: modprobe algif_aead correctly refused to load"
-
-  echo "$test:Finish"
-}
-
-# DirtyFrag: Verify xfrm ESP and RxRPC kernel modules are disabled.
-# These modules are used in the DirtyFrag LPE exploit chain.
-# The rxrpc path bypasses AppArmor userns restrictions.
-testDirtyFragModulesDisabled() {
-  local test="testDirtyFragModulesDisabled"
+# Verify all kernel modules with known LPE vulnerabilities are disabled.
+# Covers: CVE-2026-31431 (algif_aead), DirtyFrag (esp4, esp6, rxrpc).
+# To add a new CVE mitigation, append the module to the loop below.
+testVulnerableKernelModulesDisabled() {
+  local test="testVulnerableKernelModulesDisabled"
   echo "$test:Start"
 
   local failed=0
-  for mod in esp4 esp6 rxrpc; do
-    # Verify modprobe config blocks the module
+  for mod in algif_aead esp4 esp6 rxrpc; do
     if ! grep -qs "install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then
       err "$test" "${mod} disable rule not found in /etc/modprobe.d/*.conf"
       failed=1
@@ -1312,7 +1278,6 @@ testDirtyFragModulesDisabled() {
       echo "$test: modprobe config correctly blocks ${mod}"
     fi
 
-    # Verify the module is not currently loaded
     if grep -qE "^${mod} " /proc/modules 2>/dev/null; then
       err "$test" "${mod} kernel module is loaded despite being disabled"
       failed=1
@@ -1320,7 +1285,6 @@ testDirtyFragModulesDisabled() {
       echo "$test: ${mod} module is not loaded"
     fi
 
-    # Verify that attempting to load the module fails
     if modprobe "${mod}" 2>/dev/null; then
       err "$test" "modprobe ${mod} succeeded — module should be blocked"
       rmmod "${mod}" 2>/dev/null || true
@@ -2419,5 +2383,4 @@ testInspektorGadgetAssets
 testPackageDownloadURLFallbackLogic
 testFileOwnership $OS_SKU
 testDiskQueueServiceIsActive
-testAlgifAeadDisabled
-testDirtyFragModulesDisabled
+testVulnerableKernelModulesDisabled

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1304,6 +1304,7 @@ testDirtyFragModulesDisabled() {
 
   local failed=0
   for mod in esp4 esp6 rxrpc; do
+    # Verify modprobe config blocks the module
     if ! grep -qs "install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then
       err "$test" "${mod} disable rule not found in /etc/modprobe.d/*.conf"
       failed=1
@@ -1311,11 +1312,21 @@ testDirtyFragModulesDisabled() {
       echo "$test: modprobe config correctly blocks ${mod}"
     fi
 
+    # Verify the module is not currently loaded
     if grep -qE "^${mod} " /proc/modules 2>/dev/null; then
       err "$test" "${mod} kernel module is loaded despite being disabled"
       failed=1
     else
       echo "$test: ${mod} module is not loaded"
+    fi
+
+    # Verify that attempting to load the module fails
+    if modprobe "${mod}" 2>/dev/null; then
+      err "$test" "modprobe ${mod} succeeded — module should be blocked"
+      rmmod "${mod}" 2>/dev/null || true
+      failed=1
+    else
+      echo "$test: modprobe ${mod} correctly refused to load"
     fi
   done
 


### PR DESCRIPTION
## Summary

Blacklist rxrpc, esp4, and esp6 kernel modules to mitigate the DirtyFrag universal Linux LPE. The rxrpc path bypasses AppArmor `restrict_unprivileged_userns` — confirmed exploitable on Ubuntu 24.04 AKS nodes (kernel 6.8.0-1052-azure).

## Evidence

Exploit tested live on AKS node: unprivileged user (uid=1001) overwrote `/etc/passwd` root line via rxrpc.ko page-cache write, removing shadow reference (`root:x:` → `root::`). No user namespaces needed.

## Changes

- `modprobe-CIS.conf`: add `install/blacklist` rules for esp4, esp6, rxrpc (same pattern as algif_aead for CVE-2026-31431)
- `cse_main.sh`: add CSE hotfix for existing VHDs that don't have the new modprobe-CIS.conf baked in
- `linux-vhd-content-test.sh`: add `testDirtyFragModulesDisabled` VHD content test

## Testing

- Verified DirtyFrag exploit fails when modules are blacklisted
- VHD content test validates modprobe config and module state
- Pattern matches existing algif_aead mitigation (proven in production)

## References

- https://github.com/V4bel/dirtyfrag
- https://github.com/0xdeadbeefnetwork/Copy_Fail2-Electric_Boogaloo

## Related

- AB#37878493