### PR TITLE
fix: remove gcc/make from Ubuntu AKS VHDs

### DIFF
--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
@@ -48,7 +48,7 @@ installDeps() {
     holdWALinuxAgent hold
     apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT
 
-    pkg_list=(apparmor-utils bind9-dnsutils ca-certificates ceph-common cgroup-lite cifs-utils conntrack cracklib-runtime ebtables ethtool glusterfs-client htop init-system-helpers inotify-tools iotop iproute2 ipset iptables nftables jq libpam-pwquality libpwquality-tools mount nfs-common pigz socat sysfsutils sysstat util-linux xz-utils netcat-openbsd zip rng-tools kmod gcc make dkms initramfs-tools linux-headers-$(uname -r) linux-modules-extra-$(uname -r))
+    pkg_list=(apparmor-utils bind9-dnsutils ca-certificates ceph-common cgroup-lite cifs-utils conntrack cracklib-runtime ebtables ethtool glusterfs-client htop init-system-helpers inotify-tools iotop iproute2 ipset iptables nftables jq libpam-pwquality libpwquality-tools mount nfs-common pigz socat sysfsutils sysstat util-linux xz-utils netcat-openbsd zip rng-tools kmod dkms initramfs-tools linux-headers-$(uname -r) linux-modules-extra-$(uname -r))
 
     local OSVERSION=$(grep DISTRIB_RELEASE /etc/*-release| cut -f 2 -d "=")
     while IFS= read -r fallback_pkg; do

--- a/vhdbuilder/packer/cleanup-vhd.sh
+++ b/vhdbuilder/packer/cleanup-vhd.sh
@@ -21,5 +21,11 @@ fi
 rm -f /opt/azure/disk-usage.txt
 # remove image-fetcher binary from the image since it's only needed during build and is not expected to be present on the final image
 rm -f /opt/azure/containers/image-fetcher
+# Security: remove compiler toolchain from Ubuntu VHDs to prevent on-node exploit compilation.
+# gcc/make are needed at build time (dkms, kernel module compilation) but should not ship.
+# Azure Linux already does not include gcc. See AB#37878492.
+if command -v apt-get &>/dev/null; then
+  apt-get purge -y --auto-remove gcc gcc-[0-9]* cpp cpp-[0-9]* make 2>/dev/null || true
+fi
 # Cleanup IMDS instance metadata cache file
 rm -f /opt/azure/containers/imds_instance_metadata_cache.json

--- a/vhdbuilder/packer/cleanup-vhd.sh
+++ b/vhdbuilder/packer/cleanup-vhd.sh
@@ -25,12 +25,14 @@ rm -f /opt/azure/containers/image-fetcher
 # gcc/make are needed at build time (dkms, kernel module compilation) but should not ship.
 # Azure Linux already does not include gcc. See AB#37878492.
 if command -v apt-get &>/dev/null; then
-  # Resolve installed gcc/cpp/make packages explicitly to avoid silent glob failures
-  GCC_PKGS=$(dpkg --get-selections 2>/dev/null | awk '/^(gcc|cpp|g\+\+|make)[- \t]/{print $1}' | grep -v 'lib' || true)
+  # Resolve installed gcc/cpp/make packages explicitly to avoid silent glob failures.
+  # Exclude *-base packages (e.g. gcc-12-base) — they provide libgcc-s1 which is a
+  # system-critical dependency; --auto-remove would cascade into removing libc6.
+  GCC_PKGS=$(dpkg --get-selections 2>/dev/null | awk '/^(gcc|cpp|g\+\+|make)[- \t]/{print $1}' | grep -vE '(lib|-base)' || true)
   if [ -n "$GCC_PKGS" ]; then
     echo "Purging compiler toolchain: $GCC_PKGS"
     # shellcheck disable=SC2086
-    apt-get purge -y --auto-remove $GCC_PKGS
+    apt-get purge -y $GCC_PKGS
   fi
   # Verify removal — fail the build if compiler tools remain
   for tool in gcc g++ cc make; do

--- a/vhdbuilder/packer/cleanup-vhd.sh
+++ b/vhdbuilder/packer/cleanup-vhd.sh
@@ -25,7 +25,21 @@ rm -f /opt/azure/containers/image-fetcher
 # gcc/make are needed at build time (dkms, kernel module compilation) but should not ship.
 # Azure Linux already does not include gcc. See AB#37878492.
 if command -v apt-get &>/dev/null; then
-  apt-get purge -y --auto-remove gcc gcc-[0-9]* cpp cpp-[0-9]* make 2>/dev/null || true
+  # Resolve installed gcc/cpp/make packages explicitly to avoid silent glob failures
+  GCC_PKGS=$(dpkg --get-selections 2>/dev/null | awk '/^(gcc|cpp|g\+\+|make)[- \t]/{print $1}' | grep -v 'lib' || true)
+  if [ -n "$GCC_PKGS" ]; then
+    echo "Purging compiler toolchain: $GCC_PKGS"
+    # shellcheck disable=SC2086
+    apt-get purge -y --auto-remove $GCC_PKGS
+  fi
+  # Verify removal — fail the build if compiler tools remain
+  for tool in gcc g++ cc make; do
+    if command -v "$tool" &>/dev/null; then
+      echo "ERROR: $tool is still present after purge at $(command -v "$tool")"
+      exit 1
+    fi
+  done
+  echo "Compiler toolchain successfully removed"
 fi
 # Cleanup IMDS instance metadata cache file
 rm -f /opt/azure/containers/imds_instance_metadata_cache.json

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -2386,7 +2386,7 @@ testCompilerToolchainAbsent() {
   local test="testCompilerToolchainAbsent"
   echo "$test:Start"
 
-  if [[ "${OS_SKU}" == "CBLMariner" ]] || [[ "${OS_SKU}" == "AzureLinux" ]]; then
+  if [ "$OS_SKU" = "CBLMariner" ] || [ "$OS_SKU" = "AzureLinux" ] || [ "$OS_SKU" = "AzureLinuxOSGuard" ] || [ "$OS_SKU" = "Flatcar" ] || [ "$OS_SKU" = "AzureContainerLinux" ]; then
     echo "$test: Skipping on ${OS_SKU} (gcc never shipped)"
     echo "$test:Finish"
     return 0
@@ -2404,7 +2404,7 @@ testCompilerToolchainAbsent() {
 
   # Also check no gcc packages installed
   local gcc_pkgs
-  gcc_pkgs=$(dpkg --get-selections 2>/dev/null | awk '/^(gcc|cpp|g\+\+|make)[- \t]/' | grep -v 'lib' || true)
+  gcc_pkgs=$(dpkg --get-selections 2>/dev/null | awk '/^(gcc|cpp|g\+\+|make)[- \t]/' | grep -vE '(lib|-base)' || true)
   if [ -n "$gcc_pkgs" ]; then
     err "$test" "gcc-related packages still installed: ${gcc_pkgs}"
     failed=1

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -2378,3 +2378,42 @@ testPackageDownloadURLFallbackLogic
 testFileOwnership $OS_SKU
 testDiskQueueServiceIsActive
 testAlgifAeadDisabled
+
+# Security: Verify compiler toolchain is not present on the VHD.
+# gcc/make enable on-node compilation of kernel exploits (e.g., DirtyFrag).
+# Only applicable to Ubuntu — Azure Linux never ships gcc.
+testCompilerToolchainAbsent() {
+  local test="testCompilerToolchainAbsent"
+  echo "$test:Start"
+
+  if [[ "${OS_SKU}" == "CBLMariner" ]] || [[ "${OS_SKU}" == "AzureLinux" ]]; then
+    echo "$test: Skipping on ${OS_SKU} (gcc never shipped)"
+    echo "$test:Finish"
+    return 0
+  fi
+
+  local failed=0
+  for tool in gcc g++ cc make; do
+    if command -v "$tool" &>/dev/null; then
+      err "$test" "${tool} found at $(command -v "$tool") — should have been removed in cleanup-vhd.sh"
+      failed=1
+    else
+      echo "$test: ${tool} not present ✓"
+    fi
+  done
+
+  # Also check no gcc packages installed
+  local gcc_pkgs
+  gcc_pkgs=$(dpkg --get-selections 2>/dev/null | awk '/^(gcc|cpp|g\+\+|make)[- \t]/' | grep -v 'lib' || true)
+  if [ -n "$gcc_pkgs" ]; then
+    err "$test" "gcc-related packages still installed: ${gcc_pkgs}"
+    failed=1
+  fi
+
+  if [ "$failed" -ne 0 ]; then
+    return 1
+  fi
+
+  echo "$test:Finish"
+}
+testCompilerToolchainAbsent


### PR DESCRIPTION
## Summary

Remove gcc and make from Ubuntu AKS VHDs. These compiler tools allow attackers who gain host access to compile kernel exploits on-node. Azure Linux already does not ship gcc, which is one reason it was not exploitable by DirtyFrag.

## Evidence

During DirtyFrag testing, gcc on an Ubuntu 24.04 AKS node compiled the exploit successfully as an unprivileged user (uid=1001), leading to confirmed root privilege escalation via page-cache write.

## Changes

- `cse_install_ubuntu.sh`: remove `gcc` and `make` from the CSE package list (dkms and linux-headers remain for kernel module support)
- `cleanup-vhd.sh`: purge gcc/cpp/make after VHD build completes (dkms compiles during build, compiler not needed on final image)

## Testing

- dkms kernel module compilation occurs during Packer build phase (gcc is available then)
- cleanup-vhd.sh runs after build, removing gcc from the shipping image
- Existing CSE install no longer pulls gcc on fresh non-VHD installs

## Risk Assessment

- **Low risk**: gcc is not needed at runtime on AKS nodes. All kernel modules are pre-compiled during VHD build.
- **Azure Linux parity**: Azure Linux already ships without gcc, proving AKS workloads function without it.

## Related

- AB#37878492
- DirtyFrag exploit: https://github.com/V4bel/dirtyfrag