### PR TITLE
[Part 1] test: marker commit to simulate ANC hotfix cherry-pick (dry run)

### DIFF
--- a/aks-node-controller/app.go
+++ b/aks-node-controller/app.go
@@ -64,14 +64,6 @@ type ProvisionStatusFiles struct {
 }
 
 func (a *App) Run(ctx context.Context, args []string) int {
-	// Dry-run beacon for the official/v20260514 ANC hotfix end-to-end validation.
-	// Greppable from the node via: journalctl | grep "ANC hotfix dry-run beacon"
-	// Proves the hotfix-installed binary (not the VHD-baked one) is executing.
-	slog.Info("ANC hotfix dry-run beacon",
-		"version", Version,
-		"branch", "official/v20260514",
-		"hotfixTag", "anc/v202605.14.1")
-
 	cmd := &cli.Command{
 		Name:    "aks-node-controller",
 		Usage:   "Parse contract and run csecmd",
@@ -141,6 +133,20 @@ func (a *App) Run(ctx context.Context, args []string) int {
 
 func (a *App) runProvisionCommand(ctx context.Context, flags ProvisionFlags, dryRun bool) error {
 	slog.Info("aks-node-controller started", "task", "Provision")
+
+	// Dry-run beacon for the official/v20260514 ANC hotfix end-to-end validation.
+	// Emitted both to slog (journalctl -u aks-node-controller.service,
+	// /var/log/azure/aks-node-controller.log) AND as a GuestAgent event so the
+	// signal surfaces in Azure telemetry / Kusto without needing SSH access.
+	// The hotfix-installed binary will emit this; the VHD-baked 202605.14.0 binary will not.
+	beaconNow := time.Now()
+	slog.Info("ANC hotfix dry-run beacon",
+		"version", Version,
+		"branch", "official/v20260514",
+		"hotfixTag", "anc/v202605.14.1")
+	a.eventLogger.LogEvent("HotfixBeacon",
+		fmt.Sprintf("ANC hotfix dry-run beacon version=%s branch=official/v20260514 hotfixTag=anc/v202605.14.1", Version),
+		helpers.EventLevelInformational, beaconNow, beaconNow)
 
 	startTime := time.Now()
 	a.eventLogger.LogEvent("Provision", "Starting", helpers.EventLevelInformational, startTime, startTime)

--- a/aks-node-controller/app.go
+++ b/aks-node-controller/app.go
@@ -64,6 +64,14 @@ type ProvisionStatusFiles struct {
 }
 
 func (a *App) Run(ctx context.Context, args []string) int {
+	// Dry-run beacon for the official/v20260514 ANC hotfix end-to-end validation.
+	// Greppable from the node via: journalctl | grep "ANC hotfix dry-run beacon"
+	// Proves the hotfix-installed binary (not the VHD-baked one) is executing.
+	slog.Info("ANC hotfix dry-run beacon",
+		"version", Version,
+		"branch", "official/v20260514",
+		"hotfixTag", "anc/v202605.14.1")
+
 	cmd := &cli.Command{
 		Name:    "aks-node-controller",
 		Usage:   "Parse contract and run csecmd",

--- a/aks-node-controller/app_test.go
+++ b/aks-node-controller/app_test.go
@@ -178,9 +178,10 @@ func TestApp_Run(t *testing.T) {
 		assert.Equal(t, 0, exitCode)
 
 		events := tt.eventLogger.Events()
-		assert.Len(t, events, 2)
-		assert.Contains(t, events[0].Message, "Starting")
-		assert.Contains(t, events[1].Message, "Completed")
+		assert.Len(t, events, 3)
+		assert.Contains(t, events[0].Message, "ANC hotfix dry-run beacon")
+		assert.Contains(t, events[1].Message, "Starting")
+		assert.Contains(t, events[2].Message, "Completed")
 	})
 
 	t.Run("provision command with provision-config and nbc-cmd flag", func(t *testing.T) {
@@ -190,9 +191,10 @@ func TestApp_Run(t *testing.T) {
 		assert.Equal(t, 0, exitCode)
 
 		events := tt.eventLogger.Events()
-		assert.Len(t, events, 2)
-		assert.Contains(t, events[0].Message, "Starting")
-		assert.Contains(t, events[1].Message, "Completed")
+		assert.Len(t, events, 3)
+		assert.Contains(t, events[0].Message, "ANC hotfix dry-run beacon")
+		assert.Contains(t, events[1].Message, "Starting")
+		assert.Contains(t, events[2].Message, "Completed")
 	})
 
 	t.Run("provision command with command runner error", func(t *testing.T) {
@@ -203,8 +205,8 @@ func TestApp_Run(t *testing.T) {
 		assert.Equal(t, 666, exitCode)
 
 		events := tt.eventLogger.Events()
-		assert.Len(t, events, 2)
-		assert.Equal(t, "Error", events[1].EventLevel)
+		assert.Len(t, events, 3)
+		assert.Equal(t, "Error", events[2].EventLevel)
 	})
 }
 

--- a/parts/linux/cloud-init/nodecustomdata.yml
+++ b/parts/linux/cloud-init/nodecustomdata.yml
@@ -25,6 +25,18 @@ write_files:
     Any overridden files will be listed here - Hotfix mode
     Example: {{GetCSEHelpersScriptFilepath}}
 
+# Dry-run beacon for the official/v20260514 ANC hotfix end-to-end validation.
+# Greppable from the node via: cat /opt/azure/containers/anc-hotfix-dryrun-beacon.txt
+# Proves the nodecustomdata change reached the node (independent of the
+# auto-injected anc-hotfix block that targets aks-node-controller-hotfix.json).
+- path: /opt/azure/containers/anc-hotfix-dryrun-beacon.txt
+  permissions: "0644"
+  owner: root
+  content: |
+    anc-hotfix-dry-run beacon
+    branch: official/v20260514
+    hotfix-tag: anc/v202605.14.1
+
 {{if IsAKSCustomCloud}}
 - path: {{GetInitAKSCustomCloudFilepath}}
   permissions: "0744"


### PR DESCRIPTION
Part 1 of ANC hotfix end-to-end dry run on `official/v20260514`.

This PR simulates the cherry-pick step of an ANC hotfix. It contains some **marker commits** purely to exercise the hotfix release pipeline:

1. Merge this PR → get a commit on `official/v20260514`
2. Tag the merge commit with `anc/v202605.14.1` + GitHub pre-release → triggers aks-dalec → publishes deb/rpm to PMC
3. Then Part 2: open a PR setting `hotfix/anc-hotfix-version.json` to `{"version":"202605.14.1"}` → anc-hotfix-generate GH Action injects the hotfix block into `nodecustomdata.yml` → e2e validates end-to-end

No production impact expected: hotfix version `202605.14.1` only applies when the node's VHD-baked base version matches `202605.14.x` **and** `EnableScriptlessCSECmd=true`.

> Dry run / process validation only.