### PR TITLE
chore(windows): bump cilium networking package to 1.7.1 for Windows 2025

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -2197,7 +2197,7 @@
       "windowsVersions": [
         {
           "renovateTag": "<DO_NOT_UPDATE>",
-          "latestVersion": "1.7.0",
+          "latestVersion": "1.7.1",
           "windowsSkuMatch": "2025*"
         }
       ]


### PR DESCRIPTION
Bumps Windows Cilium networking package (mcr.microsoft.com/wcn/package) from 1.7.0 to 1.7.1 for the Windows 2025 SKU.