### PR TITLE
fix: make Ubuntu Pro inert on 20.04/FIPS VHDs to stop phone-home (AB#38255910)

### DIFF
--- a/spec/vhdbuilder/packer/detach_and_cleanup_ua_spec.sh
+++ b/spec/vhdbuilder/packer/detach_and_cleanup_ua_spec.sh
@@ -150,5 +150,40 @@ Describe 'detachAndCleanUpUA'
       The status should be failure
       The output should include "stopping, disabling and masking ua-timer.timer"
     End
+
+    It 'refuses to operate on a unit that is not an Ubuntu Pro unit'
+      systemctl() { echo "systemctl $*"; return 0; }
+      When call disableAndMaskUbuntuProUnit some-random.service
+      The status should be failure
+      The output should include "refusing to operate on non ubuntu pro unit some-random.service"
+      # A non Pro unit must never be touched.
+      The output should not include "systemctl mask"
+      The output should not include "systemctl cat"
+    End
+
+    It 'fails the build when systemctl is not responsive instead of skipping the mask'
+      # 'list-units' fails => systemd is unhealthy. A 'cat' miss must NOT be misread as absent.
+      systemctl() {
+        case "$1" in
+          list-units) return 1 ;;
+          *) echo "systemctl $*"; return 0 ;;
+        esac
+      }
+      When call disableAndMaskUbuntuProUnit ua-timer.timer
+      The status should be failure
+      The output should include "not responsive"
+      The output should not include "systemctl mask"
+    End
+
+    It 'does not leak the unit variable into the caller scope (uses local)'
+      systemctl() { echo "systemctl $*"; return 0; }
+      check_no_leak() {
+        disableAndMaskUbuntuProUnit ua-timer.timer >/dev/null
+        echo "leaked_unit=[${unit:-}]"
+      }
+      When call check_no_leak
+      The status should be success
+      The output should include "leaked_unit=[]"
+    End
   End
 End

