### PR TITLE
docs: instruct contributors to open PRs from the repo, not a fork

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,6 +40,10 @@ Tags of AgentBaker and corresponding Linux VHDs are released every week. Linux V
 
 Windows VHD are released separately, following windows patch tuesday schedule.
 
+## Contributing
+
+When opening a pull request against this repository, create the PR from a branch in `Azure/AgentBaker` itself — **not from a fork**. Push your branch to `origin` (the upstream repo) and open the PR from there. The `validate-pull-request-source` CI check (`.github/workflows/validate-pull-request-source.yml`) fails any PR whose head branch lives in a forked repository.
+
 ## Guidelines
 
 ### SRE Guidelines

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,7 +42,7 @@ Windows VHD are released separately, following windows patch tuesday schedule.
 
 ## Contributing
 
-When opening a pull request against this repository, create the PR from a branch in `Azure/AgentBaker` itself — **not from a fork**. Push your branch to `origin` (the upstream repo) and open the PR from there. The `validate-pull-request-source` CI check (`.github/workflows/validate-pull-request-source.yml`) fails any PR whose head branch lives in a forked repository.
+When opening a pull request against this repository, the PR's head branch must live in `Azure/AgentBaker` itself — **not in a fork**. Push your branch directly to a branch in `Azure/AgentBaker` (this requires write access to the repo) and open the PR from there; do not rely on a specific remote name, since `origin` often points at a personal fork. The `validate-pull-request-source` CI check (`.github/workflows/validate-pull-request-source.yml`) fails any PR whose head branch lives in a forked repository.
 
 ## Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,10 @@ Tags of AgentBaker and corresponding Linux VHDs are released every week. Linux V
 
 Windows VHD are released separately, following windows patch tuesday schedule.
 
+## Contributing
+
+When opening a pull request against this repository, create the PR from a branch in `Azure/AgentBaker` itself — **not from a fork**. Push your branch to `origin` (the upstream repo) and open the PR from there. The `validate-pull-request-source` CI check (`.github/workflows/validate-pull-request-source.yml`) fails any PR whose head branch lives in a forked repository.
+
 ## Guidelines
 
 ### SRE Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Windows VHD are released separately, following windows patch tuesday schedule.
 
 ## Contributing
 
-When opening a pull request against this repository, create the PR from a branch in `Azure/AgentBaker` itself — **not from a fork**. Push your branch to `origin` (the upstream repo) and open the PR from there. The `validate-pull-request-source` CI check (`.github/workflows/validate-pull-request-source.yml`) fails any PR whose head branch lives in a forked repository.
+When opening a pull request against this repository, the PR's head branch must live in `Azure/AgentBaker` itself — **not in a fork**. Push your branch directly to a branch in `Azure/AgentBaker` (this requires write access to the repo) and open the PR from there; do not rely on a specific remote name, since `origin` often points at a personal fork. The `validate-pull-request-source` CI check (`.github/workflows/validate-pull-request-source.yml`) fails any PR whose head branch lives in a forked repository.
 
 ## Guidelines
 


### PR DESCRIPTION
## What

Adds a short **Contributing** note to the agent instruction files (`AGENTS.md`, the `CLAUDE.md` symlink, and `.github/copilot-instructions.md`) telling contributors to open PRs from a branch in `Azure/AgentBaker`, not from a fork.

## Why

The `validate-pull-request-source` CI gate (`.github/workflows/validate-pull-request-source.yml`) hard-fails any PR whose head branch lives in a forked repository. Documenting this in the agent-loaded instruction files prevents contributors (and coding agents) from repeatedly opening fork PRs that can never pass checks.