### PR TITLE
stls: resolve apiserver IP locally and inject as APISERVER_IP env var

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -2429,6 +2429,41 @@ func Test_Ubuntu2404_SecureTLSBootstrapping_BootstrapToken_Fallback(t *testing.T
 	})
 }
 
+// Test_Ubuntu2204_SecureTLSBootstrapping_APIServerIPEnvVar validates that the
+// CSE shell code (configureAndStartSecureTLSBootstrapping in cse_config.sh)
+// resolves the API server IP at provisioning time and writes it as
+// APISERVER_IP=<addr> into /etc/default/secure-tls-bootstrap.
+//
+// Tracking: AB#38327357. The companion STLS client change in
+// Azure/aks-secure-tls-bootstrap reads this env var and dials the IP literal
+// directly so the gRPC dns:/// resolver is never consulted on retries.
+//
+// This test validates only the AgentBaker side (the env var is correctly
+// populated). The end-to-end "DNS blackhole, STLS still succeeds" test
+// requires the new STLS client binary baked into the VHD and is tracked as
+// a follow-up.
+func Test_Ubuntu2204_SecureTLSBootstrapping_APIServerIPEnvVar(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "validates that CSE writes APISERVER_IP into /etc/default/secure-tls-bootstrap so STLS can dial without DNS",
+		Config: Config{
+			Cluster: ClusterKubenet,
+			VHD:     config.VHDUbuntu2204Gen2Containerd,
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.SecureTLSBootstrappingConfig = &datamodel.SecureTLSBootstrappingConfig{
+					Enabled: true,
+				}
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				// The env-var line must be present and assign a non-empty value.
+				// The resolver block falls back through IMDS tag -> getent ahostsv4
+				// -> getent ahostsv6 and writes nothing if all sources fail, so a
+				// missing line would indicate a hard regression.
+				ValidateFileHasContent(ctx, s, "/etc/default/secure-tls-bootstrap", "APISERVER_IP=")
+			},
+		},
+	})
+}
+
 func Test_Ubuntu2404Gen2_GPUNoDriver(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a GPU-enabled node using the Ubuntu 2404 VHD opting for skipping gpu driver installation can be properly bootstrapped",

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -548,12 +548,58 @@ configureAndStartSecureTLSBootstrapping() {
         BOOTSTRAP_CLIENT_FLAGS="${BOOTSTRAP_CLIENT_FLAGS} --deadline=${SECURE_TLS_BOOTSTRAPPING_DEADLINE}"
     fi
 
+    # AB#38327357: resolve the apiserver IP locally and hand it to STLS via the
+    # APISERVER_IP env var so the client can dial the literal IP and skip the
+    # gRPC dns:/// resolver. If anything fails the var stays empty, the line
+    # is omitted, and STLS falls back to its existing FQDN dial path. Best
+    # effort only — must never fail CSE.
+    APISERVER_IP=""
+    case "${API_SERVER_NAME}" in
+        ''|*[!0-9.]*)
+            # Not a plain IPv4 literal. Try the IMDS aksAPIServerIPAddress tag
+            # (private clusters only — same source reconcile-private-hosts.sh
+            # uses for privatelink FQDNs), then DNS via getent.
+            case "${API_SERVER_NAME}" in
+                *.privatelink.*)
+                    APISERVER_IP=$(curl -sSL -m 5 -H "Metadata: true" \
+                        "http://169.254.169.254/metadata/instance/compute/tags?api-version=2019-03-11&format=text" 2>/dev/null \
+                        | tr ';' '\n' \
+                        | awk -F: 'tolower($1) == "aksapiserveripaddress" { print $2; exit }')
+                    # Discard IMDS values that are not plausible IP literals so
+                    # we fall through to getent instead of short-circuiting on
+                    # an invalid (or absent) tag.
+                    case "${APISERVER_IP}" in
+                        ''|*[!0-9a-fA-F:.]*) APISERVER_IP="" ;;
+                    esac
+                    ;;
+            esac
+            if [ -z "${APISERVER_IP}" ] && [ -n "${API_SERVER_NAME}" ]; then
+                APISERVER_IP=$(getent ahostsv4 "${API_SERVER_NAME}" 2>/dev/null | awk '/STREAM/ { print $1; exit }')
+            fi
+            if [ -z "${APISERVER_IP}" ] && [ -n "${API_SERVER_NAME}" ]; then
+                APISERVER_IP=$(getent ahostsv6 "${API_SERVER_NAME}" 2>/dev/null | awk '/STREAM/ { print $1; exit }')
+            fi
+            # Final sanity: discard anything that isn't a plausible IP literal.
+            # The STLS client also validates with net.ParseIP, but reject early
+            # so we don't write garbage into the EnvironmentFile.
+            case "${APISERVER_IP}" in
+                ''|*[!0-9a-fA-F:.]*) APISERVER_IP="" ;;
+            esac
+            ;;
+        *)
+            APISERVER_IP="${API_SERVER_NAME}"
+            ;;
+    esac
+
     mkdir -p "$(dirname "${SECURE_TLS_BOOTSTRAPPING_DEFAULT_FILE}")"
     touch "${SECURE_TLS_BOOTSTRAPPING_DEFAULT_FILE}"
     chmod 0600 "${SECURE_TLS_BOOTSTRAPPING_DEFAULT_FILE}"
     echo "BOOTSTRAP_FLAGS=${BOOTSTRAP_CLIENT_FLAGS}" > "${SECURE_TLS_BOOTSTRAPPING_DEFAULT_FILE}"
     if [ -n "${AZURE_ENVIRONMENT_FILEPATH}" ]; then
         echo "AZURE_ENVIRONMENT_FILEPATH=${AZURE_ENVIRONMENT_FILEPATH}" >> "${SECURE_TLS_BOOTSTRAPPING_DEFAULT_FILE}"
