### PR TITLE
fix: remove description while writing out mod file

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -61,7 +61,7 @@ disableVulnerableKernelModule() {
     local mod="$1"
     local desc="$2"
 
-    printf '# %s\ninstall %s /bin/false\nblacklist %s\n' "$desc" "$mod" "$mod" > "/etc/modprobe.d/disable-${mod}.conf"
+    printf 'install %s /bin/false\nblacklist %s\n' "$mod" "$mod" > "/etc/modprobe.d/disable-${mod}.conf"
 
     if grep -q "^${mod} " /proc/modules 2>/dev/null; then
         if modprobe -r "$mod" 2>/dev/null; then

--- a/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
@@ -30,7 +30,6 @@ Describe 'disableVulnerableKernelModule()'
         The file "${MODPROBE_DIR}/disable-algif_aead.conf" should be exist
         The contents of file "${MODPROBE_DIR}/disable-algif_aead.conf" should include "install algif_aead /bin/false"
         The contents of file "${MODPROBE_DIR}/disable-algif_aead.conf" should include "blacklist algif_aead"
-        The contents of file "${MODPROBE_DIR}/disable-algif_aead.conf" should include "CVE-2026-31431"
     End
 
     It 'creates separate config files per module'


### PR DESCRIPTION
we have code in AB which deletes all comments before creating the customdata payload
 
in bash comments start with #
 
so it treated that line as a comment 
 
and that replacement happens at runtime
 
 ```
 // This is "best-effort" - removes MOST of the comments with obvious formats, to lower the space required by CustomData component.
func removeComments(b []byte) []byte {
 var contentWithoutComments []string
 lines := strings.Split(string(b), "\n")
 for _, line := range lines {
  lineNoWhitespace := strings.TrimSpace(line)
  if lineStartsWithComment(lineNoWhitespace) {
   // ignore entire line that is a comment
   continue
  }
  line = trimTrailingComment(line)
  contentWithoutComments = append(contentWithoutComments, line)
 }
 return []byte(strings.Join(contentWithoutComments, "\n"))
}

func lineStartsWithComment(trimmedToCheck string) bool {
 return strings.HasPrefix(trimmedToCheck, "# ") || strings.HasPrefix(trimmedToCheck, "##")
}

func trimTrailingComment(line string) string {
 lastHashIndex := strings.LastIndex(line, "#")
 if lastHashIndex > 0 && isCommentAtTheEndOfLine(lastHashIndex, line) && !lineLogsToOutput(line) {
  // remove only the comment part from line
  line = line[:lastHashIndex]
 }
 return line
}
```

https://github.com/Azure/AgentBaker/blob/official/v20260424/pkg/agent/utils.go#L205
 
we need to add something to copilot instructions explaining it's unsafe to use # in command strings
 
 ```
 // Trying to avoid using a regex. There are certain patterns we ignore just to be on the safe side. This is enough to get rid of most of the obvious comments.
func isCommentAtTheEndOfLine(lastHashIndex int, trimmedToCheck string) bool {
  getSlice := func(start, end int, str string) string {
    if end > len(str) || start > end {
      return ""
    }
    return str[start:end]
  }
  // These are two of patterns that are present amongst Agent Baker files that we need to specifically check for. Non-exhaustive
  tailingCommentSegmentLen := 2
  return getSlice(lastHashIndex-1, lastHashIndex+1, trimmedToCheck) != "<#" && getSlice(lastHashIndex, lastHashIndex+tailingCommentSegmentLen, trimmedToCheck) == "# "
}
```