### PR TITLE
ci: declare workflow-level contents: read on shellcheck and no-sudo-check

### DIFF
--- a/.github/workflows/no-sudo-check.yml
+++ b/.github/workflows/no-sudo-check.yml
@@ -1,6 +1,9 @@
 name: Check for sudo in CSE scripts
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   no-sudo:
     runs-on: ubuntu-latest

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,6 +1,9 @@
 name: Lint Shell/Bash Scripts
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at the workflow level. The workflow runs checks only; no GitHub API writes.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) supply-chain hardening pattern. YAML validated locally with `yaml.safe_load`.