### PR TITLE
fix(e2e): harden localdns host plugin e2es

### DIFF
--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -1976,6 +1976,40 @@ has_valid_ip() {
     echo "$1" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'
 }
 
+# Helper: restart localdns with bounded retries.
+# The cold-start test intentionally forces a systemd restart in a path that has
+# async cleanup/startup work (networkctl reload, resolv.conf update, interface and
+# iptables teardown). A single restart can fail transiently even though a follow-up
+# retry succeeds with the same empty-hosts-file state.
+restart_localdns_with_retry() {
+    local reason="$1"
+    local max_attempts=3
+    local retry_delay=5
+    local attempt rc=0
+
+    for attempt in $(seq 1 "$max_attempts"); do
+        if sudo systemctl restart localdns; then
+            echo "localdns restart succeeded on attempt ${attempt}/${max_attempts} (${reason})"
+            return 0
+        fi
+
+        rc=$?
+        echo "WARNING: localdns restart failed on attempt ${attempt}/${max_attempts} (${reason})"
+        echo "--- localdns service status ---"
+        sudo systemctl status localdns --no-pager 2>&1 || true
+        echo "--- localdns journal (last 50 lines) ---"
+        sudo journalctl -u localdns --no-pager -n 50 2>&1 || true
+
+        if [ "$attempt" -lt "$max_attempts" ]; then
+            echo "Resetting failed state and retrying in ${retry_delay}s..."
+            sudo systemctl reset-failed localdns || true
+            sleep "${retry_delay}"
+        fi
+    done
+
+    return "$rc"
+}
+
 echo "=== Testing localdns cold start with empty hosts file ==="
 echo ""
 
@@ -1992,7 +2026,7 @@ echo ""
 # Step 1: Truncate hosts file and restart localdns (clears both hosts map and DNS cache)
 echo "Step 1: Truncating hosts file and restarting localdns..."
 sudo truncate -s 0 "$hosts_file"
-sudo systemctl restart localdns
+restart_localdns_with_retry "restart with empty hosts file"
 echo "localdns restarted with empty hosts file"
 echo ""
 
@@ -2010,7 +2044,7 @@ for i in $(seq 1 30); do
         echo "--- localdns journal (last 30 lines) ---"
         sudo journalctl -u localdns --no-pager -n 30 2>&1 || true
         echo "$saved_content" | sudo tee "$hosts_file" > /dev/null
-        sudo systemctl restart localdns
+        restart_localdns_with_retry "restore after readiness timeout" || true
         exit 1
     fi
     sleep 1
@@ -2030,7 +2064,7 @@ if ! has_valid_ip "$critical_result"; then
     echo "--- localdns journal (last 30 lines) ---"
     sudo journalctl -u localdns --no-pager -n 30 2>&1 || true
     echo "$saved_content" | sudo tee "$hosts_file" > /dev/null
-    sudo systemctl restart localdns
+    restart_localdns_with_retry "restore after critical FQDN failure" || true
     exit 1
 fi
 echo "✓ Critical FQDN resolves via fallthrough"
@@ -2045,7 +2079,7 @@ if ! has_valid_ip "$noncritical_result"; then
     echo "--- localdns journal (last 30 lines) ---"
     sudo journalctl -u localdns --no-pager -n 30 2>&1 || true
     echo "$saved_content" | sudo tee "$hosts_file" > /dev/null
-    sudo systemctl restart localdns
+    restart_localdns_with_retry "restore after non-critical FQDN failure" || true
     exit 1
 fi
 echo "✓ Non-critical FQDN resolves via fallthrough"
@@ -2086,7 +2120,7 @@ if [ "$canary_resolved" != "true" ]; then
     echo "--- localdns journal (last 30 lines) ---"
     sudo journalctl -u localdns --no-pager -n 30 2>&1 || true
     echo "$saved_content" | sudo tee "$hosts_file" > /dev/null
-    sudo systemctl restart localdns
+    restart_localdns_with_retry "restore after canary failure" || true
     exit 1
 fi
 echo ""
@@ -2094,7 +2128,7 @@ echo ""
 # Step 5: Cleanup — restore original hosts file and restart localdns
 echo "Step 5: Cleaning up — restoring original hosts file and restarting localdns..."
 echo "$saved_content" | sudo tee "$hosts_file" > /dev/null