--- a/spec/vhdbuilder/packer/detach_and_cleanup_ua_spec.sh
+++ b/spec/vhdbuilder/packer/detach_and_cleanup_ua_spec.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+# Tests for detachAndCleanUpUA / disableAndMaskUbuntuProUnit from
+# vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
+#
+# Background: the Ubuntu 20.04 / FIPS VHD must ship with Ubuntu Pro made INERT (no phone-home
+# to esm.ubuntu.com or contracts.canonical.com) while preserving the installed FIPS kernel.
+# These tests assert that detachAndCleanUpUA() removes the apt ESM hook, masks the Pro
+# background units, and removes the baked-in machine token, without ever running 'ua detach'.
+#
+# tool_installs_ubuntu.sh contains {{/* ... */}} template comments that are sed-stripped at VHD
+# build time (see vhdbuilder/packer/pre-install-dependencies.sh). We reproduce that strip here
+# and eval the result so the ERR_* constants are assigned correctly and the functions are
+# defined for the test shell.
+
+# Mock functions below are invoked indirectly by the eval'd code under test, which shellcheck
+# cannot see, so it wrongly flags them as never invoked.
+# shellcheck disable=SC2329
+
+Describe 'detachAndCleanUpUA'
+  UBUNTU_TOOL_INSTALLS="./vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh"
+
+  setup_detach_ua() {
+    # Strip the build-time template comments, then define the functions and ERR_* constants.
+    eval "$(sed 's/{{\/\*[^*]*\*\/}}//g' "${UBUNTU_TOOL_INSTALLS}")"
+
+    # ERR_APT_UPDATE_TIMEOUT is defined in cse_helpers.sh, not in this file. Give it a value so
+    # the final 'apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT' has something to reference.
+    ERR_APT_UPDATE_TIMEOUT=25
+
+    # Mocks. Each emits a trace line so assertions can observe the side effects without touching
+    # the real filesystem, systemd or apt.
+    ua() { echo "ua $*"; return 0; }
+    apt_get_update() { echo "apt_get_update"; return 0; }
+    # retrycmd_if_failure <retries> <wait> <timeout> <cmd...> -> drop the first 3 args and run cmd.
+    retrycmd_if_failure() { shift 3; "$@"; }
+    rm() { echo "rm $*"; return 0; }
+  }
+
+  Describe 'when the Ubuntu Pro background units are present'
+    setup_units_present() {
+      setup_detach_ua
+      # 'systemctl cat <unit>' returns 0 => unit is considered present on the image.
+      systemctl() { echo "systemctl $*"; return 0; }
+    }
+    BeforeEach 'setup_units_present'
+
+    It 'succeeds and makes Ubuntu Pro inert without detaching'
+      When call detachAndCleanUpUA
+      The status should be success
+      # FIPS preservation: we must NOT run 'ua detach'.
+      The output should not include "ua detach"
+      # esm.ubuntu.com fix: remove the apt ESM hook that restarts esm-cache on every apt update.
+      The output should include "rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf"
+      # Mask all four Pro background units so they cannot phone home on a customer node.
+      The output should include "systemctl mask esm-cache.service"
+      The output should include "systemctl mask apt-news.service"
+      The output should include "systemctl mask ua-timer.timer"
+      The output should include "systemctl mask ua-timer.service"
+      # Each masked unit is also stopped and disabled.
+      The output should include "systemctl stop esm-cache.service"
+      The output should include "systemctl disable ua-timer.timer"
+      # Security: remove the baked-in Ubuntu Pro machine token / private state.
+      The output should include "rm -rf /var/lib/ubuntu-advantage/private"
+      # The final apt update still runs (last, after the hook is removed and esm-cache masked).
+      The output should include "apt_get_update"
+    End
+
+    # Ordering guarantee: the hook removal and esm-cache mask must both appear before the final
+    # apt_get_update, otherwise that apt update would re-trigger esm-cache and re-establish the
+    # esm.ubuntu.com traffic. We assert ordering by checking the line numbers of the trace.
+    assert_hook_and_mask_precede_apt_update() {
+      out="$(detachAndCleanUpUA)" || return 1
+      hook_line=$(printf '%s\n' "$out" | grep -n '20apt-esm-hook.conf' | head -1 | cut -d: -f1)
+      mask_line=$(printf '%s\n' "$out" | grep -n 'mask esm-cache.service' | head -1 | cut -d: -f1)
+      update_line=$(printf '%s\n' "$out" | grep -n 'apt_get_update' | tail -1 | cut -d: -f1)
+      [ "${hook_line}" -lt "${update_line}" ] || return 1
+      [ "${mask_line}" -lt "${update_line}" ] || return 1
+      echo "ordering ok"
+    }
+
+    It 'removes the apt ESM hook before masking esm-cache (so apt update cannot re-trigger it)'
+      When call assert_hook_and_mask_precede_apt_update
+      The status should be success
+      The output should include "ordering ok"
+    End
+  End
+
+  Describe 'when an Ubuntu Pro unit is absent on the image'
+    setup_units_absent() {
+      setup_detach_ua
+      # 'systemctl cat <unit>' returns 1 => unit not present; masking must be skipped gracefully.
+      systemctl() {
+        if [ "$1" = "cat" ]; then
+          return 1
+        fi
+        echo "systemctl $*"
+        return 0
+      }
+    }
+    BeforeEach 'setup_units_absent'
+
+    It 'skips masking missing units but still succeeds and cleans up'
+      When call detachAndCleanUpUA
+      The status should be success
+      # No unit was present, so nothing should be masked.
+      The output should not include "systemctl mask"
+      # Hook removal and token cleanup still happen regardless of unit presence.
+      The output should include "rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf"
+      The output should include "rm -rf /var/lib/ubuntu-advantage/private"
+      The output should include "not present on this image, skipping"
+    End
+  End
+
+  Describe 'disableAndMaskUbuntuProUnit helper'
+    BeforeEach 'setup_detach_ua'
+
+    It 'returns success and skips when the unit does not exist'
+      systemctl() {
+        if [ "$1" = "cat" ]; then
+          return 1
+        fi
+        echo "systemctl $*"
+        return 0
+      }
+      When call disableAndMaskUbuntuProUnit ua-timer.timer
+      The status should be success
+      The output should not include "systemctl mask"
+      The output should include "not present on this image, skipping"
+    End
+
+    It 'stops, disables and masks a unit that exists'
+      systemctl() { echo "systemctl $*"; return 0; }
+      When call disableAndMaskUbuntuProUnit ua-timer.timer
+      The status should be success
+      The output should include "systemctl stop ua-timer.timer"
+      The output should include "systemctl disable ua-timer.timer"
+      The output should include "systemctl mask ua-timer.timer"
+    End
+
+    It 'fails when masking a present unit errors out'
+      systemctl() {
+        case "$1" in
+          cat) return 0 ;;
+          mask) return 1 ;;
+          *) return 0 ;;
+        esac
+      }
+      When call disableAndMaskUbuntuProUnit ua-timer.timer
+      The status should be failure
+      The output should include "stopping, disabling and masking ua-timer.timer"
+    End
+  End
+End

