### PR TITLE
fix: filter apt list by CPU architecture to prevent cross-arch kubelet install failures

### DIFF
--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
@@ -376,8 +376,8 @@ installPkgWithAptGet() {
 
         # update pmc repo to get latest versions
         updatePMCRepository "${packageVersion}"
-        # query all package versions and get the latest version for matching k8s version
-        fullPackageVersion=$(apt list "${packageName}" --all-versions | grep "${packageVersion}" | awk '{print $2}' | sort -V | tail -n 1)
+        # query all package versions and get the latest version for matching k8s version and cpu architecture
+        fullPackageVersion=$(apt list "${packageName}" --all-versions | grep "${packageVersion}" | grep "$(getCPUArch)" | awk '{print $2}' | sort -V | tail -n 1)
         if [ -z "${fullPackageVersion}" ]; then
             echo "Failed to find valid ${packageName} version for ${packageVersion}"
             return 1


### PR DESCRIPTION
## Summary

Fixes a bug where `installPkgWithAptGet` in Ubuntu CSE picks arm64-only package versions on amd64 nodes, causing kubelet download failures (404).

## Root Cause

`apt list --all-versions` returns entries for **all** architectures:
```
kubelet/noble 1.34.0-ubuntu24.04u6 arm64
kubelet/noble 1.34.0-ubuntu24.04u5 amd64
kubelet/noble 1.34.0-ubuntu24.04u5 arm64
```

The existing grep pipeline only filtered by k8s version (e.g., `1.34.0`), so `sort -V | tail -n 1` could select a version that only exists for arm64 (`u6`). When an amd64 node then calls `apt-get download kubelet=1.34.0-ubuntu24.04u6`, it fails with 404.

## Fix

Added `grep "$(getCPUArch)"` to the pipeline to filter `apt list` output to only the current node's architecture before selecting the latest version:

```bash
# Before (broken)
fullPackageVersion=$(apt list "${packageName}" --all-versions | grep "${packageVersion}" | awk '{print $2}' | sort -V | tail -n 1)

# After (fixed)
fullPackageVersion=$(apt list "${packageName}" --all-versions | grep "${packageVersion}" | grep "$(getCPUArch)" | awk '{print $2}' | sort -V | tail -n 1)
```

`getCPUArch` is already defined in `cse_helpers.sh` and returns `"amd64"` or `"arm64"`.

## Impact

Users reported kubelet download failures on Ubuntu 24.04 amd64 nodes for k8s 1.34.0 and 1.34.1:
- `kubelet_1.34.0-ubuntu24.04u6` — arm64 only, no amd64
- `kubelet_1.34.1-ubuntu24.04u5` — arm64 only, no amd64

## Testing

- [x] `GENERATE_TEST_DATA=true go test ./pkg/agent/...` — all pass
- [x] Snapshot test data unchanged (shell script change, not Go template)

AB#38257849