### PR TITLE
fix(vhd): mask fwupd on Ubuntu 24.04 to unblock E2E PR gate (AB#38355676)

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -69,6 +69,22 @@ APT::Periodic::Download-Upgradeable-Packages "0";
 APT::Periodic::AutocleanInterval "0";
 APT::Periodic::Unattended-Upgrade "0";
 EOF
+
+  # AB#38355676: fwupd ships in the Ubuntu 24.04 cloud image and tries to start on boot.
+  # On AKS Linux nodes there is no firmware to manage -- firmware on Azure VMs is handled
+  # by the host -- and recent fwupd releases on 24.04 exit non-zero (no devices / no LVFS
+  # reachability on isolated networks), tripping the ValidateNoFailedSystemdUnits E2E
+  # validator (e2e/validators.go:995) on every 2404 scenario.
+  # Mask fwupd.service and fwupd-refresh.timer so systemctl preset-all cannot re-enable
+  # them. Mirrors the apt-daily masking pattern just above and the same rationale used
+  # for Ubuntu Pro on 20.04/FIPS (PR #8638 / AB#38255910).
+  # `|| true` because the units only exist when fwupd is installed (24.04 cloud image
+  # default; not guaranteed on minimal or future SKUs) and `mask` against a non-existent
+  # unit can fail under newer systemd.
+  if [ "$OS_VERSION" = "24.04" ]; then
+    systemctl mask fwupd.service fwupd-refresh.service fwupd-refresh.timer || true
+    systemctl disable --now fwupd.service fwupd-refresh.service fwupd-refresh.timer 2>/dev/null || true
+  fi
 fi
 
 # If the IMG_SKU does not contain "minimal", installDeps normally

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1358,6 +1358,40 @@ testCoreDumpSettings() {
   echo "$test:Finish"
 }
 
+# Tests that fwupd is fully masked on Ubuntu 24.04 VHDs. fwupd is shipped by the
+# 24.04 cloud image but is not used on AKS Linux nodes (firmware on Azure VMs is
+# managed out-of-band by the host) and recent fwupd builds fail to start on these
+# images, which trips ValidateNoFailedSystemdUnits in e2e/validators.go.
+# Masking happens in vhdbuilder/packer/install-dependencies.sh (AB#38355676).
+testFwupdMaskedOnUbuntu2404() {
+  local test="testFwupdMaskedOnUbuntu2404"
+  local os_sku="${1:-$OS_SKU}"
+  local os_version="${2:-$OS_VERSION}"
+  echo "$test:Start"
+
+  if [ "$os_sku" != "Ubuntu" ] || [ "$os_version" != "24.04" ]; then
+    echo "$test: skipping; only applies to Ubuntu 24.04 (got $os_sku $os_version)"
+    echo "$test:Finish"
+    return 0
+  fi
+
+  for unit in fwupd.service fwupd-refresh.service fwupd-refresh.timer; do
+    local is_enabled=
+    is_enabled=$(systemctl is-enabled "$unit" 2>/dev/null)
+    echo "$test: ${unit} is-enabled=${is_enabled}"
+    if [ "${is_enabled}" = "masked" ]; then
+      echo "$test: ${unit} is correctly masked"
+    elif [ "${is_enabled}" = "" ] || [ "${is_enabled}" = "not-found" ]; then
+      # Unit not shipped on this VHD variant -- no masking required.
+      echo "$test: ${unit} is not installed, which is fine"
+    else
+      err $test "${unit} is not masked on Ubuntu 24.04 (is-enabled=${is_enabled}); see AB#38355676"
+    fi
+  done
+
+  echo "$test:Finish"
+}
+
 # Tests that the nfs-server systemd service is masked, per the function
 # configuremaskNfsServerNfsServer in <repo-root>/parts/linux/cloud-init/artifacts/cis.sh.
 testNfsServerService() {
@@ -2517,6 +2551,7 @@ testNetworkSettings
 testCronPermissions $IMG_SKU $OS_SKU
 testCoreDumpSettings
 testNfsServerService
+testFwupdMaskedOnUbuntu2404 $OS_SKU $OS_VERSION
 testPamDSettings $OS_SKU $OS_VERSION
 testPam $OS_SKU $OS_VERSION
 testUmaskSettings


### PR DESCRIPTION
## What this PR does

Masks `fwupd.service`, `fwupd-refresh.service`, and `fwupd-refresh.timer` during VHD build for Ubuntu 24.04, and adds a VHD-content test asserting it stays masked.

## Why

Starting around **2026-06-08 ~21:15 UTC**, every Ubuntu 24.04 E2E scenario in pipeline [119535 (`AKS Linux VHD Build - PR check-in gate`)](https://msazure.visualstudio.com/CloudNativeCompute/_build?definitionId=119535) started failing deterministically with:

```
validators.go:995: 🔴 FAIL: the following systemd units have unexpectedly entered a failed state: [fwupd.service]
- failed unit logs will be included in scenario log bundle within <service-name>.service.log
```

The failure is **distro-scoped to Ubuntu 24.04** and hits every 2404 scenario in unrelated PRs (~20 leaf failures/build). AzureLinux and Ubuntu 22.04 SKUs are NOT affected.

### Affected builds

| Build | PR |
|-------|-----|
| [167206065](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=167206065) | #8294 (node-exporter bump) |
| [167206071](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=167206071) | #8600 (kubelet/kubectl bump) |
| [167206039](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=167206039) | #8642 (secondary NICs) |
| [167206091](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=167206091) | #8652 (runc/containerd bump) |

Sample detective comment: https://github.com/Azure/AgentBaker/pull/8642#issuecomment-4653735041

### RCA (one paragraph)

`fwupd` (firmware-update daemon) is installed by the Ubuntu 24.04 cloud image and `fwupd.service` is enabled by default. On Azure VMs (Hyper-V Gen2) the daemon has no usable firmware-update surface — node firmware is managed out-of-band by the Azure host — and the recent fwupd version included in the rolled-up Ubuntu archive snapshot (likely via the 2026-05-24 security-patch refresh in #8582) exits non-zero at boot. The existing `ValidateNoFailedSystemdUnits` validator (`e2e/validators.go:995`) already allowlists the sibling `fwupd-refresh.service` (see line 936) but not `fwupd.service` itself, so every 24.04 scenario trips. Sample test-log entries from build 167206065:

```
{"Test":"Test_Ubuntu2404_Scriptless/default","Output":"validators.go:995: [231.522s] 🔴 FAIL: ... [fwupd.service] ..."}
{"Test":"Test_Ubuntu2404Gen2/default","Output":"validators.go:995: [318.300s] 🔴 FAIL: ... [fwupd.service] ..."}
{"Test":"Test_Ubuntu2404Gen2_McrChinaCloud/default","Output":"validators.go:995: [346.689s] 🔴 FAIL: ... [fwupd.service] ..."}
```

### Fix and why (option chosen: mask at VHD-build time, not validator allowlist)

We chose to mask the units rather than allowlist `fwupd.service` in the E2E validator because:
1. fwupd genuinely has **no role** on AKS Linux nodes — Azure host manages firmware.
2. Allowlisting a failing daemon hides the symptom on every future Ubuntu daemon regression.
3. Masking matches the established NodeSIG pattern for stop-phone-home / unused-on-AKS units (e.g. `apt-daily` masking 10 lines above in the same file; Ubuntu Pro inert on 20.04/FIPS in #8638).
4. `systemctl mask` (vs. `disable`) survives `systemctl preset-all` and any reinstall of fwupd.

## Changes

| File | Summary |
|------|---------|
| `vhdbuilder/packer/install-dependencies.sh` | In the existing Ubuntu-only block (next to the `apt-daily` mask), added an `OS_VERSION = "24.04"` guard that `systemctl mask`s and `disable --now`s `fwupd.service`, `fwupd-refresh.service`, and `fwupd-refresh.timer`. Trailing `\|\| true` because the units only exist when fwupd is installed (the 24.04 cloud-image default, but not guaranteed on minimal/future SKUs). |
| `vhdbuilder/packer/test/linux-vhd-content-test.sh` | Added `testFwupdMaskedOnUbuntu2404` (mirrors the existing `testNfsServerService` pattern) and wired it into the test dispatch right after `testNfsServerService`. The test treats `masked` as pass, treats absent/`not-found` as pass (variant doesn't ship fwupd), and fails on any other state, so a future regression is caught at VHD-build time rather than at E2E. |

## Tests run locally

This change is in `vhdbuilder/packer/` (not `parts/` or `pkg/`), so `make generate` snapshot regen is **not** triggered and was not run. The Windows agent this PR was authored from has no `go`, `shellcheck`, or `docker` available, so unit-level lint/build was not executed locally — the ADO CI on this PR will exercise:

- `vhdbuilder/packer/` build via the linux-vhd-build pipeline
- The new `testFwupdMaskedOnUbuntu2404` assertion will execute as part of the in-VHD `linux-vhd-content-test.sh` suite during the build
- E2E will exercise the validator — if the mask works, no 2404 scenario should report `fwupd.service` as a failed unit

## Scope / blast radius

- Scoped to **Ubuntu 24.04 only** (`[ "$OS_VERSION" = "24.04" ]` guard).
- No change to AzureLinux, Ubuntu 22.04, Ubuntu 20.04, FIPS, or any Windows path.
- No change to `e2e/validators.go` — the validator stays strict, which is what we want.
- No change to `.pipelines/.vsts-vhd-builder.yaml` or any other pipeline definition.
- The chosen `\|\| true` falls back gracefully if a future minimal SKU does not ship fwupd.

## Tracking

- ADO repair item: **AB#38355676** — https://msazure.visualstudio.com/CloudNativeCompute/_workitems/edit/38355676
- Affected 24.04-only PRs (no action needed on those PRs from their authors; the gate will heal once this merges): #8294, #8600, #8642, #8652

## Note on commit signatures

Both commits in this PR were authored from a sandboxed Windows agent without a local GPG key, and the GitHub Contents API used for the push did not auto-sign with the web-flow key (this happens for some PAT-authenticated requests on org repos). Per `CONTRIBUTING.md` the recommended remediation is `git commit --amend -S` + `git push --force-with-lease` from a GPG-equipped machine; I (Sylvain) will do that before merge. The diffs themselves are intentionally minimal and easy to review without rebasing.

## Do NOT auto-merge

This PR is deliberately **not** marked auto-complete — reviewer eyes on the masking decision are wanted before this lands.

cc @djsly @cameronmeissner @Devinwong @lilypan26 @r2k1