-sudo systemctl restart localdns
+restart_localdns_with_retry "final cleanup restore"
 echo ""
 
 # Wait for localdns to be ready after final restart

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -1985,16 +1985,18 @@ restart_localdns_with_retry() {
     local reason="$1"
     local max_attempts=3
     local retry_delay=5
-    local attempt rc=0
+    local attempt=1
+    local rc=0
 
-    for attempt in $(seq 1 "$max_attempts"); do
+    while [ "$attempt" -le "$max_attempts" ]; do
         if sudo systemctl restart localdns; then
             echo "localdns restart succeeded on attempt ${attempt}/${max_attempts} (${reason})"
             return 0
+        else
+            rc=$?
         fi
 
-        rc=$?
-        echo "WARNING: localdns restart failed on attempt ${attempt}/${max_attempts} (${reason})"
+        echo "WARNING: localdns restart failed on attempt ${attempt}/${max_attempts} (${reason}, rc=$rc)" >&2
         echo "--- localdns service status ---"
         sudo systemctl status localdns --no-pager 2>&1 || true
         echo "--- localdns journal (last 50 lines) ---"
@@ -2005,6 +2007,8 @@ restart_localdns_with_retry() {
             sudo systemctl reset-failed localdns || true
             sleep "${retry_delay}"
         fi
+
+        attempt=$((attempt + 1))
     done
 
     return "$rc"

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -1951,16 +1951,16 @@ echo "IPv6 entries in hosts file are correctly served by CoreDNS hosts plugin"
 		"CoreDNS hosts plugin should serve IPv6 entries from hosts file")
 }
 
-// ValidateLocalDNSHostsPluginColdStart verifies that localdns works correctly when restarted
+// ValidateLocalDNSHostsPluginColdStart verifies that localdns works correctly when started
 // with an empty hosts file — the exact scenario that occurs when localdns starts before
 // aks-localdns-hosts-setup finishes resolving FQDNs.
 //
 // Test flow:
-//  1. Truncate hosts file, restart localdns — CoreDNS starts fresh with empty hosts file and empty cache
+//  1. Truncate hosts file, stop/start localdns — CoreDNS starts fresh with empty hosts file and empty cache
 //  2. Verify critical and non-critical FQDNs resolve via fallthrough (upstream DNS)
 //  3. Populate hosts file with a canary entry (simulates aks-localdns-hosts-setup completing)
 //  4. Wait for CoreDNS reload (5s), verify canary resolves (hosts plugin picks up new file)
