### PR TITLE
feat(linux): emit per-step CSE timing events for GPU driver install

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1014,6 +1014,16 @@ configAzurePolicyAddon() {
     sed -i "s|<resourceId>|/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP|g" $AZURE_POLICY_ADDON_FILE
 }
 
+# Wrapped as functions so logs_to_events can time each step; the install's
+# bash -c command can't be passed to logs_to_events inline (it word-splits args).
+pullGPUDriverImage() {
+    ctr -n k8s.io image pull $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG
+}
+
+installGPUDriverImage() {
+    retrycmd_if_failure 5 10 600 bash -c "$CTR_GPU_INSTALL_CMD $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG gpuinstall /entrypoint.sh install"
+}
+
 configGPUDrivers() {
     if [ "$OS" = "$UBUNTU_OS_NAME" ]; then
         waitForContainerdReady || exit $ERR_GPU_DRIVERS_START_FAIL
@@ -1022,9 +1032,9 @@ configGPUDrivers() {
         # actually missing so provisioning doesn't pay a redundant manifest/layer round trip.
         # Use containerd's native exact-name filter rather than text-matching `images ls` output.
         if [ -z "$(ctr -n k8s.io images ls -q "name==${NVIDIA_DRIVER_IMAGE}:${NVIDIA_DRIVER_IMAGE_TAG}")" ]; then
-            ctr -n k8s.io image pull $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG
+            logs_to_events "AKS.CSE.configGPUDrivers.pullGPUDriverImage" pullGPUDriverImage
         fi
-        retrycmd_if_failure 5 10 600 bash -c "$CTR_GPU_INSTALL_CMD $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG gpuinstall /entrypoint.sh install"
+        logs_to_events "AKS.CSE.configGPUDrivers.installGPUDriverImage" installGPUDriverImage
         ret=$?
         if [ "$ret" -ne 0 ]; then
             echo "Failed to install GPU driver, exiting..."
@@ -1034,20 +1044,20 @@ configGPUDrivers() {
         # garbage collection runs asynchronously instead of blocking node provisioning.
         ctr -n k8s.io images rm $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG
     elif isMarinerOrAzureLinux "$OS" && ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
-        downloadGPUDrivers
-        installNvidiaContainerToolkit
+        logs_to_events "AKS.CSE.configGPUDrivers.downloadGPUDrivers" downloadGPUDrivers
+        logs_to_events "AKS.CSE.configGPUDrivers.installNvidiaContainerToolkit" installNvidiaContainerToolkit
         enableNvidiaPersistenceMode
     elif isACL "$OS" "$OS_VARIANT"; then
-        installNvidiaContainerToolkitSysext
-        installGPUDriverSysext
+        logs_to_events "AKS.CSE.configGPUDrivers.installNvidiaContainerToolkitSysext" installNvidiaContainerToolkitSysext
+        logs_to_events "AKS.CSE.configGPUDrivers.installGPUDriverSysext" installGPUDriverSysext
         enableNvidiaPersistenceMode
     else
         echo "os $OS $OS_VARIANT not supported at this time. skipping configGPUDrivers"
         exit 1
     fi
 
-    retrycmd_if_failure 120 5 25 nvidia-modprobe -u -c0 || exit $ERR_GPU_DRIVERS_START_FAIL
-    retrycmd_if_failure 120 5 30 nvidia-smi || exit $ERR_GPU_DRIVERS_START_FAIL
+    logs_to_events "AKS.CSE.configGPUDrivers.waitForNvidiaModprobe" "retrycmd_if_failure 120 5 25 nvidia-modprobe -u -c0" || exit $ERR_GPU_DRIVERS_START_FAIL
+    logs_to_events "AKS.CSE.configGPUDrivers.waitForNvidiaSmi" "retrycmd_if_failure 120 5 30 nvidia-smi" || exit $ERR_GPU_DRIVERS_START_FAIL
     retrycmd_if_failure 120 5 25 ldconfig || exit $ERR_GPU_DRIVERS_START_FAIL
 
     # Fix the NVIDIA /dev/char link issue (Mariner/AzureLinux only)

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -1726,4 +1726,74 @@ SETUP_EOF
             The output should include "warning: nvidia-dcgm-exporter could not be enqueued"
         End
     End
+
+    Describe 'configGPUDrivers'
+        # Assert the per-step CSE timing event names emitted via logs_to_events,
+        # without running the real (hardware/daemon) driver steps. logs_to_events
+        # is mocked to print only the event name so the wrapped commands never run.
+        logs_to_events() {
+            echo "logs_to_events $1"
+        }
+        waitForContainerdReady() { return 0; }
+        retrycmd_if_failure() { return 0; }
+        ctr() { return 0; }
+        mkdir() { return 0; }
+        enableNvidiaPersistenceMode() { return 0; }
+        createNvidiaSymlinkToAllDeviceNodes() { return 0; }
+        systemctlEnableAndStart() { return 0; }
+        systemctl() { return 0; }
+
+        UBUNTU_OS_NAME="UBUNTU"
+        NVIDIA_DRIVER_IMAGE="mcr.example/nvidia/driver"
+        NVIDIA_DRIVER_IMAGE_TAG="000.00"
+        NVIDIA_GPU_DRIVER_TYPE="cuda"
+        OS_VARIANT=""
+        ERR_GPU_DRIVERS_START_FAIL=88
+
+        It 'times the image pull and install steps on Ubuntu'
+            OS="UBUNTU"
+            isMarinerOrAzureLinux() { return 1; }
+            isAzureLinuxOSGuard() { return 1; }
+            isACL() { return 1; }
+
+            When call configGPUDrivers
+
+            The status should be success
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.pullGPUDriverImage"
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.installGPUDriverImage"
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.waitForNvidiaModprobe"
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.waitForNvidiaSmi"
+        End
+
+        It 'times the driver download and toolkit install on Mariner/AzureLinux'
+            OS="AZURELINUX"
+            isMarinerOrAzureLinux() { return 0; }
+            isAzureLinuxOSGuard() { return 1; }
+            isACL() { return 1; }
+
+            When call configGPUDrivers
+
+            The status should be success
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.downloadGPUDrivers"
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.installNvidiaContainerToolkit"
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.waitForNvidiaModprobe"
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.waitForNvidiaSmi"
+        End
+
+        It 'times the sysext pulls on Azure Container Linux (ACL)'
+            OS="AZURELINUX"
+            OS_VARIANT="acl"
+            isMarinerOrAzureLinux() { return 0; }
+            isAzureLinuxOSGuard() { return 0; }
+            isACL() { return 0; }
+
+            When call configGPUDrivers
+
+            The status should be success
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.installNvidiaContainerToolkitSysext"
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.installGPUDriverSysext"
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.waitForNvidiaModprobe"
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.waitForNvidiaSmi"
+        End
+    End
 End


### PR DESCRIPTION
## What

`configGPUDrivers()` was wrapped as a single coarse CSE event (`AKS.CSE.ensureGPUDrivers.configGPUDrivers`), so the heavy GPU **driver install** steps had no per-step timing — the most expensive part of GPU node provisioning (image pull, driver compile/install, and the `nvidia-smi` readiness wait) was lumped into one duration.

This PR wraps those steps in `logs_to_events` so each is timed individually and shows up in CSE timing telemetry (and `e2e/cse_timing.go`):

| New event (`AKS.CSE.configGPUDrivers.*`) | OS path | What it times |
|---|---|---|
| `pullGPUDriverImage` | Ubuntu | `ctr image pull` of the driver image (only on VHD cache miss) |
| `installGPUDriverImage` | Ubuntu | driver extract + compile + load via `/entrypoint.sh install` |
| `downloadGPUDrivers` | Mariner/AzureLinux | dnf install of the CUDA/GRID driver package |
| `installNvidiaContainerToolkit` | Mariner/AzureLinux | dnf install of the container toolkit |
| `installNvidiaContainerToolkitSysext` | ACL | oras pull of the toolkit sysext |
| `installGPUDriverSysext` | ACL | oras pull of the driver sysext |
| `waitForNvidiaModprobe` | all | `nvidia-modprobe` readiness retry loop |
| `waitForNvidiaSmi` | all | `nvidia-smi` readiness retry loop |

## Why

Per-step durations let us see *where* GPU provisioning time actually goes (cache-miss pull vs. compile vs. driver readiness) instead of one opaque number, which is what we need to drive down GPU node bring-up latency.

## No behavior change (observability-only)

- The CSE scripts do **not** use `set -e`; unchecked commands never aborted, so bare-wrapped calls keep the same semantics.
- `logs_to_events` returns the wrapped command's exit code (`0` on success) and writes the event **before** returning, so every existing control-flow path is preserved byte-for-byte:
  - Ubuntu pull stays **unchecked** (a failed pull still falls through to the install, which then exits with the original message/code).
  - The Ubuntu install keeps its `ret=$?` / `echo "Failed to install GPU driver, exiting..."` / `exit $ERR_GPU_DRIVERS_START_FAIL` block.
  - Mariner/ACL install functions still `exit` internally on failure.
  - Readiness waits keep `|| exit $ERR_GPU_DRIVERS_START_FAIL`.
- The Ubuntu install runs `bash -c "..."`, which can't be passed through `logs_to_events`' word-split argument form, so it (and the pull, for symmetry) are extracted into small named functions with the commands kept identical.
- Cheap steps (`ldconfig`, `enableNvidiaPersistenceMode`, `mkdir`, image `rm`, containerd/NPD restart) are intentionally left unwrapped to avoid event noise.

## Testing / scope notes

- `go test ./pkg/agent/...` and `go test ./aks-node-controller/...` pass; the new functions/commands are byte-identical to the originals.
- Shellcheck: the change adds no new `[[ ]]`/`==`; it passes the generic `verify_shell.sh` rule set.
- No e2e thresholds added: the perf scenarios in `scenario_cse_perf_test.go` run on non-GPU SKUs, so these GPU events never fire there; the `DefaultTaskThreshold` catch-all already tracks them in GPU e2e scenarios.
- No new ShellSpec specs: these are thin observability wrappers with no logic change, and `configGPUDrivers` invokes real hardware/daemon commands (covered by e2e GPU scenarios, not unit specs).
- `generatedCSECommand` reference snapshots are intentionally not regenerated — they are not asserted, are excluded from `make generate`, and recent `cse_config.sh` changes (incl. the prior GPU critical-path refactor) did not touch them.
