### PR TITLE
test: raise e2e cluster timeout so bastion create doesn't hit deadline

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -84,10 +84,11 @@ type Configuration struct {
 	TestGalleryImagePrefix                 string        `env:"TEST_GALLERY_IMAGE_PREFIX" envDefault:"abe2etest"`
 	TestGalleryNamePrefix                  string        `env:"TEST_GALLERY_NAME_PREFIX" envDefault:"abe2etest"`
 	TestPreProvision                       bool          `env:"TEST_PRE_PROVISION" envDefault:"false"`
-	TestTimeout                            time.Duration `env:"TEST_TIMEOUT" envDefault:"35m"`
-	TestTimeoutCluster                     time.Duration `env:"TEST_TIMEOUT_CLUSTER" envDefault:"20m"`
-	TestTimeoutVMSS                        time.Duration `env:"TEST_TIMEOUT_VMSS" envDefault:"17m"`
-	WindowsAdminPassword                   string        `env:"WINDOWS_ADMIN_PASSWORD"`
+	TestTimeout                            time.Duration `env:"TEST_TIMEOUT" envDefault:"50m"`
+	// Must cover cluster-create AND bastion-create (run serially in prepareCluster, ~10-11m each).
+	TestTimeoutCluster   time.Duration `env:"TEST_TIMEOUT_CLUSTER" envDefault:"30m"`
+	TestTimeoutVMSS      time.Duration `env:"TEST_TIMEOUT_VMSS" envDefault:"17m"`
+	WindowsAdminPassword string        `env:"WINDOWS_ADMIN_PASSWORD"`
 }
 
 func (c *Configuration) BlobStorageAccount() string {


### PR DESCRIPTION
## Problem

`Test_AzureLinuxV3_MA35D/default` (and intermittently other scenarios) failed in cluster prep, **before the scenario ran**:

```
prepare cluster tasks: dag execution failed: failed to create bastion: context deadline exceeded
✓ creating bastion ... done (574.8s)
✓ preparing cluster done (1200.0s)   <-- hit the 20m TestTimeoutCluster
```

This is a test-harness timeout, not a product/bootstrap failure.

## Root cause

`prepareCluster` (e2e/cluster.go) runs under a single `TestTimeoutCluster` budget (default **20m**) and does two slow Azure operations **serially**:

1. `getOrCreateCluster` — ~624s (~10.4m) on a cold create
2. bastion creation (`getOrCreateBastion` → subnet + public IP + Bastion host) — ~575s (~9.6m); Azure Bastion provisioning is inherently slow

Serial sum ≈ **1199s ≈ 20m**, so on a cold run (fresh cluster + fresh bastion) the budget is exhausted right as the bastion finishes and the poller's context is cancelled. Warm runs reuse the cached cluster/bastion and stay well under, which is why it's intermittent.

## Fix

- `TestTimeoutCluster` **20m → 30m** — headroom for cluster-create + bastion-create on the cold path.
- `TestTimeout` (overall per-test) **35m → 50m** — under `newTestCtx`, prep (`TestTimeoutCluster`) and the VMSS phase (`TestTimeoutVMSS`, 17m) run sequentially under this parent. With prep now allowed up to 30m, the overall must exceed 30m + 17m so a long-but-valid prep can't squeeze the VMSS phase. `TestTimeoutVMSS` is unchanged.

No production code changed; this only adjusts e2e timeout budgets (both overridable via `TEST_TIMEOUT*` env vars).
