### PR TITLE
fix: create per cluster api server dns zone to avoid circular dependency

### DIFF
--- a/e2e/aks_model.go
+++ b/e2e/aks_model.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // getLatestGAKubernetesVersion returns the highest GA Kubernetes version for the given location.
@@ -931,52 +930,54 @@ func createPrivateZone(ctx context.Context, nodeResourceGroup, privateZoneName s
 	if err == nil {
 		return &pzResp.PrivateZone, nil
 	}
+	return createPrivateZoneWithRetry(ctx, nodeResourceGroup, privateZoneName)
+}
+
+// createPrivateZoneWithRetry retries zone creation on 409 conflicts, which happen
+// when ARM serializes concurrent operations in the same resource group (e.g. AKS
+// provisioning resources in MC_ alongside our DNS zone creation).
+func createPrivateZoneWithRetry(ctx context.Context, nodeResourceGroup, privateZoneName string) (*armprivatedns.PrivateZone, error) {
 	dnsZoneParams := armprivatedns.PrivateZone{
 		Location: to.Ptr("global"),
 	}
-	poller, err := config.Azure.PrivateZonesClient.BeginCreateOrUpdate(
-		ctx,
-		nodeResourceGroup,
-		privateZoneName,
-		dnsZoneParams,
-		nil,
-	)
-	if err != nil {
-		// 409 means another operation is in progress — wait and re-fetch
-		var respErr *azcore.ResponseError
-		if errors.As(err, &respErr) && respErr.StatusCode == 409 {
-			return waitForPrivateZone(ctx, nodeResourceGroup, privateZoneName)
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		if attempt > 0 {
+			toolkit.Logf(ctx, "retrying private DNS zone %q creation (attempt %d, last error: %v)", privateZoneName, attempt+1, lastErr)
+			select {
+			case <-ctx.Done():
+				return nil, fmt.Errorf("context cancelled waiting to retry private dns zone creation: %w", ctx.Err())
+			case <-time.After(30 * time.Second):
+			}
+			// zone may have been created by AKS or a previous attempt that got 409
+			resp, err := config.Azure.PrivateZonesClient.Get(ctx, nodeResourceGroup, privateZoneName, nil)
+			if err == nil {
+				return &resp.PrivateZone, nil
+			}
 		}
-		return nil, fmt.Errorf("failed to create private dns zone in BeginCreateOrUpdate: %w", err)
-	}
-	resp, err := poller.PollUntilDone(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private dns zone in polling: %w", err)
-	}
-
-	toolkit.Logf(ctx, "Private DNS Zone created or updated with ID: %s", *resp.ID)
-	return &resp.PrivateZone, nil
-}
-
-func waitForPrivateZone(ctx context.Context, nodeResourceGroup, privateZoneName string) (*armprivatedns.PrivateZone, error) {
-	defer toolkit.LogStepCtxf(ctx, "waiting for private DNS zone %s (409 conflict)", privateZoneName)()
-	var zone *armprivatedns.PrivateZone
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		resp, err := config.Azure.PrivateZonesClient.Get(ctx, nodeResourceGroup, privateZoneName, nil)
+		poller, err := config.Azure.PrivateZonesClient.BeginCreateOrUpdate(
+			ctx,
+			nodeResourceGroup,
+			privateZoneName,
+			dnsZoneParams,
+			nil,
+		)
 		if err != nil {
 			var respErr *azcore.ResponseError
-			if errors.As(err, &respErr) && respErr.StatusCode == 404 {
-				return false, nil // zone doesn't exist yet
+			if errors.As(err, &respErr) && respErr.StatusCode == 409 {
+				lastErr = err
+				continue
 			}
-			return false, err
+			return nil, fmt.Errorf("failed to create private dns zone: %w", err)
 		}
-		zone = &resp.PrivateZone
-		return true, nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("waiting for private dns zone %q: %w", privateZoneName, err)
+		resp, err := poller.PollUntilDone(ctx, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private dns zone in polling: %w", err)
+		}
+		toolkit.Logf(ctx, "Private DNS Zone created or updated with ID: %s", *resp.ID)
+		return &resp.PrivateZone, nil
 	}
-	return zone, nil
+	return nil, fmt.Errorf("failed to create private dns zone %q after 5 attempts, last error: %w", privateZoneName, lastErr)
 }
 
 func createPrivateDNSLink(ctx context.Context, vnet VNet, resourceGroup, privateZoneName string) error {
@@ -988,9 +989,7 @@ func createPrivateDNSLink(ctx context.Context, vnet VNet, resourceGroup, private
 		networkLinkName,
 		nil,
 	)
-
 	if err == nil {
-		// private dns link already created
 		return nil
 	}
 
@@ -1011,40 +1010,45 @@ func createPrivateDNSLink(ctx context.Context, vnet VNet, resourceGroup, private
 			RegistrationEnabled: to.Ptr(false),
 		},
 	}
-	poller, err := config.Azure.VirutalNetworkLinksClient.BeginCreateOrUpdate(
-		ctx,
-		resourceGroup,
-		privateZoneName,
-		networkLinkName,
-		linkParams,
-		nil,
-	)
-	if err != nil {
-		// 409 means another operation is in progress — link is being created by another run
-		var respErr *azcore.ResponseError
-		if errors.As(err, &respErr) && respErr.StatusCode == 409 {
-			toolkit.Logf(ctx, "Virtual network link creation conflict (409), waiting for completion")
-			return wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-				_, err := config.Azure.VirutalNetworkLinksClient.Get(ctx, resourceGroup, privateZoneName, networkLinkName, nil)
-				if err != nil {
-					var respErr *azcore.ResponseError
-					if errors.As(err, &respErr) && respErr.StatusCode == 404 {
-						return false, nil // link doesn't exist yet
-					}
-					return false, err
-				}
-				return true, nil
-			})
-		}
-		return fmt.Errorf("failed to create virtual network link in BeginCreateOrUpdate: %w", err)
-	}
-	resp, err := poller.PollUntilDone(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create virtual network link in polling: %w", err)
-	}
 