+    fi
+    if [ -n "${APISERVER_IP}" ]; then
+        echo "APISERVER_IP=${APISERVER_IP}" >> "${SECURE_TLS_BOOTSTRAPPING_DEFAULT_FILE}"
     fi
 
     mkdir -p "$(dirname "${SECURE_TLS_BOOTSTRAPPING_DROP_IN}")"

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -1227,6 +1227,17 @@ SETUP_EOF
             echo "chmod $@"
         }
 
+        # AB#38327357: stub external resolvers so the default tests do not depend on
+        # CI DNS / IMDS reachability. Per-test overrides further down provide
+        # specific responses for the new IP-resolution cases.
+        curl() {
+            return 1
+        }
+
+        getent() {
+            return 2
+        }
+
         cleanup() {
             rm -rf "$SECURE_TLS_BOOTSTRAPPING_DROP_IN_DIR"
             rm -rf "$SECURE_TLS_BOOTSTRAPPING_DEFAULT_FILE_DIR"
@@ -1250,6 +1261,7 @@ SETUP_EOF
             The contents of file "secure-tls-bootstrap.service.d/10-securetlsbootstrap.conf" should include "WantedBy=kubelet.service"
             The contents of file "default/secure-tls-bootstrap" should include 'BOOTSTRAP_FLAGS=--aad-resource=6dae42f8-4368-4678-94ff-3960e28e3630 --apiserver-fqdn=fqdn --cloud-provider-config=/etc/kubernetes/azure.json'
             The contents of file "default/secure-tls-bootstrap" should not include 'AZURE_ENVIRONMENT_FILEPATH'
+            The contents of file "default/secure-tls-bootstrap" should not include 'APISERVER_IP='
             The status should be success
         End
 
@@ -1262,6 +1274,7 @@ SETUP_EOF
             The output should include "systemctlEnableAndStartNoBlock secure-tls-bootstrap 30"
             The contents of file "default/secure-tls-bootstrap" should include 'BOOTSTRAP_FLAGS=--aad-resource=6dae42f8-4368-4678-94ff-3960e28e3630 --apiserver-fqdn=fqdn --cloud-provider-config=/etc/kubernetes/azure.json'
             The contents of file "default/secure-tls-bootstrap" should include 'AZURE_ENVIRONMENT_FILEPATH=/etc/kubernetes/akscustom.json'
+            The contents of file "default/secure-tls-bootstrap" should not include 'APISERVER_IP='
             The status should be success
         End
 
@@ -1289,6 +1302,138 @@ SETUP_EOF
             The contents of file "secure-tls-bootstrap.service.d/10-securetlsbootstrap.conf" should include "[Install]"
             The contents of file "secure-tls-bootstrap.service.d/10-securetlsbootstrap.conf" should include "WantedBy=kubelet.service"
             The contents of file "default/secure-tls-bootstrap" should include 'BOOTSTRAP_FLAGS=--aad-resource=custom-resource --apiserver-fqdn=fqdn --cloud-provider-config=/etc/kubernetes/azure.json --user-assigned-identity-id=custom-identity-id --validate-kubeconfig-timeout=custom-validate-kubeconfig-timeout --get-access-token-timeout=custom-get-access-token-timeout --get-instance-data-timeout=custom-get-instance-data-timeout --get-nonce-timeout=custom-get-nonce-timeout --get-attested-data-timeout=custom-get-attested-data-timeout --get-credential-timeout=custom-get-credential-timeout --deadline=custom-deadline'
+            The status should be success
+        End
+
+        # AB#38327357: APISERVER_IP resolution coverage. The new resolver runs
+        # before the EnvironmentFile is written so STLS can dial the apiserver
+        # IP directly and bypass gRPC's dns resolver when node DNS is broken.
+        It 'should write APISERVER_IP as-is when API_SERVER_NAME is already an IPv4 literal'
+            systemctlEnableAndStartNoBlock() {
+                echo "systemctlEnableAndStartNoBlock $@"
+            }
+            API_SERVER_NAME="10.0.0.5"
+            When call configureAndStartSecureTLSBootstrapping
+            The output should include "systemctlEnableAndStartNoBlock secure-tls-bootstrap 30"
+            The contents of file "default/secure-tls-bootstrap" should include 'APISERVER_IP=10.0.0.5'
+            The status should be success
+        End
+
+        It 'should resolve APISERVER_IP via getent ahostsv4 when DNS works'
+            systemctlEnableAndStartNoBlock() {
+                echo "systemctlEnableAndStartNoBlock $@"
+            }
+            getent() {
+                # First arg is the database (ahostsv4 / ahostsv6).
+                if [ "$1" = "ahostsv4" ]; then
+                    printf '10.0.0.6      STREAM example.hcp.eastus.azmk8s.io\n10.0.0.6      DGRAM\n10.0.0.6      RAW\n'
+                    return 0
+                fi
+                return 2
+            }
+            API_SERVER_NAME="example.hcp.eastus.azmk8s.io"
+            When call configureAndStartSecureTLSBootstrapping
+            The output should include "systemctlEnableAndStartNoBlock secure-tls-bootstrap 30"
+            The contents of file "default/secure-tls-bootstrap" should include 'APISERVER_IP=10.0.0.6'
+            The status should be success
+        End
+
+        It 'should fall back to getent ahostsv6 when ahostsv4 has no answer'
+            systemctlEnableAndStartNoBlock() {
+                echo "systemctlEnableAndStartNoBlock $@"
+            }
+            getent() {
+                if [ "$1" = "ahostsv6" ]; then
+                    printf '2603:1030::1      STREAM v6only.hcp.eastus.azmk8s.io\n'
+                    return 0
+                fi
+                return 2
+            }
+            API_SERVER_NAME="v6only.hcp.eastus.azmk8s.io"
+            When call configureAndStartSecureTLSBootstrapping
+            The output should include "systemctlEnableAndStartNoBlock secure-tls-bootstrap 30"
+            The contents of file "default/secure-tls-bootstrap" should include 'APISERVER_IP=2603:1030::1'
+            The status should be success
+        End
+
+        It 'should prefer the IMDS aksAPIServerIPAddress tag for privatelink FQDNs'
+            systemctlEnableAndStartNoBlock() {
+                echo "systemctlEnableAndStartNoBlock $@"
+            }
+            curl() {
+                # IMDS returns key:value pairs separated by semicolons.
+                echo "aksAPIServerIPAddress:10.224.0.4;otherTag:someValue"
+                return 0
+            }
+            getent() {
+                # Must not be needed once IMDS hits; if called, fail loudly.
+                echo "getent should not have been called" >&2
+                return 1
+            }
+            API_SERVER_NAME="example.privatelink.eastus.azmk8s.io"
+            When call configureAndStartSecureTLSBootstrapping
+            The output should include "systemctlEnableAndStartNoBlock secure-tls-bootstrap 30"
+            The contents of file "default/secure-tls-bootstrap" should include 'APISERVER_IP=10.224.0.4'
+            The status should be success
+        End
+
+        It 'should fall back to DNS when IMDS returns no aksAPIServerIPAddress tag'
+            systemctlEnableAndStartNoBlock() {
+                echo "systemctlEnableAndStartNoBlock $@"
+            }
+            curl() {
+                echo "otherTag:someValue;anotherTag:moreData"
+                return 0
+            }
+            getent() {
+                if [ "$1" = "ahostsv4" ]; then
+                    printf '10.224.0.5      STREAM example.privatelink.eastus.azmk8s.io\n'
+                    return 0
+                fi
+                return 2
+            }
+            API_SERVER_NAME="example.privatelink.eastus.azmk8s.io"
+            When call configureAndStartSecureTLSBootstrapping
+            The output should include "systemctlEnableAndStartNoBlock secure-tls-bootstrap 30"
+            The contents of file "default/secure-tls-bootstrap" should include 'APISERVER_IP=10.224.0.5'
+            The status should be success
+        End
+
+        It 'should omit APISERVER_IP when every resolver fails'
+            systemctlEnableAndStartNoBlock() {
+                echo "systemctlEnableAndStartNoBlock $@"
+            }
+            # curl + getent inherit the Describe-level stubs that return failure.
+            API_SERVER_NAME="unresolvable.example.com"
+            When call configureAndStartSecureTLSBootstrapping
+            The output should include "systemctlEnableAndStartNoBlock secure-tls-bootstrap 30"
+            The contents of file "default/secure-tls-bootstrap" should include 'BOOTSTRAP_FLAGS='
+            The contents of file "default/secure-tls-bootstrap" should not include 'APISERVER_IP='
+            The status should be success
+        End
+
+        It 'should reject IMDS responses that are not plausible IP literals'
+            systemctlEnableAndStartNoBlock() {
+                echo "systemctlEnableAndStartNoBlock $@"
+            }
+            curl() {
+                # Garbage / injected value masquerading as a tag value.
+                echo "aksAPIServerIPAddress:not-an-ip!@#"
+                return 0
+            }
+            getent() {
+                if [ "$1" = "ahostsv4" ]; then
+                    printf '10.224.0.9      STREAM example.privatelink.eastus.azmk8s.io\n'
+                    return 0
+                fi
+                return 2
+            }
+            API_SERVER_NAME="example.privatelink.eastus.azmk8s.io"
+            When call configureAndStartSecureTLSBootstrapping
+            The output should include "systemctlEnableAndStartNoBlock secure-tls-bootstrap 30"
+            # Garbage discarded, falls through to getent.
+            The contents of file "default/secure-tls-bootstrap" should include 'APISERVER_IP=10.224.0.9'
+            The contents of file "default/secure-tls-bootstrap" should not include 'APISERVER_IP=not-an-ip'
             The status should be success
         End
     End


### PR DESCRIPTION
## Summary

Eliminates infinite STLS bootstrap retries caused by node-local DNS failures by injecting a pre-resolved API server IP into the STLS client via an `APISERVER_IP` environment variable.

Tracked by **AB#38327357** (parent feature **AB#34681743**, Cameron Meissner).

## Background

When DNS is broken on a node at STLS bootstrap time (CoreDNS not ready, systemd-resolved race, custom DNS misconfig), the STLS client emits

```
rpc error: code = DeadlineExceeded ... name resolver error: produced zero addresses
```

and retries forever (`retry.WithMax(math.MaxUint)` in the gRPC interceptor). Root cause: `client/internal/bootstrap/grpc.go::getServiceClient` builds the dial target as `fmt.Sprintf("%s:443", cfg.APIServerFQDN)`, so gRPC's built-in `dns` resolver re-resolves the FQDN on every retry attempt.

Reference incident: VMId `b409a057-44a0-4b06-a6de-2e24e59a90a5`, 53+ hours of retries on Jun 5–6.

## What this PR does

`configureAndStartSecureTLSBootstrapping` in `parts/linux/cloud-init/artifacts/cse_config.sh` now resolves the API server IP at provisioning time and writes it as `APISERVER_IP=<addr>` into `/etc/default/secure-tls-bootstrap` (the systemd `EnvironmentFile` for `secure-tls-bootstrap.service`).

Resolution order:

1. If `API_SERVER_NAME` is already an IPv4 literal → use it as-is.
2. For `*.privatelink.*` hosts → IMDS instance tag `aksAPIServerIPAddress` (same source as `reconcile-private-hosts.sh`; survives cluster DNS failures).
3. `getent ahostsv4 ${API_SERVER_NAME}` (IPv4 preferred).
4. `getent ahostsv6 ${API_SERVER_NAME}` (IPv6 fallback).
5. Any non-`[0-9a-fA-F:.]` result is discarded.

If every step fails (e.g., DNS already down on a public cluster at CSE time), `APISERVER_IP` stays empty, the line is **not** emitted, and STLS falls back to its existing FQDN-dial behaviour — no regression.

The companion **[Azure/aks-secure-tls-bootstrap#180](https://github.com/Azure/aks-secure-tls-bootstrap/pull/180)** PR:
- Adds `APIServerIP` to `bootstrap.Config`, populated from `os.Getenv("APISERVER_IP")`.
- Switches `getServiceClient` to a `passthrough:///` dial target when the IP is set, with `tls.Config.ServerName = cfg.APIServerFQDN` and `grpc.WithAuthority(net.JoinHostPort(cfg.APIServerFQDN, "443"))` so TLS SAN validation and HTTP/2 `:authority` still resolve against the FQDN. The gRPC `dns` resolver is bypassed entirely.

## Backward / forward compatibility (6-month VHD window)

| AgentBaker (CSE) | STLS client binary | Behaviour |
| --- | --- | --- |
| Old (no env var) | Old (no env reader) | Status quo — DNS dial on every retry. |
| Old (no env var) | New (env reader) | `APISERVER_IP` unset → STLS falls back to FQDN dial. Identical to status quo. |
| New (writes env var) | Old (no env reader) | Old binary silently ignores unknown env vars. FQDN dial. Identical to status quo. |
| New (writes env var) | New (env reader) | **Fix activates**: STLS dials the IP literal, no DNS at gRPC time. |

All four cells are safe — the fix only activates when both sides are new.

## Why this lives in `cse_config.sh` and not RP / parser

STLS is started at `cse_main.sh` line ~390 — **before** the cluster-validation `nslookup` at line ~515. We cannot rely on a side effect of that later DNS call. Resolving and writing the env var inside `configureAndStartSecureTLSBootstrapping`, right before the `EnvironmentFile` write, is the only place that gives us both:
- A live cluster context (so the IMDS tag and `getent` can run).
- An atomic write of `APISERVER_IP` and `BOOTSTRAP_FLAGS` into the same `EnvironmentFile`.

No RP-side / `pkg/agent/datamodel/types.go` / proto changes — IP is resolved locally by CSE.

## aks-node-controller parity

The ANC provisioning path invokes the same `configureAndStartSecureTLSBootstrapping` function via `cse_main.sh`, so no additional ANC code change is required. Confirmed by grep: no separate STLS bootstrap path exists in `aks-node-controller/`.

## Testing

### Unit (ShellSpec)

`spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh` adds 6 new `It` blocks covering every resolver branch:

1. `API_SERVER_NAME` is an IPv4 literal → echoed as-is.
2. `getent ahostsv4` returns an IPv4 → captured, written.
3. `ahostsv4` fails, `ahostsv6` returns an IPv6 → captured.
4. `*.privatelink.*` host + IMDS returns valid tag → IP from IMDS, no `getent` call.
5. `*.privatelink.*` host + IMDS returns no tag → falls through to DNS.
6. All resolvers fail → `APISERVER_IP=` line absent, CSE does **not** fail.
7. IMDS returns garbage → discarded by sanity-strip, falls through to DNS.

Full suite: **97/97 green** under podman + the standard `aksdataplanedev.azurecr.io/shellspec` base image.

### E2E

New test `Test_Ubuntu2204_SecureTLSBootstrapping_APIServerIPEnvVar` in `e2e/scenario_test.go` provisions an STLS-enabled Ubuntu 22.04 node and validates that `/etc/default/secure-tls-bootstrap` contains `APISERVER_IP=`. This is a smoke test of the AgentBaker side.

The full DNS-blackhole e2e (assert STLS bootstrap succeeds with DNS broken) requires the new STLS client binary baked into the VHD and will be added in a follow-up PR once #180 lands.

### Lint / generate

- `make validate-shell`: no new shellcheck issues introduced (pre-existing SC3014 warnings unchanged).
- `make generate`: no snapshot drift (verified via `GOPROXY=https://proxy.golang.org,direct GENERATE_TEST_DATA="true" go test ./pkg/agent/...`).

## Risks / open items

- **CSE-time DNS already broken on a public cluster**: no IMDS tag (private only), `getent` fails, `APISERVER_IP=""`, STLS falls back to FQDN dial — same as today. Not worse, but the fix doesn't help this narrow case. Future RP-side enhancement is the only complete fix; out of scope.
- **API server IP changes mid-bootstrap**: extremely rare within the short STLS window; would surface as TCP/TLS error rather than DNS, eventually retries succeed. Acceptable; orthogonal to AB#38327355 (retry cap).
- **Windows**: out of scope.
- **`kube-apiserver-proxy` literal naming** (from the ADO item): the string does not appear in either repo. The real dial target is `${APIServerFQDN}`. Flagging for cross-check with **@cameronmeissner** before landing.

## Related work items

- **AB#38327357** — this PR
- **AB#34681743** — parent STLS Phase 1 feature
- **AB#38327355** — STLS retry cap (sibling)
- **AB#38327356** — per-VM STLS QoS metric (sibling)

🤖 *Generated by GitHub Copilot*