### PR TITLE
fix: remove AzureLinux 3.0 modprobe LPE blacklist (CSE-time + VHD bake-in) — kernel 6.6.139.1-1.azl3+ fixes upstream

### DIFF
--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2911,13 +2911,44 @@ func ValidateCollectWindowsLogsScript(ctx context.Context, s *Scenario) {
 
 // ValidateVulnerableKernelModulesDisabled verifies that kernel modules with known
 // LPE vulnerabilities are blocked via modprobe config, not loaded, and cannot be loaded.
-// Covers: CVE-2026-31431 (algif_aead), DirtyFrag (esp4, esp6, rxrpc).
+// Covers: CVE-2026-31431 (algif_aead), DirtyFrag (esp4, esp6, rxrpc), Fragnesia (esp4, esp6).
+//
+// AzureLinux 3.0 is excluded from the runtime apply because kernel 6.6.139.1-1.azl3
+// and later fix all three CVEs upstream. The static modprobe-CIS.conf baked into the
+// VHD still drops the install/blacklist directives, so we verify those entries are
+// present on AzureLinux 3.0 (defense-in-depth) but do not require an active modprobe
+// refusal — the kernel-level fix is the authoritative mitigation. See
+// https://github.com/Azure/AKS/issues/5753.
+//
 // To add a new CVE mitigation, append the module name to the list below.
 func ValidateVulnerableKernelModulesDisabled(ctx context.Context, s *Scenario) {
 	s.T.Helper()
 
 	if s.VHD.Flatcar && s.VHD.OS != config.OSACL {
 		s.T.Log("Skipping vulnerable kernel module validation: not applicable for Flatcar")
+		return
+	}
+
+	// On AzureLinux 3.0 the kernel fix in 6.6.139.1-1.azl3+ is the authoritative
+	// mitigation; the CSE-time runtime apply is intentionally skipped. We still
+	// validate that the baked-in modprobe-CIS.conf entries are present as
+	// defense-in-depth, but we do NOT require the module to be refused by modprobe
+	// (the kernel-level fix supersedes the module disable).
+	if s.VHD.OS == config.OSAzureLinux {
+		script := strings.Join([]string{
+			`failed=0`,
+			`for mod in algif_aead esp4 esp6 rxrpc; do`,
+			`  if ! grep -qsE "^install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then`,
+			`    echo "FAIL: ${mod} disable rule not found in /etc/modprobe.d/*.conf (expected from baked-in modprobe-CIS.conf)"`,
+			`    failed=1`,
+			`  else`,
+			`    echo "PASS: modprobe config blocks ${mod} (defense-in-depth)"`,
+			`  fi`,
+			`done`,
+			`exit $failed`,
+		}, "\n")
+		execScriptOnVMForScenarioValidateExitCode(ctx, s, script, 0,
+			"AzureLinux 3.0 modprobe-CIS.conf defense-in-depth check failed (algif_aead/esp4/esp6/rxrpc)")
 		return
 	}
 

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2931,15 +2931,16 @@ func ValidateVulnerableKernelModulesDisabled(ctx context.Context, s *Scenario) {
 		return
 	}
 
-	// AzureLinux 3.0: kernel 6.6.139.1-1.azl3+ supersedes the modprobe blacklist and
-	// the bake-in has been removed because customers need those modules. Assert the
-	// blacklist entries are NOT present on freshly-built AzL3 VHDs.
-	if s.VHD.OS == config.OSAzureLinux {
+	// AzureLinux 3.0 (regular, NOT OSGuard): kernel 6.6.139.1-1.azl3+ supersedes the modprobe
+	// blacklist and the bake-in has been removed because customers need those modules. Assert
+	// the blacklist entries are NOT present on freshly-built AzL3 VHDs. AzureLinux OSGuard is
+	// intentionally kept in-scope (falls through to the full presence + load-refusal check below).
+	if s.VHD.OS == config.OSAzureLinux && !s.VHD.Distro.IsAzureLinuxOSGuardDistro() {
 		script := strings.Join([]string{
 			`failed=0`,
 			`for mod in algif_aead esp4 esp6 rxrpc; do`,
-			`  if grep -qsE "^install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then`,
-			`    echo "FAIL: ${mod} disable rule unexpectedly present on AzureLinux 3.0 (bake-in removed; kernel 6.6.139.1-1.azl3+ supersedes)"`,
+			`  if grep -qsE "^(install ${mod} /bin/false|blacklist ${mod})" /etc/modprobe.d/*.conf 2>/dev/null; then`,
+			`    echo "FAIL: ${mod} blacklist entry unexpectedly present on AzureLinux 3.0 (bake-in removed; kernel 6.6.139.1-1.azl3+ supersedes)"`,
 			`    failed=1`,
 			`  else`,
 			`    echo "PASS: ${mod} blacklist correctly absent on AzureLinux 3.0"`,
@@ -2948,7 +2949,7 @@ func ValidateVulnerableKernelModulesDisabled(ctx context.Context, s *Scenario) {
 			`exit $failed`,
 		}, "\n")
 		execScriptOnVMForScenarioValidateExitCode(ctx, s, script, 0,
-			"AzureLinux 3.0 modprobe blacklist should be absent (kernel fix 6.6.139.1-1.azl3+ supersedes; bake-in removed)")
+			"AzureLinux 3.0 modprobe blacklist should be absent (kernel fix 6.6.139.1-1.azl3+ supersedes; bake-in removed; no `install` or `blacklist` directive should remain)")
 		return
 	}
 

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2922,7 +2922,8 @@ func ValidateCollectWindowsLogsScript(ctx context.Context, s *Scenario) {
 //     no longer ship the modprobe-CIS.conf entries, and E2E runs against freshly-built
 //     VHDs. See https://github.com/Azure/AKS/issues/5753.
 //
-// To add a new CVE mitigation, append the module name to the list below.
+// To add a new CVE mitigation, append the module name to BOTH lists below —
+// the AzureLinux 3.0 absence-check list AND the default presence + load-refusal list.
 func ValidateVulnerableKernelModulesDisabled(ctx context.Context, s *Scenario) {
 	s.T.Helper()
 

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2913,11 +2913,11 @@ func ValidateCollectWindowsLogsScript(ctx context.Context, s *Scenario) {
 // LPE vulnerabilities are blocked via modprobe config, not loaded, and cannot be loaded.
 // Covers: CVE-2026-31431 (algif_aead), DirtyFrag (esp4, esp6, rxrpc), Fragnesia (esp4, esp6).
 //
-// AzureLinux 3.0 is excluded from the runtime apply because kernel 6.6.139.1-1.azl3
-// and later fix all three CVEs upstream. The static modprobe-CIS.conf baked into the
-// VHD still drops the install/blacklist directives, so we verify those entries are
-// present on AzureLinux 3.0 (defense-in-depth) but do not require an active modprobe
-// refusal — the kernel-level fix is the authoritative mitigation. See
+// AzureLinux 3.0 is descoped from the mitigation because kernel 6.6.139.1-1.azl3 and
+// later fix all three CVEs upstream, AND customer workloads on AzL3 require those
+// modules (the blacklist actively blocks legitimate use cases). Newly-built AzL3 VHDs
+// therefore no longer ship the modprobe-CIS.conf entries. E2E runs against freshly-built
+// VHDs, so on AzureLinux we assert the four module entries are ABSENT. See
 // https://github.com/Azure/AKS/issues/5753.
 //
 // To add a new CVE mitigation, append the module name to the list below.
@@ -2929,26 +2929,24 @@ func ValidateVulnerableKernelModulesDisabled(ctx context.Context, s *Scenario) {
 		return
 	}
 
-	// On AzureLinux 3.0 the kernel fix in 6.6.139.1-1.azl3+ is the authoritative
-	// mitigation; the CSE-time runtime apply is intentionally skipped. We still
-	// validate that the baked-in modprobe-CIS.conf entries are present as
-	// defense-in-depth, but we do NOT require the module to be refused by modprobe
-	// (the kernel-level fix supersedes the module disable).
+	// AzureLinux 3.0: kernel 6.6.139.1-1.azl3+ supersedes the modprobe blacklist and
+	// the bake-in has been removed because customers need those modules. Assert the
+	// blacklist entries are NOT present on freshly-built AzL3 VHDs.
 	if s.VHD.OS == config.OSAzureLinux {
 		script := strings.Join([]string{
 			`failed=0`,
 			`for mod in algif_aead esp4 esp6 rxrpc; do`,
-			`  if ! grep -qsE "^install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then`,
-			`    echo "FAIL: ${mod} disable rule not found in /etc/modprobe.d/*.conf (expected from baked-in modprobe-CIS.conf)"`,
+			`  if grep -qsE "^install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then`,
+			`    echo "FAIL: ${mod} disable rule unexpectedly present on AzureLinux 3.0 (bake-in removed; kernel 6.6.139.1-1.azl3+ supersedes)"`,
 			`    failed=1`,
 			`  else`,
-			`    echo "PASS: modprobe config blocks ${mod} (defense-in-depth)"`,
+			`    echo "PASS: ${mod} blacklist correctly absent on AzureLinux 3.0"`,
 			`  fi`,
 			`done`,
 			`exit $failed`,
 		}, "\n")
 		execScriptOnVMForScenarioValidateExitCode(ctx, s, script, 0,
-			"AzureLinux 3.0 modprobe-CIS.conf defense-in-depth check failed (algif_aead/esp4/esp6/rxrpc)")
+			"AzureLinux 3.0 modprobe blacklist should be absent (kernel fix 6.6.139.1-1.azl3+ supersedes; bake-in removed)")
 		return
 	}
 

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2909,16 +2909,18 @@ func ValidateCollectWindowsLogsScript(ctx context.Context, s *Scenario) {
 		"collect-windows-logs.ps1 failed or did not produce a zip file")
 }
 
-// ValidateVulnerableKernelModulesDisabled verifies that kernel modules with known
-// LPE vulnerabilities are blocked via modprobe config, not loaded, and cannot be loaded.
-// Covers: CVE-2026-31431 (algif_aead), DirtyFrag (esp4, esp6, rxrpc), Fragnesia (esp4, esp6).
+// ValidateVulnerableKernelModulesDisabled verifies that kernel modules with known LPE
+// vulnerabilities (CVE-2026-31431 / DirtyFrag / Fragnesia: algif_aead, esp4, esp6, rxrpc)
+// are handled correctly per OS:
 //
-// AzureLinux 3.0 is descoped from the mitigation because kernel 6.6.139.1-1.azl3 and
-// later fix all three CVEs upstream, AND customer workloads on AzL3 require those
-// modules (the blacklist actively blocks legitimate use cases). Newly-built AzL3 VHDs
-// therefore no longer ship the modprobe-CIS.conf entries. E2E runs against freshly-built
-// VHDs, so on AzureLinux we assert the four module entries are ABSENT. See
-// https://github.com/Azure/AKS/issues/5753.
+//   - Ubuntu / Mariner: full check — modprobe config entries are present, modules are
+//     NOT loaded, and modprobe refuses to load them.
+//   - AzureLinux 3.0: assert ABSENCE of the four modprobe blacklist entries. AzL3 is
+//     descoped from the mitigation because kernel 6.6.139.1-1.azl3 and later fix all
+//     three CVEs upstream, AND customer workloads on AzL3 require those modules (the
+//     blacklist actively blocks legitimate use cases). Newly-built AzL3 VHDs therefore
+//     no longer ship the modprobe-CIS.conf entries, and E2E runs against freshly-built
+//     VHDs. See https://github.com/Azure/AKS/issues/5753.
 //
 // To add a new CVE mitigation, append the module name to the list below.
 func ValidateVulnerableKernelModulesDisabled(ctx context.Context, s *Scenario) {

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -334,13 +334,13 @@ EOF
     # scope as defense-in-depth: OSGuard workloads are security-sensitive and do not require
     # the affected kernel modules.
     #
-    # Mariner (AzL2) is not gated here: AKS stopped building Mariner VHDs on 2025-12-06 and the
-    # 6-month support window for the last Mariner VHD closes ~2026-06. The mitigation is already
-    # baked into modprobe-CIS.conf in every in-support Mariner VHD, so the runtime apply was
-    # purely defense-in-depth and is no longer needed.
+    # Mariner/AzureLinux 2.0 (AzL2) images are frozen (see FrozenCBLMarinerV2AndAzureLinuxV2SIGImageVersion=202512.06.0),
+    # so they cannot pick up new modprobe-CIS.conf entries for these 2026 CVEs via VHD refresh.
+    # Keep the CSE-time runtime apply enabled for AzL2/Mariner while those images remain supported.
+    # See https://github.com/Azure/AKS/issues/5753.
     #
     # See https://github.com/Azure/AKS/issues/5753.
-    if isUbuntu "$OS" || isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
+    if isUbuntu "$OS" || isAzureLinuxOSGuard "$OS" "$OS_VARIANT" || { isMarinerOrAzureLinux "$OS" && [ "${OS_VERSION}" = "2.0" ]; }; then
         disableVulnerableKernelModule "algif_aead" "CVE-2026-31431 (Copy Fail)"
         disableVulnerableKernelModule "esp4" "DirtyFrag (xfrm-ESP page-cache write)"
         disableVulnerableKernelModule "esp6" "DirtyFrag (xfrm-ESP6 page-cache write)"

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -319,10 +319,16 @@ EOF
 
     logs_to_events "AKS.CSE.ensureSysctl" ensureSysctl || exit $ERR_SYSCTL_RELOAD
 
-    # Disable kernel modules with known LPE vulnerabilities (CVE-2026-31431, DirtyFrag).
+    # Disable kernel modules with known LPE vulnerabilities (CVE-2026-31431, DirtyFrag, Fragnesia).
     # Applies to existing VHDs that don't yet have the modprobe-CIS.conf fix baked in.
     # To add a new CVE mitigation, add a disableVulnerableKernelModule call below.
-    if isUbuntu "$OS" || isMarinerOrAzureLinux "$OS"; then
+    #
+    # AzureLinux 3.0 is excluded: kernel 6.6.139.1-1.azl3 and later fix Copy Fail / DirtyFrag /
+    # Fragnesia upstream, so the runtime modprobe blacklist is no longer required there.
+    # See https://github.com/Azure/AKS/issues/5753.
+    # The static /etc/modprobe.d/modprobe-CIS.conf baked into the VHD remains in place on
+    # all OS variants as defense-in-depth for the 6-month VHD support window.
+    if isUbuntu "$OS" || isMariner "$OS"; then
         disableVulnerableKernelModule "algif_aead" "CVE-2026-31431 (Copy Fail)"
         disableVulnerableKernelModule "esp4" "DirtyFrag (xfrm-ESP page-cache write)"
         disableVulnerableKernelModule "esp6" "DirtyFrag (xfrm-ESP6 page-cache write)"

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -320,21 +320,20 @@ EOF
     logs_to_events "AKS.CSE.ensureSysctl" ensureSysctl || exit $ERR_SYSCTL_RELOAD
 
     # Disable kernel modules with known LPE vulnerabilities (CVE-2026-31431, DirtyFrag, Fragnesia).
-    # Ubuntu-only: applies the runtime modprobe blacklist to existing Ubuntu VHDs that don't yet
-    # have the modprobe-CIS.conf fix baked in. To add a new CVE mitigation, add a
-    # disableVulnerableKernelModule call below.
+    # Applied at CSE provisioning time on Ubuntu, Mariner (AzL2), and AzureLinux OSGuard. To add a
+    # new CVE mitigation, add a disableVulnerableKernelModule call below.
     #
-    # AKS no longer builds Mariner (AzureLinux 2.0) VHDs, so Mariner is not gated here.
-    #
-    # AzureLinux 3.0 is excluded: kernel 6.6.139.1-1.azl3 and later fix Copy Fail / DirtyFrag /
-    # Fragnesia upstream, so neither the runtime modprobe blacklist nor the baked-in
-    # /etc/modprobe.d/CIS.conf entries are required. Newly-built AzL3 VHDs no longer ship
-    # the four module entries — customers reported the blacklist actively blocks legitimate
-    # workloads that use algif_aead / esp4 / esp6 / rxrpc on the patched kernel. Existing
-    # in-support AzL3 VHDs (built before this change) still have the bake-in until they are
-    # rolled; no CSE-time active removal is performed — customers will get the unblocked
-    # configuration on their next AzL3 VHD upgrade. See https://github.com/Azure/AKS/issues/5753.
-    if isUbuntu "$OS"; then
+    # AzureLinux 3.0 (regular and Kata) is excluded: kernel 6.6.139.1-1.azl3 and later fix Copy
+    # Fail / DirtyFrag / Fragnesia upstream, so the runtime modprobe blacklist is no longer
+    # required. Newly-built AzL3 VHDs also no longer ship the four entries in modprobe-CIS.conf —
+    # customers reported the blacklist actively blocks legitimate workloads that use
+    # algif_aead / esp4 / esp6 / rxrpc on the patched kernel. Existing in-support AzL3 VHDs
+    # (built before this change) still have the bake-in until they are rolled; no CSE-time active
+    # removal is performed — customers will get the unblocked configuration on their next AzL3
+    # VHD upgrade. AzureLinux OSGuard is intentionally kept in scope (defense-in-depth — OSGuard
+    # is the hardened secure-boot variant and explicitly retains the mitigation).
+    # See https://github.com/Azure/AKS/issues/5753.
+    if isUbuntu "$OS" || isMariner "$OS" || isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
         disableVulnerableKernelModule "algif_aead" "CVE-2026-31431 (Copy Fail)"
         disableVulnerableKernelModule "esp4" "DirtyFrag (xfrm-ESP page-cache write)"
         disableVulnerableKernelModule "esp6" "DirtyFrag (xfrm-ESP6 page-cache write)"

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -320,8 +320,11 @@ EOF
     logs_to_events "AKS.CSE.ensureSysctl" ensureSysctl || exit $ERR_SYSCTL_RELOAD
 
     # Disable kernel modules with known LPE vulnerabilities (CVE-2026-31431, DirtyFrag, Fragnesia).
-    # Applies to existing VHDs that don't yet have the modprobe-CIS.conf fix baked in.
-    # To add a new CVE mitigation, add a disableVulnerableKernelModule call below.
+    # Ubuntu-only: applies the runtime modprobe blacklist to existing Ubuntu VHDs that don't yet
+    # have the modprobe-CIS.conf fix baked in. To add a new CVE mitigation, add a
+    # disableVulnerableKernelModule call below.
+    #
+    # AKS no longer builds Mariner (AzureLinux 2.0) VHDs, so Mariner is not gated here.
     #
     # AzureLinux 3.0 is excluded: kernel 6.6.139.1-1.azl3 and later fix Copy Fail / DirtyFrag /
     # Fragnesia upstream, so neither the runtime modprobe blacklist nor the baked-in
@@ -331,7 +334,7 @@ EOF
     # in-support AzL3 VHDs (built before this change) still have the bake-in until they are
     # rolled; no CSE-time active removal is performed — customers will get the unblocked
     # configuration on their next AzL3 VHD upgrade. See https://github.com/Azure/AKS/issues/5753.
-    if isUbuntu "$OS" || isMariner "$OS"; then
+    if isUbuntu "$OS"; then
         disableVulnerableKernelModule "algif_aead" "CVE-2026-31431 (Copy Fail)"
         disableVulnerableKernelModule "esp4" "DirtyFrag (xfrm-ESP page-cache write)"
         disableVulnerableKernelModule "esp6" "DirtyFrag (xfrm-ESP6 page-cache write)"

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -320,8 +320,8 @@ EOF
     logs_to_events "AKS.CSE.ensureSysctl" ensureSysctl || exit $ERR_SYSCTL_RELOAD
 
     # Disable kernel modules with known LPE vulnerabilities (CVE-2026-31431, DirtyFrag, Fragnesia).
-    # Applied at CSE provisioning time on Ubuntu, Mariner (AzL2), and AzureLinux OSGuard. To add a
-    # new CVE mitigation, add a disableVulnerableKernelModule call below.
+    # Applied at CSE provisioning time on Ubuntu and AzureLinux OSGuard. To add a new CVE
+    # mitigation, add a disableVulnerableKernelModule call below.
     #
     # AzureLinux 3.0 (regular and Kata) is excluded: kernel 6.6.139.1-1.azl3 and later fix Copy
     # Fail / DirtyFrag / Fragnesia upstream, so the runtime modprobe blacklist is no longer
@@ -330,10 +330,17 @@ EOF
     # algif_aead / esp4 / esp6 / rxrpc on the patched kernel. Existing in-support AzL3 VHDs
     # (built before this change) still have the bake-in until they are rolled; no CSE-time active
     # removal is performed — customers will get the unblocked configuration on their next AzL3
-    # VHD upgrade. AzureLinux OSGuard is intentionally kept in scope (defense-in-depth — OSGuard
-    # is the hardened secure-boot variant and explicitly retains the mitigation).
+    # VHD upgrade. AzureLinux OSGuard (hardened secure-boot variant) is intentionally kept in
+    # scope as defense-in-depth: OSGuard workloads are security-sensitive and do not require
+    # the affected kernel modules.
+    #
+    # Mariner (AzL2) is not gated here: AKS stopped building Mariner VHDs on 2025-12-06 and the
+    # 6-month support window for the last Mariner VHD closes ~2026-06. The mitigation is already
+    # baked into modprobe-CIS.conf in every in-support Mariner VHD, so the runtime apply was
+    # purely defense-in-depth and is no longer needed.
+    #
     # See https://github.com/Azure/AKS/issues/5753.
-    if isUbuntu "$OS" || isMariner "$OS" || isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
+    if isUbuntu "$OS" || isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
         disableVulnerableKernelModule "algif_aead" "CVE-2026-31431 (Copy Fail)"
         disableVulnerableKernelModule "esp4" "DirtyFrag (xfrm-ESP page-cache write)"
         disableVulnerableKernelModule "esp6" "DirtyFrag (xfrm-ESP6 page-cache write)"

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -320,8 +320,8 @@ EOF
     logs_to_events "AKS.CSE.ensureSysctl" ensureSysctl || exit $ERR_SYSCTL_RELOAD
 
     # Disable kernel modules with known LPE vulnerabilities (CVE-2026-31431, DirtyFrag, Fragnesia).
-    # Applied at CSE provisioning time on Ubuntu and AzureLinux OSGuard. To add a new CVE
-    # mitigation, add a disableVulnerableKernelModule call below.
+    # Applied at CSE provisioning time on Ubuntu, AzureLinux OSGuard, and AzureLinux 2.0 / Mariner.
+    # To add a new CVE mitigation, add a disableVulnerableKernelModule call below.
     #
     # AzureLinux 3.0 (regular and Kata) is excluded: kernel 6.6.139.1-1.azl3 and later fix Copy
     # Fail / DirtyFrag / Fragnesia upstream, so the runtime modprobe blacklist is no longer
@@ -334,7 +334,7 @@ EOF
     # scope as defense-in-depth: OSGuard workloads are security-sensitive and do not require
     # the affected kernel modules.
     #
-    # Mariner/AzureLinux 2.0 (AzL2) images are frozen (see FrozenCBLMarinerV2AndAzureLinuxV2SIGImageVersion=202512.06.0),
+    # Mariner / AzureLinux 2.0 (AzL2) images are frozen (see FrozenCBLMarinerV2AndAzureLinuxV2SIGImageVersion=202512.06.0),
     # so they cannot pick up new modprobe-CIS.conf entries for these 2026 CVEs via VHD refresh.
     # Keep the CSE-time runtime apply enabled for AzL2/Mariner while those images remain supported.
     # See https://github.com/Azure/AKS/issues/5753.

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -339,7 +339,6 @@ EOF
     # Keep the CSE-time runtime apply enabled for AzL2/Mariner while those images remain supported.
     # See https://github.com/Azure/AKS/issues/5753.
     #
-    # See https://github.com/Azure/AKS/issues/5753.
     if isUbuntu "$OS" || isAzureLinuxOSGuard "$OS" "$OS_VARIANT" || { isMarinerOrAzureLinux "$OS" && [ "${OS_VERSION}" = "2.0" ]; }; then
         disableVulnerableKernelModule "algif_aead" "CVE-2026-31431 (Copy Fail)"
         disableVulnerableKernelModule "esp4" "DirtyFrag (xfrm-ESP page-cache write)"

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -324,10 +324,13 @@ EOF
     # To add a new CVE mitigation, add a disableVulnerableKernelModule call below.
     #
     # AzureLinux 3.0 is excluded: kernel 6.6.139.1-1.azl3 and later fix Copy Fail / DirtyFrag /
-    # Fragnesia upstream, so the runtime modprobe blacklist is no longer required there.
-    # See https://github.com/Azure/AKS/issues/5753.
-    # The static /etc/modprobe.d/modprobe-CIS.conf baked into the VHD remains in place on
-    # all OS variants as defense-in-depth for the 6-month VHD support window.
+    # Fragnesia upstream, so neither the runtime modprobe blacklist nor the baked-in
+    # /etc/modprobe.d/CIS.conf entries are required. Newly-built AzL3 VHDs no longer ship
+    # the four module entries — customers reported the blacklist actively blocks legitimate
+    # workloads that use algif_aead / esp4 / esp6 / rxrpc on the patched kernel. Existing
+    # in-support AzL3 VHDs (built before this change) still have the bake-in until they are
+    # rolled; no CSE-time active removal is performed — customers will get the unblocked
+    # configuration on their next AzL3 VHD upgrade. See https://github.com/Azure/AKS/issues/5753.
     if isUbuntu "$OS" || isMariner "$OS"; then
         disableVulnerableKernelModule "algif_aead" "CVE-2026-31431 (Copy Fail)"
         disableVulnerableKernelModule "esp4" "DirtyFrag (xfrm-ESP page-cache write)"

--- a/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
@@ -73,16 +73,17 @@ Describe 'disableVulnerableKernelModule()'
 End
 
 # Tests the OS gate that decides whether to call disableVulnerableKernelModule
-# at CSE provisioning time. Ubuntu-only: AKS no longer builds Mariner VHDs, and
-# AzureLinux 3.0 is excluded because the kernel fix in 6.6.139.1-1.azl3+ supersedes
-# the modprobe blacklist (and customers reported the blacklist actively blocks
-# legitimate workloads on AzL3). See https://github.com/Azure/AKS/issues/5753.
+# at CSE provisioning time. Apply on: Ubuntu, Mariner (AzL2 — kernel still vulnerable),
+# AzureLinux OSGuard (defense-in-depth — hardened variant intentionally retains the
+# mitigation). Skip on: AzureLinux 3.0 regular/Kata (kernel 6.6.139.1-1.azl3+ has the
+# upstream fix and customers reported the blacklist actively blocks legitimate workloads),
+# ACL, Flatcar. See https://github.com/Azure/AKS/issues/5753.
 Describe 'CVE kernel module mitigation OS gate'
     Include "./parts/linux/cloud-init/artifacts/cse_helpers.sh"
 
     gate() {
         # Mirrors the condition in cse_main.sh basePrep — must be kept in sync.
-        if isUbuntu "$OS"; then
+        if isUbuntu "$OS" || isMariner "$OS" || isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
             echo "APPLY"
         else
             echo "SKIP"
@@ -96,35 +97,49 @@ Describe 'CVE kernel module mitigation OS gate'
         The output should equal "APPLY"
     End
 
-    It 'skips the runtime mitigation on AzureLinux 2.0 (Mariner) — no longer built'
+    It 'applies the mitigation on Mariner (AzureLinux 2.0) — kernel still vulnerable'
         OS="${MARINER_OS_NAME}"
         OS_VARIANT=""
         When call gate
-        The output should equal "SKIP"
+        The output should equal "APPLY"
     End
 
-    It 'skips the runtime mitigation on AzureLinux 3.0 (kernel 6.6.139.1-1.azl3+ has upstream fix)'
+    It 'applies the mitigation on Mariner Kata'
+        OS="${MARINER_KATA_OS_NAME}"
+        OS_VARIANT=""
+        When call gate
+        The output should equal "APPLY"
+    End
+
+    It 'applies the mitigation on AzureLinux 3.0 OSGuard — defense-in-depth retained'
+        OS="${AZURELINUX_OS_NAME}"
+        OS_VARIANT="${AZURELINUX_OSGUARD_OS_VARIANT}"
+        When call gate
+        The output should equal "APPLY"
+    End
+
+    It 'skips the runtime mitigation on AzureLinux 3.0 regular (kernel 6.6.139.1-1.azl3+ has upstream fix)'
         OS="${AZURELINUX_OS_NAME}"
         OS_VARIANT=""
         When call gate
         The output should equal "SKIP"
     End
 
-    It 'skips the runtime mitigation on AzureLinux 3.0 Kata'
+    It 'skips the runtime mitigation on AzureLinux 3.0 Kata (same kernel as AzL3 regular)'
         OS="${AZURELINUX_KATA_OS_NAME}"
         OS_VARIANT=""
         When call gate
         The output should equal "SKIP"
     End
 
-    It 'skips on ACL (Flatcar-based)'
+    It 'skips on ACL (Flatcar-based; never in scope)'
         OS="${ACL_OS_NAME}"
         OS_VARIANT=""
         When call gate
         The output should equal "SKIP"
     End
 
-    It 'skips on Flatcar'
+    It 'skips on Flatcar (never in scope)'
         OS="${FLATCAR_OS_NAME}"
         OS_VARIANT=""
         When call gate

--- a/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
@@ -73,17 +73,18 @@ Describe 'disableVulnerableKernelModule()'
 End
 
 # Tests the OS gate that decides whether to call disableVulnerableKernelModule
-# at CSE provisioning time. Apply on: Ubuntu, Mariner (AzL2 — kernel still vulnerable),
-# AzureLinux OSGuard (defense-in-depth — hardened variant intentionally retains the
-# mitigation). Skip on: AzureLinux 3.0 regular/Kata (kernel 6.6.139.1-1.azl3+ has the
-# upstream fix and customers reported the blacklist actively blocks legitimate workloads),
+# at CSE provisioning time. Apply on: Ubuntu, AzureLinux OSGuard (defense-in-depth —
+# hardened secure-boot variant intentionally retains the mitigation). Skip on:
+# AzureLinux 3.0 regular/Kata (kernel 6.6.139.1-1.azl3+ has the upstream fix and
+# customers reported the blacklist actively blocks legitimate workloads), Mariner
+# (no longer built; mitigation already baked in all in-support Mariner VHDs),
 # ACL, Flatcar. See https://github.com/Azure/AKS/issues/5753.
 Describe 'CVE kernel module mitigation OS gate'
     Include "./parts/linux/cloud-init/artifacts/cse_helpers.sh"
 
     gate() {
         # Mirrors the condition in cse_main.sh basePrep — must be kept in sync.
-        if isUbuntu "$OS" || isMariner "$OS" || isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
+        if isUbuntu "$OS" || isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
             echo "APPLY"
         else
             echo "SKIP"
@@ -97,20 +98,6 @@ Describe 'CVE kernel module mitigation OS gate'
         The output should equal "APPLY"
     End
 
-    It 'applies the mitigation on Mariner (AzureLinux 2.0) — kernel still vulnerable'
-        OS="${MARINER_OS_NAME}"
-        OS_VARIANT=""
-        When call gate
-        The output should equal "APPLY"
-    End
-
-    It 'applies the mitigation on Mariner Kata'
-        OS="${MARINER_KATA_OS_NAME}"
-        OS_VARIANT=""
-        When call gate
-        The output should equal "APPLY"
-    End
-
     It 'applies the mitigation on AzureLinux 3.0 OSGuard — defense-in-depth retained'
         OS="${AZURELINUX_OS_NAME}"
         OS_VARIANT="${AZURELINUX_OSGUARD_OS_VARIANT}"
@@ -118,14 +105,28 @@ Describe 'CVE kernel module mitigation OS gate'
         The output should equal "APPLY"
     End
 
-    It 'skips the runtime mitigation on AzureLinux 3.0 regular (kernel 6.6.139.1-1.azl3+ has upstream fix)'
+    It 'skips on Mariner (AzL2) — AKS stopped building Mariner on 2025-12-06; bake-in covers in-support VHDs'
+        OS="${MARINER_OS_NAME}"
+        OS_VARIANT=""
+        When call gate
+        The output should equal "SKIP"
+    End
+
+    It 'skips on Mariner Kata — same rationale as Mariner'
+        OS="${MARINER_KATA_OS_NAME}"
+        OS_VARIANT=""
+        When call gate
+        The output should equal "SKIP"
+    End
+
+    It 'skips on AzureLinux 3.0 regular (kernel 6.6.139.1-1.azl3+ has upstream fix)'
         OS="${AZURELINUX_OS_NAME}"
         OS_VARIANT=""
         When call gate
         The output should equal "SKIP"
     End
 
-    It 'skips the runtime mitigation on AzureLinux 3.0 Kata (same kernel as AzL3 regular)'
+    It 'skips on AzureLinux 3.0 Kata (same kernel as AzL3 regular)'
         OS="${AZURELINUX_KATA_OS_NAME}"
         OS_VARIANT=""
         When call gate

--- a/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env shellspec
 
 # Unit tests for disableVulnerableKernelModule() in cse_main.sh
 # and the OS gate that selects which OS variants get the runtime apply.

--- a/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
@@ -84,7 +84,7 @@ Describe 'CVE kernel module mitigation OS gate'
 
     gate() {
         # Mirrors the condition in cse_main.sh basePrep — must be kept in sync.
-        if isUbuntu "$OS" || isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
+        if isUbuntu "$OS" || isAzureLinuxOSGuard "$OS" "$OS_VARIANT" || { isMarinerOrAzureLinux "$OS" && [ "${OS_VERSION}" = "2.0" ]; }; then
             echo "APPLY"
         else
             echo "SKIP"
@@ -105,19 +105,19 @@ Describe 'CVE kernel module mitigation OS gate'
         The output should equal "APPLY"
     End
 
-    It 'skips on Mariner (AzL2) — AKS stopped building Mariner on 2025-12-06; bake-in covers in-support VHDs'
+    It 'applies the mitigation on Mariner/AzureLinux 2.0 (AzL2) — VHDs are frozen so CSE-time apply is required'
         OS="${MARINER_OS_NAME}"
         OS_VARIANT=""
+        OS_VERSION="2.0"
         When call gate
-        The output should equal "SKIP"
-    End
+        The output should equal "APPLY"
 
-    It 'skips on Mariner Kata — same rationale as Mariner'
+    It 'applies the mitigation on Mariner Kata (AzL2) — VHDs are frozen so CSE-time apply is required'
         OS="${MARINER_KATA_OS_NAME}"
         OS_VARIANT=""
+        OS_VERSION="2.0"
         When call gate
-        The output should equal "SKIP"
-    End
+        The output should equal "APPLY"
 
     It 'skips on AzureLinux 3.0 regular (kernel 6.6.139.1-1.azl3+ has upstream fix)'
         OS="${AZURELINUX_OS_NAME}"

--- a/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
@@ -73,16 +73,16 @@ Describe 'disableVulnerableKernelModule()'
 End
 
 # Tests the OS gate that decides whether to call disableVulnerableKernelModule
-# at CSE provisioning time. AzureLinux 3.0 is excluded because the kernel fix
-# in 6.6.139.1-1.azl3+ supersedes the modprobe blacklist. Ubuntu and Mariner
-# still receive the runtime apply because their upstream kernel is not yet patched.
-# See https://github.com/Azure/AKS/issues/5753.
+# at CSE provisioning time. Ubuntu-only: AKS no longer builds Mariner VHDs, and
+# AzureLinux 3.0 is excluded because the kernel fix in 6.6.139.1-1.azl3+ supersedes
+# the modprobe blacklist (and customers reported the blacklist actively blocks
+# legitimate workloads on AzL3). See https://github.com/Azure/AKS/issues/5753.
 Describe 'CVE kernel module mitigation OS gate'
     Include "./parts/linux/cloud-init/artifacts/cse_helpers.sh"
 
     gate() {
         # Mirrors the condition in cse_main.sh basePrep — must be kept in sync.
-        if isUbuntu "$OS" || isMariner "$OS"; then
+        if isUbuntu "$OS"; then
             echo "APPLY"
         else
             echo "SKIP"
@@ -96,11 +96,11 @@ Describe 'CVE kernel module mitigation OS gate'
         The output should equal "APPLY"
     End
 
-    It 'applies the mitigation on AzureLinux 2.0 (Mariner)'
+    It 'skips the runtime mitigation on AzureLinux 2.0 (Mariner) — no longer built'
         OS="${MARINER_OS_NAME}"
         OS_VARIANT=""
         When call gate
-        The output should equal "APPLY"
+        The output should equal "SKIP"
     End
 
     It 'skips the runtime mitigation on AzureLinux 3.0 (kernel 6.6.139.1-1.azl3+ has upstream fix)'

--- a/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
@@ -73,12 +73,11 @@ Describe 'disableVulnerableKernelModule()'
 End
 
 # Tests the OS gate that decides whether to call disableVulnerableKernelModule
-# at CSE provisioning time. Apply on: Ubuntu, AzureLinux OSGuard (defense-in-depth —
-# hardened secure-boot variant intentionally retains the mitigation). Skip on:
+# at CSE provisioning time. Apply on: Ubuntu, Mariner/AzureLinux 2.0 (AzL2), AzureLinux OSGuard
+# (defense-in-depth — hardened secure-boot variant intentionally retains the mitigation). Skip on:
 # AzureLinux 3.0 regular/Kata (kernel 6.6.139.1-1.azl3+ has the upstream fix and
-# customers reported the blacklist actively blocks legitimate workloads), Mariner
-# (no longer built; mitigation already baked in all in-support Mariner VHDs),
-# ACL, Flatcar. See https://github.com/Azure/AKS/issues/5753.
+# customers reported the blacklist actively blocks legitimate workloads), ACL, Flatcar.
+# See https://github.com/Azure/AKS/issues/5753.
 Describe 'CVE kernel module mitigation OS gate'
     Include "./parts/linux/cloud-init/artifacts/cse_helpers.sh"
 
@@ -111,14 +110,14 @@ Describe 'CVE kernel module mitigation OS gate'
         OS_VERSION="2.0"
         When call gate
         The output should equal "APPLY"
-
+    End
     It 'applies the mitigation on Mariner Kata (AzL2) — VHDs are frozen so CSE-time apply is required'
         OS="${MARINER_KATA_OS_NAME}"
         OS_VARIANT=""
         OS_VERSION="2.0"
         When call gate
         The output should equal "APPLY"
-
+    End
     It 'skips on AzureLinux 3.0 regular (kernel 6.6.139.1-1.azl3+ has upstream fix)'
         OS="${AZURELINUX_OS_NAME}"
         OS_VARIANT=""

--- a/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
@@ -1,6 +1,7 @@
-#!/usr/bin/env shellspec
+#!/bin/bash
 
 # Unit tests for disableVulnerableKernelModule() in cse_main.sh
+# and the OS gate that selects which OS variants get the runtime apply.
 
 Describe 'disableVulnerableKernelModule()'
     MODPROBE_DIR=""
@@ -68,5 +69,65 @@ Describe 'disableVulnerableKernelModule()'
         }
         When call not_loaded_test
         The output should not include "unloaded"
+    End
+End
+
+# Tests the OS gate that decides whether to call disableVulnerableKernelModule
+# at CSE provisioning time. AzureLinux 3.0 is excluded because the kernel fix
+# in 6.6.139.1-1.azl3+ supersedes the modprobe blacklist. Ubuntu and Mariner
+# still receive the runtime apply because their upstream kernel is not yet patched.
+# See https://github.com/Azure/AKS/issues/5753.
+Describe 'CVE kernel module mitigation OS gate'
+    Include "./parts/linux/cloud-init/artifacts/cse_helpers.sh"
+
+    gate() {
+        # Mirrors the condition in cse_main.sh basePrep — must be kept in sync.
+        if isUbuntu "$OS" || isMariner "$OS"; then
+            echo "APPLY"
+        else
+            echo "SKIP"
+        fi
+    }
+
+    It 'applies the mitigation on Ubuntu'
+        OS="${UBUNTU_OS_NAME}"
+        OS_VARIANT=""
+        When call gate
+        The output should equal "APPLY"
+    End
+
+    It 'applies the mitigation on AzureLinux 2.0 (Mariner)'
+        OS="${MARINER_OS_NAME}"
+        OS_VARIANT=""
+        When call gate
+        The output should equal "APPLY"
+    End
+
+    It 'skips the runtime mitigation on AzureLinux 3.0 (kernel 6.6.139.1-1.azl3+ has upstream fix)'
+        OS="${AZURELINUX_OS_NAME}"
+        OS_VARIANT=""
+        When call gate
+        The output should equal "SKIP"
+    End
+
+    It 'skips the runtime mitigation on AzureLinux 3.0 Kata'
+        OS="${AZURELINUX_KATA_OS_NAME}"
+        OS_VARIANT=""
+        When call gate
+        The output should equal "SKIP"
+    End
+
+    It 'skips on ACL (Flatcar-based)'
+        OS="${ACL_OS_NAME}"
+        OS_VARIANT=""
+        When call gate
+        The output should equal "SKIP"
+    End
+
+    It 'skips on Flatcar'
+        OS="${FLATCAR_OS_NAME}"
+        OS_VARIANT=""
+        When call gate
+        The output should equal "SKIP"
     End
 End

--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -432,8 +432,8 @@ copyPackerFiles() {
   #      blocks legitimate use cases.
   # Ubuntu and Mariner (AzL2) still get the bake-in — their kernels are not patched
   # upstream yet. See https://github.com/Azure/AKS/issues/5753.
-  if isAzureLinux "$OS" "$OS_VARIANT" && [ "${OS_VERSION}" = "3.0" ]; then
-    echo "Skipping modprobe-CIS.conf bake-in on AzureLinux 3.0 (kernel 6.6.139.1-1.azl3+ has upstream fix)"
+  if isAzureLinux "$OS" "$OS_VARIANT" && [ "${OS_VERSION}" = "3.0" ] && ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
+    echo "Skipping modprobe-CIS.conf bake-in on AzureLinux 3.0 (kernel 6.6.139.1-1.azl3+ has upstream fix; OSGuard intentionally retains the bake-in)"
   else
     cpAndMode $MODPROBE_CIS_SRC $MODPROBE_CIS_DEST 644
   fi

--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -423,7 +423,20 @@ copyPackerFiles() {
   cpAndMode $ETC_ISSUE_CONFIG_SRC $ETC_ISSUE_CONFIG_DEST 644
   cpAndMode $ETC_ISSUE_NET_CONFIG_SRC $ETC_ISSUE_NET_CONFIG_DEST 644
   cpAndMode $SSHD_CONFIG_SRC $SSHD_CONFIG_DEST 600
-  cpAndMode $MODPROBE_CIS_SRC $MODPROBE_CIS_DEST 644
+  # CVE-2026-31431 (Copy Fail), DirtyFrag, Fragnesia mitigation: bake modprobe blacklist
+  # for algif_aead / esp4 / esp6 / rxrpc into the VHD.
+  #
+  # Skipped on AzureLinux 3.0 because:
+  #   1. The upstream kernel fix in 6.6.139.1-1.azl3+ supersedes the modprobe blacklist.
+  #   2. Customer workloads on AzL3 require those kernel modules; the bake-in actively
+  #      blocks legitimate use cases.
+  # Ubuntu and Mariner (AzL2) still get the bake-in — their kernels are not patched
+  # upstream yet. See https://github.com/Azure/AKS/issues/5753.
+  if isAzureLinux "$OS" "$OS_VARIANT" && [ "${OS_VERSION}" = "3.0" ]; then
+    echo "Skipping modprobe-CIS.conf bake-in on AzureLinux 3.0 (kernel 6.6.139.1-1.azl3+ has upstream fix)"
+  else
+    cpAndMode $MODPROBE_CIS_SRC $MODPROBE_CIS_DEST 644
+  fi
   cpAndMode $PWQUALITY_CONF_SRC $PWQUALITY_CONF_DEST 600
   cpAndMode $PAM_D_SU_SRC $PAM_D_SU_DEST 644
   cpAndMode $PROFILE_D_PATH_SH_SRC $PROFILE_D_PATH_SH_DEST 755

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1369,8 +1369,8 @@ testVulnerableKernelModulesDisabled() {
 
   if [ "$os_sku" = "AzureLinux" ] && [ "$os_version" = "3.0" ]; then
     for mod in algif_aead esp4 esp6 rxrpc; do
-      if grep -qsE "^install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then
-        err "$test" "${mod} disable rule unexpectedly present in /etc/modprobe.d/*.conf on AzureLinux 3.0 (bake-in removed; kernel 6.6.139.1-1.azl3+ supersedes)"
+      if grep -qsE "^(install ${mod} /bin/false|blacklist ${mod})" /etc/modprobe.d/*.conf 2>/dev/null; then
+        err "$test" "${mod} blacklist entry unexpectedly present in /etc/modprobe.d/*.conf on AzureLinux 3.0 (bake-in removed; kernel 6.6.139.1-1.azl3+ supersedes; no 'install' or 'blacklist' directive should remain)"
         failed=1
       else
         echo "$test: ${mod} blacklist correctly absent on AzureLinux 3.0"

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1353,7 +1353,8 @@ testNfsServerService() {
 
 # Verify all kernel modules with known LPE vulnerabilities are disabled.
 # Covers: CVE-2026-31431 (algif_aead), DirtyFrag (esp4, esp6, rxrpc).
-# To add a new CVE mitigation, append the module to the loop below.
+# To add a new CVE mitigation, append the module to BOTH loops below — the
+# AzureLinux 3.0 absence loop AND the default presence + load-refusal loop.
 #
 # AzureLinux 3.0 is descoped: kernel 6.6.139.1-1.azl3+ fixes the CVEs upstream and
 # the modprobe blacklist is NOT baked into newly-built AzL3 VHDs (customer workloads

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1354,11 +1354,37 @@ testNfsServerService() {
 # Verify all kernel modules with known LPE vulnerabilities are disabled.
 # Covers: CVE-2026-31431 (algif_aead), DirtyFrag (esp4, esp6, rxrpc).
 # To add a new CVE mitigation, append the module to the loop below.
+#
+# AzureLinux 3.0 is descoped: kernel 6.6.139.1-1.azl3+ fixes the CVEs upstream and
+# the modprobe blacklist is NOT baked into newly-built AzL3 VHDs (customer workloads
+# require those modules). On AzL3 we therefore assert the blacklist entries are
+# ABSENT. Ubuntu and Mariner (AzL2) still assert presence + load-refusal.
 testVulnerableKernelModulesDisabled() {
+  local os_sku="${1:-$OS_SKU}"
+  local os_version="${2:-$OS_VERSION}"
   local test="testVulnerableKernelModulesDisabled"
   echo "$test:Start"
 
   local failed=0
+
+  if [ "$os_sku" = "AzureLinux" ] && [ "$os_version" = "3.0" ]; then
+    for mod in algif_aead esp4 esp6 rxrpc; do
+      if grep -qsE "^install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then
+        err "$test" "${mod} disable rule unexpectedly present in /etc/modprobe.d/*.conf on AzureLinux 3.0 (bake-in removed; kernel 6.6.139.1-1.azl3+ supersedes)"
+        failed=1
+      else
+        echo "$test: ${mod} blacklist correctly absent on AzureLinux 3.0"
+      fi
+    done
+
+    if [ "$failed" -ne 0 ]; then
+      return 1
+    fi
+
+    echo "$test:Finish"
+    return 0
+  fi
+
   for mod in algif_aead esp4 esp6 rxrpc; do
     if ! grep -qsE "^install ${mod} /bin/false" /etc/modprobe.d/*.conf 2>/dev/null; then
       err "$test" "${mod} disable rule not found in /etc/modprobe.d/*.conf"
@@ -2472,4 +2498,4 @@ testInspektorGadgetAssets
 testPackageDownloadURLFallbackLogic
 testFileOwnership $OS_SKU
 testDiskQueueServiceIsActive
-testVulnerableKernelModulesDisabled
+testVulnerableKernelModulesDisabled $OS_SKU $OS_VERSION


### PR DESCRIPTION
## Summary

Three kernel LPE vulnerabilities tracked in [Azure/AKS#5753](https://github.com/Azure/AKS/issues/5753) are now fixed **upstream in the AzureLinux 3.0 kernel as of `6.6.139.1-1.azl3`**. The corresponding modprobe blacklist mitigations are no longer required on AzureLinux 3.0 and have been **fully descoped on that OS** — both the CSE-time runtime apply *and* the VHD-build bake-in.

| Vulnerability | CVE(s) | Modules |
|---|---|---|
| Copy Fail | CVE-2026-31431 | `algif_aead` |
| DirtyFrag | CVE-2026-43284, CVE-2026-43500 | `esp4`, `esp6`, `rxrpc` |
| Fragnesia | CVE-2026-46300 | `esp4`, `esp6` (covered by DirtyFrag) |

> **Only AzureLinux 3.0 (regular and Kata) is descoped**, because kernel `6.6.139.1-1.azl3` fixes all three CVEs upstream AND customers reported the blacklist actively blocks legitimate workloads that need those modules. Ubuntu and AzureLinux OSGuard mitigations are unchanged (defense-in-depth retained — OSGuard workloads do not require the affected modules). AzureLinux 2.0 (Mariner) keeps the CSE-time runtime apply because those VHD images are frozen at `202512.06.0` (see `FrozenCBLMarinerV2AndAzureLinuxV2SIGImageVersion`) and cannot pick up new `modprobe-CIS.conf` entries via VHD refresh — the runtime apply is the only path to deliver the mitigation to AzL2 nodes.

## Decision rationale

Initial iteration of this PR kept the four `install <mod> /bin/false` + `blacklist <mod>` entries baked into AzureLinux 3.0 VHDs as defense-in-depth, removing only the CSE-time runtime apply. Customer feedback during review made it clear that **legitimate AzL3 workloads require some of those kernel modules** (notably the `esp*` modules for IPsec/XFRM use cases and `rxrpc` for AFS-style RPC see https://github.com/cilium/cilium/issues/46023). With the upstream kernel fix shipping, keeping the blacklist baked in is no longer defense-in-depth — it is an active regression. This PR therefore removes the bake-in on AzureLinux 3.0 too.

## Scope

| OS | Before this PR | After this PR | Reason |
|---|---|---|---|
| Ubuntu 22.04 / 24.04 | runtime apply + bake-in | **unchanged** (apply + bake-in) | Upstream kernel fix not yet shipped |
| AzureLinux 2.0 / Mariner (`OS_VERSION=2.0`) | runtime apply + bake-in | **unchanged** (apply + bake-in) | AzL2 SIG images frozen at `202512.06.0` — cannot deliver new bake-in via VHD refresh, so the runtime apply is retained as the only mitigation path |
| AzureLinux 3.0 regular + Kata (`azurelinux`, `azurelinux-kata`) | runtime apply + bake-in | **runtime apply skipped + bake-in removed** | Kernel `6.6.139.1-1.azl3`+ fixes all three CVEs; blacklist blocks legitimate workloads |
| AzureLinux OSGuard (AzL3-OSGuard) | runtime apply + bake-in | **unchanged** (apply + bake-in) | Hardened secure-boot variant — defense-in-depth retained; OSGuard workloads do not require the affected modules |
| Flatcar / ACL | never in scope | unchanged | Never applied |
| Windows | N/A | N/A | Never affected |

## What this PR does NOT do

> **Customers running existing in-support AzL3 VHDs will continue to have the blacklist baked in until they upgrade to a newer VHD; no CSE-time active removal is implemented in this PR.**

The four-module blacklist will simply not be present on **newly-built** AzL3 VHDs going forward. Existing in-support AzL3 VHDs (built before this change merges) keep the baked-in `/etc/modprobe.d/CIS.conf` blacklist entries. We did **not** add a CSE-time `rm` or rewrite-on-boot path that would actively scrub pre-existing blacklist files on already-deployed nodes — that was considered and explicitly rejected to avoid mutating in-place security configuration on already-provisioned fleet. Affected customers will pick up the unblocked configuration when they roll their node pools to a newer AzL3 VHD.

## Backward-compat analysis (6-month VHD window)

- **New CSE on old AzL3 VHD (still has bake-in)**: CSE-time gate skips the runtime apply on AzL3 regular/Kata. The pre-existing `/etc/modprobe.d/CIS.conf` is left in place. Net effect: the four modules remain blocked on old AzL3 VHDs until the customer rolls. Kernel-fix-only mitigation kicks in once they upgrade.
- **Old CSE on new AzL3 VHD (no bake-in)**: old CSE would have called `disableVulnerableKernelModule` for the four modules and written `/etc/modprobe.d/disable-<mod>.conf` drop-ins itself. Until both pieces (new CSE *and* new VHD) are in the field for an AzL3 customer, the runtime CSE writes will still block. Once both ship, customers requiring those modules on AzL3 see the unblocked configuration.
- **Ubuntu / OSGuard / AzL2-Mariner**: unchanged — runtime apply still runs, bake-in still present.

## Final CSE-time OS gate

```bash
if isUbuntu "$OS" \
   || isAzureLinuxOSGuard "$OS" "$OS_VARIANT" \
   || { isMarinerOrAzureLinux "$OS" && [ "${OS_VERSION}" = "2.0" ]; }; then
    disableVulnerableKernelModule "algif_aead" ...
    # esp4, esp6, rxrpc
fi
```

Applies on: Ubuntu (all), AzureLinux OSGuard, AzureLinux 2.0 / Mariner. Skips on: AzureLinux 3.0 regular/Kata, ACL, Flatcar.

## Files changed

| File | Change |
|---|---|
| `parts/linux/cloud-init/artifacts/cse_main.sh` | CSE-time OS gate is now `isUbuntu \|\| isAzureLinuxOSGuard \|\| (isMarinerOrAzureLinux && OS_VERSION=2.0)`. Drops AzL3 regular/Kata (kernel fixed); keeps Ubuntu, OSGuard, and AzL2/Mariner (the latter because its VHD image is frozen and can't deliver new bake-ins). Comment block rewritten with full rationale. |
| `vhdbuilder/packer/packer_source.sh` | `cpAndMode $MODPROBE_CIS_SRC …` now wrapped in `if isAzureLinux "$OS" "$OS_VARIANT" && [ "${OS_VERSION}" = "3.0" ] && ! isAzureLinuxOSGuard …` skip → else copy. OSGuard explicitly retains the bake-in. Ubuntu, Mariner, ACL, Flatcar paths unchanged byte-for-byte. |
| `vhdbuilder/packer/test/linux-vhd-content-test.sh` | `testVulnerableKernelModulesDisabled` takes `$OS_SKU $OS_VERSION` and asserts ABSENCE of both `install <mod> /bin/false` and `blacklist <mod>` directives on AzL3 (`os_sku=AzureLinux && os_version=3.0`), presence + load-refusal otherwise. OSGuard's `OS_SKU` is `AzureLinuxOSGuard` — distinct from `AzureLinux` — so it falls through to the full presence check correctly. |
| `e2e/validators.go` | `ValidateVulnerableKernelModulesDisabled` is now OS-conditional: AzL3 regular (NOT OSGuard, via `!s.VHD.Distro.IsAzureLinuxOSGuardDistro()`) asserts absence of both `install` and `blacklist` directives; Ubuntu and OSGuard fall through to the full presence + load-refusal check. |
| `spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh` | Shebang restored to `#!/usr/bin/env shellspec`. New OS-gate test suite covering Ubuntu APPLY, OSGuard APPLY, Mariner-2.0 APPLY, AzL3 regular/Kata SKIP, ACL SKIP, Flatcar SKIP. Existing unit tests for `disableVulnerableKernelModule()` are unchanged. |
| `parts/linux/cloud-init/artifacts/modprobe-CIS.conf` | **Unchanged** — file still ships in the repo and is still baked into Ubuntu / Mariner / ACL / Flatcar / AzureLinuxOSGuard VHDs. |

## Test plan

- [x] `shellspec --shell bash spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh` — all cases pass.
- [x] `cd e2e && go build ./...` — clean.
- [x] `bash -n` syntax-check on `packer_source.sh`, `linux-vhd-content-test.sh`, `cse_main.sh`.
- [ ] AzL3 VHD content test on freshly-built VHD: `testVulnerableKernelModulesDisabled AzureLinux 3.0` must PASS with all four modules absent (both `install` and `blacklist` directives).
- [ ] AzL2 / Mariner VHD content test: existing presence + load-refusal assertions must continue to PASS (runtime apply kept).
- [ ] OSGuard VHD content test: existing presence + load-refusal assertions must continue to PASS.
- [ ] Ubuntu 22.04 / 24.04 VHD content test on freshly-built VHD: existing presence + load-refusal assertions must continue to PASS.
- [ ] E2E on AzL3 regular: validator must report all four entries ABSENT.
- [ ] E2E on AzL3 OSGuard: validator must report presence + not-loaded + load-refused.
- [ ] E2E on Ubuntu 22.04 / 24.04: validator must report presence + not-loaded + load-refused (unchanged).

## Related

- Refs: [Azure/AKS#5753](https://github.com/Azure/AKS/issues/5753) — kernel `6.6.139.1-1.azl3` upstream fix
- ADO: [AB#38070527](https://msazure.visualstudio.com/CloudNativeCompute/_workitems/edit/38070527)
- Original mitigation PRs: #8443, #8444, #8475

🤖 Generated with [GitHub Copilot CLI](https://github.com/features/copilot)
