### PR TITLE
chore: upgrade azurefile-csi-driver to v1.35.3, v1.34.6, v1.33.10

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -552,29 +552,35 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.35.2"
+          "latestVersion": "v1.35.3",
+          "previousLatestVersion": "v1.35.2"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.33.9"
+          "latestVersion": "v1.33.10",
+          "previousLatestVersion": "v1.33.9"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.34.5"
+          "latestVersion": "v1.34.6",
+          "previousLatestVersion": "v1.34.5"
         }
       ],
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.35.2-windows-hp"
+          "latestVersion": "v1.35.3-windows-hp",
+          "previousLatestVersion": "v1.35.2-windows-hp"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.33.9-windows-hp"
+          "latestVersion": "v1.33.10-windows-hp",
+          "previousLatestVersion": "v1.33.9-windows-hp"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.34.5-windows-hp"
+          "latestVersion": "v1.34.6-windows-hp",
+          "previousLatestVersion": "v1.34.5-windows-hp"
         }
       ]
     },


### PR DESCRIPTION
Upgrade azurefile-csi-driver image versions:
- v1.35.2 → v1.35.3
- v1.34.5 → v1.34.6
- v1.33.9 → v1.33.10

Including corresponding windows-hp image updates.