### PR TITLE
fix: bump windows base image version for 5B & improve windows image bump script output

### DIFF
--- a/schemas/windows_settings.cue
+++ b/schemas/windows_settings.cue
@@ -21,8 +21,8 @@
 #WindowsBaseVersion: {
   comment?:              string
   os_disk_size:          string
-  base_image_publisher?: string
-  base_image_offer?:     string
+  base_image_publisher: string
+  base_image_offer:     string
   base_image_sku:        string
   base_image_version:    string
   windows_image_name:    string

--- a/vhdbuilder/packer/windows/update_windows_base_versions.sh
+++ b/vhdbuilder/packer/windows/update_windows_base_versions.sh
@@ -66,7 +66,7 @@ for key in "${sku_keys[@]}"; do
 	printf '%q ' "${az_image_list_cmd[@]}"
 	echo ""
 
-	latest_version=$(eval "${az_image_list_cmd[@]}" 2>/dev/null | sort -uV | tail -n 1) || true
+	latest_version=$("${az_image_list_cmd[@]}" 2>/dev/null | sort -uV | tail -n 1) || true
 	status=$? # Capture the exit status immediately
 	if [ $status -ne 0 ]; then
 		echo "  ERROR: Command to get latest versions failed with exit code $status"

--- a/vhdbuilder/packer/windows/update_windows_base_versions.sh
+++ b/vhdbuilder/packer/windows/update_windows_base_versions.sh
@@ -53,10 +53,10 @@ for key in "${sku_keys[@]}"; do
 
 	echo ""
 	echo "Querying latest version for ${key} (publisher=${publisher}, offer=${offer}, sku=${sku})..."
-	command="az vm image list -p \"${publisher}\" -f \"${offer}\" -s \"${sku}\" --all --query [].version -o tsv"
-	echo "  ${command}"
+	azimagelistcommand="az vm image list -p \"${publisher}\" -f \"${offer}\" -s \"${sku}\" --all --query [].version -o tsv"
+	echo "  ${azimagelistcommand}"
 
-	latest_version=$(eval "${command}" 2>/dev/null | sort -uV | tail -n 1) || true
+	latest_version=$(eval "${azimagelistcommand}" 2>/dev/null | sort -uV | tail -n 1) || true
 	status=$? # Capture the exit status immediately
 	if [ $status -ne 0 ]; then
 		echo "  ERROR: Command to get latest versions failed with exit code $status"

--- a/vhdbuilder/packer/windows/update_windows_base_versions.sh
+++ b/vhdbuilder/packer/windows/update_windows_base_versions.sh
@@ -21,19 +21,19 @@ DEFAULT_OFFER="MicrosoftWindowsServer"
 DRY_RUN=false
 
 if [ "${1:-}" = "--dry-run" ]; then
-    DRY_RUN=true
+	DRY_RUN=true
 fi
 
 if [ ! -f "${SETTINGS_FILE}" ]; then
-    echo "ERROR: ${SETTINGS_FILE} not found"
-    exit 1
+	echo "ERROR: ${SETTINGS_FILE} not found"
+	exit 1
 fi
 
 for cmd in az jq; do
-    if ! command -v "${cmd}" &>/dev/null; then
-        echo "ERROR: ${cmd} is required but not installed"
-        exit 1
-    fi
+	if ! command -v "${cmd}" &>/dev/null; then
+		echo "ERROR: ${cmd} is required but not installed"
+		exit 1
+	fi
 done
 
 # Build a list of unique (publisher, sku) pairs to query.
@@ -46,57 +46,55 @@ updated=0
 errors=0
 
 for key in "${sku_keys[@]}"; do
-    sku=$(jq -r ".WindowsBaseVersions.\"${key}\".base_image_sku" "${SETTINGS_FILE}")
-    offer=$(jq -r ".WindowsBaseVersions.\"${key}\".base_image_offer // \"${DEFAULT_OFFER}\"" "${SETTINGS_FILE}")
-    publisher=$(jq -r ".WindowsBaseVersions.\"${key}\".base_image_publisher // \"${DEFAULT_PUBLISHER}\"" "${SETTINGS_FILE}")
-    current_version=$(jq -r ".WindowsBaseVersions.\"${key}\".base_image_version" "${SETTINGS_FILE}")
+	sku=$(jq -r ".WindowsBaseVersions.\"${key}\".base_image_sku" "${SETTINGS_FILE}")
+	offer=$(jq -r ".WindowsBaseVersions.\"${key}\".base_image_offer // \"${DEFAULT_OFFER}\"" "${SETTINGS_FILE}")
+	publisher=$(jq -r ".WindowsBaseVersions.\"${key}\".base_image_publisher // \"${DEFAULT_PUBLISHER}\"" "${SETTINGS_FILE}")
+	current_version=$(jq -r ".WindowsBaseVersions.\"${key}\".base_image_version" "${SETTINGS_FILE}")
 
