### PR TITLE
fix(vhd): remove bundled overlaybd packages after artifact streaming install

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -646,6 +646,8 @@ installAndConfigureArtifactStreaming() {
   /opt/acr/tools/overlaybd/config.sh exporterConfig.enable true
   /opt/acr/tools/overlaybd/config.sh exporterConfig.port 9863
   systemctl link /opt/overlaybd/overlaybd-tcmu.service /opt/overlaybd/snapshotter/overlaybd-snapshotter.service
+  # Remove the bundled overlaybd installer packages (~55-58 MB); install.sh already installed them and they're unused at runtime.
+  rm -f /opt/acr/tools/overlaybd/bin/*.deb /opt/acr/tools/overlaybd/bin/*.rpm
   echo "  - acr-mirror version ${version}" >> ${VHD_LOGS_FILEPATH}
 }
 

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -538,6 +538,27 @@ testAuditDNotPresent() {
   echo "$test:Finish"
 }
 
+testArtifactStreamingPackagesCleanedUp() {
+  local test="testArtifactStreamingPackagesCleanedUp"
+  echo "$test:Start"
+  local overlaybdBinDir="/opt/acr/tools/overlaybd/bin"
+  # Skip if artifact streaming (acr-mirror) isn't installed on this VHD.
+  if [ ! -d "$overlaybdBinDir" ]; then
+    echo "$overlaybdBinDir not present; artifact streaming not installed on this VHD, skipping"
+    echo "$test:Finish"
+    return
+  fi
+  # The bundled overlaybd installer packages are unused at runtime and must be removed after install.
+  local leftovers
+  leftovers=$(find "$overlaybdBinDir" -maxdepth 1 -type f \( -name '*.deb' -o -name '*.rpm' \) 2>/dev/null)
+  if [ -n "$leftovers" ]; then
+    err $test "Leftover overlaybd install packages found (should be removed after install): ${leftovers}"
+  else
+    echo "No leftover overlaybd .deb/.rpm packages found, as expected"
+  fi
+  echo "$test:Finish"
+}
+
 testChrony() {
   os_sku=$1
   local test="testChrony"
@@ -2512,3 +2533,4 @@ testPackageDownloadURLFallbackLogic
 testFileOwnership $OS_SKU
 testDiskQueueServiceIsActive
 testVulnerableKernelModulesDisabled $OS_SKU $OS_VERSION
+testArtifactStreamingPackagesCleanedUp


### PR DESCRIPTION
**What this PR does / why we need it**:

The `acr-mirror` package (artifact streaming) bundles the overlaybd installer packages under `/opt/acr/tools/overlaybd/bin/` as install-time inputs:

- `.deb` variant: `overlaybd.deb` (~14 MB) + `overlaybd-snapshotter.deb` (~44 MB)
- `.rpm` variant: `overlaybd.rpm` (~11 MB) + `overlaybd-snapshotter.rpm` (~45 MB)

`/opt/acr/tools/overlaybd/install.sh` `dpkg`/`tdnf`-installs these at VHD bake time, and nothing references them at runtime (the only reference to `bin/*.{deb,rpm}` is `install.sh` itself). They were left on disk and shipped on **every** VHD where artifact streaming is installed — ~55-58 MB of dead weight — regardless of whether a customer ever enables the feature.

This change removes them right after install, mirroring the existing cleanup of the downloaded `acr-mirror` package (`rm "$MIRROR_DOWNLOAD_PATH"` a few lines above). It covers both `.deb` and `.rpm` so it applies to Ubuntu and Azure Linux. A `linux-vhd-content-test` assertion verifies no leftover `.deb`/`.rpm` packages remain under the overlaybd `bin` directory (guarded so it is skipped on VHDs where artifact streaming is not installed).

No runtime behavior change: the overlaybd binaries are already installed into their system locations by `install.sh`; only the now-redundant installer packages are deleted.

**Which issue(s) this PR fixes**:

Fixes #