### PR TITLE
chore: upgrade azuredisk-csi-driver to v1.33.10, v1.34.4 and blob-csi-driver to v1.26.12, v1.27.5

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -505,21 +505,25 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azuredisk-csi",
-          "latestVersion": "v1.34.3"
+          "latestVersion": "v1.34.4",
+          "previousLatestVersion": "v1.34.3"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azuredisk-csi",
-          "latestVersion": "v1.33.9"
+          "latestVersion": "v1.33.10",
+          "previousLatestVersion": "v1.33.9"
         }
       ],
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azuredisk-csi",
-          "latestVersion": "v1.34.3-windows-hp"
+          "latestVersion": "v1.34.4-windows-hp",
+          "previousLatestVersion": "v1.34.3-windows-hp"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azuredisk-csi",
-          "latestVersion": "v1.33.9-windows-hp"
+          "latestVersion": "v1.33.10-windows-hp",
+          "previousLatestVersion": "v1.33.9-windows-hp"
         }
       ]
     },
@@ -567,11 +571,13 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/blob-csi",
-          "latestVersion": "v1.26.11"
+          "latestVersion": "v1.26.12",
+          "previousLatestVersion": "v1.26.11"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/blob-csi",
-          "latestVersion": "v1.27.4"
+          "latestVersion": "v1.27.5",
+          "previousLatestVersion": "v1.27.4"
         }
       ],
       "windowsVersions": []


### PR DESCRIPTION
Upgrade azuredisk-csi-driver image versions:
- v1.34.3 → v1.34.4
- v1.33.9 → v1.33.10

Upgrade blob-csi-driver image versions:
- v1.26.11 → v1.26.12
- v1.27.4 → v1.27.5

Including corresponding windows-hp image updates.