-//  5. Restore original hosts file and restart localdns to leave node in clean state
+//  5. Restore original hosts file and stop/start localdns to leave node in clean state
 func ValidateLocalDNSHostsPluginColdStart(ctx context.Context, s *Scenario) {
 	s.T.Helper()
 
@@ -1970,48 +1970,94 @@ func ValidateLocalDNSHostsPluginColdStart(ctx context.Context, s *Scenario) {
 hosts_file="/etc/localdns/hosts"
 canary_fqdn="canary.localdns.test"
 canary_ip="192.0.2.99"
+localdns_ip="169.254.10.10"
+resolv_conf="/run/systemd/resolve/resolv.conf"
 
 # Helper: validate that dig output contains at least one valid IP address (not error text).
 has_valid_ip() {
     echo "$1" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'
 }
 
-# Helper: restart localdns with bounded retries.
-# The cold-start test intentionally forces a systemd restart in a path that has
-# async cleanup/startup work (networkctl reload, resolv.conf update, interface and
-# iptables teardown). A single restart can fail transiently even though a follow-up
-# retry succeeds with the same empty-hosts-file state.
-restart_localdns_with_retry() {
+# Helper: dump localdns state for debugging.
+dump_localdns_diagnostics() {
+    echo "--- localdns service status ---"
+    sudo systemctl status localdns --no-pager 2>&1 || true
+    echo "--- localdns journal (last 50 lines) ---"
+    sudo journalctl -u localdns --no-pager -n 50 2>&1 || true
+}
+
+# Helper: wait for localdns teardown side effects to settle before starting again.
+# localdns stop triggers cleanup that removes the DNS drop-in, reloads network config,
+# tears down the dummy interface, and exits CoreDNS. Some of that state converges
+# asynchronously outside the systemd unit, so we explicitly wait for it here instead of
+# relying on a one-shot systemctl restart.
+wait_for_localdns_shutdown_stability() {
     local reason="$1"
-    local max_attempts=3
-    local retry_delay=5
+    local max_wait_seconds=30
     local attempt=1
-    local rc=0
+    local current_dns systemd_state interface_present
 
-    while [ "$attempt" -le "$max_attempts" ]; do
-        if sudo systemctl restart localdns; then
-            echo "localdns restart succeeded on attempt ${attempt}/${max_attempts} (${reason})"
+    echo "Waiting for localdns teardown to settle (${reason})..."
+    while [ "$attempt" -le "$max_wait_seconds" ]; do
+        current_dns=$(awk '/^nameserver/ {print $2}' "$resolv_conf" 2>/dev/null | paste -sd' ')
+        systemd_state=$(sudo systemctl is-active localdns 2>&1 || true)
+        interface_present="false"
+        if ip link show dev localdns >/dev/null 2>&1; then
+            interface_present="true"
+        fi
+
+        if [ "$systemd_state" != "active" ] && [ "$systemd_state" != "activating" ] && [ "$systemd_state" != "deactivating" ] && \
+            ! grep -qwF "$localdns_ip" <<< "$current_dns" && [ "$interface_present" = "false" ]; then
+            echo "localdns teardown settled after ${attempt}s (${reason}); systemd=${systemd_state}, DNS=${current_dns:-<none>}"
             return 0
-        else
-            rc=$?
         fi
 
-        echo "WARNING: localdns restart failed on attempt ${attempt}/${max_attempts} (${reason}, rc=$rc)" >&2
-        echo "--- localdns service status ---"
-        sudo systemctl status localdns --no-pager 2>&1 || true
-        echo "--- localdns journal (last 50 lines) ---"
-        sudo journalctl -u localdns --no-pager -n 50 2>&1 || true
-
-        if [ "$attempt" -lt "$max_attempts" ]; then
-            echo "Resetting failed state and retrying in ${retry_delay}s..."
-            sudo systemctl reset-failed localdns || true
-            sleep "${retry_delay}"
-        fi
-
+        sleep 1
         attempt=$((attempt + 1))
     done
 
-    return "$rc"
+    echo "ERROR: localdns teardown did not settle after ${max_wait_seconds}s (${reason})" >&2
+    echo "systemctl is-active localdns: $(sudo systemctl is-active localdns 2>&1 || true)"
+    echo "Current DNS: $(awk '/^nameserver/ {print $2}' "$resolv_conf" 2>/dev/null | paste -sd' ')"
+    if ip link show dev localdns >/dev/null 2>&1; then
+        echo "localdns interface is still present"
+    else
+        echo "localdns interface has been removed"
+    fi
+    return 1
+}
+
+# Helper: cold-start localdns by splitting restart into stop -> wait for stable teardown -> start.
+# This targets the actual flaky edge in the E2E: external DNS/network state settling after stop.
+restart_localdns_cleanly() {
+    local reason="$1"
+    local rc=0
+
+    echo "Stopping localdns (${reason})..."
+    if ! sudo systemctl stop localdns; then
+        rc=$?
+        echo "ERROR: localdns stop failed (${reason}, rc=$rc)" >&2
+        dump_localdns_diagnostics
+        return "$rc"
+    fi
+
+    if ! wait_for_localdns_shutdown_stability "$reason"; then
+        dump_localdns_diagnostics
+        return 1
+    fi
+
+    sudo systemctl reset-failed localdns || true
+
+    echo "Starting localdns (${reason})..."
+    if ! sudo systemctl start localdns; then
+        rc=$?
+        echo "ERROR: localdns start failed (${reason}, rc=$rc)" >&2
+        dump_localdns_diagnostics
+        return "$rc"
+    fi
+
+    echo "localdns start completed (${reason})"
+    return 0
 }
 
 echo "=== Testing localdns cold start with empty hosts file ==="
@@ -2027,11 +2073,11 @@ saved_content=$(cat "$hosts_file")
 echo "Saved hosts file ($(echo "$saved_content" | wc -l) lines)"
 echo ""
 
-# Step 1: Truncate hosts file and restart localdns (clears both hosts map and DNS cache)
-echo "Step 1: Truncating hosts file and restarting localdns..."
+# Step 1: Truncate hosts file and cold-start localdns (clears both hosts map and DNS cache)
+echo "Step 1: Truncating hosts file and cold-starting localdns..."
 sudo truncate -s 0 "$hosts_file"
-restart_localdns_with_retry "restart with empty hosts file"
-echo "localdns restarted with empty hosts file"
+restart_localdns_cleanly "start with empty hosts file"
+echo "localdns started with empty hosts file"
 echo ""
 
 # Wait for localdns to be fully ready
@@ -2043,12 +2089,9 @@ for i in $(seq 1 30); do
     fi
     if [ "$i" -eq 30 ]; then
         echo "ERROR: localdns did not become ready after 30s"
-        echo "--- localdns service status ---"
-        sudo systemctl status localdns --no-pager 2>&1 || true
-        echo "--- localdns journal (last 30 lines) ---"
-        sudo journalctl -u localdns --no-pager -n 30 2>&1 || true
+        dump_localdns_diagnostics
         echo "$saved_content" | sudo tee "$hosts_file" > /dev/null
-        restart_localdns_with_retry "restore after readiness timeout" || true
+        restart_localdns_cleanly "restore after readiness timeout" || true
         exit 1
     fi
     sleep 1
@@ -2063,12 +2106,9 @@ critical_result=$(dig "$critical_fqdn" @169.254.10.10 -t A +short +timeout=5 +tr
 echo "Critical FQDN ($critical_fqdn): '$critical_result'"
 if ! has_valid_ip "$critical_result"; then
     echo "ERROR: Critical FQDN did not return a valid IP after cold start with empty hosts file"
-    echo "--- localdns service status ---"
-    sudo systemctl status localdns --no-pager 2>&1 || true
-    echo "--- localdns journal (last 30 lines) ---"
-    sudo journalctl -u localdns --no-pager -n 30 2>&1 || true
+    dump_localdns_diagnostics
     echo "$saved_content" | sudo tee "$hosts_file" > /dev/null
-    restart_localdns_with_retry "restore after critical FQDN failure" || true
+    restart_localdns_cleanly "restore after critical FQDN failure" || true
     exit 1
 fi
 echo "✓ Critical FQDN resolves via fallthrough"
@@ -2078,12 +2118,9 @@ noncritical_result=$(dig "$noncritical_fqdn" @169.254.10.10 -t A +short +timeout
 echo "Non-critical FQDN ($noncritical_fqdn): '$noncritical_result'"
 if ! has_valid_ip "$noncritical_result"; then
     echo "ERROR: Non-critical FQDN did not return a valid IP after cold start with empty hosts file"
-    echo "--- localdns service status ---"
-    sudo systemctl status localdns --no-pager 2>&1 || true
-    echo "--- localdns journal (last 30 lines) ---"
-    sudo journalctl -u localdns --no-pager -n 30 2>&1 || true
+    dump_localdns_diagnostics
     echo "$saved_content" | sudo tee "$hosts_file" > /dev/null
-    restart_localdns_with_retry "restore after non-critical FQDN failure" || true
+    restart_localdns_cleanly "restore after non-critical FQDN failure" || true
     exit 1
 fi
 echo "✓ Non-critical FQDN resolves via fallthrough"
@@ -2119,23 +2156,20 @@ if [ "$canary_resolved" != "true" ]; then
     echo "ERROR: Canary did not resolve after 60s — hot-reload after cold start broken"
     echo "Expected: $canary_ip"
     echo "Last dig result: '$canary_result'"
-    echo "--- localdns service status ---"
-    sudo systemctl status localdns --no-pager 2>&1 || true
-    echo "--- localdns journal (last 30 lines) ---"
-    sudo journalctl -u localdns --no-pager -n 30 2>&1 || true
+    dump_localdns_diagnostics
     echo "$saved_content" | sudo tee "$hosts_file" > /dev/null
-    restart_localdns_with_retry "restore after canary failure" || true
+    restart_localdns_cleanly "restore after canary failure" || true
     exit 1
 fi
 echo ""
 
-# Step 5: Cleanup — restore original hosts file and restart localdns
-echo "Step 5: Cleaning up — restoring original hosts file and restarting localdns..."
+# Step 5: Cleanup — restore original hosts file and cold-start localdns
+echo "Step 5: Cleaning up — restoring original hosts file and cold-starting localdns..."
 echo "$saved_content" | sudo tee "$hosts_file" > /dev/null
-restart_localdns_with_retry "final cleanup restore"
+restart_localdns_cleanly "final cleanup restore"
 echo ""
 
-# Wait for localdns to be ready after final restart
+# Wait for localdns to be ready after final cold start
 for i in $(seq 1 30); do
     if dig "health-check.localdns.local" @169.254.10.10 +short +timeout=1 +tries=1 >/dev/null 2>&1; then
         echo "localdns is ready after cleanup"
@@ -2143,17 +2177,14 @@ for i in $(seq 1 30); do
     fi
     if [ "$i" -eq 30 ]; then
         echo "WARNING: localdns did not become ready after cleanup (30s)"
-        echo "--- localdns service status ---"
-        sudo systemctl status localdns --no-pager 2>&1 || true
-        echo "--- localdns journal (last 30 lines) ---"
-        sudo journalctl -u localdns --no-pager -n 30 2>&1 || true
+        dump_localdns_diagnostics
     fi
     sleep 1
 done
 
 echo "=== SUCCESS ==="
 echo "localdns cold start with empty hosts file verified:"
-echo "  1. Restart with empty hosts file: DNS resolves via fallthrough"
+echo "  1. Start with empty hosts file: DNS resolves via fallthrough"
 echo "  2. Hosts file populated later: CoreDNS picks it up via reload"
 `
 

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -1966,7 +1966,8 @@ func ValidateLocalDNSHostsPluginColdStart(ctx context.Context, s *Scenario) {
 
 	s.T.Log("Testing localdns cold start with empty hosts file then population")
 
-	script := `set -euo pipefail
+	script := `#!/bin/bash
+set -euo pipefail
 hosts_file="/etc/localdns/hosts"
 canary_fqdn="canary.localdns.test"
 canary_ip="192.0.2.99"
@@ -2034,7 +2035,9 @@ restart_localdns_cleanly() {
     local rc=0
 
     echo "Stopping localdns (${reason})..."
-    if ! sudo systemctl stop localdns; then
+    if sudo systemctl stop localdns; then
+        :
+    else
         rc=$?
         echo "ERROR: localdns stop failed (${reason}, rc=$rc)" >&2
         dump_localdns_diagnostics
@@ -2049,7 +2052,9 @@ restart_localdns_cleanly() {
     sudo systemctl reset-failed localdns || true
 
     echo "Starting localdns (${reason})..."
-    if ! sudo systemctl start localdns; then
+    if sudo systemctl start localdns; then
+        :
+    else
         rc=$?
         echo "ERROR: localdns start failed (${reason}, rc=$rc)" >&2
         dump_localdns_diagnostics


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR hardens `ValidateLocalDNSHostsPluginColdStart` against a false-negative cold-start failure in the E2E itself.

The cold-start validator needs to exercise the case where LocalDNS starts with an empty `/etc/localdns/hosts` file and later picks up populated entries via the hosts plugin reload path. The flaky part was not LocalDNS behavior with an empty hosts file; it was the validator's forced service restart path. `localdns.service` runs a wrapper script that performs multi-step teardown and startup work, including DNS drop-in cleanup, `networkctl reload`, dummy interface teardown/recreate, and readiness gating. Some of that state converges asynchronously outside the unit, especially around DNS/network refresh.

Instead of using a one-shot `systemctl restart localdns` and retrying on failure, this change now cold-starts LocalDNS explicitly by:
- stopping `localdns`
- waiting for teardown stability before starting again
- starting `localdns`

The teardown stability check waits for the unit to leave active/deactivating state, for `169.254.10.10` to disappear from `/run/systemd/resolve/resolv.conf`, and for the `localdns` dummy interface to be removed. This directly targets the flake instead of masking it with a blind retry.

This PR only changes the E2E validator. It does not change LocalDNS product behavior, bootstrap order, or scriptless CSE timing.

**Which issue(s) this PR fixes**:

N/A (test-only flake)