--- a/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
+++ b/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
@@ -233,9 +233,32 @@ attachUA() {
 # customer node. The set of Pro units differs across releases, so a unit that is not present
 # on this image is skipped rather than failing the build. Any other (unexpected) failure DOES
 # fail the build: leaving an active Ubuntu Pro unit on a shipped VHD is a security/compliance
-# regression and must not be silently swallowed.
+# regression and must not be silently swallowed. The helper only operates on known Pro units
+# and verifies systemd is responsive before treating a missing unit as "not present", so a
+# transient systemctl failure fails the build rather than silently skipping the mask.
 disableAndMaskUbuntuProUnit() {
-    unit="$1"
+    local unit="$1"
+
+    # Defense in depth: only ever operate on known Ubuntu Pro units so a future caller cannot
+    # accidentally stop/disable/mask an unrelated systemd unit through this helper.
+    case "${unit}" in
+        esm-cache.service|apt-news.service|ua-timer.timer|ua-timer.service) ;;
+        *)
+            echo "refusing to operate on non ubuntu pro unit ${unit}"
+            return 1
+            ;;
+    esac
+
+    # Confirm systemd is responsive BEFORE interpreting a 'systemctl cat' miss as "unit absent".
+    # Otherwise a transient systemctl/DBus failure would be misread as "not present", silently
+    # skipping the mask and potentially leaving a live Ubuntu Pro unit on the shipped VHD.
+    if ! systemctl list-units --all >/dev/null 2>&1; then
+        echo "systemctl is not responsive while handling ${unit}; failing the build"
+        return 1
+    fi
+
+    # With systemd confirmed healthy, a 'systemctl cat' miss genuinely means the unit is not
+    # shipped on this release, so it is safe to skip.
     if ! systemctl cat "${unit}" >/dev/null 2>&1; then
         echo "ubuntu pro unit ${unit} not present on this image, skipping"
         return 0

--- a/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
+++ b/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
@@ -8,6 +8,9 @@ ERR_UA_ENABLE_FIPS=184 {{/* Error to enable UA FIPS */}}
 ERR_UA_DETACH=185 {{/* Error to detach UA */}}
 ERR_LINUX_HEADER_INSTALL_TIMEOUT=186 {{/* Timeout to install linux header */}}
 ERR_STRONGSWAN_INSTALL_TIMEOUT=187 {{/* Timeout to install strongswan */}}
+ERR_UA_ESM_HOOK_CLEANUP=188 {{/* Error removing the apt ESM hook for Ubuntu Pro */}}
+ERR_UA_MASK_UNIT=189 {{/* Error stopping/disabling/masking an Ubuntu Pro background unit */}}
+ERR_UA_TOKEN_CLEANUP=190 {{/* Error removing the baked-in Ubuntu Pro machine token state */}}
 
 ERR_NTP_INSTALL_TIMEOUT=10 {{/*Unable to install NTP */}}
 ERR_NTP_START_TIMEOUT=11 {{/* Unable to start NTP */}}
