### PR TITLE
feat(e2e): isolate Kubeclient rate limiters to prevent test flakes

### DIFF
--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -39,6 +39,7 @@ type ClusterParams struct {
 type Cluster struct {
 	Model            *armcontainerservice.ManagedCluster
 	Kube             *Kubeclient
+	KubeConfig       []byte // raw kubeconfig for minting per-test clients
 	KubeletIdentity  *armcontainerservice.UserAssignedIdentity
 	SubnetID         string
 	VNetResourceGUID string
@@ -46,6 +47,13 @@ type Cluster struct {
 	Bastion          *Bastion
 	ProxyURL         string
 	TenantID         string
+}
+
+// NewKubeclientForTest creates an independent Kubeclient with its own rate limiter.
+// Use this in individual tests to avoid sharing rate limiter tokens with other
+// parallel tests hitting the same cluster.
+func (c *Cluster) NewKubeclientForTest() (*Kubeclient, error) {
+	return NewKubeclient(c.KubeConfig)
 }
 
 // Returns true if the cluster is configured with Azure CNI
@@ -110,7 +118,20 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 	vNet := dag.Go(g, func(ctx context.Context) (VNet, error) {
 		return getClusterVNet(ctx, cluster)
 	})
-	kube := dag.Go(g, func(ctx context.Context) (*Kubeclient, error) { return getClusterKubeClient(ctx, cluster) })
+	// Fetch kubeconfig bytes once, then each heavy DAG task creates its own
+	// Kubeclient with an independent rate limiter to prevent starvation.
+	kubeconfigBytes := dag.Go(g, func(ctx context.Context) ([]byte, error) {
+		resourceGroupName := config.ResourceGroupName(*cluster.Location)
+		return getClusterKubeconfigBytes(ctx, resourceGroupName, *cluster.Name)
+	})
+	newKubeFromBytes := func(ctx context.Context, data []byte) (*Kubeclient, error) {
+		return NewKubeclient(data)
+	}
+	kubeForGC := dag.Go1(g, kubeconfigBytes, newKubeFromBytes)
+	kubeForDebug := dag.Go1(g, kubeconfigBytes, newKubeFromBytes)
+	kubeForExtract := dag.Go1(g, kubeconfigBytes, newKubeFromBytes)
+	kubeForACR := dag.Go1(g, kubeconfigBytes, newKubeFromBytes)
+	kubePrimary := dag.Go1(g, kubeconfigBytes, newKubeFromBytes)
 	identity := dag.Go(g, func(ctx context.Context) (*armcontainerservice.UserAssignedIdentity, error) {
 		return getClusterKubeletIdentity(ctx, cluster)
 	})
@@ -127,7 +148,7 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 	if isNetworkIsolated {
 		networkDeps = append(networkDeps, dag.Run(g, func(ctx context.Context) error { return addNetworkIsolatedSettings(ctx, cluster) }, bastion))
 	}
-	dag.Run1(g, kube, func(ctx context.Context, k *Kubeclient) error { return collectGarbageVMSS(ctx, cluster, k) }, networkDeps...)
+	dag.Run1(g, kubeForGC, func(ctx context.Context, k *Kubeclient) error { return collectGarbageVMSS(ctx, cluster, k) }, networkDeps...)
 	needACR := isNetworkIsolated || attachPrivateAcr
 
 	// The private DNS zone and VNet link must exist before any PE is created.
@@ -138,14 +159,14 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 			_, err := ensurePrivateDNSZone(ctx, v)
 			return err
 		}, bastion)
-		acrNonAnon = dag.Run2(g, kube, identity, addACR(cluster, true), dnsReady)
-		acrAnon = dag.Run2(g, kube, identity, addACR(cluster, false), dnsReady)
+		acrNonAnon = dag.Run2(g, kubeForACR, identity, addACR(cluster, true), dnsReady)
+		acrAnon = dag.Run2(g, kubeForACR, identity, addACR(cluster, false), dnsReady)
 	}
 	debugDeps := append(networkDeps[:0:0], networkDeps...)
 	if acrNonAnon != nil {
 		debugDeps = append(debugDeps, acrNonAnon, acrAnon)
 	}
