### PR TITLE
fix(e2e): allow DHCP INPUT rule in iptables eBPF compatibility validator

### DIFF
--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -229,6 +229,7 @@ func dllLoadedWindows(ctx context.Context, s *Scenario, dllName string) bool {
 func getIPTablesRulesCompatibleWithEBPFHostRouting() (map[string][]string, []string) {
 	tablePatterns := map[string][]string{
 		"filter": {
+			`^-A INPUT -p udp -m udp --dport 68 -j ACCEPT$`,
 			`-A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 32526 -j DROP`,
 			`-A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 80 -j DROP`,
 		},


### PR DESCRIPTION
## Summary

`ValidateIPTablesCompatibleWithCiliumEBPF` rejects any iptables rule not in its allowlist. AzureLinux V3 ARM64 images have a host DHCP client rule that causes `Test_AzureLinuxV3_ARM64/scriptless_nbc` to fail consistently (5/5 builds where test reached validation).

## Change

Add `^-A INPUT -p udp -m udp --dport 68 -j ACCEPT$` to the filter table allowlist.

## Details

- **Failing test**: `Test_AzureLinuxV3_ARM64/scriptless_nbc` — consistent, not flaky
- **Rule**: `-A INPUT -p udp -m udp --dport 68 -j ACCEPT` (standard DHCP client, UDP port 68)
- **Scope**: host INPUT chain — unrelated to pod FORWARD datapath or eBPF host routing
- **AMD64 vs ARM64**: same `iptables-1.8.10-4.azl3` and `nftables-1.0.9-1.azl3` packages on both, but only ARM64 has this rule. Root cause of that difference is unknown — needs node-level investigation.
- **Not from AgentBaker**: repo search found no code that adds this rule
- **Validator added by**: @AruSahni in PR #7197 (Nov 2025)