@@ -225,10 +228,50 @@ attachUA() {
     retrycmd_if_failure 5 10 300 ua disable livepatch || exit $ERR_UA_DISABLE_LIVEPATCH
 }
 
+# disableAndMaskUbuntuProUnit stops, disables and masks a single Ubuntu Pro background
+# systemd unit so it can never phone home (esm.ubuntu.com / contracts.canonical.com) on a
+# customer node. The set of Pro units differs across releases, so a unit that is not present
+# on this image is skipped rather than failing the build. Any other (unexpected) failure DOES
+# fail the build: leaving an active Ubuntu Pro unit on a shipped VHD is a security/compliance
+# regression and must not be silently swallowed.
+disableAndMaskUbuntuProUnit() {
+    unit="$1"
+    if ! systemctl cat "${unit}" >/dev/null 2>&1; then
+        echo "ubuntu pro unit ${unit} not present on this image, skipping"
+        return 0
+    fi
+    echo "stopping, disabling and masking ${unit} to keep ubuntu pro inert on customer nodes..."
+    systemctl stop "${unit}" || return 1
+    systemctl disable "${unit}" || return 1
+    systemctl mask "${unit}" || return 1
+}
+
 detachAndCleanUpUA() {
     echo "disabling ua services individually to preserve FIPS kernel and grub config..."
     retrycmd_if_failure 5 10 300 ua disable esm-apps || exit $ERR_UA_DETACH
     retrycmd_if_failure 5 10 300 ua disable esm-infra || exit $ERR_UA_DETACH
+
+    # The VHD is intentionally NOT 'ua detach'ed: detaching would tear down the installed FIPS
+    # kernel/grub configuration. Instead we make Ubuntu Pro inert so the running customer node
+    # performs NO phone-home, while leaving the FIPS packages in place. The apt ESM hook removal
+    # and esm-cache masking MUST happen before the final apt_get_update below, otherwise that
+    # apt update would re-trigger esm-cache and re-establish the esm.ubuntu.com traffic.
+
+    # 1. Remove the apt ESM hook. Without this, every 'apt update' on a customer node (both
+    # cloud-init and CSE run apt update during provisioning) restarts esm-cache.service, which
+    # fetches ESM metadata from esm.ubuntu.com using its OWN cache independently of
+    # /etc/apt/sources.list.d -- so deleting the .list files below is not sufficient on its own.
+    rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf || exit $ERR_UA_ESM_HOOK_CLEANUP
+
+    # 2. Stop, disable and mask the Ubuntu Pro background units. ua-timer drives the periodic
+    # contract/metering/MOTD refresh against contracts.canonical.com; esm-cache and apt-news
+    # reach out to esm.ubuntu.com. Masking keeps ubuntu-pro-client installed but inert. esm-cache
+    # is masked before the final apt update so the hook (even if re-added by a package) cannot
+    # start it.
+    disableAndMaskUbuntuProUnit esm-cache.service || exit $ERR_UA_MASK_UNIT
+    disableAndMaskUbuntuProUnit apt-news.service || exit $ERR_UA_MASK_UNIT
+    disableAndMaskUbuntuProUnit ua-timer.timer || exit $ERR_UA_MASK_UNIT
+    disableAndMaskUbuntuProUnit ua-timer.service || exit $ERR_UA_MASK_UNIT
 
     # now that the ESM/FIPS packages are installed, clean up apt settings in the vhd,
     # the VMs created on customers' subscriptions don't have access to UA repo
@@ -240,5 +283,15 @@ detachAndCleanUpUA() {
     rm -f /etc/apt/sources.list.d/ubuntu-fips-updates.list
     rm -f /etc/apt/sources.list.d/ubuntu-fips-preview.list
     rm -f /etc/apt/auth.conf.d/*ubuntu-advantage
+
+    # 3. Remove the baked-in Ubuntu Pro machine identity/state. The VHD is generalized and cloned
+    # onto every customer node, so a leftover machine token would give every node the same Pro
+    # machine identity. Remove the private machine-token/access state (security-relevant -> fail
+    # the build on error) and the local esm-cache state (best-effort: it is only a cache and the
+    # unit is already masked). ubuntu-pro-client stays installed -- removing it risks dependency
+    # breakage -- but with no attached identity it stays inert.
+    rm -rf /var/lib/ubuntu-advantage/private || exit $ERR_UA_TOKEN_CLEANUP
+    rm -rf /var/lib/ubuntu-advantage/messages /var/lib/ubuntu-advantage/esm-cache || true
+
     apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT
 }


### PR DESCRIPTION
## Summary

Ubuntu **20.04** and **FIPS** VHDs ship with Ubuntu Pro (UA) still active. As a result, provisioned customer nodes phone home to:

- **`esm.ubuntu.com`** — from `esm-cache.service`, which is started by the apt ESM hook (`/etc/apt/apt.conf.d/20apt-esm-hook.conf`) on **every** `apt update`. `esm-cache` keeps its **own** cache independent of `/etc/apt/sources.list.d`, so deleting the `.list` files alone does **not** stop it.
- **`contracts.canonical.com`** — from `ua-timer` (periodic contract/metering/MOTD refresh).

A leftover machine token under `/var/lib/ubuntu-advantage/private/` also gives every cloned node the **same** Pro machine identity.

## Why not `ua detach`?

Running `ua detach` tears down the installed **FIPS kernel/grub** configuration. So instead of detaching, this change makes Ubuntu Pro **inert** while preserving the FIPS packages — "installed but silent."

## Changes (`detachAndCleanUpUA` in `tool_installs_ubuntu.sh`)

1. **Remove the apt ESM hook** (`20apt-esm-hook.conf`) **before** the final `apt_get_update`, so that update cannot re-trigger `esm-cache`.
2. **Stop / disable / mask** the Pro background units — `esm-cache.service`, `apt-news.service`, `ua-timer.timer`, `ua-timer.service` — via a new `disableAndMaskUbuntuProUnit()` helper.
3. **Remove the baked-in machine-token state** (`/var/lib/ubuntu-advantage/private`, fail-on-error) and **best-effort** clear local cache state (`messages`, `esm-cache`).

`ubuntu-pro-client` stays installed (removing it risks dependency breakage) but with no attached identity and masked units, it stays inert.

## Design decisions

- **`disableAndMaskUbuntuProUnit()`** uses `systemctl cat` to detect unit presence. Units absent on a given release are **skipped** (Pro unit set varies across releases); any **other** failure **fails the build** — leaving an active Pro unit on a shipped VHD is a security/compliance regression.
- **Token-dir removal fails the build** on error (security-relevant). Cache/state removal is **best-effort** (`|| true`).
- New error constants: `ERR_UA_ESM_HOOK_CLEANUP=188`, `ERR_UA_MASK_UNIT=189`, `ERR_UA_TOKEN_CLEANUP=190`.

## Affected SKUs

All Ubuntu **20.04** variants + all **FIPS** Ubuntu images (caller in `post-install-dependencies.sh` runs for `20.04 OR ENABLE_FIPS=true`).

## Compatibility (6-month VHD lifetime)

Backward/forward compatible: the change only **masks inert units** and **removes baked-in identity state** during VHD build. It does not alter any provisioning-time (CSE / cloud-init) code path, so older CSE scripts running on this newer VHD — and newer CSE on older VHDs — are unaffected.

## Testing

- New ShellSpec: `spec/vhdbuilder/packer/detach_and_cleanup_ua_spec.sh` — **6 examples, 0 failures**. Covers: units present (hook removed, units masked, token removed, ordering of hook/mask before apt update, no `ua detach`), unit absent (skipped cleanly), and the helper's success/skip/failure paths.
- `make validate-shell` (shellcheck): the two changed files produce **zero** findings. (verify_shell.sh exits non-zero from pre-existing repo-wide POSIX warnings in unrelated files; confirmed identical on a clean tree.)

Linked work item: **AB#38255910**

> 🤖 *Generated by GitHub Copilot*