-	proxyURL := dag.Go1(g, kube, func(ctx context.Context, k *Kubeclient) (string, error) {
+	proxyURL := dag.Go1(g, kubeForDebug, func(ctx context.Context, k *Kubeclient) (string, error) {
 		if err := k.EnsureDebugDaemonsets(ctx, isNetworkIsolated, config.GetPrivateACRName(true, *cluster.Location)); err != nil {
 			return "", err
 		}
@@ -157,14 +178,15 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 	dag.Run(g, func(ctx context.Context) error {
 		return setupPrivateDNSForAPIServer(ctx, vNet.MustGet().resourceGroup, cluster)
 	})
-	extract := dag.Go1(g, kube, extractClusterParams(cluster))
+	extract := dag.Go1(g, kubeForExtract, extractClusterParams(cluster))
 
 	if err := g.Wait(); err != nil {
 		return nil, fmt.Errorf("prepare cluster tasks: %w", err)
 	}
 	return &Cluster{
 		Model:            cluster,
-		Kube:             kube.MustGet(),
+		Kube:             kubePrimary.MustGet(),
+		KubeConfig:       kubeconfigBytes.MustGet(),
 		KubeletIdentity:  identity.MustGet(),
 		SubnetID:         subnet.MustGet(),
 		VNetResourceGUID: vNet.MustGet().resourceGUID,

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -39,7 +39,7 @@ type ClusterParams struct {
 type Cluster struct {
 	Model            *armcontainerservice.ManagedCluster
 	Kube             *Kubeclient
-	KubeConfig       []byte // raw kubeconfig for minting per-test clients
+	kubeconfig       []byte // raw kubeconfig for minting per-test clients
 	KubeletIdentity  *armcontainerservice.UserAssignedIdentity
 	SubnetID         string
 	VNetResourceGUID string
@@ -53,7 +53,7 @@ type Cluster struct {
 // Use this in individual tests to avoid sharing rate limiter tokens with other
 // parallel tests hitting the same cluster.
 func (c *Cluster) NewKubeclientForTest() (*Kubeclient, error) {
-	return NewKubeclient(c.KubeConfig)
+	return NewKubeclient(c.kubeconfig)
 }
 
 // Returns true if the cluster is configured with Azure CNI
@@ -186,7 +186,7 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 	return &Cluster{
 		Model:            cluster,
 		Kube:             kubePrimary.MustGet(),
-		KubeConfig:       kubeconfigBytes.MustGet(),
+		kubeconfig:       kubeconfigBytes.MustGet(),
 		KubeletIdentity:  identity.MustGet(),
 		SubnetID:         subnet.MustGet(),
 		VNetResourceGUID: vNet.MustGet().resourceGUID,

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -38,7 +38,6 @@ type ClusterParams struct {
 
 type Cluster struct {
 	Model            *armcontainerservice.ManagedCluster
-	Kube             *Kubeclient
 	kubeconfig       []byte // raw kubeconfig for minting per-test clients
 	KubeletIdentity  *armcontainerservice.UserAssignedIdentity
 	SubnetID         string
@@ -131,7 +130,6 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 	kubeForDebug := dag.Go1(g, kubeconfigBytes, newKubeFromBytes)
 	kubeForExtract := dag.Go1(g, kubeconfigBytes, newKubeFromBytes)
 	kubeForACR := dag.Go1(g, kubeconfigBytes, newKubeFromBytes)
-	kubePrimary := dag.Go1(g, kubeconfigBytes, newKubeFromBytes)
 	identity := dag.Go(g, func(ctx context.Context) (*armcontainerservice.UserAssignedIdentity, error) {
 		return getClusterKubeletIdentity(ctx, cluster)
 	})
@@ -185,7 +183,6 @@ func prepareCluster(ctx context.Context, clusterModel *armcontainerservice.Manag
 	}
 	return &Cluster{
 		Model:            cluster,
-		Kube:             kubePrimary.MustGet(),
 		kubeconfig:       kubeconfigBytes.MustGet(),
 		KubeletIdentity:  identity.MustGet(),
 		SubnetID:         subnet.MustGet(),

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -155,9 +155,9 @@ func execOnUnprivilegedPod(ctx context.Context, kube *Kubeclient, namespace stri
 
 func execOnVMForScenarioOnUnprivilegedPod(ctx context.Context, s *Scenario, cmd string) *podExecResult {
 	s.T.Helper()
-	nonHostPod, err := s.Runtime.Cluster.Kube.GetPodNetworkDebugPodForNode(ctx, s.Runtime.VM.KubeName)
+	nonHostPod, err := s.Runtime.Kube.GetPodNetworkDebugPodForNode(ctx, s.Runtime.VM.KubeName)
 	require.NoError(s.T, err, "failed to get non host debug pod name")
-	execResult, err := execOnUnprivilegedPod(ctx, s.Runtime.Cluster.Kube, nonHostPod.Namespace, nonHostPod.Name, cmd)
+	execResult, err := execOnUnprivilegedPod(ctx, s.Runtime.Kube, nonHostPod.Namespace, nonHostPod.Name, cmd)
 	require.NoErrorf(s.T, err, "failed to execute command on pod: %v", cmd)
 	return execResult
 }

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -616,7 +616,7 @@ func daemonsetProxy(ctx context.Context) *appsv1.DaemonSet {
 // on at least one system pool node.
 func (k *Kubeclient) GetProxyURL(ctx context.Context) (string, error) {
 	var proxyURL string
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
 		pods, err := k.Typed.CoreV1().Pods("default").List(ctx, metav1.ListOptions{
 			LabelSelector: "app=" + proxyAppLabel,
 		})

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -616,6 +616,7 @@ func daemonsetProxy(ctx context.Context) *appsv1.DaemonSet {
 // on at least one system pool node.
 func (k *Kubeclient) GetProxyURL(ctx context.Context) (string, error) {
 	var proxyURL string
+	var lastPodStatuses []string
 	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
 		pods, err := k.Typed.CoreV1().Pods("default").List(ctx, metav1.ListOptions{
 			LabelSelector: "app=" + proxyAppLabel,
@@ -624,8 +625,10 @@ func (k *Kubeclient) GetProxyURL(ctx context.Context) (string, error) {
 			return false, fmt.Errorf("listing proxy pods: %w", err)
 		}
 		if len(pods.Items) == 0 {
+			lastPodStatuses = []string{"no proxy pods found"}
 			return false, nil
 		}
+		lastPodStatuses = lastPodStatuses[:0]
 		for _, pod := range pods.Items {
 			for _, c := range pod.Status.Conditions {
 				if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue && pod.Status.HostIP != "" {
@@ -633,13 +636,60 @@ func (k *Kubeclient) GetProxyURL(ctx context.Context) (string, error) {
 					return true, nil
 				}
 			}
+			lastPodStatuses = append(lastPodStatuses, formatPodDiagnostics(&pod))
 		}
 		return false, nil
 	})
 	if err != nil {
+		k.logProxyTimeoutDiagnostics(ctx, lastPodStatuses)
 		return "", fmt.Errorf("waiting for proxy pod to be ready: %w", err)
 	}
 	return proxyURL, nil
+}
+
+func formatPodDiagnostics(pod *corev1.Pod) string {
+	status := fmt.Sprintf("pod=%s node=%s phase=%s", pod.Name, pod.Spec.NodeName, pod.Status.Phase)
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Waiting != nil {
+			status += fmt.Sprintf(" container=%s waiting(reason=%s, message=%s)", cs.Name, cs.State.Waiting.Reason, cs.State.Waiting.Message)
+		} else if cs.State.Terminated != nil {
+			status += fmt.Sprintf(" container=%s terminated(reason=%s, exitCode=%d)", cs.Name, cs.State.Terminated.Reason, cs.State.Terminated.ExitCode)
+		} else if cs.State.Running != nil {
+			status += fmt.Sprintf(" container=%s running(ready=%v)", cs.Name, cs.Ready)
+		}
+	}
+	for _, c := range pod.Status.Conditions {
+		if c.Status != corev1.ConditionTrue {
+			status += fmt.Sprintf(" condition(%s=%s: %s)", c.Type, c.Status, c.Message)
+		}
+	}
+	return status
+}
+
+func (k *Kubeclient) logProxyTimeoutDiagnostics(ctx context.Context, lastPodStatuses []string) {
+	toolkit.Logf(ctx, "⚠️  proxy pod readiness timeout — last observed pod statuses:")
+	for _, s := range lastPodStatuses {
+		toolkit.Logf(ctx, "    %s", s)
+	}
+	// Log node conditions for nodepool1 nodes to diagnose scheduling/node issues
+	nodes, err := k.Typed.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
+		LabelSelector: "kubernetes.azure.com/agentpool=nodepool1",
+	})
+	if err != nil {
+		toolkit.Logf(ctx, "    (failed to list nodepool1 nodes: %v)", err)
+		return
+	}
+	for _, node := range nodes.Items {
+		nodeStatus := fmt.Sprintf("node=%s", node.Name)
+		for _, c := range node.Status.Conditions {
+			if c.Type == corev1.NodeReady {
+				nodeStatus += fmt.Sprintf(" Ready=%s", c.Status)
+			} else if c.Status != corev1.ConditionFalse {
+				nodeStatus += fmt.Sprintf(" %s=%s(%s)", c.Type, c.Status, c.Message)
+			}
+		}
+		toolkit.Logf(ctx, "    %s", nodeStatus)
+	}
 }
 
 func getClusterSubnetID(ctx context.Context, cluster *armcontainerservice.ManagedCluster) (string, error) {

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -51,26 +51,32 @@ func getClusterKubeClient(ctx context.Context, cluster *armcontainerservice.Mana
 	if err != nil {
 		return nil, fmt.Errorf("get cluster kubeconfig bytes: %w", err)
 	}
+	return NewKubeclient(data)
+}
 
-	config, err := clientcmd.RESTConfigFromKubeConfig(data)
+// NewKubeclient creates a Kubeclient from raw kubeconfig bytes.
+// Each call returns an independent client with its own rate limiter,
+// allowing concurrent operations to avoid starving each other.
+func NewKubeclient(kubeconfigBytes []byte) (*Kubeclient, error) {
+	cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigBytes)
 	if err != nil {
 		return nil, fmt.Errorf("convert kubeconfig bytes to rest config: %w", err)
 	}
 
 	// it's a test cluster - avoid unnecessary rate limiting
-	config.QPS = 200
-	config.Burst = 400
+	cfg.QPS = 200
+	cfg.Burst = 400
 
 	// Defense-in-depth against silent connection wedges (apiserver SPDY proxy
 	// hangs, NAT/LB idle timeouts) which manifest as kube exec calls that hang
 	// indefinitely. Bound the TCP dial and enable HTTP/2 keep-alive pings so
 	// the transport itself surfaces a dead peer as a connection error,
 	// triggering retries instead of consuming the caller's timeout budget.
-	config.Dial = (&net.Dialer{
+	cfg.Dial = (&net.Dialer{
 		Timeout:   10 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}).DialContext
-	config.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+	cfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
 		if t, ok := rt.(*http.Transport); ok {
 			if h2, err := http2.ConfigureTransports(t); err == nil {
 				h2.ReadIdleTimeout = 30 * time.Second
@@ -80,12 +86,12 @@ func getClusterKubeClient(ctx context.Context, cluster *armcontainerservice.Mana
 		return rt
 	}
 
-	dynamic, err := client.New(config, client.Options{})
+	dynamic, err := client.New(cfg, client.Options{})
 	if err != nil {
 		return nil, fmt.Errorf("create dynamic Kubeclient: %w", err)
 	}
 
-	clientset, err := kubernetes.NewForConfig(config)
+	clientset, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating kubernetes clientset from rest config: %w", err)
 	}
@@ -93,8 +99,8 @@ func getClusterKubeClient(ctx context.Context, cluster *armcontainerservice.Mana
 	return &Kubeclient{
 		Dynamic:    dynamic,
 		Typed:      clientset,
-		RESTConfig: config,
-		KubeConfig: data,
+		RESTConfig: cfg,
+		KubeConfig: kubeconfigBytes,
 	}, nil
 }
 

--- a/e2e/scenario_gpu_daemonset_test.go
+++ b/e2e/scenario_gpu_daemonset_test.go
@@ -203,14 +203,14 @@ func deployNvidiaDevicePluginDaemonset(ctx context.Context, s *Scenario) {
 	// Delete any existing DaemonSet from a previous failed run
 	deleteCtx, deleteCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer deleteCancel()
-	_ = s.Runtime.Cluster.Kube.Typed.AppsV1().DaemonSets(ds.Namespace).Delete(
+	_ = s.Runtime.Kube.Typed.AppsV1().DaemonSets(ds.Namespace).Delete(
 		deleteCtx,
 		ds.Name,
 		metav1.DeleteOptions{},
 	)
 
 	// Create the DaemonSet
-	err := s.Runtime.Cluster.Kube.CreateDaemonset(ctx, ds)
+	err := s.Runtime.Kube.CreateDaemonset(ctx, ds)
 	require.NoError(s.T, err, "failed to create NVIDIA device plugin DaemonSet")
 
 	s.T.Logf("NVIDIA device plugin DaemonSet %s/%s created successfully", ds.Namespace, ds.Name)
@@ -220,7 +220,7 @@ func deployNvidiaDevicePluginDaemonset(ctx context.Context, s *Scenario) {
 		s.T.Logf("Cleaning up NVIDIA device plugin DaemonSet %s/%s...", ds.Namespace, ds.Name)
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cleanupCancel()
-		deleteErr := s.Runtime.Cluster.Kube.Typed.AppsV1().DaemonSets(ds.Namespace).Delete(
+		deleteErr := s.Runtime.Kube.Typed.AppsV1().DaemonSets(ds.Namespace).Delete(
 			cleanupCtx,
 			ds.Name,
 			metav1.DeleteOptions{},
@@ -239,7 +239,7 @@ func waitForNvidiaDevicePluginDaemonsetReady(ctx context.Context, s *Scenario) {
 	dsName := nvidiaDevicePluginDaemonsetName(s.Runtime.VM.KubeName)
 	s.T.Logf("Waiting for NVIDIA device plugin DaemonSet pod to be ready on node %s...", s.Runtime.VM.KubeName)
 
-	_, err := s.Runtime.Cluster.Kube.WaitUntilPodRunning(
+	_, err := s.Runtime.Kube.WaitUntilPodRunning(
 		ctx,
 		"kube-system",
 		fmt.Sprintf("name=%s", dsName),

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -236,6 +236,10 @@ func runScenario(t testing.TB, s *Scenario) error {
 	s.Runtime.Cluster = cluster
 	s.Runtime.VMSSName = generateVMSSName(s)
 
+	testKube, err := cluster.NewKubeclientForTest()
+	require.NoError(t, err, "creating per-test kubeclient")
+	s.Runtime.Kube = testKube
+
 	// use shorter timeout for faster feedback on test failures
 	vmssCtx, cancel := context.WithTimeout(ctx, config.Config.TestTimeoutVMSS)
 	defer cancel()
@@ -337,7 +341,7 @@ func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 	if !s.Config.SkipDefaultValidation {
 		vmssCreatedAt := time.Now()         // Record the start time
 		creationElapse := time.Since(start) // Calculate the elapsed time
-		scenarioVM.KubeName = s.Runtime.Cluster.Kube.WaitUntilNodeReady(ctx, s.T, s.Runtime.VMSSName)
+		scenarioVM.KubeName = s.Runtime.Kube.WaitUntilNodeReady(ctx, s.T, s.Runtime.VMSSName)
 		readyElapse := time.Since(vmssCreatedAt) // Calculate the elapsed time
 		totalElapse := time.Since(start)
 		toolkit.LogDuration(ctx, totalElapse, 3*time.Minute, fmt.Sprintf("Node %s took %s to be created and %s to be ready", s.Runtime.VMSSName, creationElapse, readyElapse))

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -156,6 +156,7 @@ type ScenarioRuntime struct {
 	NBC                       *datamodel.NodeBootstrappingConfiguration
 	AKSNodeConfig             *aksnodeconfigv1.Configuration
 	Cluster                   *Cluster
+	Kube                      *Kubeclient // per-test client with independent rate limiter
 	VM                        *ScenarioVM
 	VMSSName                  string
 	EnableScriptlessNBCCSECmd bool

--- a/e2e/validate_localdns_exporter_metrics.go
+++ b/e2e/validate_localdns_exporter_metrics.go
@@ -29,7 +29,7 @@ func ValidateLocalDNSExporterMetrics(ctx context.Context, s *Scenario) {
 	// so it's visible in test output rather than silently passing.
 	// If the label IS present, the exporter must be fully working — any failure is a real bug.
 	const exporterLabelKey = "kubernetes.azure.com/localdns-exporter"
-	node, err := s.Runtime.Cluster.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
+	node, err := s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
 	require.NoError(s.T, err, "failed to get node %q", s.Runtime.VM.KubeName)
 
 	if _, exists := node.Labels[exporterLabelKey]; !exists {

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -140,7 +140,7 @@ func ValidateCommonWindows(ctx context.Context, s *Scenario) {
 }
 
 func validatePodRunning(ctx context.Context, s *Scenario, pod *corev1.Pod) error {
-	kube := s.Runtime.Cluster.Kube
+	kube := s.Runtime.Kube
 	truncatePodName(s.T, pod)
 	start := time.Now()
 
@@ -186,7 +186,7 @@ func waitUntilResourceAvailable(ctx context.Context, s *Scenario, resourceName s
 		case <-ctx.Done():
 			s.T.Fatalf("context cancelled: %v", ctx.Err())
 		case <-ticker.C:
-			node, err := s.Runtime.Cluster.Kube.Typed.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+			node, err := s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 			require.NoError(s.T, err, "failed to get node %q", nodeName)
 
 			if isResourceAvailable(node, resourceName) {
@@ -291,7 +291,7 @@ func getIPTablesRulesCompatibleWithEBPFHostRouting() (map[string][]string, []str
 func validateWireServerBlocked(ctx context.Context, s *Scenario) {
 	defer toolkit.LogStep(s.T, "validating wireserver is blocked from unprivileged pods")()
 
-	nonHostPod, err := s.Runtime.Cluster.Kube.GetPodNetworkDebugPodForNode(ctx, s.Runtime.VM.KubeName)
+	nonHostPod, err := s.Runtime.Kube.GetPodNetworkDebugPodForNode(ctx, s.Runtime.VM.KubeName)
 	require.NoError(s.T, err, "failed to get non host debug pod for wireserver validation")
 
 	type wireServerCheck struct {
@@ -320,7 +320,7 @@ func validateWireServerBlocked(ctx context.Context, s *Scenario) {
 		pollErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 			attemptCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 			defer cancel()
-			r, execErr := execOnUnprivilegedPod(attemptCtx, s.Runtime.Cluster.Kube, nonHostPod.Namespace, nonHostPod.Name, check.cmd)
+			r, execErr := execOnUnprivilegedPod(attemptCtx, s.Runtime.Kube, nonHostPod.Namespace, nonHostPod.Name, check.cmd)
 			if execErr != nil {
 				if errors.Is(execErr, context.DeadlineExceeded) {
 					s.T.Logf("wireserver check %q: exec attempt timed out after 15s (retrying): %v", check.desc, execErr)

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -151,7 +151,7 @@ func validateKubeletServingCertificateRotationWindows(ctx context.Context, s *Sc
 
 func validateKubeletClientCSRCreatedBySecureTLSBootstrapping(ctx context.Context, s *Scenario) {
 	fieldSelector := fmt.Sprintf("spec.signerName=%s", certv1.KubeAPIServerClientKubeletSignerName)
-	kubeletClientCSRs, err := s.Runtime.Cluster.Kube.Typed.CertificatesV1().CertificateSigningRequests().List(ctx, metav1.ListOptions{
+	kubeletClientCSRs, err := s.Runtime.Kube.Typed.CertificatesV1().CertificateSigningRequests().List(ctx, metav1.ListOptions{
 		FieldSelector: fieldSelector,
 	})
 	require.NoError(s.T, err, "failed to list CSRs with field selector: %s", fieldSelector)
@@ -1147,7 +1147,7 @@ func validateNPDCondition(ctx context.Context, s *Scenario, conditionType, condi
 	// Wait for NPD to report initial condition
 	var condition *corev1.NodeCondition
 	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
-		node, err := s.Runtime.Cluster.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
+		node, err := s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
 		if err != nil {
 			s.T.Logf("Failed to get node %q: %v", s.Runtime.VM.KubeName, err)
 			return false, nil // Continue polling on transient errors
@@ -1534,7 +1534,7 @@ func GetFieldFromJsonObjectOnNode(ctx context.Context, s *Scenario, fileName str
 // ValidateTaints checks if the node has the expected taints that are set in the kubelet config with --register-with-taints flag
 func ValidateTaints(ctx context.Context, s *Scenario, expectedTaints string) {
 	s.T.Helper()
-	node, err := s.Runtime.Cluster.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
+	node, err := s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
 	require.NoError(s.T, err, "failed to get node %q", s.Runtime.VM.KubeName)
 	var taints []string
 	for _, taint := range node.Spec.Taints {
@@ -1710,7 +1710,7 @@ func ValidateLocalDNSHostsPluginBypass(ctx context.Context, s *Scenario) {
 	maxAttempts := 33 // ~5 minutes: first 4 attempts use 1+2+4+8=15s, then ~29 attempts at 10s cap = ~305s
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		node, err = s.Runtime.Cluster.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
+		node, err = s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
 		require.NoError(s.T, err, "failed to get node %q", s.Runtime.VM.KubeName)
 
 		annotationValue, exists = node.Annotations[annotationKey]
@@ -2266,7 +2266,7 @@ func ValidateNPDFilesystemCorruption(ctx context.Context, s *Scenario) {
 	// our start should detect it. Use 8 minutes as a safety margin.
 	var filesystemCorruptionProblem *corev1.NodeCondition
 	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 8*time.Minute, true, func(ctx context.Context) (bool, error) {
-		node, err := s.Runtime.Cluster.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
+		node, err := s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
 		if err != nil {
 			s.T.Logf("Failed to get node %q: %v", s.Runtime.VM.KubeName, err)
 			return false, nil // Continue polling on transient errors
@@ -2313,7 +2313,7 @@ func ValidateNodeAdvertisesGPUResources(ctx context.Context, s *Scenario, gpuCou
 
 	// Get the node using the Kubernetes client from the test framework
 	nodeName := s.Runtime.VM.KubeName
-	node, err := s.Runtime.Cluster.Kube.Typed.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	node, err := s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	require.NoError(s.T, err, "failed to get node %q", nodeName)
 
 	// Check if the node advertises GPU capacity
@@ -2634,7 +2634,7 @@ func truncatePodName(t testing.TB, pod *corev1.Pod) {
 // ValidateNodeHasLabel checks if the node has the expected label with the expected value
 func ValidateNodeHasLabel(ctx context.Context, s *Scenario, labelKey, expectedValue string) {
 	s.T.Helper()
-	node, err := s.Runtime.Cluster.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
+	node, err := s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
 	require.NoError(s.T, err, "failed to get node %q", s.Runtime.VM.KubeName)
 
 	actualValue, exists := node.Labels[labelKey]


### PR DESCRIPTION
## Problem

E2E tests intermittently fail with:
```
prepare cluster tasks: dag execution failed: waiting for proxy pod to be ready:
listing proxy pods: client rate limiter Wait returned an error: context deadline exceeded
```

This happens because all DAG tasks in `prepareCluster` share a single Kubeclient (and its rate limiter). When `collectGarbageVMSS` deletes many stale nodes, it consumes all rate limiter tokens, starving `GetProxyURL`'s polling. Similarly, parallel test scenarios sharing the same cached `Cluster.Kube` compete for tokens during validation.

Test runs:
* Linux e2e: https://dev.azure.com/msazure/CloudNativeCompute/_build/results?buildId=167407592&view=results
* Windows e2e: https://dev.azure.com/msazure/CloudNativeCompute/_build/results?buildId=167407085&view=results

## Fix

Three layers of Kubeclient isolation:

1. **Per-test Kubeclient** — each scenario creates its own client via `Cluster.NewKubeclientForTest()`, so parallel validations don't compete on the same rate limiter.

2. **Per-DAG-task Kubeclients** — within `prepareCluster`, heavy operations (`collectGarbageVMSS`, `EnsureDebugDaemonsets`/`GetProxyURL`, `extractClusterParams`, ACR setup) each get their own independent client. Kubeconfig bytes are fetched once, then each task mints its own client.

3. **Extracted `NewKubeclient` factory** — reusable function that creates a Kubeclient from raw kubeconfig bytes with consistent config (200 QPS, 400 burst, TCP keepalive, HTTP/2 pings).

## Changes

- `e2e/kube.go` — Extract `NewKubeclient(kubeconfigBytes)` factory
- `e2e/cluster.go` — Add `KubeConfig` field, `NewKubeclientForTest()` method, per-task DAG clients
- `e2e/types.go` — Add `Kube` field to `ScenarioRuntime`
- `e2e/test_helpers.go` — Create per-test client, use it for `WaitUntilNodeReady`
- `e2e/validators.go`, `validation.go`, `exec.go`, etc. — Replace `s.Runtime.Cluster.Kube` → `s.Runtime.Kube`

## Testing

- `go build ./...` ✅
- `go vet ./...` ✅
- No behavioral change to test logic — same operations, just independent rate limiters