### PR TITLE
fix: prewarm containerd, increase timeout value for wait for containerd ready

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -667,7 +667,7 @@ waitForContainerdReady() {
     local ret=0
 
     echo "Waiting for containerd to become ready..."
-    retrycmd_if_failure 120 0.1 1 bash -c 'ctr version >/dev/null 2>&1'
+    retrycmd_if_failure 240 0.1 1 bash -c 'ctr version >/dev/null 2>&1'
     ret=$?
     if [ "$ret" -ne 0 ]; then
         echo "containerd did not become ready"

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -199,6 +199,9 @@ function basePrep {
     fi
     setupCNIDirs
 
+    # pre-warm containerd by checking its version.
+    nohup /bin/sh -c '/usr/bin/containerd --version >/dev/null 2>&1' >/dev/null 2>&1 &
+
     # Network plugin already installed on Azure Linux OS Guard
     if ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
         logs_to_events "AKS.CSE.installNetworkPlugin" installNetworkPlugin


### PR DESCRIPTION
We noticed in production, containerd can take upto 21s and in E2E at minimum it takes 5s, speed everything up.