### PR TITLE
fix(windows): register k8s-restart-job in NodePrep to avoid PIS bootstrap race

### DIFF
--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -440,6 +440,31 @@ func Test_Windows2022_VHDCaching(t *testing.T) {
 	})
 }
 
+// Test_Windows2022_VHDCaching_LegacyTLSBootstrap exercises Windows PIS /
+// VHD-cached provisioning with secure TLS bootstrap disabled, forcing kubelet
+// to use the legacy bootstrap-token path. Catches regressions in the two-stage
+// CSE flow that only surface when no secure-tls-bootstrap client is around to
+// overwrite the temporary kubeconfig.
+func Test_Windows2022_VHDCaching_LegacyTLSBootstrap(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "VHD Caching with secure TLS bootstrap disabled",
+		Config: Config{
+			Cluster:    ClusterAzureNetwork,
+			VHD:        config.VHDWindows2022Containerd,
+			VHDCaching: true,
+			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
+				vmss.SKU.Capacity = to.Ptr[int64](2)
+			},
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				if nbc.SecureTLSBootstrappingConfig == nil {
+					nbc.SecureTLSBootstrappingConfig = &datamodel.SecureTLSBootstrappingConfig{}
+				}
+				nbc.SecureTLSBootstrappingConfig.Enabled = false
+			},
+		},
+	})
+}
+
 func Test_Windows2022Gen2_k8s_133(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Windows Server 2022 with Containerd 2- hyperv gen 2",

--- a/parts/windows/kuberneteswindowssetup.ps1
+++ b/parts/windows/kuberneteswindowssetup.ps1
@@ -485,7 +485,6 @@ function BasePrep {
     PREPROVISION_EXTENSION
     Adjust-DynamicPortRange
     Register-LogsCleanupScriptTask
-    Register-NodeResetScriptTask
 
     Update-DefenderPreferences
 
@@ -578,6 +577,11 @@ function NodePrep {
         $kubeConfigFile = [io.path]::Combine($KubeDir, "config")
         Remove-Item $kubeConfigFile
     }
+
+    # Register AFTER temp kubeconfig removal: the -AtStartup trigger would
+    # otherwise race PIS-baked VHD first boot and bring kubelet up with the
+    # embedded "nodeclient" cert instead of doing TLS bootstrap.
+    Register-NodeResetScriptTask
 
     Start-InstallGPUDriver -EnableInstall $global:ConfigGPUDriverIfNeeded -GpuDriverURL $global:GpuDriverURL
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Move `Register-NodeResetScriptTask` from `BasePrep` to `NodePrep` (after the temporary kubeconfig removal) on Windows. This fixes a silent kubelet TLS bootstrap failure that hits Windows agentpools attached to a Prepared Image Specification (PIS) / pre-baked VHD path.

**Root cause**

Windows CSE runs in two phases for PIS / baked VHDs:

1. **BasePrep** (bake time, `PreProvisionOnly=true`):
   - `Write-KubeConfig` writes a temporary `c:\k\config` with `client-certificate-data: <clusterClientCertificate>` embedded — the cluster-shared "nodeclient" cert produced by the AKS RP's `certificates_goal_resolver.go` (`Subject: CN=nodeclient, O=system:nodes`).
   - `Register-NodeResetScriptTask` registers `k8s-restart-job` with an `-AtStartup` trigger.
   - VHD is captured / staged for the agentpool.

2. **NodePrep** (provision time):
   - Eventually removes `c:\k\config` (line ~579) if TLS bootstrap is enabled.
   - Calls `Start-ScheduledTask k8s-restart-job`.

Because `k8s-restart-job` is `-AtStartup`, on the FIRST boot from the baked VHD the task fires **before** `NodePrep` removes the temporary kubeconfig. `windowsnodereset.ps1` calls `Start-Service kubelet`. Kubelet reads `c:\k\config`, extracts the embedded `nodeclient` certificate into `c:\k\pki\kubelet-client-<ts>.pem`, never performs the proper bootstrap-token CSR exchange. Subsequent API server calls fail because `CN=nodeclient` doesn't satisfy the NodeAuthorizer:

```
"Failed while requesting a signed certificate from the control plane"
err="cannot create certificate signing request:
     certificatesigningrequests.certificates.k8s.io is forbidden:
     User \"nodeclient\" cannot create resource \"certificatesigningrequests\"..."
```

The pool reports `Succeeded` (CSE / extension level), so the failure is silent — the node never registers with the cluster.

**Reproduction (verified)**

On the AKS New Zealand Sandbox subscription, cluster `aks-pis-test` in `australiaeast`, K8s 1.34.7, Windows Server 2022:

| Pool | PIS attached | Cert subject | K8s join |
|---|---|---|---|
| `pislinux` | yes (Linux PIS, NodeProvisionTime) | `CN=system:node:aks-pislinux-...` | ✅ Ready |
| `piswin`   | yes (Windows PIS, NodeProvisionTime) | `CN=nodeclient`                  | ❌ Never registered |
| `winctl`   | **no** (same cluster, same SKU)      | `CN=system:node:akswinctl000000` | ✅ Ready in 30s |

Timeline on the broken pool (from `C:\AzureData\CustomDataSetupScript.log` + `C:\k\windowsnodereset.log` + `C:\k\kubelet.err.log`):

```
01:43-01:44   BasePrep (PreProvisionOnly=true), Register-NodeResetScriptTask registered
01:44:04      base_prep.complete written, NodePrep skipped
~01:57:00     VM reboots from baked VHD
01:57:07      windowsnodereset.ps1 starts (k8s-restart-job AtStartup fires)
01:57:11      CSE invocation 2 begins
01:57:20      windowsnodereset.ps1 calls Start-Service kubelet
01:57:30      kubelet writes kubelet-client-<ts>.pem with the nodeclient cert
01:57:33      NodePrep removes c:\k\config (too late)
01:57:44      NodePrep completes
```

**Fix**

Move the task registration out of `BasePrep` and into `NodePrep`, after the temporary kubeconfig has been removed. The scheduled task does not exist on a baked VHD, so the first boot does not race with `NodePrep` and kubelet only starts via the explicit `Start-ScheduledTask` call at the end of `NodePrep` — at which point the temporary kubeconfig with the embedded cluster client cert is gone and kubelet correctly falls back to the bootstrap-token path in `c:\k\bootstrap-config`.

**Risk / blast radius**

- Linux and non-PIS Windows pools are unaffected (single-phase CSE; the task was never registered before the cleanup ran in practice).
- Subsequent boots after the node has been properly provisioned behave identically to today: the task fires `-AtStartup`, `windowsnodereset.ps1` restarts kubelet/kubeproxy as before.

**Which issue(s) this PR fixes**:

Fixes #
