### PR TITLE
ci: declare least-privilege permissions on the remaining 11 workflows

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   Auto:
     name: Auto-update

--- a/.github/workflows/generate-kubelet-flags.yaml
+++ b/.github/workflows/generate-kubelet-flags.yaml
@@ -2,6 +2,11 @@ name: Generate valid kubelet flags per supported k8s version
 on:
   workflow_dispatch: {}
 
+# The push + PR creation steps below explicitly use secrets.PERSONAL_ACCESS_TOKEN,
+# so the default GITHUB_TOKEN does not need write scopes here.
+permissions:
+  contents: read
+
 jobs:
   generate-kubelet-flags:
     runs-on: ubuntu-24.04

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,6 +1,9 @@
 name: Go Unit Tests
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   go-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/no-sudo-check.yml
+++ b/.github/workflows/no-sudo-check.yml
@@ -1,6 +1,9 @@
 name: Check for sudo in CSE scripts
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   no-sudo:
     runs-on: ubuntu-latest

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,6 +1,9 @@
 name: Lint Shell/Bash Scripts
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/shellspec.yaml
+++ b/.github/workflows/shellspec.yaml
@@ -1,6 +1,9 @@
 name: Shell/Bash Script Unit Tests
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   shellspec:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-components.yml
+++ b/.github/workflows/validate-components.yml
@@ -1,6 +1,9 @@
 name: Validate Components
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   cue:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-image-version.yml
+++ b/.github/workflows/validate-image-version.yml
@@ -1,6 +1,9 @@
 name: validate-image-version
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   validate-image-version:
     runs-on: ubuntu-24.04

--- a/.github/workflows/validate-pull-request-source.yml
+++ b/.github/workflows/validate-pull-request-source.yml
@@ -1,6 +1,9 @@
 name: validate-pull-request-source
 on: pull_request
 
+# This workflow only reads pull_request event metadata; no checkout, no API calls.
+permissions: {}
+
 jobs:
   validate-pull-request-source:
     runs-on: ubuntu-24.04

--- a/.github/workflows/validate-windows-binary-signature.yaml
+++ b/.github/workflows/validate-windows-binary-signature.yaml
@@ -10,6 +10,9 @@ on:
       - 'vhdbuilder/packer/windows/windows_settings.json'
       - 'vhdbuilder/packer/windows/components_json_helpers.ps1'
 
+permissions:
+  contents: read
+
 jobs:
   check-files-for-ws2022:
     name: Check for Windows 2022

--- a/.github/workflows/validate-windows-ut.yml
+++ b/.github/workflows/validate-windows-ut.yml
@@ -5,6 +5,9 @@ on: pull_request
 # stored in WSL. So you'll need to change directory to whereever you have the repo checked out in WSL. Something like this:
 # cd \\wsl$\Ubuntu\home\tim\git\AgentBaker
 
+permissions:
+  contents: read
+
 jobs:
   pester-test:
     name: Pester test


### PR DESCRIPTION
This repo already has explicit `permissions:` blocks on the major workflows (`codeql-analysis.yml`, `golangci-lint.yml`, `hotfix-generate.yml`, `labeler.yaml`, `pr-lint.yaml`, `tidy.yaml`, etc.). This PR finishes the job by adding scoped permissions to the 11 remaining workflows so none of them implicitly inherit a write-capable `GITHUB_TOKEN`.

The bulk of the changes are `permissions: contents: read` because the workflows just lint, vet, or test against a checkout:

- `go-test.yml`, `no-sudo-check.yml`, `shellcheck.yml`, `shellspec.yaml`
- `validate-components.yml`, `validate-image-version.yml`
- `validate-windows-binary-signature.yaml`, `validate-windows-ut.yml`

Three workflows get a different scope because they actually do something with a token:

- `auto-update.yml` invokes `tibdex/auto-update@v2` with `secrets.GITHUB_TOKEN` to refresh PR branches off `main`, so it gets `contents: write` + `pull-requests: read`.
- `generate-kubelet-flags.yaml` performs its push + PR creation using `secrets.PERSONAL_ACCESS_TOKEN` (an explicit user PAT, not the default token). The default `GITHUB_TOKEN` only needs `contents: read` for the checkout; an inline comment was added documenting that.
- `validate-pull-request-source.yml` doesn't even check out the repo; it only inspects `github.event.pull_request.head.repo.full_name`. `permissions: {}` (deny all) is the most accurate.

Each edited file was validated with `python3 -c "import yaml; yaml.safe_load(...)"`.