### PR TITLE
feat(gpu): pre-bake NVIDIA CUDA kernel module into the VHD

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1221,11 +1221,16 @@ configGPUDrivers() {
         mkdir -p /opt/{actions,gpu}
         # When the kernel module was pre-built into the VHD (build-only at image-bake time),
         # a marker is present. Ask aks-gpu to skip the ~100s DKMS recompile and run only the
-        # device-dependent steps. aks-gpu independently re-validates the marker (kernel +
-        # driver_version + driver_kind) and falls back to a full build on any mismatch, so this
-        # is safe even after a kernel upgrade or on a shared VHD with a different driver kind.
+        # device-dependent steps -- but ONLY when the marker's driver_kind matches THIS node's
+        # driver (NVIDIA_GPU_DRIVER_TYPE). A CUDA-prebaked marker on a GRID node (or vice-versa)
+        # must request a full "install": the other driver image may not even support
+        # install-skip-build and would fail to stage its userspace files (e.g. /opt/gpu/config.sh).
+        # aks-gpu still independently re-validates the marker (kernel + driver_version +
+        # driver_kind) and falls back to a full build on any remaining mismatch (e.g. kernel drift).
         GPU_INSTALL_ACTION="install"
-        if [ -f "${GPU_DKMS_MARKER_FILE:-/opt/azure/aks-gpu/dkms-marker}" ]; then
+        GPU_DKMS_MARKER="${GPU_DKMS_MARKER_FILE:-/opt/azure/aks-gpu/dkms-marker}"
+        if [ -f "$GPU_DKMS_MARKER" ] && \
+           [ "$(sed -n 's/^driver_kind=//p' "$GPU_DKMS_MARKER" | head -n1)" = "$NVIDIA_GPU_DRIVER_TYPE" ]; then
             GPU_INSTALL_ACTION="install-skip-build"
         fi
         # The driver image is normally pre-pulled into the VHD; only hit the registry when it is

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1211,20 +1211,30 @@ pullGPUDriverImage() {
 }
 
 installGPUDriverImage() {
-    retrycmd_if_failure 5 10 600 bash -c "$CTR_GPU_INSTALL_CMD $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG gpuinstall /entrypoint.sh install"
+    local gpuInstallAction="${1:-install}"
+    retrycmd_if_failure 5 10 600 bash -c "$CTR_GPU_INSTALL_CMD $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG gpuinstall /entrypoint.sh ${gpuInstallAction}"
 }
 
 configGPUDrivers() {
     if [ "$OS" = "$UBUNTU_OS_NAME" ]; then
         waitForContainerdReady || exit $ERR_GPU_DRIVERS_START_FAIL
         mkdir -p /opt/{actions,gpu}
+        # When the kernel module was pre-built into the VHD (build-only at image-bake time),
+        # a marker is present. Ask aks-gpu to skip the ~100s DKMS recompile and run only the
+        # device-dependent steps. aks-gpu independently re-validates the marker (kernel +
+        # driver_version + driver_kind) and falls back to a full build on any mismatch, so this
+        # is safe even after a kernel upgrade or on a shared VHD with a different driver kind.
+        GPU_INSTALL_ACTION="install"
+        if [ -f "${GPU_DKMS_MARKER_FILE:-/opt/azure/aks-gpu/dkms-marker}" ]; then
+            GPU_INSTALL_ACTION="install-skip-build"
+        fi
         # The driver image is normally pre-pulled into the VHD; only hit the registry when it is
         # actually missing so provisioning doesn't pay a redundant manifest/layer round trip.
         # Use containerd's native exact-name filter rather than text-matching `images ls` output.
         if [ -z "$(ctr -n k8s.io images ls -q "name==${NVIDIA_DRIVER_IMAGE}:${NVIDIA_DRIVER_IMAGE_TAG}")" ]; then
             logs_to_events "AKS.CSE.configGPUDrivers.pullGPUDriverImage" pullGPUDriverImage
         fi
-        logs_to_events "AKS.CSE.configGPUDrivers.installGPUDriverImage" installGPUDriverImage
+        logs_to_events "AKS.CSE.configGPUDrivers.installGPUDriverImage" installGPUDriverImage "$GPU_INSTALL_ACTION"
         ret=$?
         if [ "$ret" -ne 0 ]; then
             echo "Failed to install GPU driver, exiting..."

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1227,8 +1227,8 @@ configGPUDrivers() {
         # install-skip-build and would fail to stage its userspace files (e.g. /opt/gpu/config.sh).
         # aks-gpu still independently re-validates the marker (kernel + driver_version +
         # driver_kind) and falls back to a full build on any remaining mismatch (e.g. kernel drift).
-        GPU_INSTALL_ACTION="install"
-        GPU_DKMS_MARKER="${GPU_DKMS_MARKER_FILE:-/opt/azure/aks-gpu/dkms-marker}"
+        local GPU_INSTALL_ACTION="install"
+        local GPU_DKMS_MARKER="${GPU_DKMS_MARKER_FILE:-/opt/azure/aks-gpu/dkms-marker}"
         if [ -f "$GPU_DKMS_MARKER" ] && \
            [ "$(sed -n 's/^driver_kind=//p' "$GPU_DKMS_MARKER" | head -n1)" = "$NVIDIA_GPU_DRIVER_TYPE" ]; then
             GPU_INSTALL_ACTION="install-skip-build"

--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
@@ -247,9 +247,11 @@ cleanUpPrebakedGPUDriver() {
     # depmod/initramfs refresh is required.
     rm -rf /var/lib/dkms/nvidia || true
     rm -f /lib/modules/*/updates/dkms/nvidia*.ko* 2>/dev/null || true
-    # aks-gpu relocates the userspace libs under GPU_DEST/lib64; on Ubuntu GPU_DEST=/usr/bin.
+    # aks-gpu stages the driver userspace libs under its container's GPU_DEST/lib64. NOTE: that is
+    # the aks-gpu *container's* GPU_DEST=/usr/bin (aks-gpu config.sh), NOT this CSE script's
+    # GPU_DEST=/usr/local/nvidia -- the prebake writes to /usr/bin, so the teardown clears /usr/bin.
     rm -rf /usr/bin/lib64 || true
-    # nvidia-installer also drops driver userspace BINARIES under GPU_DEST (=/usr/bin on Ubuntu).
+    # nvidia-installer likewise drops the driver userspace BINARIES under that same /usr/bin.
     # Remove them too so a non-GPU node looks genuinely driver-free: otherwise e.g. `nvidia-smi`
     # remains on PATH and, with its libs (lib64) gone, errors instead of being "command not found".
     for nvidiaBin in nvidia-smi nvidia-debugdump nvidia-persistenced nvidia-cuda-mps-control \

--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
@@ -240,17 +240,23 @@ cleanUpPrebakedGPUDriver() {
     fi
     echo "Removing pre-baked NVIDIA driver inherited from shared VHD on non-GPU node"
 
-    # Deregister the nvidia DKMS module so future kernel upgrades stop rebuilding it. Parsing stops
-    # at the first ',', ':' or space so "nvidia/<ver>: added" and "nvidia/<ver>, <kernel>: installed"
-    # both yield just <ver>.
-    if command -v dkms >/dev/null 2>&1; then
-        dkms status 2>/dev/null | sed -n 's#^nvidia/\([^,: ]*\).*#\1#p' | sort -u | while read -r nvidiaVersion; do
-            [ -n "${nvidiaVersion}" ] && dkms remove "nvidia/${nvidiaVersion}" --all || true
-        done
-    fi
+    # Deregister the nvidia DKMS module so future kernel upgrades stop rebuilding it, WITHOUT the
+    # slow `dkms remove --all` (it dominated CSE duration on the non-GPU provisioning path, ~35s).
+    # Removing the DKMS source tree deregisters it (dkms autoinstall iterates /var/lib/dkms/*), and
+    # removing the built module reclaims disk. The module is never loaded on a non-GPU node, so no
+    # depmod/initramfs refresh is required.
     rm -rf /var/lib/dkms/nvidia || true
+    rm -f /lib/modules/*/updates/dkms/nvidia*.ko* 2>/dev/null || true
     # aks-gpu relocates the userspace libs under GPU_DEST/lib64; on Ubuntu GPU_DEST=/usr/bin.
     rm -rf /usr/bin/lib64 || true
+    # nvidia-installer also drops driver userspace BINARIES under GPU_DEST (=/usr/bin on Ubuntu).
+    # Remove them too so a non-GPU node looks genuinely driver-free: otherwise e.g. `nvidia-smi`
+    # remains on PATH and, with its libs (lib64) gone, errors instead of being "command not found".
+    for nvidiaBin in nvidia-smi nvidia-debugdump nvidia-persistenced nvidia-cuda-mps-control \
+                     nvidia-cuda-mps-server nvidia-modprobe nvidia-bug-report.sh nvidia-powerd \
+                     nvidia-ngx-updater nvidia-sleep.sh; do
+        rm -f "/usr/bin/${nvidiaBin}" || true
+    done
     rm -f /etc/ld.so.conf.d/nvidia.conf || true
     ldconfig || true
     rm -f "${marker}" || true

--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
@@ -223,12 +223,50 @@ removeNvidiaRepos() {
     fi
 }
 
+# cleanUpPrebakedGPUDriver tears down a CUDA driver that was pre-baked into a shared Ubuntu VHD
+# when this node is NOT a GPU node. On a non-GPU node the installed driver is dead weight: it
+# wastes disk and, because it stays DKMS-registered, forces an nvidia.ko rebuild on every kernel
+# patch. The nvidia module is never loaded on a non-GPU node, so deregistration cannot hit
+# "module in use". It is a no-op unless the aks-gpu prebake marker is present, so today's
+# non-prebaked VHDs are completely unaffected. Idempotent and safe to re-run.
+# NOTE: this runs synchronously on the (non-GPU) provisioning path; the teardown is light
+# (deregister + rm + ldconfig, no initramfs rebuild). To move it fully off the critical path it
+# can be launched via a transient systemd unit (systemd-run --no-block) instead -- see the PR
+# description for that variant and its trade-offs.
+cleanUpPrebakedGPUDriver() {
+    local marker="${GPU_DKMS_MARKER_FILE:-/opt/azure/aks-gpu/dkms-marker}"
+    if [ ! -f "${marker}" ]; then
+        return 0
+    fi
+    echo "Removing pre-baked NVIDIA driver inherited from shared VHD on non-GPU node"
+
+    # Deregister the nvidia DKMS module so future kernel upgrades stop rebuilding it. Parsing stops
+    # at the first ',', ':' or space so "nvidia/<ver>: added" and "nvidia/<ver>, <kernel>: installed"
+    # both yield just <ver>.
+    if command -v dkms >/dev/null 2>&1; then
+        dkms status 2>/dev/null | sed -n 's#^nvidia/\([^,: ]*\).*#\1#p' | sort -u | while read -r nvidiaVersion; do
+            [ -n "${nvidiaVersion}" ] && dkms remove "nvidia/${nvidiaVersion}" --all || true
+        done
+    fi
+    rm -rf /var/lib/dkms/nvidia || true
+    # aks-gpu relocates the userspace libs under GPU_DEST/lib64; on Ubuntu GPU_DEST=/usr/bin.
+    rm -rf /usr/bin/lib64 || true
+    rm -f /etc/ld.so.conf.d/nvidia.conf || true
+    ldconfig || true
+    rm -f "${marker}" || true
+}
+
 cleanUpGPUDrivers() {
     rm -Rf $GPU_DEST /opt/gpu
 
     for packageName in $(managedGPUPackageList); do
         rm -rf "/opt/${packageName}"
     done
+
+    # A CUDA driver pre-baked into a shared Ubuntu VHD is dead weight on a non-GPU node, and while
+    # DKMS-registered it forces an nvidia.ko rebuild on every kernel patch. Tear it down here.
+    # No-op on VHDs without the aks-gpu prebake marker.
+    cleanUpPrebakedGPUDriver
 }
 
 installCriCtlPackage() {

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -1909,7 +1909,7 @@ SETUP_EOF
         # Capture the action passed to the install container.
         retrycmd_if_failure() { shift 3; echo "INSTALL_CMD: $*"; return 0; }
 
-        BeforeEach 'OS="$UBUNTU_OS_NAME"; NVIDIA_GPU_DRIVER_TYPE="cuda"; NVIDIA_DRIVER_IMAGE="mcr.microsoft.com/aks/aks-gpu-cuda"; NVIDIA_DRIVER_IMAGE_TAG="580.0.0"; CTR_GPU_INSTALL_CMD="ctr-run"; GPU_DKMS_MARKER_FILE="$(mktemp -u)"'
+        BeforeEach 'OS="$UBUNTU_OS_NAME"; NVIDIA_GPU_DRIVER_TYPE="cuda"; NVIDIA_DRIVER_IMAGE="mcr.microsoft.com/aks/aks-gpu-cuda"; NVIDIA_DRIVER_IMAGE_TAG="580.0.0"; CTR_GPU_INSTALL_CMD="ctr-run"; GPU_DKMS_MARKER_FILE="$(mktemp)"; rm -f "$GPU_DKMS_MARKER_FILE"'
 
         It 'uses the full install action when no prebake marker is present'
             When call configGPUDrivers

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -1888,6 +1888,39 @@ SETUP_EOF
         End
     End
 
+    Describe 'configGPUDrivers'
+        # Mock everything the Ubuntu path touches so the test exercises only the
+        # marker -> aks-gpu action selection (install vs install-skip-build).
+        waitForContainerdReady() { return 0; }
+        mkdir() { :; }
+        ctr() { echo "ctr $*"; }
+        nvidia-modprobe() { return 0; }
+        nvidia-smi() { return 0; }
+        ldconfig() { return 0; }
+        isMarinerOrAzureLinux() { return 1; }
+        isACL() { return 1; }
+        systemctlEnableAndStart() { return 0; }
+        systemctl() { return 0; }
+        # Capture the action passed to the install container.
+        retrycmd_if_failure() { shift 3; echo "INSTALL_CMD: $*"; return 0; }
+
+        BeforeEach 'OS="$UBUNTU_OS_NAME"; NVIDIA_DRIVER_IMAGE="mcr.microsoft.com/aks/aks-gpu-cuda"; NVIDIA_DRIVER_IMAGE_TAG="580.0.0"; CTR_GPU_INSTALL_CMD="ctr-run"; GPU_DKMS_MARKER_FILE="$(mktemp -u)"'
+
+        It 'uses the full install action when no prebake marker is present'
+            When call configGPUDrivers
+            The output should include "/entrypoint.sh install"
+            The output should not include "install-skip-build"
+        End
+
+        It 'uses install-skip-build when the prebake marker is present'
+            marker="$(mktemp)"
+            GPU_DKMS_MARKER_FILE="$marker"
+            When call configGPUDrivers
+            The output should include "/entrypoint.sh install-skip-build"
+            rm -f "$marker"
+        End
+    End
+
     Describe 'configureManagedGPUExperience'
         # Mock the helper functions
         logs_to_events() {

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -1890,7 +1890,11 @@ SETUP_EOF
 
     Describe 'configGPUDrivers'
         # Mock everything the Ubuntu path touches so the test exercises only the
-        # marker -> aks-gpu action selection (install vs install-skip-build).
+        # marker -> aks-gpu action selection (install vs install-skip-build), including the
+        # driver_kind guard (a CUDA-baked marker on a GRID node must NOT skip the build).
+        # logs_to_events is mocked to faithfully dispatch the wrapped command (dropping the
+        # event-name arg) so the real installGPUDriverImage runs and surfaces the action.
+        logs_to_events() { shift; $@; }
         waitForContainerdReady() { return 0; }
         mkdir() { :; }
         ctr() { echo "ctr $*"; }
@@ -1898,13 +1902,14 @@ SETUP_EOF
         nvidia-smi() { return 0; }
         ldconfig() { return 0; }
         isMarinerOrAzureLinux() { return 1; }
+        isAzureLinuxOSGuard() { return 1; }
         isACL() { return 1; }
         systemctlEnableAndStart() { return 0; }
         systemctl() { return 0; }
         # Capture the action passed to the install container.
         retrycmd_if_failure() { shift 3; echo "INSTALL_CMD: $*"; return 0; }
 
-        BeforeEach 'OS="$UBUNTU_OS_NAME"; NVIDIA_DRIVER_IMAGE="mcr.microsoft.com/aks/aks-gpu-cuda"; NVIDIA_DRIVER_IMAGE_TAG="580.0.0"; CTR_GPU_INSTALL_CMD="ctr-run"; GPU_DKMS_MARKER_FILE="$(mktemp -u)"'
+        BeforeEach 'OS="$UBUNTU_OS_NAME"; NVIDIA_GPU_DRIVER_TYPE="cuda"; NVIDIA_DRIVER_IMAGE="mcr.microsoft.com/aks/aks-gpu-cuda"; NVIDIA_DRIVER_IMAGE_TAG="580.0.0"; CTR_GPU_INSTALL_CMD="ctr-run"; GPU_DKMS_MARKER_FILE="$(mktemp -u)"'
 
         It 'uses the full install action when no prebake marker is present'
             When call configGPUDrivers
@@ -1912,11 +1917,24 @@ SETUP_EOF
             The output should not include "install-skip-build"
         End
 
-        It 'uses install-skip-build when the prebake marker is present'
+        It 'uses install-skip-build when the prebake marker matches the node driver kind'
             marker="$(mktemp)"
+            printf 'driver_kind=cuda\n' > "$marker"
             GPU_DKMS_MARKER_FILE="$marker"
             When call configGPUDrivers
             The output should include "/entrypoint.sh install-skip-build"
+            rm -f "$marker"
+        End
+
+        It 'falls back to full install when the marker driver_kind does not match the node (CUDA marker on GRID node)'
+            marker="$(mktemp)"
+            printf 'driver_kind=cuda\n' > "$marker"
+            GPU_DKMS_MARKER_FILE="$marker"
+            NVIDIA_GPU_DRIVER_TYPE="grid"
+            NVIDIA_DRIVER_IMAGE="mcr.microsoft.com/aks/aks-gpu-grid"
+            When call configGPUDrivers
+            The output should include "/entrypoint.sh install"
+            The output should not include "install-skip-build"
             rm -f "$marker"
         End
     End

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
@@ -11,43 +11,24 @@ Describe 'cse_install_ubuntu.sh'
             The output should equal ""
         End
 
-        It 'deregisters the nvidia DKMS module and removes baked artifacts when the marker is present'
+        It 'deregisters the nvidia DKMS module and removes baked artifacts (libs, binaries, marker) when present'
             marker="$(mktemp)"
             GPU_DKMS_MARKER_FILE="${marker}"
-            # mock dkms so `command -v dkms` succeeds and `dkms status` returns the installed form
-            dkms() {
-                if [ "$1" = "status" ]; then
-                    echo "nvidia/580.126.09, 6.8.0-1029-azure, x86_64: installed"
-                else
-                    echo "mock dkms $*"
-                fi
-            }
             rm() { echo "mock rm $*"; }
             ldconfig() { echo "mock ldconfig"; }
             When call cleanUpPrebakedGPUDriver
             The status should be success
             The output should include "Removing pre-baked NVIDIA driver"
-            The output should include "mock dkms remove nvidia/580.126.09 --all"
+            # deregisters via the DKMS source tree + built module removal (no slow dkms remove)
             The output should include "mock rm -rf /var/lib/dkms/nvidia"
+            The output should include "mock rm -f /lib/modules"
+            # relocated userspace libs
             The output should include "mock rm -rf /usr/bin/lib64"
+            # driver userspace binaries so nvidia-smi becomes "command not found" on non-GPU nodes
+            The output should include "mock rm -f /usr/bin/nvidia-smi"
             The output should include "mock ldconfig"
-        End
-
-        It 'parses the bare "nvidia/<ver>: added" dkms status form to a clean version'
-            marker="$(mktemp)"
-            GPU_DKMS_MARKER_FILE="${marker}"
-            dkms() {
-                if [ "$1" = "status" ]; then
-                    echo "nvidia/570.86.15: added"
-                else
-                    echo "mock dkms $*"
-                fi
-            }
-            rm() { echo "mock rm $*"; }
-            ldconfig() { echo "mock ldconfig"; }
-            When call cleanUpPrebakedGPUDriver
-            The status should be success
-            The output should include "mock dkms remove nvidia/570.86.15 --all"
+            # the slow per-version dkms remove --all must NOT be on the critical path anymore
+            The output should not include "dkms remove"
         End
     End
 End

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+Describe 'cse_install_ubuntu.sh'
+    Include "./parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh"
+
+    Describe 'cleanUpPrebakedGPUDriver'
+        It 'is a no-op when the prebake marker is absent'
+            GPU_DKMS_MARKER_FILE="/tmp/aks-gpu-marker-absent-$$"
+            When call cleanUpPrebakedGPUDriver
+            The status should be success
+            The output should equal ""
+        End
+
+        It 'deregisters the nvidia DKMS module and removes baked artifacts when the marker is present'
+            marker="$(mktemp)"
+            GPU_DKMS_MARKER_FILE="${marker}"
+            # mock dkms so `command -v dkms` succeeds and `dkms status` returns the installed form
+            dkms() {
+                if [ "$1" = "status" ]; then
+                    echo "nvidia/580.126.09, 6.8.0-1029-azure, x86_64: installed"
+                else
+                    echo "mock dkms $*"
+                fi
+            }
+            rm() { echo "mock rm $*"; }
+            ldconfig() { echo "mock ldconfig"; }
+            When call cleanUpPrebakedGPUDriver
+            The status should be success
+            The output should include "Removing pre-baked NVIDIA driver"
+            The output should include "mock dkms remove nvidia/580.126.09 --all"
+            The output should include "mock rm -rf /var/lib/dkms/nvidia"
+            The output should include "mock rm -rf /usr/bin/lib64"
+            The output should include "mock ldconfig"
+        End
+
+        It 'parses the bare "nvidia/<ver>: added" dkms status form to a clean version'
+            marker="$(mktemp)"
+            GPU_DKMS_MARKER_FILE="${marker}"
+            dkms() {
+                if [ "$1" = "status" ]; then
+                    echo "nvidia/570.86.15: added"
+                else
+                    echo "mock dkms $*"
+                fi
+            }
+            rm() { echo "mock rm $*"; }
+            ldconfig() { echo "mock ldconfig"; }
+            When call cleanUpPrebakedGPUDriver
+            The status should be success
+            The output should include "mock dkms remove nvidia/570.86.15 --all"
+        End
+    End
+End

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -749,6 +749,11 @@ EOF
   # Dropping the image is a separate, deferred size optimization.
   if grep -q "NVIDIA_CUDA_PREBAKE" <<< "$FEATURE_FLAGS"; then
     echo "Pre-building NVIDIA CUDA kernel module into the VHD (build-only) for kernel $(uname -r)"
+    # nvidia-installer compiles the kernel module and needs the libc development headers (libc6-dev),
+    # which the standard (non-GPU) VHD builder image does not ship by default (gcc/make are present
+    # but libc6-dev is not). Ensure the kernel-module build toolchain before the bake; the boot-time
+    # fallback path already gets these via installDeps, so the runtime recompile stays intact.
+    apt_get_install 10 2 300 gcc make libc6-dev || exit 1
     CTR_GPU_PREBUILD_CMD="ctr -n k8s.io run --privileged --rm --net-host --with-ns pid:/proc/1/ns/pid --mount type=bind,src=/opt/gpu,dst=/mnt/gpu,options=rbind --mount type=bind,src=/opt/actions,dst=/mnt/actions,options=rbind"
     retrycmd_if_failure 3 10 600 bash -c "$CTR_GPU_PREBUILD_CMD $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG gpuprebuild /entrypoint.sh build-only" || exit 1
     if [ ! -f /opt/azure/aks-gpu/dkms-marker ]; then

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -737,6 +737,28 @@ if [ $OS = $UBUNTU_OS_NAME ] && [ "$(isARM64)" -ne 1 ]; then  # No ARM64 SKU wit
     cat << EOF >> ${VHD_LOGS_FILEPATH}
   - nvidia-cuda-driver=${NVIDIA_DRIVER_IMAGE_TAG}
 EOF
+
+  # Opt-in: pre-build the NVIDIA kernel module into the VHD so node provisioning skips the
+  # ~100s in-CSE DKMS compile. The aks-gpu container is run in "build-only" mode: it compiles
+  # and DKMS-registers the kernel module + stages userspace libs against THIS VHD's kernel,
+  # performs NO device access (safe on the GPU-less Packer builder), and writes the marker
+  # /opt/azure/aks-gpu/dkms-marker. At node boot, configGPUDrivers passes "install-skip-build"
+  # when that marker matches, running only the device-dependent steps.
+  # The driver image is intentionally LEFT in the VHD: boot-time device init still sources the
+  # container toolkit debs, fabric manager, containerd runtime config and udev rules from it.
+  # Dropping the image is a separate, deferred size optimization.
+  if grep -q "NVIDIA_CUDA_PREBAKE" <<< "$FEATURE_FLAGS"; then
+    echo "Pre-building NVIDIA CUDA kernel module into the VHD (build-only) for kernel $(uname -r)"
+    CTR_GPU_PREBUILD_CMD="ctr -n k8s.io run --privileged --rm --net-host --with-ns pid:/proc/1/ns/pid --mount type=bind,src=/opt/gpu,dst=/mnt/gpu,options=rbind --mount type=bind,src=/opt/actions,dst=/mnt/actions,options=rbind"
+    retrycmd_if_failure 3 10 600 bash -c "$CTR_GPU_PREBUILD_CMD $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG gpuprebuild /entrypoint.sh build-only" || exit 1
+    if [ ! -f /opt/azure/aks-gpu/dkms-marker ]; then
+      echo "Error: NVIDIA CUDA prebake did not produce /opt/azure/aks-gpu/dkms-marker"
+      exit 1
+    fi
+    cat << EOF >> ${VHD_LOGS_FILEPATH}
+  - nvidia-cuda-driver-prebaked=${NVIDIA_DRIVER_IMAGE_TAG} (kernel $(uname -r))
+EOF
+  fi
 fi
 
 if grep -q "NVIDIA_GB" <<< "$FEATURE_FLAGS"; then


### PR DESCRIPTION
## What
Move the ~80–150s in-CSE NVIDIA **DKMS kernel-module compile** off the node-provisioning critical path by compiling it at VHD build time.

- **VHD build** (`install-dependencies.sh`), opt-in via `FEATURE_FLAGS=NVIDIA_CUDA_PREBAKE`: after pre-pulling the `aks-gpu-cuda` image, run it in **build-only** mode. aks-gpu compiles + DKMS-registers the kernel module and stages userspace libs against the VHD's target kernel with **no device access** (safe on the GPU-less Packer builders), and writes `/opt/azure/aks-gpu/dkms-marker`. The build-only path first installs `gcc make libc6-dev` — the standard non-GPU builder ships gcc/make but **not** `libc6-dev`, without which `nvidia-installer` cannot compile.
- **Node boot** (`cse_config.sh`): `configGPUDrivers` passes **install-skip-build** when the marker is present **and the marker's `driver_kind` matches this node's `NVIDIA_GPU_DRIVER_TYPE`**, so aks-gpu skips the recompile and runs only device-init. aks-gpu independently re-validates the marker (kernel + version + kind) and falls back to a full build on any remaining mismatch (e.g. kernel drift), so behaviour is unchanged on non-prebaked VHDs (no marker → `install`). Integrated with the timed `installGPUDriverImage` wrapper on `main`.
- **Non-GPU / `gpu-driver=none` teardown** (`cse_install_ubuntu.sh::cleanUpPrebakedGPUDriver`): when a shared Ubuntu VHD that was prebaked is used for a non-GPU node, deregister the DKMS module and remove the staged driver userspace **libs and binaries** (e.g. `nvidia-smi`) so the node is genuinely driver-free.

## Why
The DKMS compile dominates GPU driver install on every GPU node boot. Pre-baking removes it from the critical path. Works transparently on GPU pools (which default to `ConfigGPUDriverIfNeeded=true`).

## Key correctness decisions (surfaced by e2e)
- **`driver_kind` guard (GRID safety):** a CUDA-prebaked marker on a *shared* VHD must **not** short-circuit a **GRID** node's install — the GRID image may not support `install-skip-build` and would fail to stage its own userspace files (observed as **CSE exit 84** in e2e). The guard restricts skip-build to nodes whose driver kind matches the baked marker.
- **Teardown removes binaries + skips slow `dkms remove`:** leaving `nvidia-smi` on `PATH` with its libs removed makes it *error* instead of being "command not found" (a non-GPU node should look driver-free). Replacing the per-version `dkms remove --all` (~35s) with source-tree + built-module removal keeps the non-GPU provisioning path fast.
- **Secure Boot:** the baked module is unsigned, exactly like today's runtime-DKMS-built module. AKS Ubuntu nodes run with Secure Boot **off**, so this is **no regression** vs the existing flow (Secure Boot ON is already incompatible with both the prebake and the runtime-build path; out of scope here).

## Validation (real AgentBaker e2e, `[TEST All VHDs]` pipeline)
Validated end-to-end by baking prebaked VHDs (a test ACR carried the unmerged aks-gpu#162 build-only image) and running the relevant GPU e2e scenarios on Ubuntu 22.04 + 24.04 Gen2:
- **CUDA skip-build proven on a real GPU:** marker exact-match (kernel + driver version + kind) → prebuilt module loads → "recompile skipped" → `nvidia-smi` healthy.
- **GRID** nodes provision via full install (driver_kind guard).
- **GPUNoDriver / gpu-driver=none** node ends up genuinely driver-free.
- **CSE cached-performance** teardown back under budget.
- Bake proven cross-kernel (2204 = 5.15.x, 2404 = 6.8.x); the builder runs an older kernel than the VHD boots, so aks-gpu#162 compiles against the VHD's **target** kernel (newest with installed headers), not `uname -r`.

## Notes / sequencing
- **Depends on Azure/aks-gpu#162** (build-only / install-skip-build + target-kernel selection). The `aks-gpu-cuda` image in `components.json` must carry that support before the flag is enabled.
- The flag is **off by default** here. A follow-up enables `FEATURE_FLAGS=NVIDIA_CUDA_PREBAKE` on the GPU SKU build jobs once the aks-gpu image has shipped — so this PR cannot break existing VHD builds.
- The driver image is intentionally **kept** in the VHD — boot device-init still sources the container toolkit, fabric manager, containerd runtime config and udev rules from it. Dropping it for VHD-size savings is a separate, deferred follow-up.
- The boot-time fallback recompile remains fully intact: nodes get `gcc/libc6-dev` via `installDeps`, so a marker mismatch still compiles at boot.

## Tests
- `make generate-testdata`: no drift (the CSE scripts are dropped via cloud-init, not embedded in the customdata snapshot).
- `verify_shell` POSIX gate: changed lines introduce no new `SC3010/SC3014`.
- ShellSpec (full suite green): new examples for the marker → action selection **including the driver_kind mismatch guard** (match → skip-build, CUDA-marker-on-GRID → full install), plus the faster libs+binaries+marker teardown.
