### PR TITLE
perf(gpu): skip redundant dkms autoinstall on boot when nvidia modules already built

### DIFF
--- a/parts/linux/cloud-init/artifacts/nvidia-modprobe.service
+++ b/parts/linux/cloud-init/artifacts/nvidia-modprobe.service
@@ -4,7 +4,7 @@ Before=kubelet.service
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStartPre=/bin/sh -c "dkms autoinstall --verbose"
+ExecStartPre=/bin/sh -c "if modinfo nvidia >/dev/null 2>&1 && modinfo nvidia-uvm >/dev/null 2>&1; then echo 'nvidia kernel modules already built for running kernel; skipping dkms autoinstall'; else dkms autoinstall --verbose; fi"
 ExecStart=/bin/sh -c "nvidia-modprobe -u -c0"
 [Install]
 WantedBy=multi-user.target kubelet.service


### PR DESCRIPTION
## What

`nvidia-modprobe.service` runs `ExecStartPre=dkms autoinstall --verbose` on **every** GPU node boot, ordered `Before=kubelet.service`. On AKS GPU VHDs the NVIDIA driver is pre-built via DKMS and baked into the image (`modules.dep` is generated at image-bake time), so this re-scan/rebuild is **redundant work (~5s measured)** that sits on the provisioning critical path and gates kubelet on every boot.

This guards the autoinstall so it only runs when the kernel modules `ExecStart` (`nvidia-modprobe -u -c0`) actually needs are missing for the **running** kernel:

```ini
ExecStartPre=/bin/sh -c "if modinfo nvidia >/dev/null 2>&1 && modinfo nvidia-uvm >/dev/null 2>&1; then echo 'nvidia kernel modules already built for running kernel; skipping dkms autoinstall'; else dkms autoinstall --verbose; fi"
```

## Why it's correct across kernel upgrades

`modinfo` resolves modules from `/lib/modules/$(uname -r)`. If the running kernel changed (e.g. an unattended kernel upgrade so the baked module no longer matches), that tree has no nvidia modules → `modinfo` fails → `dkms autoinstall` still runs and rebuilds. So behavior is **identical to today on exactly the path where the rebuild is genuinely needed**; we only skip the redundant rebuild in the common baked-and-unchanged-kernel case.

## Design notes
- **Checks both `nvidia` and `nvidia-uvm`.** The `-u` flag in `ExecStart` sets up the UVM device node, so the UVM module is required. Checking only `nvidia` could false-positive on a partial module set and then fail `ExecStart`, blocking kubelet.
- **No shell variables in the predicate**, so systemd does not perform unintended `$`-expansion on the Exec line. Parses cleanly under `/bin/sh` (dash).
- **CSE-install path** (driver installed at provision time via the privileged driver container) is unaffected: if `depmod` hasn't indexed the module yet, `modinfo` fails and we fall back to `dkms autoinstall` — same as today.
- DKMS registration for future kernel upgrades is unchanged (registration comes from driver/package install, not from `autoinstall`).

## Lifecycle / compatibility
- File is **VHD-resident** (copied by `vhdbuilder/packer/packer_source.sh`), not embedded in CSE custom data — no old-VHD/new-CSE skew concern. The unit is started only on Ubuntu by `ensureGPUDrivers`.
- `make generate` produces no testdata diff (the unit is not embedded in CSE snapshots).
- Works on Ubuntu 22.04 / 24.04 (`modinfo`/`dkms` standard).

## Testing
- `GENERATE_TEST_DATA=true go test ./pkg/agent...` — pass, no snapshot drift.
- Predicate validated under `/bin/sh -n` (POSIX parse OK).
- Existing GPU e2e coverage exercises resulting node state: `e2e/validators.go` runs `sudo nvidia-modprobe`; `e2e/scenario_test.go` asserts the unit does not restart kubelet / cause unschedulability.

## Risk
🟢 Low / ⚡ node provisioning latency improvement. Fallback path is byte-for-byte the original behavior; the only new behavior is skipping a provably-redundant rebuild.
