### PR TITLE
fix(security): enable Dependabot pip updates + bump pytest to 9.0.3 (CVE-2025-71176)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,13 @@ updates:
     labels:
       - "cleanup"
       - "dependabot"
+
+  - package-ecosystem: "pip"
+    directory: "/vhdbuilder/packer/test/pam"
+    schedule:
+      interval: daily
+      time: "01:00"
+    labels:
+      - "cleanup"
+      - "dependabot"
+    versioning-strategy: increase

--- a/vhdbuilder/packer/test/pam/requirements.txt
+++ b/vhdbuilder/packer/test/pam/requirements.txt
@@ -1,3 +1,3 @@
-pexpect>=4.8.0,<4.9.0
-pytest>=7.3.1,<7.4.0
-pytest-rerunfailures>=14.0,<15.0
+pexpect>=4.9.0,<5.0
+pytest>=9.0.3,<10.0
+pytest-rerunfailures>=16.0,<17.0


### PR DESCRIPTION
## Why

GitHub Dependabot alert [#43](https://github.com/Azure/AgentBaker/security/dependabot/43) flags **CVE-2025-71176** (GHSA-6w46-j5rx-g56g, medium) in `pytest` used by `vhdbuilder/packer/test/pam/requirements.txt`. The alert has been open but **no auto-PR was ever created**.

Diagnosis turned up two compounding root causes:

1. **`.github/dependabot.yml` was missing a `pip` ecosystem entry.** Only `gomod` and `github-actions` were declared. Dependabot's vulnerability scanner happily fires *alerts* for any manifest it discovers, but the *version-update* scanner only runs against ecosystems explicitly listed in the config — so no PR attempt was ever made for this manifest.
2. **The pin `pytest>=7.3.1,<7.4.0` is too tight to widen.** Even if we'd enabled `pip`, the default `versioning-strategy: auto` for pip won't push past an explicit upper bound. The fix lives in pytest **9.0.3**, far outside `<7.4.0`.

## What this PR does

### `.github/dependabot.yml`
Adds a `pip` ecosystem block scoped to `/vhdbuilder/packer/test/pam` with `versioning-strategy: increase`, so future Python CVE bumps land automatically.

### `vhdbuilder/packer/test/pam/requirements.txt`
| Package | Old | New | Why |
|---|---|---|---|
| `pytest` | `>=7.3.1,<7.4.0` | `>=9.0.3,<10.0` | **Closes CVE-2025-71176** (predictable `tmpdir` name → local DoS) |
| `pytest-rerunfailures` | `>=14.0,<15.0` | `>=16.0,<17.0` | Required for pytest 9.x (rerunfailures 16.3 → `pytest>=8.1,!=8.2.2`) |
| `pexpect` | `>=4.8.0,<4.9.0` | `>=4.9.0,<5.0` | Drop-in patch bump, no API changes consumed by `test_pam.py` |

## Compatibility analysis

The only consumer of these requirements is the `testPam` function in `vhdbuilder/packer/test/linux-vhd-content-test.sh:1610-1640`, which runs `pip3 install -r requirements.txt` on Mariner / AzureLinux VHD builds only (other OSes skip).

| Distro | Default `python3` | pytest 9.0.3 requires ≥3.10 | Currently building VHDs? |
|---|---|---|---|
| Ubuntu 22.04 / 24.04 | n/a (testPam skips) | n/a | yes — but testPam is skipped |
| MarinerV2 / AzureLinuxV2 | 3.9 | ❌ no | **no — frozen** at `202512.06.0` via `FrozenCBLMarinerV2AndAzureLinuxV2SIGImageVersion` (`pkg/agent/datamodel/sig_config.go:387`) |
| AzureLinux V3 (incl. Kata, FIPS, OSGuard, ARM, CVM, TL) | **3.12** | ✅ yes | yes |

So in practice the bump only needs to work on AzureLinux V3 (Python 3.12), which it does.

## Verification

- `pip` ecosystem entry follows the existing `gomod` / `github-actions` schema (same `time`, same `cleanup` + `dependabot` labels).
- `conftest.py` in the test dir uses only stable pytest hooks (`pytest_configure`, `pytest_addoption`), no API breakage 7.x → 9.x.
- testPam already has `--reruns 5` resilience for transient flakes.

## Out of scope

- No application code changes.
- No changes to `testPam` invocation logic.

🤖 *Generated by GitHub Copilot*
