### PR TITLE
Bake nouveau blacklist into Ubuntu VHD to cut GPU node boot time

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -718,6 +718,24 @@ if [ $OS = $UBUNTU_OS_NAME ] && [ "$(isARM64)" -ne 1 ]; then  # No ARM64 SKU wit
     cat << EOF >> ${VHD_LOGS_FILEPATH}
   - nvidia-cuda-driver=${NVIDIA_DRIVER_IMAGE_TAG}
 EOF
+
+  # Bake the nouveau blacklist + initramfs into the VHD so GPU nodes skip the ~10-30s per-boot
+  # `update-initramfs -u` that aks-gpu/install.sh would otherwise run. The kernel purge/reinstall/
+  # reboot to the final shipped kernel happens before this script (see the kernel log near the top),
+  # so `uname -r` here is the node's boot kernel and the baked initramfs matches it. The Ubuntu VHD
+  # is shared with non-GPU nodes; blacklisting nouveau is safe there because AKS Ubuntu node images
+  # have no functional dependency on nouveau, while GPU nodes require it disabled before the
+  # proprietary NVIDIA driver loads. aks-gpu/install.sh only skips its own update-initramfs when the
+  # marker kernel matches AND the on-disk blacklist content matches the image's copy, otherwise it
+  # falls back to the full path. Mirrors the existing NVIDIA GB VHD path below.
+  cat << EOF > /etc/modprobe.d/blacklist-nouveau.conf
+blacklist nouveau
+options nouveau modeset=0
+EOF
+  update-initramfs -u
+  mkdir -p /opt/azure/aks-gpu
+  echo "kernel=$(uname -r)" > /opt/azure/aks-gpu/nouveau-blacklist-marker
+  echo "  - nouveau blacklist baked into VHD initramfs for kernel $(uname -r)" >> ${VHD_LOGS_FILEPATH}
 fi
 
 if grep -q "NVIDIA_GB" <<< "$FEATURE_FLAGS"; then


### PR DESCRIPTION
## What
Bake the nouveau blacklist + initramfs into the shared Ubuntu amd64 VHD at build time and write a kernel-gated marker, so `aks-gpu/install.sh` can skip its per-boot `update-initramfs -u` (~10-30s on GPU node boot).

Added to the existing Ubuntu amd64 GPU block in `install-dependencies.sh` (which already pre-pulls the aks-gpu-cuda image):
- write `/etc/modprobe.d/blacklist-nouveau.conf` (same 2 lines aks-gpu installs),
- `update-initramfs -u`,
- write `/opt/azure/aks-gpu/nouveau-blacklist-marker` containing `kernel=$(uname -r)`.

Runs **after** the kernel purge/reinstall/reboot to the final shipped kernel (logged near the top of the script), so `uname -r` is the node's boot kernel and the baked initramfs matches it.

## Why
GPU provisioning-time reduction. Removes a deterministic per-boot cost and makes nouveau blacklisted from first boot.

## Safety on the shared VHD
The Ubuntu VHD is shared with non-GPU nodes. Blacklisting nouveau is safe there: AKS Ubuntu node images have no functional dependency on nouveau, while GPU nodes require it disabled before the proprietary driver loads. This mirrors the existing **NVIDIA GB** VHD path, which already bakes the same blacklist + initramfs.

## Cross-repo dependency
The boot-time skip lives in **Azure/aks-gpu** PR #161. The skip only triggers when the marker kernel matches AND the on-disk blacklist content matches the image's copy, so old aks-gpu images simply ignore the marker and rebuild as before. Draft pending a VHD build validation.

## Validation
- `bash -n` clean; `shellcheck` introduces no new findings on the added lines.
- Confirmed the baked `blacklist-nouveau.conf` is byte-identical (44 bytes) to aks-gpu's `/opt/gpu/blacklist-nouveau.conf` so the `cmp` fast-path gate engages.