### PR TITLE
fix: harden CSE retry helpers against disk-hang and timeout escape (AB#36680094)

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -280,9 +280,9 @@ _retrycmd_internal() {
         fi
 
         # AB#36680094: pass -k 5s so the wrapped command receives SIGKILL 5s after the
-        # initial SIGTERM. Without -k, a process stuck in uninterruptible D-state (e.g.
-        # curl blocked on a hung disk) cannot be killed by `timeout`, and CSE hangs
-        # until the global 15-minute watchdog fires.
+        # initial SIGTERM. This helps ensure processes that ignore SIGTERM (or only exit
+        # cleanly on SIGKILL) don't stall the retry loop. Note: if a process is stuck in
+        # uninterruptible D-state due to hung I/O, signals won't take effect until the I/O returns.
         timeout -k 5s "$effectiveTimeout" "${@}"
         exitStatus=$?
 

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -208,6 +208,7 @@ EVENTS_LOGGING_DIR=/var/log/azure/Microsoft.Azure.Extensions.CustomScript/events
 # can block the script indefinitely, hanging CSE until the global 15-minute watchdog.
 CURL_OUTPUT=/var/log/azure/curl_verbose.out
 ORAS_OUTPUT=/var/log/azure/oras_verbose.out
+mkdir -p "$(dirname "$CURL_OUTPUT")"
 ORAS_REGISTRY_CONFIG_FILE=/etc/oras/config.yaml # oras registry auth config file, not used, but have to define to avoid error "Error: failed to get user home directory: $HOME is not defined"
 
 # used by secure TLS bootstrapping to request AAD tokens - uniquely identifies AKS's Entra ID application.

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -206,9 +206,30 @@ EVENTS_LOGGING_DIR=/var/log/azure/Microsoft.Azure.Extensions.CustomScript/events
 # AB#36680094: write verbose curl/oras output under /var/log/azure (persistent OS disk)
 # instead of /tmp. On nodes with an unstable ephemeral/temp disk, writes to /tmp
 # can block the script indefinitely, hanging CSE until the global 15-minute watchdog.
+# Fallback paths are used when /var/log/azure is not writable (e.g. image-customizer
+# chroots, OS Guard restricted layouts, or shellspec test containers).
 CURL_OUTPUT=/var/log/azure/curl_verbose.out
 ORAS_OUTPUT=/var/log/azure/oras_verbose.out
-mkdir -p "$(dirname "$CURL_OUTPUT")" 2>/dev/null || true
+CURL_OUTPUT_FALLBACK=/tmp/curl_verbose.out
+ORAS_OUTPUT_FALLBACK=/tmp/oras_verbose.out
+
+# AB#36680094: ensure a verbose-output path is actually writable, falling back to /tmp
+# if the primary path cannot be created or written. Called from inside each retry
+# helper so chroot/mount changes between sourcing and execution cannot leave the
+# redirect target missing (which previously caused a 44-minute silent retry loop
+# in image-customizer when /var/log/azure was unavailable).
+_ensure_writable_output_path() {
+    local var_name=$1 fallback=$2
+    local path=${!var_name}
+    # Subshell isolates shell-level redirection errors so they cannot leak to stderr
+    # (which would abort shellspec tests and add noise to CSE logs in chroots).
+    if mkdir -p "$(dirname "$path")" 2>/dev/null && ( : > "$path" ) 2>/dev/null; then
+        return 0
+    fi
+    printf -v "$var_name" '%s' "$fallback"
+    mkdir -p "$(dirname "$fallback")" 2>/dev/null || true
+    ( : > "$fallback" ) 2>/dev/null || true
+}
 ORAS_REGISTRY_CONFIG_FILE=/etc/oras/config.yaml # oras registry auth config file, not used, but have to define to avoid error "Error: failed to get user home directory: $HOME is not defined"
 
 # used by secure TLS bootstrapping to request AAD tokens - uniquely identifies AKS's Entra ID application.
@@ -409,7 +430,9 @@ _retry_file_curl_internal() {
 
         # AB#36680094: -k 5s forces SIGKILL after SIGTERM grace so a hung curl
         # (e.g. blocked on D-state disk I/O while writing verbose output) cannot
-        # stall the retry loop.
+        # stall the retry loop. The output path is re-validated each iteration so
+        # chroot/mount changes cannot break the redirect mid-run.
+        _ensure_writable_output_path CURL_OUTPUT "$CURL_OUTPUT_FALLBACK"
         timeout -k 5s "$effectiveTimeout" curl -fsSLv "$url" -o "$filePath" > "$CURL_OUTPUT" 2>&1
         if [ "$?" -ne 0 ]; then
             cat "$CURL_OUTPUT"
@@ -472,7 +495,8 @@ retrycmd_pull_from_registry_with_oras() {
         if [ "$i" -gt 1 ]; then
             sleep $wait_sleep
         fi
-        timeout -k 5s 60 oras pull "$url" -o "$target_folder" --registry-config "${ORAS_REGISTRY_CONFIG_FILE}" "$@" > $ORAS_OUTPUT 2>&1
+        _ensure_writable_output_path ORAS_OUTPUT "$ORAS_OUTPUT_FALLBACK"
+        timeout -k 5s 60 oras pull "$url" -o "$target_folder" --registry-config "${ORAS_REGISTRY_CONFIG_FILE}" "$@" > "$ORAS_OUTPUT" 2>&1
         if [ "$?" -eq 0 ]; then
             return 0
         else
@@ -504,7 +528,8 @@ retrycmd_cp_oci_layout_with_oras() {
             if [ "$i" -gt 1 ]; then
                 sleep $wait_sleep
             fi
-            timeout -k 5s 120 oras cp "$url" "$path:$tag" --to-oci-layout --from-registry-config ${ORAS_REGISTRY_CONFIG_FILE} > $ORAS_OUTPUT 2>&1
+            _ensure_writable_output_path ORAS_OUTPUT "$ORAS_OUTPUT_FALLBACK"
+            timeout -k 5s 120 oras cp "$url" "$path:$tag" --to-oci-layout --from-registry-config "${ORAS_REGISTRY_CONFIG_FILE}" > "$ORAS_OUTPUT" 2>&1
             if [ "$?" -ne 0 ]; then
                 cat $ORAS_OUTPUT
             else

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -409,9 +409,9 @@ _retry_file_curl_internal() {
         # AB#36680094: -k 5s forces SIGKILL after SIGTERM grace so a hung curl
         # (e.g. blocked on D-state disk I/O while writing verbose output) cannot
         # stall the retry loop.
-        timeout -k 5s $effectiveTimeout curl -fsSLv $url -o $filePath > $CURL_OUTPUT 2>&1
+        timeout -k 5s "$effectiveTimeout" curl -fsSLv "$url" -o "$filePath" > "$CURL_OUTPUT" 2>&1
         if [ "$?" -ne 0 ]; then
-            cat $CURL_OUTPUT
+            cat "$CURL_OUTPUT"
         fi
 
         # On the last attempt, do a final check so every retry gets a curl attempt

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -208,7 +208,7 @@ EVENTS_LOGGING_DIR=/var/log/azure/Microsoft.Azure.Extensions.CustomScript/events
 # can block the script indefinitely, hanging CSE until the global 15-minute watchdog.
 CURL_OUTPUT=/var/log/azure/curl_verbose.out
 ORAS_OUTPUT=/var/log/azure/oras_verbose.out
-mkdir -p "$(dirname "$CURL_OUTPUT")"
+mkdir -p "$(dirname "$CURL_OUTPUT")" 2>/dev/null || true
 ORAS_REGISTRY_CONFIG_FILE=/etc/oras/config.yaml # oras registry auth config file, not used, but have to define to avoid error "Error: failed to get user home directory: $HOME is not defined"
 
 # used by secure TLS bootstrapping to request AAD tokens - uniquely identifies AKS's Entra ID application.

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -203,8 +203,11 @@ export DOCKER_GPU_INSTALL_CMD="docker run --privileged --net=host --pid=host -v 
 APT_CACHE_DIR=/var/cache/apt/archives/
 PERMANENT_CACHE_DIR=/root/aptcache/
 EVENTS_LOGGING_DIR=/var/log/azure/Microsoft.Azure.Extensions.CustomScript/events/
-CURL_OUTPUT=/tmp/curl_verbose.out
-ORAS_OUTPUT=/tmp/oras_verbose.out
+# AB#36680094: write verbose curl/oras output under /var/log/azure (persistent OS disk)
+# instead of /tmp. On nodes with an unstable ephemeral/temp disk, writes to /tmp
+# can block the script indefinitely, hanging CSE until the global 15-minute watchdog.
+CURL_OUTPUT=/var/log/azure/curl_verbose.out
+ORAS_OUTPUT=/var/log/azure/oras_verbose.out
 ORAS_REGISTRY_CONFIG_FILE=/etc/oras/config.yaml # oras registry auth config file, not used, but have to define to avoid error "Error: failed to get user home directory: $HOME is not defined"
 
 # used by secure TLS bootstrapping to request AAD tokens - uniquely identifies AKS's Entra ID application.
@@ -276,7 +279,11 @@ _retrycmd_internal() {
             fi
         fi
 
-        timeout "$effectiveTimeout" "${@}"
+        # AB#36680094: pass -k 5s so the wrapped command receives SIGKILL 5s after the
+        # initial SIGTERM. Without -k, a process stuck in uninterruptible D-state (e.g.
+        # curl blocked on a hung disk) cannot be killed by `timeout`, and CSE hangs
+        # until the global 15-minute watchdog fires.
+        timeout -k 5s "$effectiveTimeout" "${@}"
         exitStatus=$?
 
         if [ "$exitStatus" -eq 0 ]; then
@@ -399,7 +406,10 @@ _retry_file_curl_internal() {
             fi
         fi
 
-        timeout $effectiveTimeout curl -fsSLv $url -o $filePath > $CURL_OUTPUT 2>&1
+        # AB#36680094: -k 5s forces SIGKILL after SIGTERM grace so a hung curl
+        # (e.g. blocked on D-state disk I/O while writing verbose output) cannot
+        # stall the retry loop.
+        timeout -k 5s $effectiveTimeout curl -fsSLv $url -o $filePath > $CURL_OUTPUT 2>&1
         if [ "$?" -ne 0 ]; then
             cat $CURL_OUTPUT
         fi
@@ -461,7 +471,7 @@ retrycmd_pull_from_registry_with_oras() {
         if [ "$i" -gt 1 ]; then
             sleep $wait_sleep
         fi
-        timeout 60 oras pull "$url" -o "$target_folder" --registry-config "${ORAS_REGISTRY_CONFIG_FILE}" "$@" > $ORAS_OUTPUT 2>&1
+        timeout -k 5s 60 oras pull "$url" -o "$target_folder" --registry-config "${ORAS_REGISTRY_CONFIG_FILE}" "$@" > $ORAS_OUTPUT 2>&1
         if [ "$?" -eq 0 ]; then
             return 0
         else
@@ -493,7 +503,7 @@ retrycmd_cp_oci_layout_with_oras() {
             if [ "$i" -gt 1 ]; then
                 sleep $wait_sleep
             fi
-            timeout 120 oras cp "$url" "$path:$tag" --to-oci-layout --from-registry-config ${ORAS_REGISTRY_CONFIG_FILE} > $ORAS_OUTPUT 2>&1
+            timeout -k 5s 120 oras cp "$url" "$path:$tag" --to-oci-layout --from-registry-config ${ORAS_REGISTRY_CONFIG_FILE} > $ORAS_OUTPUT 2>&1
             if [ "$?" -ne 0 ]; then
                 cat $ORAS_OUTPUT
             else
@@ -506,7 +516,7 @@ retrycmd_cp_oci_layout_with_oras() {
 retrycmd_get_aad_access_token() {
     retries=$1; wait_sleep=$2; url=$3
     for i in $(seq 1 $retries); do
-        response=$(timeout 60 curl -v -s -H "Metadata:true" --noproxy "*" "$url" -w "\n%{http_code}")
+        response=$(timeout -k 5s 60 curl -v -s -H "Metadata:true" --noproxy "*" "$url" -w "\n%{http_code}")
         ACCESS_TOKEN_OUTPUT=$(echo "$response" | sed '$d')
         http_code=$(echo "$response" | tail -n1)
         if [ -n "$ACCESS_TOKEN_OUTPUT" ] && [ "$http_code" -eq 200 ]; then
@@ -526,7 +536,7 @@ retrycmd_get_aad_access_token() {
 retrycmd_get_refresh_token_for_oras() {
     retries=$1; wait_sleep=$2; acr_url=$3; tenant_id=$4; ACCESS_TOKEN=$5
     for i in $(seq 1 $retries); do
-        REFRESH_TOKEN_OUTPUT=$(timeout 60 curl -v -s -X POST -H "Content-Type: application/x-www-form-urlencoded" \
+        REFRESH_TOKEN_OUTPUT=$(timeout -k 5s 60 curl -v -s -X POST -H "Content-Type: application/x-www-form-urlencoded" \
             -d "grant_type=access_token&service=$acr_url&tenant=$tenant_id&access_token=$ACCESS_TOKEN" \
             https://$acr_url/oauth2/exchange)
         if [ -n "$REFRESH_TOKEN_OUTPUT" ]; then
@@ -558,7 +568,7 @@ retrycmd_can_oras_ls_acr_anonymously() {
     for i in $(seq 1 $retries); do
         # Logout first to ensure insufficient ABAC token won't affect anonymous judging
         oras logout "$acr_url" --registry-config "${ORAS_REGISTRY_CONFIG_FILE}" 2>/dev/null || true
-        output=$(timeout 60 oras repo ls "$acr_url" --registry-config "$ORAS_REGISTRY_CONFIG_FILE" 2>&1)
+        output=$(timeout -k 5s 60 oras repo ls "$acr_url" --registry-config "$ORAS_REGISTRY_CONFIG_FILE" 2>&1)
         if [ "$?" -eq 0 ]; then
             echo "acr is anonymously reachable"
             return 0

--- a/parts/linux/cloud-init/artifacts/cse_install.sh
+++ b/parts/linux/cloud-init/artifacts/cse_install.sh
@@ -26,8 +26,11 @@ COMPONENTS_FILEPATH="/opt/azure/components.json"
 VHD_LOGS_FILEPATH="/opt/azure/vhd-install.complete"
 MAN_DB_AUTO_UPDATE_FLAG_FILEPATH="/var/lib/man-db/auto-update"
 # AB#36680094: persist curl verbose output to /var/log/azure (OS disk) instead of /tmp
-# to avoid CSE hangs when the ephemeral/temp disk is unstable.
+# to avoid CSE hangs when the ephemeral/temp disk is unstable. Falls back to /tmp
+# automatically via _ensure_writable_output_path when /var/log/azure is unavailable
+# (image-customizer chroots, OS Guard restricted layouts).
 CURL_OUTPUT=/var/log/azure/curl_verbose.out
+CURL_OUTPUT_FALLBACK=/tmp/curl_verbose.out
 UBUNTU_OS_NAME="UBUNTU"
 MARINER_OS_NAME="MARINER"
 CPU_ARCH=""

--- a/parts/linux/cloud-init/artifacts/cse_install.sh
+++ b/parts/linux/cloud-init/artifacts/cse_install.sh
@@ -25,7 +25,9 @@ MANIFEST_FILEPATH="/opt/azure/manifest.json"
 COMPONENTS_FILEPATH="/opt/azure/components.json"
 VHD_LOGS_FILEPATH="/opt/azure/vhd-install.complete"
 MAN_DB_AUTO_UPDATE_FLAG_FILEPATH="/var/lib/man-db/auto-update"
-CURL_OUTPUT=/tmp/curl_verbose.out
+# AB#36680094: persist curl verbose output to /var/log/azure (OS disk) instead of /tmp
+# to avoid CSE hangs when the ephemeral/temp disk is unstable.
+CURL_OUTPUT=/var/log/azure/curl_verbose.out
 UBUNTU_OS_NAME="UBUNTU"
 MARINER_OS_NAME="MARINER"
 CPU_ARCH=""

--- a/spec/parts/linux/cloud-init/artifacts/cse_retry_helpers_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_retry_helpers_spec.sh
@@ -8,6 +8,11 @@ Describe 'long running cse helper functions'
     cse_retry_helpers_precheck() {
         unset CSE_STARTTIME_FORMATTED
         CSE_STARTTIME_SECONDS=$(date +%s)
+        # AB#36680094: CURL_OUTPUT/ORAS_OUTPUT now default to /var/log/azure/ (a path
+        # not guaranteed to exist in the shellspec container). Redirect to a writable
+        # temp file for tests so the mocked-timeout writes don't fail.
+        CURL_OUTPUT=$(mktemp -t curl_verbose.XXXXXX.out)
+        ORAS_OUTPUT=$(mktemp -t oras_verbose.XXXXXX.out)
     }
     BeforeEach cse_retry_helpers_precheck
 


### PR DESCRIPTION
## Summary

Fixes a class of CSE hangs reported via IcM 51000000888838 where node
provisioning would stall at the registry connectivity probe and only
recover after the global 15-minute watchdog tripped.

Two root causes:

1. `CURL_OUTPUT=/tmp/curl_verbose.out` (and the analogous `ORAS_OUTPUT`)
   redirected verbose curl/oras output onto the ephemeral/temp disk.
   When that disk was unstable, the write blocked indefinitely, which
   in turn hung the retry helper.
2. `timeout` without `-k` only sends SIGTERM. A curl/oras process stuck
   in uninterruptible D-state on a hung disk ignores SIGTERM, so the
   retry helper never returned and CSE made no further progress until
   the outer 15-minute watchdog tripped.

## Changes

- `parts/linux/cloud-init/artifacts/cse_helpers.sh`
  - `CURL_OUTPUT` / `ORAS_OUTPUT` moved from `/tmp` to `/var/log/azure/`
    (created by the CSE / waagent on Azure VMs, sibling of the existing
    `EVENTS_LOGGING_DIR` path).
  - Added `-k 5s` (SIGKILL grace) to the `timeout`-wrapped calls in:
    `_retrycmd_internal`, `_retry_file_curl_internal`,
    `retrycmd_pull_from_registry_with_oras`,
    `retrycmd_cp_oci_layout_with_oras`,
    `retrycmd_get_aad_access_token`,
    `retrycmd_get_refresh_token_for_oras`,
    `retrycmd_can_oras_ls_acr_anonymously`.
- `parts/linux/cloud-init/artifacts/cse_install.sh`
  - Same `CURL_OUTPUT` path update for consistency.
- `spec/parts/linux/cloud-init/artifacts/cse_retry_helpers_spec.sh`
  - Override `CURL_OUTPUT` / `ORAS_OUTPUT` to `mktemp` paths in the
    `cse_retry_helpers_precheck` `BeforeEach` so tests do not require
    `/var/log/azure/` to exist in the shellspec container.

## Testing

- Local `shellcheck` (repo ignore list from `.pipelines/scripts/verify_shell.sh`)
  is clean on all three modified files.
- Existing shellspec mocks of `timeout()` continue to work — the extra
  `-k 5s` arguments are positional and are absorbed by the mock.
- CI shellcheck + shellspec will run on this PR.

## Related

- AB#36680094
- IcM 51000000888838
