### PR TITLE
Pass github.head_ref through env in hotfix-generate workflow

### DIFF
--- a/.github/workflows/hotfix-generate.yml
+++ b/.github/workflows/hotfix-generate.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Commit changes via API
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           FILE="parts/linux/cloud-init/nodecustomdata.yml"
           if git diff --quiet "$FILE"; then
@@ -80,10 +81,10 @@ jobs:
             exit 0
           fi
           CONTENT=$(base64 -w 0 "$FILE")
-          SHA=$(gh api "repos/${{ github.repository }}/contents/${FILE}?ref=${{ github.head_ref }}" --jq '.sha')
+          SHA=$(gh api "repos/${{ github.repository }}/contents/${FILE}?ref=$HEAD_REF" --jq '.sha')
           gh api "repos/${{ github.repository }}/contents/${FILE}" \
             -X PUT \
             -f message="chore: auto-generate hotfix template entries" \
             -f content="$CONTENT" \
-            -f branch="${{ github.head_ref }}" \
+            -f branch="$HEAD_REF" \
             -f sha="$SHA"


### PR DESCRIPTION
I research software supply chain security and have been going through GitHub Actions workflows for places where untrusted input reaches a shell. Small hardening change to `hotfix-generate.yml`.

The "Commit changes via API" step puts `${{ github.head_ref }}` straight into the `gh api` command line: once as the `?ref=` query parameter and once as the `-f branch=` value. Because Actions expands `${{ }}` into the script text before bash executes it, a branch name with backticks or `$(...)` would be evaluated as a command. That step runs after the GitHub App token is generated, so it executes with write access.

To be clear about reach: the job's `if:` requires `github.event.pull_request.head.repo.full_name == github.repository`, so fork PRs are already excluded. This is therefore defense-in-depth against a push-access account that is malicious or compromised, not an anonymous external vector. I still think it is worth closing because the payload lives in the branch name, which is not something a diff review surfaces.

The change moves the value into a `HEAD_REF` env var and uses `"$HEAD_REF"`; environment values are not re-parsed by the shell. Behavior is unchanged for ordinary branch names. The `ref:` input on the checkout step is an action input rather than a shell expansion, so I left it alone.