-	toolkit.Logf(ctx, "Virtual Network Link created or updated with ID: %s", *resp.ID)
-	return nil
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		if attempt > 0 {
+			toolkit.Logf(ctx, "retrying VNet link for zone %q (attempt %d, last error: %v)", privateZoneName, attempt+1, lastErr)
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("context cancelled waiting to retry VNet link creation: %w", ctx.Err())
+			case <-time.After(30 * time.Second):
+			}
+			// link may have been created by another concurrent run
+			if _, err := config.Azure.VirutalNetworkLinksClient.Get(ctx, resourceGroup, privateZoneName, networkLinkName, nil); err == nil {
+				return nil
+			}
+		}
+		poller, err := config.Azure.VirutalNetworkLinksClient.BeginCreateOrUpdate(
+			ctx,
+			resourceGroup,
+			privateZoneName,
+			networkLinkName,
+			linkParams,
+			nil,
+		)
+		if err != nil {
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && respErr.StatusCode == 409 {
+				lastErr = err
+				continue
+			}
+			return fmt.Errorf("failed to create virtual network link: %w", err)
+		}
+		resp, err := poller.PollUntilDone(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create virtual network link in polling: %w", err)
+		}
+		toolkit.Logf(ctx, "Virtual Network Link created or updated with ID: %s", *resp.ID)
+		return nil
+	}
+	return fmt.Errorf("failed to create VNet link for zone %q after 5 attempts, last error: %w", privateZoneName, lastErr)
 }
 
 // addRecordSetToPrivateDNSZone creates A records in the private DNS zone for a

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -133,6 +133,9 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 	identity := dag.Go(g, func(ctx context.Context) (*armcontainerservice.UserAssignedIdentity, error) {
 		return getClusterKubeletIdentity(ctx, cluster)
 	})
