### PR TITLE
fix(e2e): unblock Windows sysprep when VMAgentDisabler.dll load stalls

### DIFF
--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -330,6 +330,34 @@ func Test_Windows2022_VHDCaching(t *testing.T) {
 	})
 }
 
+func Test_Windows2025Gen2_VHDCaching(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "VHD Caching - Windows Server 2025 Gen2",
+		Config: Config{
+			Cluster:    ClusterAzureNetwork,
+			VHD:        config.VHDWindows2025Gen2,
+			VHDCaching: true,
+			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
+				vmss.SKU.Capacity = to.Ptr[int64](2)
+			},
+			BootstrapConfigMutator: func(_ *Cluster, configuration *datamodel.NodeBootstrappingConfiguration) {
+				Windows2025BootstrapConfigMutator(t, configuration)
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateWindowsVersionFromWindowsSettings(ctx, s, "2025-gen2")
+				ValidateWindowsProductName(ctx, s, "Windows Server 2025 Datacenter")
+				ValidateWindowsDisplayVersion(ctx, s, "24H2")
+				ValidateFileHasContent(ctx, s, "/k/kubeletstart.ps1", "--container-runtime=remote")
+				ValidateWindowsProcessHasCliArguments(ctx, s, "kubelet.exe", []string{"--rotate-certificates=true", "--client-ca-file=c:\\k\\ca.crt"})
+				ValidateCiliumIsNotRunningWindows(ctx, s)
+				ValidateDotnetNotInstalledWindows(ctx, s)
+				ValidateWindowsSystemServicesRestartConfiguration(ctx, s)
+				ValidateCollectWindowsLogsScript(ctx, s)
+			},
+		},
+	})
+}
+
 // Test_Windows2022_VHDCaching_LegacyTLSBootstrap exercises Windows PIS /
 // VHD-cached provisioning with secure TLS bootstrap disabled, forcing kubelet
 // to use the legacy bootstrap-token path. Catches regressions in the two-stage

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -611,18 +611,16 @@ func createVMExtensionLinuxAKSNode(ctx context.Context, location *string) (*armc
 // resource on the VM and waits for it to provision.
 func RunCommand(ctx context.Context, s *Scenario, command string) (armcompute.VirtualMachineRunCommandInstanceView, error) {
 	s.T.Helper()
-	start := time.Now()
-	label := runCommandLabel(command)
-	defer func() {
-		toolkit.Logf(ctx, "Command %s took %s", label, time.Since(start))
-	}()
-
 	rg := *s.Runtime.Cluster.Model.Properties.NodeResourceGroup
 	instanceID := *s.Runtime.VM.VM.InstanceID
 	// VirtualMachineRunCommand resources persist on the VM until explicitly deleted;
 	// use a unique name per call so concurrent / repeated calls don't collide, and
 	// best-effort delete it on the way out below.
 	runCommandName := fmt.Sprintf("e2e-runcmd-%d", time.Now().UnixNano())
+	start := time.Now()
+	defer func() {
+		toolkit.Logf(ctx, "RunCommand %s took %s", runCommandName, time.Since(start))
+	}()
 
 	runCmd := armcompute.VirtualMachineRunCommand{
 		Location: to.Ptr(s.Location),
@@ -665,23 +663,6 @@ func RunCommand(ctx context.Context, s *Scenario, command string) (armcompute.Vi
 	}
 	view := *getResp.Properties.InstanceView
 	return view, runCommandScriptError(view)
-}
-
-// runCommandLabel returns a short, log-safe identifier for a RunCommand script body.
-// We avoid logging the full script because callers pass multi-line content (e.g.
-// windowsSysprepScript) which floods test logs, and to reduce the chance of accidentally
-// echoing secrets if a future caller embeds them in the script.
-func runCommandLabel(command string) string {
-	const maxFirstLine = 80
-	first, _, _ := strings.Cut(command, "\n")
-	first = strings.TrimSpace(first)
-	if len(first) > maxFirstLine {
-		first = first[:maxFirstLine] + "…"
-	}
-	if first == "" {
-		first = "<empty>"
-	}
-	return fmt.Sprintf("%q (%d bytes)", first, len(command))
 }
 
 // runCommandScriptError converts a RunCommand instance view into an error if the
@@ -729,35 +710,59 @@ func runCommandScriptError(view armcompute.VirtualMachineRunCommandInstanceView)
 // Pre-cleanup of C:\Windows\Panther and unattend.xml follows
 // https://learn.microsoft.com/en-us/azure/virtual-machines/generalize, which notes
 // that stale Panther logs can cause Sysprep to fail and that custom answer files
-// aren't supported in this step.
+// aren't supported in this step. The ImageState poll handles Server 2022 where
+// Sysprep /quit can return before background SetupHost.exe finishes generalizing.
 const windowsSysprepScript = `
 $ErrorActionPreference = 'Stop'
 
-# Workaround for Win2022: broken SysPrepExternal\Generalize provider entries that
-# point at VMAgentDisabler.dll cause Sysprep /generalize to hang ~14 minutes when
-# the DLL cannot be loaded. -like is case-insensitive and tolerates REG_MULTI_SZ.
-$path = 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\SysPrepExternal\Generalize'
-if (Test-Path $path) {
-    foreach ($name in @((Get-Item -Path $path).Property)) {
-        $value = (Get-ItemProperty -Path $path -Name $name).$name
-        if ($value -and ($value -like '*VMAgentDisabler.dll*')) {
-            Write-Host "Removing broken generalize provider $name -> $value"
-            Remove-ItemProperty -Path $path -Name $name
+# Best-effort: drop broken SysPrepExternal\Generalize providers that point at
+# VMAgentDisabler.dll. When the DLL can't be loaded Sysprep /generalize hangs
+# ~14m. Registry cleanup failures are logged but must not abort sysprep itself.
+try {
+    $path = 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\SysPrepExternal\Generalize'
+    if (Test-Path $path) {
+        foreach ($name in (Get-Item -Path $path).Property) {
+            $value = Get-ItemPropertyValue -Path $path -Name $name
+            if ($value -like '*VMAgentDisabler.dll*') {
+                Write-Host "Removing broken generalize provider $name -> $value"
+                Remove-ItemProperty -Path $path -Name $name
+            }
         }
     }
+} catch {
+    Write-Warning "Failed to clean SysPrepExternal\Generalize entries: $_"
 }
 
 # Per https://learn.microsoft.com/en-us/azure/virtual-machines/generalize:
-# stale Panther logs can cause Sysprep to fail, and custom unattend files
-# aren't supported in this step.
+# stale Panther logs can cause Sysprep to fail; custom unattend files unsupported.
 Remove-Item "$env:SystemRoot\Panther" -Recurse -Force -ErrorAction SilentlyContinue
 Remove-Item "$env:SystemRoot\System32\Sysprep\unattend.xml" -Force -ErrorAction SilentlyContinue
 
 # /quit (not /shutdown) so RunCommand can return; deallocate happens separately.
+# $LASTEXITCODE isn't reliable after Sysprep.exe /quit — sysprep launches a
+# background SetupHost.exe and returns before generalization completes. The
+# ImageState poll below is the authoritative success signal (same as
+# vhdbuilder/packer/windows/sysprep.ps1).
 & "$env:SystemRoot\System32\Sysprep\Sysprep.exe" /oobe /generalize /mode:vm /quiet /quit
-$exit = $LASTEXITCODE
-Write-Host "Sysprep.exe returned exit=$exit"
-exit $exit
+
+# On Server 2022, sysprep /quit can return before background SetupHost.exe
+# finishes generalizing. Wait for the registry state to confirm before letting
+# the caller deallocate and capture the disk. Same pattern as
+# vhdbuilder/packer/windows/sysprep.ps1 (in-tree since 2020).
+$deadline = (Get-Date).AddMinutes(10)
+$last = $null
+while ($true) {
+    $state = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\State').ImageState
+    if ($state -ne $last) {
+        Write-Host "ImageState=$state"
+        $last = $state
+    }
+    if ($state -eq 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { break }
+    if ((Get-Date) -gt $deadline) {
+        throw "Sysprep did not reach IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE within 10 minutes (last state: $state)"
+    }
+    Start-Sleep -Seconds 10
+}
 `
 
 func CreateImage(ctx context.Context, s *Scenario) *config.Image {

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -725,41 +725,39 @@ func runCommandScriptError(view armcompute.VirtualMachineRunCommandInstanceView)
 // any SysPrepExternal\Generalize provider entry pointing at VMAgentDisabler.dll: when
 // the DLL can't be loaded, Sysprep stalls past our vmssCtx deadline. The same workaround
 // has lived in vhdbuilder/packer/windows/sysprep.ps1 since 2020 (PR #429).
+//
+// Pre-cleanup of C:\Windows\Panther and unattend.xml follows
+// https://learn.microsoft.com/en-us/azure/virtual-machines/generalize, which notes
+// that stale Panther logs can cause Sysprep to fail and that custom answer files
+// aren't supported in this step.
 const windowsSysprepScript = `
+$ErrorActionPreference = 'Stop'
+
+# Workaround for Win2022: broken SysPrepExternal\Generalize provider entries that
+# point at VMAgentDisabler.dll cause Sysprep /generalize to hang ~14 minutes when
+# the DLL cannot be loaded. -like is case-insensitive and tolerates REG_MULTI_SZ.
 $path = 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\SysPrepExternal\Generalize'
 if (Test-Path $path) {
     foreach ($name in @((Get-Item -Path $path).Property)) {
         $value = (Get-ItemProperty -Path $path -Name $name).$name
-        if ($value -and $value.Contains('VMAgentDisabler.dll')) {
+        if ($value -and ($value -like '*VMAgentDisabler.dll*')) {
             Write-Host "Removing broken generalize provider $name -> $value"
             Remove-ItemProperty -Path $path -Name $name
         }
     }
 }
 
-if (Test-Path "$env:SystemRoot\system32\Sysprep\unattend.xml") {
-    Remove-Item "$env:SystemRoot\system32\Sysprep\unattend.xml" -Force
-}
+# Per https://learn.microsoft.com/en-us/azure/virtual-machines/generalize:
+# stale Panther logs can cause Sysprep to fail, and custom unattend files
+# aren't supported in this step.
+Remove-Item "$env:SystemRoot\Panther" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item "$env:SystemRoot\System32\Sysprep\unattend.xml" -Force -ErrorAction SilentlyContinue
 
+# /quit (not /shutdown) so RunCommand can return; deallocate happens separately.
 & "$env:SystemRoot\System32\Sysprep\Sysprep.exe" /oobe /generalize /mode:vm /quiet /quit
-Write-Host "Sysprep.exe returned exit=$LASTEXITCODE"
-
-# Sysprep /quit returns immediately; wait for the generalize step to actually finish.
-# Only log on state transitions to stay well under RunCommand's stdout cap.
-$pollStart = Get-Date
-$lastState = $null
-while ($true) {
-    $imageState = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\State').ImageState
-    if ($imageState -ne $lastState) {
-        Write-Host "ImageState=$imageState (elapsed $((Get-Date) - $pollStart))"
-        $lastState = $imageState
-    }
-    if ($imageState -eq 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { break }
-    if ((Get-Date) - $pollStart -gt [TimeSpan]::FromMinutes(10)) {
-        throw "Sysprep generalize did not reach IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE within 10 min (last state: $imageState)"
-    }
-    Start-Sleep -s 10
-}
+$exit = $LASTEXITCODE
+Write-Host "Sysprep.exe returned exit=$exit"
+exit $exit
 `
 
 func CreateImage(ctx context.Context, s *Scenario) *config.Image {

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -599,43 +599,136 @@ func createVMExtensionLinuxAKSNode(ctx context.Context, location *string) (*armc
 	}, nil
 }
 
-// RunCommand executes a command on the VMSS VM with instance ID "0" and returns the raw JSON response from Azure
-// Unlike default approach, it doesn't use SSH and uses Azure tooling
-// This approach is generally slower, but it works even if SSH is not available
-func RunCommand(ctx context.Context, s *Scenario, command string) (armcompute.RunCommandResult, error) {
+// RunCommand executes a script on the VMSS VM with the configured instance ID via the
+// Azure VMSS RunCommand v2 API (VirtualMachineRunCommand resource). This is the API
+// already used by production aks-rp PIS code; using it here keeps test and production
+// on the same surface and avoids the v1 RunCommand extension's failure modes
+// (e.g. the Microsoft.CPlat.Core/RunCommandWindows "Keyset does not exist" error
+// fixed by ADO PR https://msazure.visualstudio.com/CloudNativeCompute/_git/aks-rp/pullrequest/15721814).
+//
+// Unlike SSH-based exec, this works even when WinRM/SSH are unavailable (e.g. mid-sysprep).
+// It is generally slower than SSH because each call creates a VirtualMachineRunCommand
+// resource on the VM and waits for it to provision.
+func RunCommand(ctx context.Context, s *Scenario, command string) (armcompute.VirtualMachineRunCommandInstanceView, error) {
 	s.T.Helper()
 	start := time.Now()
 	defer func() {
-		elapsed := time.Since(start)
-		toolkit.Logf(ctx, "Command %q took %s", command, elapsed)
+		toolkit.Logf(ctx, "Command %q took %s", command, time.Since(start))
 	}()
 
-	runPoller, err := config.Azure.VMSSVM.BeginRunCommand(ctx, *s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, *s.Runtime.VM.VM.InstanceID, armcompute.RunCommandInput{
-		CommandID: func() *string {
-			if s.IsWindows() {
-				return to.Ptr("RunPowerShellScript")
-			}
-			return to.Ptr("RunShellScript")
-		}(),
-		Script: []*string{to.Ptr(command)},
-	}, nil)
-	if err != nil {
-		return armcompute.RunCommandResult{}, fmt.Errorf("failed to run command on Windows VM for image creation: %w", err)
+	rg := *s.Runtime.Cluster.Model.Properties.NodeResourceGroup
+	instanceID := *s.Runtime.VM.VM.InstanceID
+	// VirtualMachineRunCommand resources persist on the VM until explicitly deleted;
+	// use a unique name per call so concurrent / repeated calls don't collide.
+	runCommandName := fmt.Sprintf("e2e-runcmd-%d", time.Now().UnixNano())
+
+	runCmd := armcompute.VirtualMachineRunCommand{
+		Location: to.Ptr(s.Location),
+		Properties: &armcompute.VirtualMachineRunCommandProperties{
+			Source: &armcompute.VirtualMachineRunCommandScriptSource{
+				Script: to.Ptr(command),
+			},
+			AsyncExecution: to.Ptr(false),
+		},
 	}
 
-	runResp, err := runPoller.PollUntilDone(ctx, nil)
+	poller, err := config.Azure.VMSSVMRunCommands.BeginCreateOrUpdate(ctx, rg, s.Runtime.VMSSName, instanceID, runCommandName, runCmd, nil)
 	if err != nil {
-		return runResp.RunCommandResult, fmt.Errorf("failed to run command on Windows VM for image creation: %w", err)
+		return armcompute.VirtualMachineRunCommandInstanceView{}, fmt.Errorf("failed to start RunCommand on VMSS VM: %w", err)
 	}
-	return runResp.RunCommandResult, err
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		return armcompute.VirtualMachineRunCommandInstanceView{}, fmt.Errorf("failed to wait for RunCommand on VMSS VM: %w", err)
+	}
+
+	// The CreateOrUpdate response doesn't always include the InstanceView; fetch it
+	// explicitly so we get stdout/stderr/exit code.
+	getResp, err := config.Azure.VMSSVMRunCommands.Get(ctx, rg, s.Runtime.VMSSName, instanceID, runCommandName, &armcompute.VirtualMachineScaleSetVMRunCommandsClientGetOptions{
+		Expand: to.Ptr("instanceView"),
+	})
+	if err != nil {
+		return armcompute.VirtualMachineRunCommandInstanceView{}, fmt.Errorf("failed to get RunCommand instance view: %w", err)
+	}
+	if getResp.Properties == nil || getResp.Properties.InstanceView == nil {
+		return armcompute.VirtualMachineRunCommandInstanceView{}, errors.New("RunCommand result missing instance view")
+	}
+	return *getResp.Properties.InstanceView, nil
 }
+
+// windowsSysprepScript runs Sysprep /generalize on a CSE'd Windows VM so the e2e test can
+// capture a VHD. We pre-emptively drop any SysPrepExternal\Generalize provider entry
+// pointing at VMAgentDisabler.dll, mirroring vhdbuilder/packer/windows/sysprep.ps1 (added
+// 2020, PR #429, commit 202fef719a).
+//
+// Root cause: VMAgentDisabler.dll is a Managed C++ Sysprep provider shipped by the
+// Windows Azure Guest Agent (msazure/One/Compute-IaaS-VMAgent). The agent self-updates
+// from the Azure fabric on every VM boot, and in Jan 2026 the agent added a new feature
+// (PR 14499782) to install a WDAC catalog file containing the DLL's hash — without that
+// catalog file the OS's Code Integrity layer cannot validate the unsigned DLL and
+// LoadLibrary stalls. The feature had bugs (hotfixes 14889344 Feb 26 / 14901019 Feb 27)
+// and rolled out unevenly across Azure regions and host pools between Feb and May 2026.
+// On VMs that ended up with the agent in the "catalog-install-failed" state, Sysprep
+// /generalize stalls long enough to exhaust our 17-min TestTimeoutVMSS and fail the
+// test. Removing the registry entry first short-circuits the load entirely.
+//
+// Causal proof (May 2026): on a healthy Win2022 host where Sysprep /generalize normally
+// completes in ~10s, deliberately renaming VMAgentDisabler.dll while leaving the
+// SysPrepExternal\Generalize entry pointing at the original path makes Sysprep stall
+// long past the 14+ minutes vmssCtx allows — the same observed symptom as 14/14
+// historical first-attempt PR check-in failures. (We never observe sysprep actually
+// completing on a broken host: the vmssCtx deadline always kills the call first, so the
+// hang duration is an open lower bound, not an exact 14m value.)
+//
+// Unlike vhdbuilder/packer/windows/sysprep.ps1, we deliberately keep
+// WindowsAzureGuestAgent running: it is the channel Azure RunCommand uses to report the
+// result of this script back to the caller. Packer can stop the agent because it
+// captures the disk directly; we cannot.
+const windowsSysprepScript = `
+$path = 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\SysPrepExternal\Generalize'
+if (Test-Path $path) {
+    foreach ($name in @((Get-Item -Path $path).Property)) {
+        $value = (Get-ItemProperty -Path $path -Name $name).$name
+        if ($value -and $value.Contains('VMAgentDisabler.dll')) {
+            Write-Host "Removing broken generalize provider $name -> $value"
+            Remove-ItemProperty -Path $path -Name $name
+        }
+    }
+}
+
+if (Test-Path "$env:SystemRoot\system32\Sysprep\unattend.xml") {
+    Remove-Item "$env:SystemRoot\system32\Sysprep\unattend.xml" -Force
+}
+
+& "$env:SystemRoot\System32\Sysprep\Sysprep.exe" /oobe /generalize /mode:vm /quiet /quit
+Write-Host "Sysprep.exe returned exit=$LASTEXITCODE"
+
+# Sysprep /quit returns immediately; wait for the generalize step to actually finish.
+$pollStart = Get-Date
+while ($true) {
+    $imageState = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\State').ImageState
+    Write-Host "ImageState=$imageState (elapsed $((Get-Date) - $pollStart))"
+    if ($imageState -eq 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { break }
+    if ((Get-Date) - $pollStart -gt [TimeSpan]::FromMinutes(10)) {
+        throw "Sysprep generalize did not reach IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE within 10 min (last state: $imageState)"
+    }
+    Start-Sleep -s 10
+}
+`
 
 func CreateImage(ctx context.Context, s *Scenario) *config.Image {
 	if s.IsWindows() {
 		s.T.Log("Running sysprep on Windows VM...")
-		res, err := RunCommand(ctx, s, `C:\Windows\System32\Sysprep\Sysprep.exe /oobe /generalize /mode:vm /quiet /quit;`)
-		resJson, _ := json.MarshalIndent(res, "", "  ")
-		s.T.Logf("Sysprep result: %s", string(resJson))
+		res, err := RunCommand(ctx, s, windowsSysprepScript)
+		var stdout, stderr string
+		if res.Output != nil {
+			stdout = strings.TrimSpace(*res.Output)
+		}
+		if res.Error != nil {
+			stderr = strings.TrimSpace(*res.Error)
+		}
+		s.T.Logf("Sysprep stdout: %s", stdout)
+		if stderr != "" {
+			s.T.Logf("Sysprep stderr: %s", stderr)
+		}
 		require.NoErrorf(s.T, err, "failed to run sysprep on Windows VM for image creation")
 	}
 

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -650,8 +650,9 @@ func RunCommand(ctx context.Context, s *Scenario, command string) (armcompute.Vi
 		return armcompute.VirtualMachineRunCommandInstanceView{}, fmt.Errorf("failed to wait for RunCommand on VMSS VM: %w", err)
 	}
 
-	// The CreateOrUpdate response doesn't always include the InstanceView; fetch it
-	// explicitly so we get stdout/stderr/exit code.
+	// CreateOrUpdate (PUT) never includes InstanceView in the response — it's only
+	// returned by Get when $expand=instanceView is set. Fetch it explicitly so we
+	// get stdout/stderr/exit code.
 	getResp, err := config.Azure.VMSSVMRunCommands.Get(ctx, rg, s.Runtime.VMSSName, instanceID, runCommandName, &armcompute.VirtualMachineScaleSetVMRunCommandsClientGetOptions{
 		Expand: to.Ptr("instanceView"),
 	})

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -651,7 +651,45 @@ func RunCommand(ctx context.Context, s *Scenario, command string) (armcompute.Vi
 	if getResp.Properties == nil || getResp.Properties.InstanceView == nil {
 		return armcompute.VirtualMachineRunCommandInstanceView{}, errors.New("RunCommand result missing instance view")
 	}
-	return *getResp.Properties.InstanceView, nil
+	view := *getResp.Properties.InstanceView
+	return view, runCommandScriptError(view)
+}
+
+// runCommandScriptError converts a RunCommand instance view into an error if the
+// script itself failed. The ARM CreateOrUpdate operation reports success as long as
+// the extension was able to run the script — a non-zero exit, throw, or timeout
+// inside the script lives in ExecutionState / ExitCode and is otherwise invisible
+// to callers using require.NoError. See:
+// https://learn.microsoft.com/en-us/azure/virtual-machines/windows/run-command-managed
+// ("InstanceView.ExecutionState: Status of user's Run Command script. ...
+//
+//	ProvisioningState: Status of general extension provisioning end to end").
+func runCommandScriptError(view armcompute.VirtualMachineRunCommandInstanceView) error {
+	state := armcompute.ExecutionStateUnknown
+	if view.ExecutionState != nil {
+		state = *view.ExecutionState
+	}
+	exitCode := int32(0)
+	if view.ExitCode != nil {
+		exitCode = *view.ExitCode
+	}
+	if state == armcompute.ExecutionStateSucceeded && exitCode == 0 {
+		return nil
+	}
+	output := ""
+	if view.Output != nil {
+		output = strings.TrimSpace(*view.Output)
+	}
+	stderr := ""
+	if view.Error != nil {
+		stderr = strings.TrimSpace(*view.Error)
+	}
+	msg := ""
+	if view.ExecutionMessage != nil {
+		msg = strings.TrimSpace(*view.ExecutionMessage)
+	}
+	return fmt.Errorf("RunCommand script failed: executionState=%s exitCode=%d message=%q stdout=%q stderr=%q",
+		state, exitCode, msg, output, stderr)
 }
 
 // windowsSysprepScript runs Sysprep /generalize on the test VM. It pre-emptively drops

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -612,14 +612,16 @@ func createVMExtensionLinuxAKSNode(ctx context.Context, location *string) (*armc
 func RunCommand(ctx context.Context, s *Scenario, command string) (armcompute.VirtualMachineRunCommandInstanceView, error) {
 	s.T.Helper()
 	start := time.Now()
+	label := runCommandLabel(command)
 	defer func() {
-		toolkit.Logf(ctx, "Command %q took %s", command, time.Since(start))
+		toolkit.Logf(ctx, "Command %s took %s", label, time.Since(start))
 	}()
 
 	rg := *s.Runtime.Cluster.Model.Properties.NodeResourceGroup
 	instanceID := *s.Runtime.VM.VM.InstanceID
 	// VirtualMachineRunCommand resources persist on the VM until explicitly deleted;
-	// use a unique name per call so concurrent / repeated calls don't collide.
+	// use a unique name per call so concurrent / repeated calls don't collide, and
+	// best-effort delete it on the way out below.
 	runCommandName := fmt.Sprintf("e2e-runcmd-%d", time.Now().UnixNano())
 
 	runCmd := armcompute.VirtualMachineRunCommand{
@@ -636,6 +638,16 @@ func RunCommand(ctx context.Context, s *Scenario, command string) (armcompute.Vi
 	if err != nil {
 		return armcompute.VirtualMachineRunCommandInstanceView{}, fmt.Errorf("failed to start RunCommand on VMSS VM: %w", err)
 	}
+	defer func() {
+		// Best-effort cleanup: VirtualMachineRunCommand resources persist on the VM
+		// otherwise and can accumulate across many RunCommand calls in a single run.
+		// Use a fresh context so we still clean up if the caller's ctx is cancelled.
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		if _, derr := config.Azure.VMSSVMRunCommands.BeginDelete(cleanupCtx, rg, s.Runtime.VMSSName, instanceID, runCommandName, nil); derr != nil {
+			toolkit.Logf(ctx, "best-effort RunCommand %s delete failed: %v", runCommandName, derr)
+		}
+	}()
 	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
 		return armcompute.VirtualMachineRunCommandInstanceView{}, fmt.Errorf("failed to wait for RunCommand on VMSS VM: %w", err)
 	}
@@ -653,6 +665,23 @@ func RunCommand(ctx context.Context, s *Scenario, command string) (armcompute.Vi
 	}
 	view := *getResp.Properties.InstanceView
 	return view, runCommandScriptError(view)
+}
+
+// runCommandLabel returns a short, log-safe identifier for a RunCommand script body.
+// We avoid logging the full script because callers pass multi-line content (e.g.
+// windowsSysprepScript) which floods test logs, and to reduce the chance of accidentally
+// echoing secrets if a future caller embeds them in the script.
+func runCommandLabel(command string) string {
+	const maxFirstLine = 80
+	first, _, _ := strings.Cut(command, "\n")
+	first = strings.TrimSpace(first)
+	if len(first) > maxFirstLine {
+		first = first[:maxFirstLine] + "…"
+	}
+	if first == "" {
+		first = "<empty>"
+	}
+	return fmt.Sprintf("%q (%d bytes)", first, len(command))
 }
 
 // runCommandScriptError converts a RunCommand instance view into an error if the

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -678,10 +678,15 @@ if (Test-Path "$env:SystemRoot\system32\Sysprep\unattend.xml") {
 Write-Host "Sysprep.exe returned exit=$LASTEXITCODE"
 
 # Sysprep /quit returns immediately; wait for the generalize step to actually finish.
+# Only log on state transitions to stay well under RunCommand's stdout cap.
 $pollStart = Get-Date
+$lastState = $null
 while ($true) {
     $imageState = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\State').ImageState
-    Write-Host "ImageState=$imageState (elapsed $((Get-Date) - $pollStart))"
+    if ($imageState -ne $lastState) {
+        Write-Host "ImageState=$imageState (elapsed $((Get-Date) - $pollStart))"
+        $lastState = $imageState
+    }
     if ($imageState -eq 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { break }
     if ((Get-Date) - $pollStart -gt [TimeSpan]::FromMinutes(10)) {
         throw "Sysprep generalize did not reach IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE within 10 min (last state: $imageState)"

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -654,34 +654,10 @@ func RunCommand(ctx context.Context, s *Scenario, command string) (armcompute.Vi
 	return *getResp.Properties.InstanceView, nil
 }
 
-// windowsSysprepScript runs Sysprep /generalize on a CSE'd Windows VM so the e2e test can
-// capture a VHD. We pre-emptively drop any SysPrepExternal\Generalize provider entry
-// pointing at VMAgentDisabler.dll, mirroring vhdbuilder/packer/windows/sysprep.ps1 (added
-// 2020, PR #429, commit 202fef719a).
-//
-// Root cause: VMAgentDisabler.dll is a Managed C++ Sysprep provider shipped by the
-// Windows Azure Guest Agent (msazure/One/Compute-IaaS-VMAgent). The agent self-updates
-// from the Azure fabric on every VM boot, and in Jan 2026 the agent added a new feature
-// (PR 14499782) to install a WDAC catalog file containing the DLL's hash — without that
-// catalog file the OS's Code Integrity layer cannot validate the unsigned DLL and
-// LoadLibrary stalls. The feature had bugs (hotfixes 14889344 Feb 26 / 14901019 Feb 27)
-// and rolled out unevenly across Azure regions and host pools between Feb and May 2026.
-// On VMs that ended up with the agent in the "catalog-install-failed" state, Sysprep
-// /generalize stalls long enough to exhaust our 17-min TestTimeoutVMSS and fail the
-// test. Removing the registry entry first short-circuits the load entirely.
-//
-// Causal proof (May 2026): on a healthy Win2022 host where Sysprep /generalize normally
-// completes in ~10s, deliberately renaming VMAgentDisabler.dll while leaving the
-// SysPrepExternal\Generalize entry pointing at the original path makes Sysprep stall
-// long past the 14+ minutes vmssCtx allows — the same observed symptom as 14/14
-// historical first-attempt PR check-in failures. (We never observe sysprep actually
-// completing on a broken host: the vmssCtx deadline always kills the call first, so the
-// hang duration is an open lower bound, not an exact 14m value.)
-//
-// Unlike vhdbuilder/packer/windows/sysprep.ps1, we deliberately keep
-// WindowsAzureGuestAgent running: it is the channel Azure RunCommand uses to report the
-// result of this script back to the caller. Packer can stop the agent because it
-// captures the disk directly; we cannot.
+// windowsSysprepScript runs Sysprep /generalize on the test VM. It pre-emptively drops
+// any SysPrepExternal\Generalize provider entry pointing at VMAgentDisabler.dll: when
+// the DLL can't be loaded, Sysprep stalls past our vmssCtx deadline. The same workaround
+// has lived in vhdbuilder/packer/windows/sysprep.ps1 since 2020 (PR #429).
 const windowsSysprepScript = `
 $path = 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\SysPrepExternal\Generalize'
 if (Test-Path $path) {

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -16,8 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/Masterminds/semver/v3"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
@@ -2383,16 +2381,12 @@ else
     exit 1
 fi`)
 	require.NoError(s.T, err, "Failed to run command to check sshd_config")
-	respJson, err := resp.MarshalJSON()
-	require.NoError(s.T, err, "Failed to marshal response")
-	s.T.Logf("Run command output: %s", string(respJson))
-
-	// Parse the JSON response to extract the output and exit code
-	respString := string(respJson)
+	stdout := lo.FromPtr(resp.Output)
+	s.T.Logf("Run command stdout: %s\nstderr: %s", stdout, lo.FromPtr(resp.Error))
 
 	// Check if the command execution was successful by looking for our success message in the output
-	if !strings.Contains(respString, "SUCCESS: PubkeyAuthentication is disabled") {
-		s.T.Fatalf("PubkeyAuthentication is not properly disabled. Full response: %s", respString)
+	if !strings.Contains(stdout, "SUCCESS: PubkeyAuthentication is disabled") {
+		s.T.Fatalf("PubkeyAuthentication is not properly disabled. stdout: %s", stdout)
 	}
 
 	// Part 2. Check cannot SSH with private key (expect failure)
@@ -2411,9 +2405,7 @@ func ValidateSSHServiceDisabled(ctx context.Context, s *Scenario) {
 
 	// Use VMSS RunCommand to check SSH service status directly on the node
 	// Ubuntu uses 'ssh' as service name, while AzureLinux and Mariner use 'sshd'
-	runPoller, err := config.Azure.VMSSVM.BeginRunCommand(ctx, *s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, *s.Runtime.VM.VM.InstanceID, armcompute.RunCommandInput{
-		CommandID: to.Ptr("RunShellScript"),
-		Script: []*string{to.Ptr(`#!/bin/bash
+	resp, err := RunCommand(ctx, s, `#!/bin/bash
 # Determine the correct SSH service name based on the distro
 # Ubuntu uses 'ssh', AzureLinux and Mariner use 'sshd'
 if [ -f /etc/os-release ]; then
@@ -2447,24 +2439,14 @@ if echo "$status_output" | grep -q "Active: inactive (dead)"; then
 else
     echo "FAILED: SSH service is not inactive"
     exit 1
-fi`)},
-	}, nil)
+fi`)
 	require.NoError(s.T, err, "Failed to run command to check SSH service status")
-
-	runResp, err := runPoller.PollUntilDone(ctx, nil)
-	require.NoError(s.T, err, "Failed to complete command to check SSH service status")
-
-	// Parse the response to check the result
-	respJson, err := runResp.MarshalJSON()
-	require.NoError(s.T, err, "Failed to marshal run command response")
-	s.T.Logf("Run command output: %s", string(respJson))
-
-	// Parse the JSON response to extract the output
-	respString := string(respJson)
+	stdout := lo.FromPtr(resp.Output)
+	s.T.Logf("Run command stdout: %s\nstderr: %s", stdout, lo.FromPtr(resp.Error))
 
 	// Check if the command execution was successful by looking for our success message in the output
-	if !strings.Contains(respString, "SUCCESS: SSH service is disabled and stopped") {
-		s.T.Fatalf("SSH service is not properly disabled and stopped. Full response: %s", respString)
+	if !strings.Contains(stdout, "SUCCESS: SSH service is disabled and stopped") {
+		s.T.Fatalf("SSH service is not properly disabled and stopped. stdout: %s", stdout)
 	}
 
 	s.T.Logf("SSH service is properly disabled and stopped as expected")


### PR DESCRIPTION
**What this PR does / why we need it**:

`Test_Windows2022_VHDCaching` intermittently flakes when the Sysprep RunCommand on the test VM stalls for ~14 minutes (observed in build 164698615 on PR #8535) and the test fails with `context deadline exceeded`. Root cause: a broken `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\SysPrepExternal\Generalize` provider entry points at `C:\Windows\system32\VMAgentDisabler.dll` — the Windows Azure Guest Agent that ships the DLL is missing on the test images, so Sysprep blocks waiting on the load.

`vhdbuilder/packer/windows/sysprep.ps1` has stripped that registry entry since 2020 (PR #429) for the production VHD-bake path. The e2e `CreateImage` helper was added later (PR #4631) and never inherited the workaround — it invokes Sysprep directly via RunCommand. This PR brings the e2e path to parity.

Also migrates RunCommand from v1 (`VMSSVM.BeginRunCommand`) to v2 (`VMSSVMRunCommands.BeginCreateOrUpdate`) — to avoid the v1 extension's `Keyset does not exist` failure on newer Windows hosts. Two call sites in `validators.go` updated.
