### PR TITLE
chore(vhdbuilder): add COSI conversion for ACL VHD images

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -886,6 +886,7 @@ stages:
               echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_VERSION]3.0.20260401'
               echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_CONTAINER]mcr.microsoft.com/azurelinux/imagecustomizer'
               echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_VERSION]1.2.0-2'
+              echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_CONFIG]cosi-acl'
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
@@ -916,6 +917,7 @@ stages:
               echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_VERSION]3.0.20260401'
               echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_CONTAINER]mcr.microsoft.com/azurelinux/imagecustomizer'
               echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_VERSION]1.2.0-2'
+              echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_CONFIG]cosi-acl'
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -881,6 +881,11 @@ stages:
               echo '##vso[task.setvariable variable=ENABLE_FIPS]false'
               echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]True'
               echo '##vso[task.setvariable variable=ENABLE_CGROUPV2]True'
+              echo '##vso[task.setvariable variable=SIG_SOURCE_GALLERY_UNIQUE_NAME]b3e01d89-bd55-414f-bbb4-cdfeb2628caa-ACL'
+              echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_NAME]acl'
+              echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_VERSION]3.0.20260401'
+              echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_CONTAINER]mcr.microsoft.com/azurelinux/imagecustomizer'
+              echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_VERSION]1.2.0-2'
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:
@@ -906,6 +911,11 @@ stages:
               echo '##vso[task.setvariable variable=ENABLE_FIPS]false'
               echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]True'
               echo '##vso[task.setvariable variable=ENABLE_CGROUPV2]True'
+              echo '##vso[task.setvariable variable=SIG_SOURCE_GALLERY_UNIQUE_NAME]b3e01d89-bd55-414f-bbb4-cdfeb2628caa-ACL'
+              echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_NAME]acl-arm64'
+              echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_VERSION]3.0.20260401'
+              echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_CONTAINER]mcr.microsoft.com/azurelinux/imagecustomizer'
+              echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_VERSION]1.2.0-2'
             displayName: Setup Build Variables
           - template: ./templates/.builder-release-template.yaml
             parameters:

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -225,6 +225,7 @@ stages:
             echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_VERSION]3.0.20260401'
             echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_CONTAINER]mcr.microsoft.com/azurelinux/imagecustomizer'
             echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_VERSION]1.2.0-2'
+            echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_CONFIG]cosi-acl'
           displayName: Setup Build Variables
         - template: ./templates/.builder-release-template.yaml
           parameters:
@@ -252,6 +253,7 @@ stages:
             echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_VERSION]3.0.20260401'
             echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_CONTAINER]mcr.microsoft.com/azurelinux/imagecustomizer'
             echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_VERSION]1.2.0-2'
+            echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_CONFIG]cosi-acl'
           displayName: Setup Build Variables
         - template: ./templates/.builder-release-template.yaml
           parameters:

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -220,6 +220,11 @@ stages:
             echo '##vso[task.setvariable variable=ENABLE_FIPS]false'
             echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]True'
             echo '##vso[task.setvariable variable=ENABLE_CGROUPV2]True'
+            echo '##vso[task.setvariable variable=SIG_SOURCE_GALLERY_UNIQUE_NAME]b3e01d89-bd55-414f-bbb4-cdfeb2628caa-ACL'
+            echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_NAME]acl'
+            echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_VERSION]3.0.20260401'
+            echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_CONTAINER]mcr.microsoft.com/azurelinux/imagecustomizer'
+            echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_VERSION]1.2.0-2'
           displayName: Setup Build Variables
         - template: ./templates/.builder-release-template.yaml
           parameters:
@@ -242,6 +247,11 @@ stages:
             echo '##vso[task.setvariable variable=ENABLE_FIPS]false'
             echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]True'
             echo '##vso[task.setvariable variable=ENABLE_CGROUPV2]True'