-    echo "Querying latest version for ${key} (publisher=${publisher}, offer=${offer}, sku=${sku})..."
+	echo ""
+	echo "Querying latest version for ${key} (publisher=${publisher}, offer=${offer}, sku=${sku})..."
+	command="az vm image list -p \"${publisher}\" -f \"${offer}\" -s \"${sku}\" --all --query [].version -o tsv"
+	echo "  ${command}"
 
-    latest_version=$(
-        az vm image list \
-            -p "${publisher}" \
-            -f "${offer}" \
-            -s "${sku}" \
-            --all \
-            --query "[].version" \
-            -o tsv 2>/dev/null |
-            sort -uV |
-            tail -n 1
-    ) || true
+	latest_version=$(eval "${command}" 2>/dev/null | sort -uV | tail -n 1) || true
+	status=$? # Capture the exit status immediately
+	if [ $status -ne 0 ]; then
+		echo "  ERROR: Command to get latest versions failed with exit code $status"
+		errors=$((errors + 1))
+		continue
+	fi
 
-    if [ -z "${latest_version}" ]; then
-        echo "  WARNING: no versions found for sku=${sku}, skipping"
-        errors=$((errors + 1))
-        continue
-    fi
+	if [ -z "${latest_version}" ]; then
+		echo "  ERROR: no versions found for sku=${sku}, skipping"
+		errors=$((errors + 1))
+		continue
+	fi
 
-    if [ "${current_version}" = "${latest_version}" ]; then
-        echo "  ${key}: already up to date (${current_version})"
-        continue
-    fi
+	if [ "${current_version}" = "${latest_version}" ]; then
+		echo "  INFO: ${key}: already up to date (${current_version})"
+		continue
+	fi
 
-    echo "  ${key}: ${current_version} -> ${latest_version}"
+	echo "  INFO: ${key}: ${current_version} -> ${latest_version}"
 
-    if [ "${DRY_RUN}" = "false" ]; then
-        tmp=$(mktemp)
-        jq ".WindowsBaseVersions.\"${key}\".base_image_version = \"${latest_version}\"" \
-            "${SETTINGS_FILE}" >"${tmp}" &&
-            mv "${tmp}" "${SETTINGS_FILE}"
-        updated=$((updated + 1))
-    else
-        updated=$((updated + 1))
-    fi
+	if [ "${DRY_RUN}" = "false" ]; then
+		tmp=$(mktemp)
+		jq ".WindowsBaseVersions.\"${key}\".base_image_version = \"${latest_version}\"" \
+			"${SETTINGS_FILE}" >"${tmp}" &&
+			mv "${tmp}" "${SETTINGS_FILE}"
+		updated=$((updated + 1))
+	else
+		updated=$((updated + 1))
+	fi
 done
 
 echo ""
 if [ "${DRY_RUN}" = "true" ]; then
-    echo "Dry run complete. ${updated} version(s) would be updated, ${errors} error(s)."
+	echo "Dry run complete. ${updated} version(s) would be updated, ${errors} error(s)."
 else
-    echo "Done. ${updated} version(s) updated, ${errors} error(s)."
+	echo "Done. ${updated} version(s) updated, ${errors} error(s)."
 fi
 
 if [ "${errors}" -gt 0 ]; then
-    exit 1
+	exit 1
 fi
-

--- a/vhdbuilder/packer/windows/update_windows_base_versions.sh
+++ b/vhdbuilder/packer/windows/update_windows_base_versions.sh
@@ -53,10 +53,20 @@ for key in "${sku_keys[@]}"; do
 
 	echo ""
 	echo "Querying latest version for ${key} (publisher=${publisher}, offer=${offer}, sku=${sku})..."
-	azimagelistcommand="az vm image list -p \"${publisher}\" -f \"${offer}\" -s \"${sku}\" --all --query [].version -o tsv"
-	echo "  ${azimagelistcommand}"
+	az_image_list_cmd=(
+		az vm image list
+		-p "${publisher}"
+		-f "${offer}"
+		-s "${sku}"
+		--all
+		--query "[].version"
+		-o tsv
+	)
+	printf "  "
+	printf '%q ' "${az_image_list_cmd[@]}"
+	echo ""
 
