### PR TITLE
fix: re-add few more files to nodecustomdata.yaml to allow bootstrapping azurelinuxv2

### DIFF
--- a/e2e/config/vhd.go
+++ b/e2e/config/vhd.go
@@ -77,7 +77,7 @@ var (
 		// Secure TLS Bootstrapping isn't currently supported on FIPS-enabled VHDs
 		UnsupportedSecureTLSBootstrapping: true,
 		UnsupportedGen2:                   true,
-		Skip2004Validations:               true,
+		SkipOldVHDValidations:             true,
 	}
 	VHDUbuntu2204FIPSContainerd = &Image{
 		Name:                "2204fipscontainerd",
@@ -109,6 +109,15 @@ var (
 		UnsupportedLocalDns: true,
 		// Secure TLS Bootstrapping isn't currently supported on FIPS-enabled VHDs
 		UnsupportedSecureTLSBootstrapping: true,
+	}
+	VHDAzureLinuxV2Gen2 = &Image{
+		Name:                  "V2gen2",
+		OS:                    OSAzureLinux,
+		Arch:                  "amd64",
+		Distro:                datamodel.AKSAzureLinuxV2Gen2,
+		Version:               datamodel.FrozenCBLMarinerV2AndAzureLinuxV2SIGImageVersion,
+		Gallery:               imageGalleryLinux,
+		SkipOldVHDValidations: true,
 	}
 	VHDAzureLinuxV3Gen2 = &Image{
 		Name:    "AzureLinuxV3gen2",
@@ -295,7 +304,7 @@ type Image struct {
 	UnsupportedGen2                     bool
 	IgnoreFailedCgroupTelemetryServices bool
 	Flatcar                             bool
-	Skip2004Validations                 bool
+	SkipOldVHDValidations               bool
 	// OSDiskSizeGB overrides the default OS disk size (50 GB) when set.
 	OSDiskSizeGB int32
 }

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -542,6 +542,25 @@ func Test_AzureLinuxV3(t *testing.T) {
 	})
 }
 
+func Test_AzureLinuxV2(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "Tests that an AzureLinuxV2 node can be properly bootstrapped",
+		Config: Config{
+			Cluster:           ClusterKubenet,
+			VHD:               config.VHDAzureLinuxV2Gen2,
+			SkipScriptlessNBC: true,
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				k8sVersion := "1.30.101-akslts"
+				nbc.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = k8sVersion
+				nbc.EnableScriptlessCSECmd = false
+				nbc.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.CustomKubeBinaryURL = fmt.Sprintf("https://packages.aks.azure.com/kubernetes/v%s/binaries/kubernetes-node-linux-amd64.tar.gz", k8sVersion)
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+			},
+		},
+	})
+}
+
 // Returns config for the 'base' E2E scenario
 
 func Test_Ubuntu2204_Scriptless(t *testing.T) {

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/agentbaker/e2e/components"
 	"github.com/Azure/agentbaker/e2e/config"
 	"github.com/Azure/agentbaker/pkg/agent"
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	certv1 "k8s.io/api/certificates/v1"
@@ -923,7 +924,7 @@ func ValidateSystemdUnitIsNotFailed(ctx context.Context, s *Scenario, serviceNam
 }
 
 func ValidateNoFailedSystemdUnits(ctx context.Context, s *Scenario) {
-	if s.VHD != nil && s.VHD.Skip2004Validations {
+	if s.VHD != nil && s.VHD.SkipOldVHDValidations {
 		return
 	}
 	unitFailureAllowList := map[string]bool{
@@ -2715,7 +2716,7 @@ func ValidateRxBufferDefault(ctx context.Context, s *Scenario) {
 func ValidateKernelLogs(ctx context.Context, s *Scenario) {
 	s.T.Helper()
 
-	if s.VHD != nil && s.VHD.Skip2004Validations {
+	if s.VHD != nil && s.VHD.SkipOldVHDValidations {
 		return
 	}
 
@@ -2802,7 +2803,7 @@ func ValidateKernelLogs(ctx context.Context, s *Scenario) {
 func ValidateWaagentLog(ctx context.Context, s *Scenario) {
 	s.T.Helper()
 
-	if s.VHD.Flatcar || strings.Contains(string(s.VHD.Distro), "osguard") {
+	if s.VHD.Flatcar || strings.Contains(string(s.VHD.Distro), "osguard") || s.VHD.SkipOldVHDValidations {
 		s.T.Logf("Skipping waagent log validation: not applicable for %s", s.VHD.Distro)
 		return
 	}
@@ -2911,7 +2912,7 @@ func ValidateVulnerableKernelModulesDisabled(ctx context.Context, s *Scenario) {
 	// blacklist and the bake-in has been removed because customers need those modules. Assert
 	// the blacklist entries are NOT present on freshly-built AzL3 VHDs. AzureLinux OSGuard is
 	// intentionally kept in-scope (falls through to the full presence + load-refusal check below).
-	if s.VHD.OS == config.OSAzureLinux && !s.VHD.Distro.IsAzureLinuxOSGuardDistro() {
+	if s.VHD.OS == config.OSAzureLinux && !s.VHD.Distro.IsAzureLinuxOSGuardDistro() && s.VHD.Distro != datamodel.AKSAzureLinuxV2Gen2 {
 		script := strings.Join([]string{
 			`failed=0`,
 			`for mod in algif_aead esp4 esp6 rxrpc; do`,

--- a/parts/linux/cloud-init/nodecustomdata.yml
+++ b/parts/linux/cloud-init/nodecustomdata.yml
@@ -153,4 +153,32 @@ write_files:
   owner: root
   content: !!binary |
     {{GetVariableProperty "cloudInitData" "initAKSCustomCloud"}}
+
+- path: /etc/systemd/system/reconcile-private-hosts.service
+  permissions: "0644"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{GetVariableProperty "cloudInitData" "reconcilePrivateHostsService"}}
+
+- path: /etc/systemd/system/kubelet.service
+  permissions: "0600"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{GetVariableProperty "cloudInitData" "kubeletSystemdService"}}
+
+- path: /opt/azure-network/configure-azure-network.sh
+  permissions: "0755"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{GetVariableProperty "cloudInitData" "configureAzureNetworkScript"}}
+
+- path: /etc/udev/rules.d/99-azure-network.rules
+  permissions: "0644"
+  encoding: gzip
+  owner: root
+  content: !!binary |
+    {{GetVariableProperty "cloudInitData" "azureNetworkUdevRule"}}
 {{- end }}


### PR DESCRIPTION
- Re-add few files back to nodecustomdata since its required by azure linux v2 which we apparently support for k8s lts versions