+            echo '##vso[task.setvariable variable=SIG_SOURCE_GALLERY_UNIQUE_NAME]b3e01d89-bd55-414f-bbb4-cdfeb2628caa-ACL'
+            echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_NAME]acl-arm64'
+            echo '##vso[task.setvariable variable=SIG_SOURCE_IMAGE_VERSION]3.0.20260401'
+            echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_CONTAINER]mcr.microsoft.com/azurelinux/imagecustomizer'
+            echo '##vso[task.setvariable variable=IMG_CUSTOMIZER_VERSION]1.2.0-2'
           displayName: Setup Build Variables
         - template: ./templates/.builder-release-template.yaml
           parameters:

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -399,11 +399,34 @@ steps:
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
+        make -f packer.mk convert-vhd-to-cosi
+    condition: |
+      and(
+        succeeded(),
+        eq(variables.GENERATE_PUBLISHING_INFO, 'True'),
+        eq(variables['OS_SKU'], 'AzureContainerLinux')
+      )
+    displayName: Convert ACL VHD to COSI
+    env:
+      RESOURCE_GROUP_NAME: $(AZURE_RESOURCE_GROUP_NAME)
+
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(VHD_ARM_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
         echo "Copying ${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.vhd to immutable storage container"
         export AZCOPY_AUTO_LOGIN_TYPE="AZCLI"
         export AZCOPY_CONCURRENCY_VALUE="AUTO"
         az storage blob copy start --account-name "$STORAGE_ACCOUNT_NAME" --destination-blob "${CAPTURED_SIG_VERSION}.vhd" --destination-container "$VHD_CONTAINER_NAME" --source-uri "${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.vhd" --auth-mode login || exit 1
-        echo "Successfully copied to immutable container"
+        echo "Successfully copied VHD to immutable container"
+        if [ "${OS_SKU}" = "AzureContainerLinux" ]; then
+          echo "Copying ${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.cosi to immutable storage container"
+          az storage blob copy start --account-name "$STORAGE_ACCOUNT_NAME" --destination-blob "${CAPTURED_SIG_VERSION}.cosi" --destination-container "$VHD_CONTAINER_NAME" --source-uri "${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.cosi" --auth-mode login || exit 1
+          echo "Successfully copied COSI to immutable container"
+          azcopy remove "${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.cosi" --recursive=true
+        fi
         # Remove old VHD from staging container after copy to immutable container is complete
         azcopy remove "${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true
     condition: |

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -409,6 +409,9 @@ steps:
     displayName: Convert ACL VHD to COSI
     env:
       RESOURCE_GROUP_NAME: $(AZURE_RESOURCE_GROUP_NAME)
+      AFD_UPLOAD_ENDPOINT: $(AFD_UPLOAD_ENDPOINT)
+      COSI_CONTAINER: $(COSI_CONTAINER)
+      IMG_CUSTOMIZER_CONFIG: $(IMG_CUSTOMIZER_CONFIG)
 
   - task: AzureCLI@2
     inputs:
@@ -421,12 +424,6 @@ steps:
         export AZCOPY_CONCURRENCY_VALUE="AUTO"
         az storage blob copy start --account-name "$STORAGE_ACCOUNT_NAME" --destination-blob "${CAPTURED_SIG_VERSION}.vhd" --destination-container "$VHD_CONTAINER_NAME" --source-uri "${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.vhd" --auth-mode login || exit 1
         echo "Successfully copied VHD to immutable container"
-        if [ "${OS_SKU}" = "AzureContainerLinux" ]; then
-          echo "Copying ${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.cosi to immutable storage container"
-          az storage blob copy start --account-name "$STORAGE_ACCOUNT_NAME" --destination-blob "${CAPTURED_SIG_VERSION}.cosi" --destination-container "$VHD_CONTAINER_NAME" --source-uri "${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.cosi" --auth-mode login || exit 1
-          echo "Successfully copied COSI to immutable container"
-          azcopy remove "${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.cosi" --recursive=true
-        fi
         # Remove old VHD from staging container after copy to immutable container is complete
         azcopy remove "${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.vhd" --recursive=true
     condition: |

--- a/packer.mk
+++ b/packer.mk
@@ -107,6 +107,9 @@ generate-publishing-info: az-login
 convert-sig-to-classic-storage-account-blob: az-login
 	@./vhdbuilder/packer/convert-sig-to-classic-storage-account-blob.sh
 
+convert-vhd-to-cosi: az-login
+	@./vhdbuilder/packer/imagecustomizer/scripts/convert-vhd-to-cosi.sh
+
 scanning-vhd: az-login
 	@./vhdbuilder/packer/vhd-scanning.sh
 

--- a/vhdbuilder/packer/imagecustomizer/scripts/convert-vhd-to-cosi.sh
+++ b/vhdbuilder/packer/imagecustomizer/scripts/convert-vhd-to-cosi.sh
@@ -2,13 +2,16 @@
 set -euo pipefail
 
 # Converts an ACL VHD from blob storage to COSI format using ImageCustomizer,
-# then uploads the COSI file back to blob storage.
+# then uploads the COSI file to PMC Storage via AFD endpoint.
 
 required_env_vars=(
     "DESTINATION_STORAGE_CONTAINER"
     "CAPTURED_SIG_VERSION"
     "IMG_CUSTOMIZER_CONTAINER"
     "IMG_CUSTOMIZER_VERSION"
+    "AFD_UPLOAD_ENDPOINT"
+    "COSI_CONTAINER"
+    "IMG_CUSTOMIZER_CONFIG"
 )
 
 for v in "${required_env_vars[@]}"
@@ -30,7 +33,8 @@ trap cleanup EXIT
 
 VHD_BLOB_URL="${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.vhd"
 LOCAL_VHD="$WORK_DIR/${CAPTURED_SIG_VERSION}.vhd"
-LOCAL_COSI="$WORK_DIR/out/${CAPTURED_SIG_VERSION}.cosi"
+COSI_BLOB_NAME="${IMG_CUSTOMIZER_CONFIG}-${CAPTURED_SIG_VERSION}.cosi"
+LOCAL_COSI="$WORK_DIR/out/${COSI_BLOB_NAME}"
 
 echo "Setting azcopy environment variables"
 export AZCOPY_AUTO_LOGIN_TYPE="AZCLI"
@@ -71,7 +75,7 @@ docker run \
         --log-level "debug" \
         --build-dir /convert/build \
         --image-file "/convert/${CAPTURED_SIG_VERSION}.vhd" \
-        --output-image-file "/convert/out/${CAPTURED_SIG_VERSION}.cosi" \
+        --output-image-file "/convert/out/${COSI_BLOB_NAME}" \
         --output-image-format cosi
 
 if [ ! -f "$LOCAL_COSI" ]; then
@@ -79,8 +83,8 @@ if [ ! -f "$LOCAL_COSI" ]; then
     exit 1
 fi
 
-echo "Uploading COSI to ${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.cosi"
-if ! azcopy copy "$LOCAL_COSI" "${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.cosi" --recursive=true; then
+echo "Uploading COSI to ${AFD_UPLOAD_ENDPOINT}/${COSI_CONTAINER}/${COSI_BLOB_NAME}"
+if ! azcopy copy "$LOCAL_COSI" "${AFD_UPLOAD_ENDPOINT}/${COSI_CONTAINER}/${COSI_BLOB_NAME}" --recursive=true; then
     azExitCode=$?
     shopt -s nullglob
     for f in "${AZCOPY_LOG_LOCATION}"/*.log; do
@@ -97,4 +101,4 @@ if ! azcopy copy "$LOCAL_COSI" "${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_
     exit $azExitCode
 fi
 
-echo "Successfully converted and uploaded COSI: ${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.cosi"
+echo "Successfully converted and uploaded COSI: ${AFD_UPLOAD_ENDPOINT}/${COSI_CONTAINER}/${COSI_BLOB_NAME}"

--- a/vhdbuilder/packer/imagecustomizer/scripts/convert-vhd-to-cosi.sh
+++ b/vhdbuilder/packer/imagecustomizer/scripts/convert-vhd-to-cosi.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+set -euo pipefail
+
+# Converts an ACL VHD from blob storage to COSI format using ImageCustomizer,
+# then uploads the COSI file back to blob storage.
+
+required_env_vars=(
+    "DESTINATION_STORAGE_CONTAINER"
+    "CAPTURED_SIG_VERSION"
+    "IMG_CUSTOMIZER_CONTAINER"
+    "IMG_CUSTOMIZER_VERSION"
+)
+
+for v in "${required_env_vars[@]}"
+do
+    if [ -z "${!v}" ]; then
+        echo "$v was not set!"
+        exit 1
+    fi
+done
+
+WORK_DIR="$(pwd)/cosi-convert"
+mkdir -p "$WORK_DIR/build" "$WORK_DIR/out"
+
+cleanup() {
+    echo "Cleaning up working directory $WORK_DIR"
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+VHD_BLOB_URL="${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.vhd"
+LOCAL_VHD="$WORK_DIR/${CAPTURED_SIG_VERSION}.vhd"
+LOCAL_COSI="$WORK_DIR/out/${CAPTURED_SIG_VERSION}.cosi"
+
+echo "Setting azcopy environment variables"
+export AZCOPY_AUTO_LOGIN_TYPE="AZCLI"
+export AZCOPY_CONCURRENCY_VALUE="AUTO"
+export AZCOPY_LOG_LOCATION="$WORK_DIR/azcopy-log-files/"
+export AZCOPY_JOB_PLAN_LOCATION="$WORK_DIR/azcopy-job-plan-files/"
+mkdir -p "${AZCOPY_LOG_LOCATION}"
+mkdir -p "${AZCOPY_JOB_PLAN_LOCATION}"
+
+echo "Downloading VHD from ${VHD_BLOB_URL}"
+if ! azcopy copy "$VHD_BLOB_URL" "$LOCAL_VHD" --recursive=true; then
+    azExitCode=$?
+    shopt -s nullglob
+    for f in "${AZCOPY_LOG_LOCATION}"/*.log; do
+        echo "Azcopy log file: $f"
+        echo "##vso[build.uploadlog]$f"
+        if grep -q '"level":"Error"' "$f"; then
+            echo "log file $f contains errors"
+            echo "##vso[task.logissue type=error]Azcopy log file $f contains errors"
+            cat "$f"
+        fi
+    done
+    shopt -u nullglob
+    echo "Failed to download VHD, exiting with code $azExitCode"
+    exit $azExitCode
+fi
+echo "Downloaded VHD to ${LOCAL_VHD}"
+
+echo "Converting VHD to COSI using ImageCustomizer ${IMG_CUSTOMIZER_CONTAINER}:${IMG_CUSTOMIZER_VERSION}"
+docker run \
+    --rm \
+    --interactive \
+    --privileged=true \
+    -v "$WORK_DIR:/convert" \
+    -v /dev:/dev \
+    "${IMG_CUSTOMIZER_CONTAINER}:${IMG_CUSTOMIZER_VERSION}" \
+    imagecustomizer convert \
+        --log-level "debug" \
+        --build-dir /convert/build \
+        --image-file "/convert/${CAPTURED_SIG_VERSION}.vhd" \
+        --output-image-file "/convert/out/${CAPTURED_SIG_VERSION}.cosi" \
+        --output-image-format cosi
+
+if [ ! -f "$LOCAL_COSI" ]; then
+    echo "##vso[task.logissue type=error]COSI file was not created at ${LOCAL_COSI}"
+    exit 1
+fi
+
+echo "Uploading COSI to ${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.cosi"
+if ! azcopy copy "$LOCAL_COSI" "${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.cosi" --recursive=true; then
+    azExitCode=$?
+    shopt -s nullglob
+    for f in "${AZCOPY_LOG_LOCATION}"/*.log; do
+        echo "Azcopy log file: $f"
+        echo "##vso[build.uploadlog]$f"
+        if grep -q '"level":"Error"' "$f"; then
+            echo "log file $f contains errors"
+            echo "##vso[task.logissue type=error]Azcopy log file $f contains errors"
+            cat "$f"
+        fi
+    done
+    shopt -u nullglob
+    echo "Failed to upload COSI, exiting with code $azExitCode"
+    exit $azExitCode
+fi
+
+echo "Successfully converted and uploaded COSI: ${DESTINATION_STORAGE_CONTAINER}/${CAPTURED_SIG_VERSION}.cosi"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a post-build pipeline step that converts AzureContainerLinux (ACL) VHD images to COSI format using ImageCustomizer's convert command (v1.2.0-2).  Export ACL COSI image, used for A/B updates.

Changes:
- New script: convert-vhd-to-cosi.sh downloads ACL VHD from blob storage, runs ImageCustomizer convert (VHD -> COSI), and uploads the COSI file
- New make target: convert-vhd-to-cosi in packer.mk
- Pipeline vars: set IMG_CUSTOMIZER_CONTAINER and IMG_CUSTOMIZER_VERSION on ACL build jobs in both PR and release pipelines
- Builder template: add Convert ACL VHD to COSI step after SIG->classic conversion, conditioned on OS_SKU=AzureContainerLinux
- Immutable copy: updated to also copy/remove .cosi files for ACL builds


**Which issue(s) this PR fixes**:

Fixes #
