### PR TITLE
ci: drop unused environment: test from validate-components

### DIFF
--- a/.github/workflows/validate-components.yml
+++ b/.github/workflows/validate-components.yml
@@ -4,7 +4,6 @@ on: pull_request
 jobs:
   cue:
     runs-on: ubuntu-latest
-    environment: test
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the `environment: test` declaration from the `cue` job in `validate-components.yml`. That job only runs `cue vet` and `go test` — it does not read any secrets, so the environment scoping is functionally a no-op.

Delete noise like this from PRs:

<img width="650" height="68" alt="image" src="https://github.com/user-attachments/assets/60ae3589-edc4-42f6-8b10-fe3dd33a9403" />