-	latest_version=$(eval "${azimagelistcommand}" 2>/dev/null | sort -uV | tail -n 1) || true
+	latest_version=$(eval "${az_image_list_cmd[@]}" 2>/dev/null | sort -uV | tail -n 1) || true
 	status=$? # Capture the exit status immediately
 	if [ $status -ne 0 ]; then
 		echo "  ERROR: Command to get latest versions failed with exit code $status"

--- a/vhdbuilder/packer/windows/update_windows_base_versions.sh
+++ b/vhdbuilder/packer/windows/update_windows_base_versions.sh
@@ -66,7 +66,7 @@ for key in "${sku_keys[@]}"; do
 	printf '%q ' "${az_image_list_cmd[@]}"
 	echo ""
 
-	latest_version=$("${az_image_list_cmd[@]}" 2>/dev/null | sort -uV | tail -n 1) || true
+	latest_version=$("${az_image_list_cmd[@]}" 2>/dev/null | sort -uV | tail -n 1)
 	status=$? # Capture the exit status immediately
 	if [ $status -ne 0 ]; then
 		echo "  ERROR: Command to get latest versions failed with exit code $status"

--- a/vhdbuilder/packer/windows/update_windows_base_versions.sh
+++ b/vhdbuilder/packer/windows/update_windows_base_versions.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SETTINGS_FILE="${SCRIPT_DIR}/windows_settings.json"
 DEFAULT_PUBLISHER="MicrosoftWindowsServer"
-DEFAULT_OFFER="MicrosoftWindowsServer"
+DEFAULT_OFFER="WindowsServer"
 DRY_RUN=false
 
 if [ "${1:-}" = "--dry-run" ]; then

--- a/vhdbuilder/packer/windows/windows_settings.json
+++ b/vhdbuilder/packer/windows/windows_settings.json
@@ -19,7 +19,7 @@
       "base_image_offer": "windowsserver2022",
       "base_image_sku": "2022-Datacenter-Core-smalldisk",
       "windows_image_name": "windows-2022-containerd",
-      "base_image_version": "20348.5020.260413",
+      "base_image_version": "20348.5139.260507",
       "patches_to_apply": []
     },
     "2022-containerd-gen2": {
@@ -28,35 +28,43 @@
       "base_image_offer": "windowsserver2022",
       "base_image_sku": "2022-datacenter-core-smalldisk-g2",
       "windows_image_name": "windows-2022-containerd",
-      "base_image_version": "20348.5020.260413",
+      "base_image_version": "20348.5139.260507",
       "patches_to_apply": []
     },
     "2025": {
+      "base_image_publisher": "MicrosoftWindowsServer",
+      "base_image_offer": "WindowsServer",
       "os_disk_size": "45",
       "base_image_sku": "2025-datacenter-core-smalldisk",
       "windows_image_name": "windows-2025",
-      "base_image_version": "26100.32690.260413",
+      "base_image_version": "26100.32860.260510",
       "patches_to_apply": []
     },
     "2025-gen2": {
+      "base_image_publisher": "MicrosoftWindowsServer",
+      "base_image_offer": "WindowsServer",
       "os_disk_size": "45",
       "base_image_sku": "2025-datacenter-core-smalldisk-g2",
       "windows_image_name": "windows-2025",
-      "base_image_version": "26100.32690.260413",
+      "base_image_version": "26100.32860.260510",
       "patches_to_apply": []
     },
     "23H2": {
+      "base_image_publisher": "MicrosoftWindowsServer",
+      "base_image_offer": "WindowsServer",
       "os_disk_size": "35",
       "base_image_sku": "23h2-datacenter-core",
       "windows_image_name": "windows-23H2",
-      "base_image_version": "25398.2274.260411",
+      "base_image_version": "25398.2330.260507",
       "patches_to_apply": []
     },
     "23H2-gen2": {
+      "base_image_publisher": "MicrosoftWindowsServer",
+      "base_image_offer": "WindowsServer",
       "os_disk_size": "35",
       "base_image_sku": "23h2-datacenter-core-g2",
       "windows_image_name": "windows-23H2",
-      "base_image_version": "25398.2274.260411",
+      "base_image_version": "25398.2330.260507",
       "patches_to_apply": []
     }
   },
@@ -766,7 +774,7 @@
       "Type": "DWORD"
     },
     {
-      "Comment":"2026-5B",
+      "Comment": "2026-5B",
       "WindowsSkuMatch": "2022*",
       "Path": "HKLM:\\SYSTEM\\CurrentControlSet\\Policies\\Microsoft\\FeatureManagement\\Overrides",
       "Name": "3658215055",


### PR DESCRIPTION

For some reason the bump image version script broke, so this PR fixes the script and bumps the image versions for 5B release.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
