### PR TITLE
feat: add 5B non-sec regkeys

### DIFF
--- a/vhdbuilder/packer/windows/windows_settings.json
+++ b/vhdbuilder/packer/windows/windows_settings.json
@@ -748,6 +748,46 @@
       "Name": "2112481934",
       "Value": "1",
       "Type": "DWORD"
+    },
+    {
+      "Comment": "2026-5B",
+      "WindowsSkuMatch": "2022*",
+      "Path": "HKLM:\\SYSTEM\\CurrentControlSet\\Policies\\Microsoft\\FeatureManagement\\Overrides",
+      "Name": "4173449358",
+      "Value": "1",
+      "Type": "DWORD"
+    },
+    {
+      "Comment": "2026-5B",
+      "WindowsSkuMatch": "2022*",
+      "Path": "HKLM:\\SYSTEM\\CurrentControlSet\\Policies\\Microsoft\\FeatureManagement\\Overrides",
+      "Name": "1491587726",
+      "Value": "1",
+      "Type": "DWORD"
+    },
+    {
+      "Comment":"2026-5B",
+      "WindowsSkuMatch": "2022*",
+      "Path": "HKLM:\\SYSTEM\\CurrentControlSet\\Policies\\Microsoft\\FeatureManagement\\Overrides",
+      "Name": "3658215055",
+      "Value": "1",
+      "Type": "DWORD"
+    },
+    {
+      "Comment": "2026-5B",
+      "WindowsSkuMatch": "2025*",
+      "Path": "HKLM:\\SYSTEM\\CurrentControlSet\\Policies\\Microsoft\\FeatureManagement\\Overrides",
+      "Name": "1861198479",
+      "Value": "1",
+      "Type": "DWORD"
+    },
+    {
+      "Comment": "2026-5B",
+      "WindowsSkuMatch": "2025*",
+      "Path": "HKLM:\\SYSTEM\\CurrentControlSet\\Policies\\Microsoft\\FeatureManagement\\Overrides",
+      "Name": "1451608719",
+      "Value": "1",
+      "Type": "DWORD"
     }
   ]
 }


### PR DESCRIPTION
This PR introduces the May “5B” non-security registry key updates to ensure consistency and compliance with the latest Windows image configuration requirements for AKS node provisioning.
What’s included

Added/updated non-security (non-sec) registry keys aligned with 5B requirements
Ensured keys are applied across relevant Windows SKUs/images used in AgentBaker
Maintained parity with upstream Windows image expectations and servicing guidance

**Why this change
Enables alignment with monthly Patch Tuesday (5B cycle) configuration updates
Ensures AKS node images remain consistent with latest platform expectations
Prevents drift between base OS images and AgentBaker-applied configuration

**Validation
✅ Verified registry key presence post-image bake
✅ Confirmed no regression in image provisioning / node pool creation
✅ Validated against current test pipelines (Hyper-V / containerd scenarios)

**Risk / Impact
Low risk – non-security configuration only
No expected impact to existing workloads or cluster behavior
Changes are scoped strictly to registry configuration

Notes

Follows established monthly release pattern for non-sec updates
Complements security fixes delivered separately in Patch Tuesday cycle