+	dag.Run1(g, vNet, func(ctx context.Context, v VNet) error {
+		return setupPrivateDNSForAPIServer(ctx, cluster, v)
+	})
 	// networkSetup adds firewall routes to the existing AKS route table or
 	// creates/associates a dedicated one when Azure CNI has none, or applies
 	// the network-isolated NSG. It must run after bastion (both mutate the
@@ -173,9 +176,6 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 		}
 		return k.GetProxyURL(ctx)
 	}, debugDeps...)
-	dag.Run(g, func(ctx context.Context) error {
-		return setupPrivateDNSForAPIServer(ctx, vNet.MustGet().resourceGroup, cluster)
-	})
 	extract := dag.Go1(g, kubeForExtract, extractClusterParams(cluster))
 
 	if err := g.Wait(); err != nil {
@@ -713,30 +713,29 @@ func ensureResourceGroup(ctx context.Context, location string) (armresources.Res
 
 // setupPrivateDNSForAPIServer adds an A record for the cluster's API server FQDN
 // to the shared private DNS zone. The zone and VNet link are created once by ensureSharedInfra.
-func setupPrivateDNSForAPIServer(ctx context.Context, resourceGroup string, cluster *armcontainerservice.ManagedCluster) error {
+func setupPrivateDNSForAPIServer(ctx context.Context, cluster *armcontainerservice.ManagedCluster, vnet VNet) error {
 	defer toolkit.LogStepCtx(ctx, "setting up private DNS for API server")()
 
 	fqdn := *cluster.Properties.Fqdn
-	zoneName := APIServerDNSZone(*cluster.Location)
-	recordName := strings.TrimSuffix(fqdn, "."+zoneName)
+	nodeRG := *cluster.Properties.NodeResourceGroup
 
 	ips, err := net.LookupHost(fqdn)
 	if err != nil {
 		return fmt.Errorf("resolving API server FQDN %q: %w", fqdn, err)
 	}
 
-	var wantIPs []string
+	var aRecords []*armprivatedns.ARecord
 	for _, ip := range ips {
 		if parsed := net.ParseIP(ip); parsed != nil && parsed.To4() != nil {
-			wantIPs = append(wantIPs, ip)
+			aRecords = append(aRecords, &armprivatedns.ARecord{IPv4Address: to.Ptr(ip)})
 		}
 	}
-	if len(wantIPs) == 0 {
+	if len(aRecords) == 0 {
 		return fmt.Errorf("no IPv4 addresses for %q", fqdn)
 	}
 
-	// Check if the record already exists with the correct IPs
-	existing, err := config.Azure.RecordSetClient.Get(ctx, resourceGroup, zoneName, armprivatedns.RecordTypeA, recordName, nil)
+	// Check if zone + record already exist and are up to date
+	existing, err := config.Azure.RecordSetClient.Get(ctx, nodeRG, fqdn, armprivatedns.RecordTypeA, "@", nil)
 	if err == nil && existing.Properties != nil && existing.Properties.ARecords != nil {
 		existingIPs := map[string]bool{}
 		for _, r := range existing.Properties.ARecords {
@@ -744,32 +743,35 @@ func setupPrivateDNSForAPIServer(ctx context.Context, resourceGroup string, clus
 				existingIPs[*r.IPv4Address] = true
 			}
 		}
-		if len(existingIPs) == len(wantIPs) {
-			allMatch := true
-			for _, ip := range wantIPs {
-				if !existingIPs[ip] {
+		allMatch := len(existingIPs) == len(aRecords)
+		if allMatch {
+			for _, r := range aRecords {
+				if !existingIPs[*r.IPv4Address] {
 					allMatch = false
 					break
 				}
 			}
-			if allMatch {
-				toolkit.Logf(ctx, "private DNS record %s already up to date", recordName)
-				return nil
-			}
+		}
+		if allMatch {
+			toolkit.Logf(ctx, "private DNS zone %q already up to date", fqdn)
+			return nil
 		}
 	}
 
-	var aRecords []*armprivatedns.ARecord
-	for _, ip := range wantIPs {
-		aRecords = append(aRecords, &armprivatedns.ARecord{IPv4Address: to.Ptr(ip)})
+	// Per-FQDN zone: zone name = full FQDN, record name = "@"
+	if _, err := createPrivateZone(ctx, nodeRG, fqdn); err != nil {
+		return fmt.Errorf("creating private zone %q: %w", fqdn, err)
+	}
+	if err := createPrivateDNSLink(ctx, vnet, nodeRG, fqdn); err != nil {
+		return fmt.Errorf("linking private zone to VNet: %w", err)
 	}
 
-	_, err = config.Azure.RecordSetClient.CreateOrUpdate(ctx, resourceGroup, zoneName, armprivatedns.RecordTypeA, recordName,
+	_, err = config.Azure.RecordSetClient.CreateOrUpdate(ctx, nodeRG, fqdn, armprivatedns.RecordTypeA, "@",
 		armprivatedns.RecordSet{Properties: &armprivatedns.RecordSetProperties{TTL: to.Ptr[int64](300), ARecords: aRecords}}, nil)
 	if err != nil {
-		return fmt.Errorf("creating A record %q in zone %q: %w", recordName, zoneName, err)
+		return fmt.Errorf("creating A record in zone %q: %w", fqdn, err)
 	}
 
-	toolkit.Logf(ctx, "private DNS: %s.%s → %v", recordName, zoneName, wantIPs)
+	toolkit.Logf(ctx, "private DNS zone %q → %v", fqdn, ips)
 	return nil
 }

--- a/e2e/shared_infra.go
+++ b/e2e/shared_infra.go
@@ -34,11 +34,6 @@ const (
 	networkContributorRolID = "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
 )
 
-// APIServerDNSZone returns the private DNS zone name for API server FQDNs in a given location.
-func APIServerDNSZone(location string) string {
-	return fmt.Sprintf("hcp.%s.azmk8s.io", location)
-}
-
 type SharedInfra struct {
 	VNetName       string
 	ResourceGroup  string
@@ -60,10 +55,6 @@ func ensureSharedInfra(ctx context.Context, location string) (*SharedInfra, erro
 
 	if err := ensurePESubnet(ctx, rg); err != nil {
 		return nil, fmt.Errorf("ensuring PE subnet: %w", err)
-	}
-
-	if err := ensureAPIServerDNSZone(ctx, rg, location); err != nil {
-		return nil, fmt.Errorf("ensuring API server DNS zone: %w", err)
 	}
 
 	bastionDNS, err := ensureSharedBastion(ctx, rg, location)
@@ -143,23 +134,6 @@ func ensurePESubnet(ctx context.Context, rg string) error {
 	_, err = poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
 	if err != nil {
 		return fmt.Errorf("waiting for PE subnet creation: %w", err)
-	}
-	return nil
-}
-
-// ensureAPIServerDNSZone creates the shared private DNS zone for API server FQDNs
-// and links it to the shared VNet. All clusters add their A records to this single zone.
-func ensureAPIServerDNSZone(ctx context.Context, rg, location string) error {
-	zoneName := APIServerDNSZone(location)
-	if _, err := createPrivateZone(ctx, rg, zoneName); err != nil {
-		return fmt.Errorf("creating API server DNS zone %s: %w", zoneName, err)
-	}
-	vnet := VNet{
-		name:          SharedVNetName,
-		resourceGroup: rg,
-	}
-	if err := createPrivateDNSLink(ctx, vnet, rg, zoneName); err != nil {
-		return fmt.Errorf("linking API server DNS zone to VNet: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
There was a circular dependency because we were trying to be smart to use single private zone, create one per cluster