### PR TITLE
fix: disable APT phased updates during Ubuntu VHD build

### DIFF
--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
@@ -167,7 +167,14 @@ apt_get_dist_upgrade() {
     dpkg --configure -a --force-confdef
     apt-get -f -y install
     dpkg --get-selections | awk '$2=="hold"{print $1}'
-    ! (apt-get -o Dpkg::Options::="--force-confnew" dist-upgrade -y 2>&1 | tee $apt_dist_upgrade_output | grep -E "^([WE]:.*)|^([Ee][Rr][Rr][Oo][Rr].*)$") && \
+    # Disable APT phased updates for the VHD build dist-upgrade. By default apt holds back a
+    # percentage of -updates packages (phasing), which makes VHD builds non-deterministic and can
+    # leave the captured image missing the latest patched packages. Always-Include-Phased-Updates
+    # tells apt to ignore the phasing percentage and install all available updates. This is passed
+    # inline (not via /etc/apt/apt.conf.d) so it does not leak into the captured VHD or change node
+    # runtime apt behavior. apt_get_dist_upgrade is only invoked during VHD build.
+    # https://ubuntu.com/server/docs/explanation/software/about-apt-upgrade-and-phased-updates/#how-do-i-turn-off-phased-updates
+    ! (apt-get -o Dpkg::Options::="--force-confnew" -o APT::Get::Always-Include-Phased-Updates=true dist-upgrade -y 2>&1 | tee $apt_dist_upgrade_output | grep -E "^([WE]:.*)|^([Ee][Rr][Rr][Oo][Rr].*)$") && \
     cat $apt_dist_upgrade_output && break || \
     cat $apt_dist_upgrade_output
     if [ $i -eq $retries ]; then

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh
@@ -121,4 +121,26 @@ Describe 'apt_get_install budget timeout'
             The stderr should include "Warning: CSE_STARTTIME_SECONDS environment variable is not set."
         End
     End
+
+    Describe 'apt_get_dist_upgrade phased updates'
+        wait_for_apt_locks() { :; }
+        dpkg() { :; }
+
+        It "passes APT::Get::Always-Include-Phased-Updates=true to dist-upgrade"
+            apt-get() {
+                # Only echo args for the dist-upgrade invocation so the assertion is unambiguous.
+                for arg in "$@"; do
+                    if [ "$arg" = "dist-upgrade" ]; then
+                        echo "$@"
+                        return 0
+                    fi
+                done
+                return 0
+            }
+            When call apt_get_dist_upgrade
+            The status should eq 0
+            The stdout should include "APT::Get::Always-Include-Phased-Updates=true"
+            The stdout should include "dist-upgrade"
+        End
+    End
 End


### PR DESCRIPTION
## Summary

During the Ubuntu VHD build, `apt_get_dist_upgrade()` runs `apt-get dist-upgrade`. On Ubuntu 22.04+, APT **phased updates** are enabled by default — APT holds back a percentage of `-updates` pocket packages based on the rollout phasing percentage (computed from package version + machine-id). This makes VHD builds **non-deterministic** and can leave the captured image missing the latest patched packages.

This PR passes `-o APT::Get::Always-Include-Phased-Updates=true` inline to the build-time `dist-upgrade` so APT ignores the phasing percentage and installs **all** available updates.

Ref: [Ubuntu docs — How do I turn off phased updates?](https://ubuntu.com/server/docs/explanation/software/about-apt-upgrade-and-phased-updates/#how-do-i-turn-off-phased-updates)

## Changes

- `parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh`: add `-o APT::Get::Always-Include-Phased-Updates=true` to the `apt_get_dist_upgrade()` invocation, with an explanatory comment.
- `spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh`: new ShellSpec test asserting the option is passed to `dist-upgrade`.

## Why inline `-o` (not `/etc/apt/apt.conf.d`)

- **No VHD leakage**: the option only applies to the build-time `dist-upgrade` run; nothing is persisted into the captured image, so node runtime apt behavior is unchanged (runtime live-patching via `ubuntu-snapshot-update.sh` still respects Ubuntu's phasing).
- **No early-exit cleanup risk**: a create/remove `apt.conf.d` file flow could leak config if the build exits early.

## Scope / compatibility

- `apt_get_dist_upgrade()` is **only invoked during VHD build** (`vhdbuilder/packer/pre-install-dependencies.sh`). It is defined in shared CSE helpers but is not called at node provision time; the acl/flatcar variants are stubs.
- Unknown `-o` config keys are accepted and ignored by older APT, so this is safe on Ubuntu 20.04 as well as 22.04/24.04.

## Testing

- New ShellSpec test passes locally (`shellspec spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh`). The 6 unrelated pre-existing failures in that file are due to a macOS bash 3.2 arithmetic quirk and are present on clean `main`.
- `GENERATE_TEST_DATA=true go test ./pkg/agent/...` produces **no snapshot diff** (this helper is not content-captured in golden files), and `go test ./pkg/agent/...` passes in verify mode.

## Related

- AB#38359754

🤖 _Generated by GitHub Copilot_