### PR TITLE
test: add ShellSpec coverage for init-aks-custom-cloud*.sh

### DIFF
--- a/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-mariner.sh
+++ b/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-mariner.sh
@@ -1,85 +1,92 @@
 #!/bin/bash
 set -x
-mkdir -p /root/AzureCACertificates
 
-IS_MARINER=0
-IS_AZURELINUX=0
-# shellcheck disable=SC3010
-if [[ -f /etc/os-release ]]; then
-        . /etc/os-release
+# Path constants — overridable for testing via env vars; defaults preserve
+# production behavior. functions defined until "${__SOURCED__:+return}" are
+# sourced and tested in spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_mariner_spec.sh.
+: "${OS_RELEASE_FILE:=/etc/os-release}"
+: "${AZURE_CA_CERTS_DIR:=/root/AzureCACertificates}"
+: "${CA_TRUST_ANCHORS_DIR:=/etc/pki/ca-trust/source/anchors}"
+: "${YUM_REPOS_D_DIR:=/etc/yum.repos.d}"
+: "${CHRONY_CONF_FILE:=/etc/chrony.conf}"
+: "${WIRESERVER_ENDPOINT:=http://168.63.129.16}"
+
+detect_distro() {
+    IS_MARINER=0
+    IS_AZURELINUX=0
     # shellcheck disable=SC3010
-    if [[ $NAME == *"Mariner"* ]]; then
-        IS_MARINER=1
-    elif [[ $NAME == *"Microsoft Azure Linux"* ]]; then
-        IS_AZURELINUX=1
+    if [[ -f "${OS_RELEASE_FILE}" ]]; then
+            . "${OS_RELEASE_FILE}"
+        # shellcheck disable=SC3010
+        if [[ $NAME == *"Mariner"* ]]; then
+            IS_MARINER=1
+        elif [[ $NAME == *"Microsoft Azure Linux"* ]]; then
+            IS_AZURELINUX=1
+        else
+            echo "Unknown Linux distribution"
+            exit 1
+        fi
     else
-        echo "Unknown Linux distribution"
+        echo "Unsupported operating system"
         exit 1
     fi
-else
-    echo "Unsupported operating system"
-    exit 1
-fi
 
-echo "distribution is $distribution"
-echo "Running on $NAME"
+    echo "distribution is $distribution"
+    echo "Running on $NAME"
+}
 
-# http://168.63.129.16 is a constant for the host's wireserver endpoint
-certs=$(curl "http://168.63.129.16/machine?comp=acmspackage&type=cacertificates&ext=json")
-IFS_backup=$IFS
-IFS=$'\r\n'
-certNames=($(echo $certs | grep -oP '(?<=Name\": \")[^\"]*'))
-certBodies=($(echo $certs | grep -oP '(?<=CertBody\": \")[^\"]*'))
-for i in ${!certBodies[@]}; do
-    echo ${certBodies[$i]}  | sed 's/\\r\\n/\n/g' | sed 's/\\//g' > "/root/AzureCACertificates/$(echo ${certNames[$i]} | sed 's/.cer/.crt/g')"
-done
-IFS=$IFS_backup
+fetch_and_install_ca_certs() {
+    mkdir -p "${AZURE_CA_CERTS_DIR}"
+    # http://168.63.129.16 is a constant for the host's wireserver endpoint
+    certs=$(curl "${WIRESERVER_ENDPOINT}/machine?comp=acmspackage&type=cacertificates&ext=json")
+    IFS_backup=$IFS
+    IFS=$'\r\n'
+    certNames=($(echo $certs | grep -oP '(?<=Name\": \")[^\"]*'))
+    certBodies=($(echo $certs | grep -oP '(?<=CertBody\": \")[^\"]*'))
+    for i in ${!certBodies[@]}; do
+        echo ${certBodies[$i]}  | sed 's/\\r\\n/\n/g' | sed 's/\\//g' > "${AZURE_CA_CERTS_DIR}/$(echo ${certNames[$i]} | sed 's/.cer/.crt/g')"
+    done
+    IFS=$IFS_backup
 
-cp /root/AzureCACertificates/*.crt /etc/pki/ca-trust/source/anchors/
-/usr/bin/update-ca-trust
+    cp "${AZURE_CA_CERTS_DIR}"/*.crt "${CA_TRUST_ANCHORS_DIR}/"
+    /usr/bin/update-ca-trust
+}
 
-# This section creates a cron job to poll for refreshed CA certs daily
-# It can be removed if not needed or desired
-action=${1:-init}
-if [ "$action" = "ca-refresh" ]; then
-    exit
-fi
-
-scriptPath=$0
-# Determine an absolute, canonical path to this script for use in cron.
-if command -v readlink >/dev/null 2>&1; then
-    # Use readlink -f when available to resolve the canonical path; fall back to $0 on error.
-    scriptPath="$(readlink -f "$0" 2>/dev/null || printf '%s' "$0")"
-fi
-
-if ! crontab -l 2>/dev/null | grep -q "\"$scriptPath\" ca-refresh"; then
-    # Quote the script path in the cron entry to avoid issues with spaces or special characters.
-    if ! (crontab -l 2>/dev/null ; printf '%s\n' "0 19 * * * \"$scriptPath\" ca-refresh") | crontab -; then
-        echo "Failed to install ca-refresh cron job via crontab" >&2
+setup_ca_refresh_cron() {
+    scriptPath=$0
+    # Determine an absolute, canonical path to this script for use in cron.
+    if command -v readlink >/dev/null 2>&1; then
+        # Use readlink -f when available to resolve the canonical path; fall back to $0 on error.
+        scriptPath="$(readlink -f "$0" 2>/dev/null || printf '%s' "$0")"
     fi
-fi
 
-cloud-init status --wait
+    if ! crontab -l 2>/dev/null | grep -q "\"$scriptPath\" ca-refresh"; then
+        # Quote the script path in the cron entry to avoid issues with spaces or special characters.
+        if ! (crontab -l 2>/dev/null ; printf '%s\n' "0 19 * * * \"$scriptPath\" ca-refresh") | crontab -; then
+            echo "Failed to install ca-refresh cron job via crontab" >&2
+        fi
+    fi
+}
 
-function init_mariner_repo_depot {
+init_mariner_repo_depot() {
     local repodepot_endpoint=$1
     echo "Adding [extended] repo"
-    cp /etc/yum.repos.d/mariner-extras.repo /etc/yum.repos.d/mariner-extended.repo
-    sed -i -e "s|extras|extended|" /etc/yum.repos.d/mariner-extended.repo
-    sed -i -e "s|Extras|Extended|" /etc/yum.repos.d/mariner-extended.repo
+    cp "${YUM_REPOS_D_DIR}/mariner-extras.repo" "${YUM_REPOS_D_DIR}/mariner-extended.repo"
+    sed -i -e "s|extras|extended|" "${YUM_REPOS_D_DIR}/mariner-extended.repo"
+    sed -i -e "s|Extras|Extended|" "${YUM_REPOS_D_DIR}/mariner-extended.repo"
 
     echo "Adding [nvidia] repo"
-    cp /etc/yum.repos.d/mariner-extras.repo /etc/yum.repos.d/mariner-nvidia.repo
-    sed -i -e "s|extras|nvidia|" /etc/yum.repos.d/mariner-nvidia.repo
-    sed -i -e "s|Extras|Nvidia|" /etc/yum.repos.d/mariner-nvidia.repo
+    cp "${YUM_REPOS_D_DIR}/mariner-extras.repo" "${YUM_REPOS_D_DIR}/mariner-nvidia.repo"
+    sed -i -e "s|extras|nvidia|" "${YUM_REPOS_D_DIR}/mariner-nvidia.repo"
+    sed -i -e "s|Extras|Nvidia|" "${YUM_REPOS_D_DIR}/mariner-nvidia.repo"
 
     echo "Adding [cloud-native] repo"
-    cp /etc/yum.repos.d/mariner-extras.repo /etc/yum.repos.d/mariner-cloud-native.repo
-    sed -i -e "s|extras|cloud-native|" /etc/yum.repos.d/mariner-cloud-native.repo
-    sed -i -e "s|Extras|Cloud-Native|" /etc/yum.repos.d/mariner-cloud-native.repo
+    cp "${YUM_REPOS_D_DIR}/mariner-extras.repo" "${YUM_REPOS_D_DIR}/mariner-cloud-native.repo"
+    sed -i -e "s|extras|cloud-native|" "${YUM_REPOS_D_DIR}/mariner-cloud-native.repo"
+    sed -i -e "s|Extras|Cloud-Native|" "${YUM_REPOS_D_DIR}/mariner-cloud-native.repo"
 
     echo "Pointing Mariner repos at RepoDepot..."
-    for f in /etc/yum.repos.d/*.repo
+    for f in "${YUM_REPOS_D_DIR}"/*.repo
     do
         sed -i -e "s|https://packages.microsoft.com|${repodepot_endpoint}/mariner/packages.microsoft.com|" $f
         echo "$f modified."
@@ -87,15 +94,15 @@ function init_mariner_repo_depot {
     echo "Mariner repo setup complete."
 }
 
-function init_azurelinux_repo_depot {
+init_azurelinux_repo_depot() {
     local repodepot_endpoint=$1
     repos=("amd" "base" "cloud-native" "extended" "ms-non-oss" "ms-oss" "nvidia")
 
     # tbd maybe we do this a bit nicer
-    rm -f /etc/yum.repos.d/azurelinux*
+    rm -f "${YUM_REPOS_D_DIR}"/azurelinux*
 
     for repo in "${repos[@]}"; do
-        output_file="/etc/yum.repos.d/azurelinux-${repo}.repo"
+        output_file="${YUM_REPOS_D_DIR}/azurelinux-${repo}.repo"
         repo_content=(
             "[azurelinux-official-$repo]"
             "name=Azure Linux Official $repo \$releasever \$basearch"
@@ -135,26 +142,29 @@ dnf_makecache() {
     echo "Executed dnf makecache -y $i times"
 }
 
-marinerRepoDepotEndpoint="$(echo "${REPO_DEPOT_ENDPOINT}" | sed 's/\/ubuntu//')"
-if [ -z "$marinerRepoDepotEndpoint" ]; then
-  >&2 echo "repo depot endpoint empty while running custom-cloud init script"
-else
-  # logic taken from https://repodepot.azure.com/scripts/cloud-init/setup_repodepot.sh
-  if [ "$IS_MARINER" -eq 1 ]; then
-      echo "Initializing Mariner repo depot settings..."
-      init_mariner_repo_depot ${marinerRepoDepotEndpoint}
-      dnf_makecache || exit 1
-  elif [ "$IS_AZURELINUX" -eq 1 ]; then
-      echo "Initializing Azure Linux repo depot settings..."
-      init_azurelinux_repo_depot ${marinerRepoDepotEndpoint}
-      dnf_makecache || exit 1
-  else
-      echo "No customizations for distribution: $NAME"
-  fi
-fi
+init_repo_depot() {
+    marinerRepoDepotEndpoint="$(echo "${REPO_DEPOT_ENDPOINT}" | sed 's/\/ubuntu//')"
+    if [ -z "$marinerRepoDepotEndpoint" ]; then
+      >&2 echo "repo depot endpoint empty while running custom-cloud init script"
+    else
+      # logic taken from https://repodepot.azure.com/scripts/cloud-init/setup_repodepot.sh
+      if [ "$IS_MARINER" -eq 1 ]; then
+          echo "Initializing Mariner repo depot settings..."
+          init_mariner_repo_depot ${marinerRepoDepotEndpoint}
+          dnf_makecache || exit 1
+      elif [ "$IS_AZURELINUX" -eq 1 ]; then
+          echo "Initializing Azure Linux repo depot settings..."
+          init_azurelinux_repo_depot ${marinerRepoDepotEndpoint}
+          dnf_makecache || exit 1
+      else
+          echo "No customizations for distribution: $NAME"
+      fi
+    fi
+}
 
-# Set the chrony config to use the PHC /dev/ptp0 clock
-cat > /etc/chrony.conf <<EOF
+write_chrony_config() {
+    # Set the chrony config to use the PHC /dev/ptp0 clock
+    cat > "${CHRONY_CONF_FILE}" <<EOF
 # This directive specify the location of the file containing ID/key pairs for
 # NTP authentication.
 keyfile /etc/chrony.keys
@@ -181,6 +191,27 @@ refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
 makestep 1.0 -1
 EOF
 
-systemctl restart chronyd
+    systemctl restart chronyd
+}
+
+main() {
+    detect_distro
+    fetch_and_install_ca_certs
+
+    # This section creates a cron job to poll for refreshed CA certs daily
+    # It can be removed if not needed or desired
+    action=${1:-init}
+    if [ "$action" = "ca-refresh" ]; then
+        exit
+    fi
+
+    setup_ca_refresh_cron
+    cloud-init status --wait
+    init_repo_depot
+    write_chrony_config
+}
+
+${__SOURCED__:+return}
+main "$@"
 
 #EOF

--- a/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-mariner.sh
+++ b/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-mariner.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+[ -n "${__SOURCED__:-}" ] || set -x
 
 # Path constants — overridable for testing via env vars; defaults preserve
 # production behavior. functions defined until "${__SOURCED__:+return}" are
@@ -31,7 +31,6 @@ detect_distro() {
         exit 1
     fi
 
-    echo "distribution is $distribution"
     echo "Running on $NAME"
 }
 

--- a/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests-mariner.sh
+++ b/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests-mariner.sh
@@ -1,31 +1,39 @@
 #!/bin/bash
 set -x
-mkdir -p /root/AzureCACertificates
 
-IS_MARINER=0
-IS_AZURELINUX=0
-# shellcheck disable=SC3010
-if [[ -f /etc/os-release ]]; then
-        . /etc/os-release
+# Path constants — overridable for testing via env vars; defaults preserve
+# production behavior. functions defined until "${__SOURCED__:+return}" are
+# sourced and tested in spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_operation_requests_mariner_spec.sh.
+: "${OS_RELEASE_FILE:=/etc/os-release}"
+: "${AZURE_CA_CERTS_DIR:=/root/AzureCACertificates}"
+: "${CA_TRUST_ANCHORS_DIR:=/etc/pki/ca-trust/source/anchors}"
+: "${YUM_REPOS_D_DIR:=/etc/yum.repos.d}"
+# http://168.63.129.16 is a constant for the host's wireserver endpoint
+: "${WIRESERVER_ENDPOINT:=http://168.63.129.16}"
+
+detect_distro() {
+    IS_MARINER=0
+    IS_AZURELINUX=0
     # shellcheck disable=SC3010
-    if [[ $NAME == *"Mariner"* ]]; then
-        IS_MARINER=1
-    elif [[ $NAME == *"Microsoft Azure Linux"* ]]; then
-        IS_AZURELINUX=1
+    if [[ -f "${OS_RELEASE_FILE}" ]]; then
+            . "${OS_RELEASE_FILE}"
+        # shellcheck disable=SC3010
+        if [[ $NAME == *"Mariner"* ]]; then
+            IS_MARINER=1
+        elif [[ $NAME == *"Microsoft Azure Linux"* ]]; then
+            IS_AZURELINUX=1
+        else
+            echo "Unknown Linux distribution"
+            exit 1
+        fi
     else
-        echo "Unknown Linux distribution"
+        echo "Unsupported operating system"
         exit 1
     fi
-else
-    echo "Unsupported operating system"
-    exit 1
-fi
 
-echo "distribution is $distribution"
-echo "Running on $NAME"
-
-# http://168.63.129.16 is a constant for the host's wireserver endpoint
-WIRESERVER_ENDPOINT="http://168.63.129.16"
+    echo "distribution is $distribution"
+    echo "Running on $NAME"
+}
 
 # Function to make HTTP request with retry logic for rate limiting
 make_request_with_retry() {
@@ -99,7 +107,7 @@ process_cert_operations() {
 
         if [ -n "$cert_content" ]; then
             # Save the certificate to the appropriate location
-            echo "$cert_content" > "/root/AzureCACertificates/$cert_filename"
+            echo "$cert_content" > "${AZURE_CA_CERTS_DIR}/$cert_filename"
             echo "Successfully saved certificate: $cert_filename"
         else
             echo "Warning: Failed to retrieve certificate content for $cert_filename"
@@ -107,58 +115,57 @@ process_cert_operations() {
     done
 }
 
-# Process root certificates
-process_cert_operations "operationrequestsroot"
+fetch_and_install_ca_certs() {
+    mkdir -p "${AZURE_CA_CERTS_DIR}"
 
-# Process intermediate certificates
-process_cert_operations "operationrequestsintermediate"
+    # Process root certificates
+    process_cert_operations "operationrequestsroot"
 
-# Copy all certificate files to the Mariner/AzureLinux system certificate directory
-cp /root/AzureCACertificates/*.crt /etc/pki/ca-trust/source/anchors/
+    # Process intermediate certificates
+    process_cert_operations "operationrequestsintermediate"
 
-# Update the system certificate store using Mariner/AzureLinux command
-/usr/bin/update-ca-trust
+    # Copy all certificate files to the Mariner/AzureLinux system certificate directory
+    cp "${AZURE_CA_CERTS_DIR}"/*.crt "${CA_TRUST_ANCHORS_DIR}/"
 
-# This section creates a cron job to poll for refreshed CA certs daily
-# It can be removed if not needed or desired
-action=${1:-init}
-if [ "$action" = "ca-refresh" ]; then
-    exit
-fi
+    # Update the system certificate store using Mariner/AzureLinux command
+    /usr/bin/update-ca-trust
+}
 
-scriptPath=$0
-# Determine an absolute, canonical path to this script for use in cron.
-if command -v readlink >/dev/null 2>&1; then
-    # Use readlink -f when available to resolve the canonical path; fall back to $0 on error.
-    scriptPath="$(readlink -f "$0" 2>/dev/null || printf '%s' "$0")"
-fi
-
-if ! crontab -l 2>/dev/null | grep -q "\"$scriptPath\" ca-refresh"; then
-    # Quote the script path in the cron entry to avoid issues with spaces or special characters.
-    if ! (crontab -l 2>/dev/null ; printf '%s\n' "0 19 * * * \"$scriptPath\" ca-refresh") | crontab -; then
-        echo "Failed to install ca-refresh cron job via crontab" >&2
+setup_ca_refresh_cron() {
+    scriptPath=$0
+    # Determine an absolute, canonical path to this script for use in cron.
+    if command -v readlink >/dev/null 2>&1; then
+        # Use readlink -f when available to resolve the canonical path; fall back to $0 on error.
+        scriptPath="$(readlink -f "$0" 2>/dev/null || printf '%s' "$0")"
     fi
-fi
 
-function init_mariner_repo_depot {
+    if ! crontab -l 2>/dev/null | grep -q "\"$scriptPath\" ca-refresh"; then
+        # Quote the script path in the cron entry to avoid issues with spaces or special characters.
+        if ! (crontab -l 2>/dev/null ; printf '%s\n' "0 19 * * * \"$scriptPath\" ca-refresh") | crontab -; then
+            echo "Failed to install ca-refresh cron job via crontab" >&2
+        fi
+    fi
+}
+
+init_mariner_repo_depot() {
     local repodepot_endpoint=$1
     echo "Adding [extended] repo"
-    cp /etc/yum.repos.d/mariner-extras.repo /etc/yum.repos.d/mariner-extended.repo
-    sed -i -e "s|extras|extended|" /etc/yum.repos.d/mariner-extended.repo
-    sed -i -e "s|Extras|Extended|" /etc/yum.repos.d/mariner-extended.repo
+    cp "${YUM_REPOS_D_DIR}/mariner-extras.repo" "${YUM_REPOS_D_DIR}/mariner-extended.repo"
+    sed -i -e "s|extras|extended|" "${YUM_REPOS_D_DIR}/mariner-extended.repo"
+    sed -i -e "s|Extras|Extended|" "${YUM_REPOS_D_DIR}/mariner-extended.repo"
 
     echo "Adding [nvidia] repo"
-    cp /etc/yum.repos.d/mariner-extras.repo /etc/yum.repos.d/mariner-nvidia.repo
-    sed -i -e "s|extras|nvidia|" /etc/yum.repos.d/mariner-nvidia.repo
-    sed -i -e "s|Extras|Nvidia|" /etc/yum.repos.d/mariner-nvidia.repo
+    cp "${YUM_REPOS_D_DIR}/mariner-extras.repo" "${YUM_REPOS_D_DIR}/mariner-nvidia.repo"
+    sed -i -e "s|extras|nvidia|" "${YUM_REPOS_D_DIR}/mariner-nvidia.repo"
+    sed -i -e "s|Extras|Nvidia|" "${YUM_REPOS_D_DIR}/mariner-nvidia.repo"
 
     echo "Adding [cloud-native] repo"
-    cp /etc/yum.repos.d/mariner-extras.repo /etc/yum.repos.d/mariner-cloud-native.repo
-    sed -i -e "s|extras|cloud-native|" /etc/yum.repos.d/mariner-cloud-native.repo
-    sed -i -e "s|Extras|Cloud-Native|" /etc/yum.repos.d/mariner-cloud-native.repo
+    cp "${YUM_REPOS_D_DIR}/mariner-extras.repo" "${YUM_REPOS_D_DIR}/mariner-cloud-native.repo"
+    sed -i -e "s|extras|cloud-native|" "${YUM_REPOS_D_DIR}/mariner-cloud-native.repo"
+    sed -i -e "s|Extras|Cloud-Native|" "${YUM_REPOS_D_DIR}/mariner-cloud-native.repo"
 
     echo "Pointing Mariner repos at RepoDepot..."
-    for f in /etc/yum.repos.d/*.repo
+    for f in "${YUM_REPOS_D_DIR}"/*.repo
     do
         sed -i -e "s|https://packages.microsoft.com|${repodepot_endpoint}/mariner/packages.microsoft.com|" $f
         echo "$f modified."
@@ -166,15 +173,15 @@ function init_mariner_repo_depot {
     echo "Mariner repo setup complete."
 }
 
-function init_azurelinux_repo_depot {
+init_azurelinux_repo_depot() {
     local repodepot_endpoint=$1
     repos=("amd" "base" "cloud-native" "extended" "ms-non-oss" "ms-oss" "nvidia")
 
     # tbd maybe we do this a bit nicer
-    rm -f /etc/yum.repos.d/azurelinux*
+    rm -f "${YUM_REPOS_D_DIR}"/azurelinux*
 
     for repo in "${repos[@]}"; do
-        output_file="/etc/yum.repos.d/azurelinux-${repo}.repo"
+        output_file="${YUM_REPOS_D_DIR}/azurelinux-${repo}.repo"
         repo_content=(
             "[azurelinux-official-$repo]"
             "name=Azure Linux Official $repo \$releasever \$basearch"
@@ -195,9 +202,8 @@ function init_azurelinux_repo_depot {
 
         echo "File '$output_file' has been created."
     done
+    echo "Azure Linux repo setup complete."
 }
-
-cloud-init status --wait
 
 dnf_makecache() {
     local retries=10
@@ -215,22 +221,43 @@ dnf_makecache() {
     echo "Executed dnf makecache -y $i times"
 }
 
-marinerRepoDepotEndpoint="$(echo "${REPO_DEPOT_ENDPOINT}" | sed 's/\/ubuntu//')"
-if [ -z "$marinerRepoDepotEndpoint" ]; then
-  >&2 echo "repo depot endpoint empty while running custom-cloud init script"
-else
-  # logic taken from https://repodepot.azure.com/scripts/cloud-init/setup_repodepot.sh
-  if [ "$IS_MARINER" -eq 1 ]; then
-      echo "Initializing Mariner repo depot settings..."
-      init_mariner_repo_depot ${marinerRepoDepotEndpoint}
-      dnf_makecache || exit 1
-  elif [ "$IS_AZURELINUX" -eq 1 ]; then
-      echo "Initializing Azure Linux repo depot settings..."
-      init_azurelinux_repo_depot ${marinerRepoDepotEndpoint}
-      dnf_makecache || exit 1
-  else
-      echo "No customizations for distribution: $NAME"
-  fi
-fi
+init_repo_depot() {
+    marinerRepoDepotEndpoint="$(echo "${REPO_DEPOT_ENDPOINT}" | sed 's/\/ubuntu//')"
+    if [ -z "$marinerRepoDepotEndpoint" ]; then
+      >&2 echo "repo depot endpoint empty while running custom-cloud init script"
+    else
+      # logic taken from https://repodepot.azure.com/scripts/cloud-init/setup_repodepot.sh
+      if [ "$IS_MARINER" -eq 1 ]; then
+          echo "Initializing Mariner repo depot settings..."
+          init_mariner_repo_depot ${marinerRepoDepotEndpoint}
+          dnf_makecache || exit 1
+      elif [ "$IS_AZURELINUX" -eq 1 ]; then
+          echo "Initializing Azure Linux repo depot settings..."
+          init_azurelinux_repo_depot ${marinerRepoDepotEndpoint}
+          dnf_makecache || exit 1
+      else
+          echo "No customizations for distribution: $NAME"
+      fi
+    fi
+}
+
+main() {
+    detect_distro
+    fetch_and_install_ca_certs
+
+    # This section creates a cron job to poll for refreshed CA certs daily
+    # It can be removed if not needed or desired
+    action=${1:-init}
+    if [ "$action" = "ca-refresh" ]; then
+        exit
+    fi
+
+    setup_ca_refresh_cron
+    cloud-init status --wait
+    init_repo_depot
+}
+
+${__SOURCED__:+return}
+main "$@"
 
 #EOF

--- a/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests-mariner.sh
+++ b/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests-mariner.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+[ -n "${__SOURCED__:-}" ] || set -x
 
 # Path constants — overridable for testing via env vars; defaults preserve
 # production behavior. functions defined until "${__SOURCED__:+return}" are
@@ -31,7 +31,6 @@ detect_distro() {
         exit 1
     fi
 
-    echo "distribution is $distribution"
     echo "Running on $NAME"
 }
 

--- a/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests.sh
+++ b/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests.sh
@@ -1,34 +1,49 @@
 #!/bin/bash
 set -x
-mkdir -p /root/AzureCACertificates
 
-IS_FLATCAR=0
-IS_UBUNTU=0
-IS_ACL=0
-# shellcheck disable=SC3010
-if [[ -f /etc/os-release ]]; then
-    . /etc/os-release
+# Path constants — overridable for testing via env vars; defaults preserve
+# production behavior. functions defined until "${__SOURCED__:+return}" are
+# sourced and tested in spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_operation_requests_spec.sh.
+: "${OS_RELEASE_FILE:=/etc/os-release}"
+: "${AZURE_CA_CERTS_DIR:=/root/AzureCACertificates}"
+: "${CA_TRUST_ANCHORS_DIR:=/etc/pki/ca-trust/source/anchors}"
+: "${SSL_CERTS_DIR:=/etc/ssl/certs}"
+: "${LOCAL_SHARE_CA_CERTS_DIR:=/usr/local/share/ca-certificates}"
+: "${OPENSSL_CERT_FILE:=/usr/lib/ssl/cert.pem}"
+: "${APT_SOURCES_LIST:=/etc/apt/sources.list}"
+: "${APT_SOURCES_LIST_D_DIR:=/etc/apt/sources.list.d}"
+: "${APT_KEYRINGS_DIR:=/etc/apt/keyrings}"
+: "${APT_BACKUP_DIR:=/etc/apt/backup}"
+: "${SYSTEMD_SYSTEM_DIR:=/etc/systemd/system}"
+# http://168.63.129.16 is a constant for the host's wireserver endpoint
+: "${WIRESERVER_ENDPOINT:=http://168.63.129.16}"
+
+detect_distro() {
+    IS_FLATCAR=0
+    IS_UBUNTU=0
+    IS_ACL=0
     # shellcheck disable=SC3010
-    if [[ $NAME == *"Ubuntu"* ]]; then
-        IS_UBUNTU=1
-    elif [[ $ID == *"flatcar"* ]]; then
-        IS_FLATCAR=1
-    elif [[ $ID == "azurecontainerlinux" ]] || { [[ $ID == "azurelinux" ]] && [[ ${VARIANT_ID:-} == "azurecontainerlinux" ]]; }; then
-        IS_ACL=1
+    if [[ -f "${OS_RELEASE_FILE}" ]]; then
+        . "${OS_RELEASE_FILE}"
+        # shellcheck disable=SC3010
+        if [[ $NAME == *"Ubuntu"* ]]; then
+            IS_UBUNTU=1
+        elif [[ $ID == *"flatcar"* ]]; then
+            IS_FLATCAR=1
+        elif [[ $ID == "azurecontainerlinux" ]] || { [[ $ID == "azurelinux" ]] && [[ ${VARIANT_ID:-} == "azurecontainerlinux" ]]; }; then
+            IS_ACL=1
+        else
+            echo "Unknown Linux distribution"
+            exit 1
+        fi
     else
-        echo "Unknown Linux distribution"
+        echo "Unsupported operating system"
         exit 1
     fi
-else
-    echo "Unsupported operating system"
-    exit 1
-fi
 
-echo "distribution is $distribution"
-echo "Running on $NAME"
-
-# http://168.63.129.16 is a constant for the host's wireserver endpoint
-WIRESERVER_ENDPOINT="http://168.63.129.16"
+    echo "distribution is $distribution"
+    echo "Running on $NAME"
+}
 
 # Function to make HTTP request with retry logic for rate limiting
 make_request_with_retry() {
@@ -102,7 +117,7 @@ process_cert_operations() {
 
         if [ -n "$cert_content" ]; then
             # Save the certificate to the appropriate location
-            echo "$cert_content" > "/root/AzureCACertificates/$cert_filename"
+            echo "$cert_content" > "${AZURE_CA_CERTS_DIR}/$cert_filename"
             echo "Successfully saved certificate: $cert_filename"
         else
             echo "Warning: Failed to retrieve certificate content for $cert_filename"
@@ -110,69 +125,64 @@ process_cert_operations() {
     done
 }
 
-# Process root certificates
-process_cert_operations "operationrequestsroot"
+fetch_and_install_ca_certs() {
+    mkdir -p "${AZURE_CA_CERTS_DIR}"
 
-# Process intermediate certificates
-process_cert_operations "operationrequestsintermediate"
+    # Process root certificates
+    process_cert_operations "operationrequestsroot"
 
-if [ "$IS_ACL" -eq 1 ]; then
-    cp /root/AzureCACertificates/*.crt /etc/pki/ca-trust/source/anchors/
-    update-ca-trust
-elif [ "${IS_FLATCAR}" -eq 0 ]; then
-    # Copy all certificate files to the system certificate directory
-    cp /root/AzureCACertificates/*.crt /usr/local/share/ca-certificates/
+    # Process intermediate certificates
+    process_cert_operations "operationrequestsintermediate"
 
-    # Update the system certificate store
-    update-ca-certificates
+    if [ "$IS_ACL" -eq 1 ]; then
+        cp "${AZURE_CA_CERTS_DIR}"/*.crt "${CA_TRUST_ANCHORS_DIR}/"
+        update-ca-trust
+    elif [ "${IS_FLATCAR}" -eq 0 ]; then
+        # Copy all certificate files to the system certificate directory
+        cp "${AZURE_CA_CERTS_DIR}"/*.crt "${LOCAL_SHARE_CA_CERTS_DIR}/"
 
-    # This copies the updated bundle to the location used by OpenSSL which is commonly used
-    cp /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl/cert.pem
-else
-    for cert in /root/AzureCACertificates/*.crt; do
-        destcert="${cert##*/}"
-        destcert="${destcert%.*}.pem"
-        cp "$cert" /etc/ssl/certs/"$destcert"
-    done
-    update-ca-certificates
-fi
+        # Update the system certificate store
+        update-ca-certificates
 
+        # This copies the updated bundle to the location used by OpenSSL which is commonly used
+        cp "${SSL_CERTS_DIR}/ca-certificates.crt" "${OPENSSL_CERT_FILE}"
+    else
+        for cert in "${AZURE_CA_CERTS_DIR}"/*.crt; do
+            destcert="${cert##*/}"
+            destcert="${destcert%.*}.pem"
+            cp "$cert" "${SSL_CERTS_DIR}/$destcert"
+        done
+        update-ca-certificates
+    fi
+}
 
-
-# This section creates a cron job to poll for refreshed CA certs daily
-# It can be removed if not needed or desired
-action=${1:-init}
-if [ "$action" = "ca-refresh" ]; then
-    exit
-fi
-
-function init_ubuntu_main_repo_depot {
+init_ubuntu_main_repo_depot() {
     local repodepot_endpoint="$1"
     # Initialize directory for keys
-    mkdir -p /etc/apt/keyrings
+    mkdir -p "${APT_KEYRINGS_DIR}"
 
     # This copies the updated bundle to the location used by OpenSSL which is commonly used
     echo "Copying updated bundle to OpenSSL .pem file..."
-    cp /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl/cert.pem
+    cp "${SSL_CERTS_DIR}/ca-certificates.crt" "${OPENSSL_CERT_FILE}"
     echo "Updated bundle copied."
 
     # Back up sources.list and sources.list.d contents
-    mkdir -p /etc/apt/backup/
-    if [ -f "/etc/apt/sources.list" ]; then
-        mv /etc/apt/sources.list /etc/apt/backup/
+    mkdir -p "${APT_BACKUP_DIR}/"
+    if [ -f "${APT_SOURCES_LIST}" ]; then
+        mv "${APT_SOURCES_LIST}" "${APT_BACKUP_DIR}/"
     fi
-    for sources_file in /etc/apt/sources.list.d/*; do
+    for sources_file in "${APT_SOURCES_LIST_D_DIR}"/*; do
         if [ -f "$sources_file" ]; then
-            mv "$sources_file" /etc/apt/backup/
+            mv "$sources_file" "${APT_BACKUP_DIR}/"
         fi
     done
 
     # Set location of sources file
-    . /etc/os-release
-    aptSourceFile="/etc/apt/sources.list.d/ubuntu.sources"
+    . "${OS_RELEASE_FILE}"
+    aptSourceFile="${APT_SOURCES_LIST_D_DIR}/ubuntu.sources"
 
     # Create main sources file
-    cat <<EOF > /etc/apt/sources.list.d/ubuntu.sources
+    cat <<EOF > "${aptSourceFile}"
 
 Types: deb
 URIs: ${repodepot_endpoint}/ubuntu
@@ -194,7 +204,7 @@ EOF
     echo ""
 }
 
-function check_url {
+check_url() {
     local url=$1
     echo "Checking url: $url"
 
@@ -208,13 +218,13 @@ function check_url {
     fi
 }
 
-function write_to_sources_file {
+write_to_sources_file() {
     local sources_list_d_file=$1
     local source_uri=$2
     shift 2
     local key_paths=("$@")
 
-    sources_file_path="/etc/apt/sources.list.d/${sources_list_d_file}.sources"
+    sources_file_path="${APT_SOURCES_LIST_D_DIR}/${sources_list_d_file}.sources"
     ubuntuDist=$(lsb_release -c | awk '{print $2}')
 
     tee -a $sources_file_path <<EOF
@@ -228,7 +238,7 @@ Signed-By: ${key_paths[*]}
 EOF
 }
 
-function add_key_ubuntu {
+add_key_ubuntu() {
     local key_name=$1
 
     key_url="${repodepot_endpoint}/keys/${key_name}"
@@ -240,18 +250,18 @@ function add_key_ubuntu {
     echo "$key_name key added to keyring."
 }
 
-function derive_key_paths {
+derive_key_paths() {
     local key_names=("$@")
     local key_paths=()
 
     for key_name in "${key_names[@]}"; do
-        key_paths+=("/etc/apt/keyrings/${key_name}.gpg")
+        key_paths+=("${APT_KEYRINGS_DIR}/${key_name}.gpg")
     done
 
     echo "${key_paths[*]}"
 }
 
-function add_ms_keys {
+add_ms_keys() {
     # Add the Microsoft package server keys to keyring.
     echo "Adding Microsoft keys to keyring..."
 
@@ -259,7 +269,7 @@ function add_ms_keys {
     add_key_ubuntu msopentech.asc
 }
 
-function aptget_update {
+aptget_update() {
     echo "apt-get updating..."
     echo "note: depending on how many sources have been added this may take a couple minutes..."
     if apt-get update | grep -q "404 Not Found"; then
@@ -270,7 +280,7 @@ function aptget_update {
     fi
 }
 
-function init_ubuntu_pmc_repo_depot {
+init_ubuntu_pmc_repo_depot() {
     local repodepot_endpoint="$1"
     # Add Microsoft packages source to the azure specific sources.list.
     echo "Adding the packages.microsoft.com Ubuntu-$ubuntuRel repo..."
@@ -284,7 +294,7 @@ function init_ubuntu_pmc_repo_depot {
     add_ms_keys $repodepot_endpoint
 }
 
-if [ "$IS_UBUNTU" -eq 1 ]; then
+setup_ubuntu_ca_refresh_cron() {
     scriptPath=$0
     # Determine an absolute, canonical path to this script for use in cron.
     if command -v readlink >/dev/null 2>&1; then
@@ -298,22 +308,12 @@ if [ "$IS_UBUNTU" -eq 1 ]; then
             echo "Failed to install ca-refresh cron job via crontab" >&2
         fi
     fi
+}
 
-    cloud-init status --wait
-    rootRepoDepotEndpoint="$(echo "${REPO_DEPOT_ENDPOINT}" | sed 's/\/ubuntu//')"
-    # logic taken from https://repodepot.azure.com/scripts/cloud-init/setup_repodepot.sh
-    ubuntuRel=$(lsb_release --release | awk '{print $2}')
-    ubuntuDist=$(lsb_release -c | awk '{print $2}')
-    # initialize archive.ubuntu.com repo
-    init_ubuntu_main_repo_depot ${rootRepoDepotEndpoint}
-    init_ubuntu_pmc_repo_depot ${rootRepoDepotEndpoint}
-    # update apt list
-    echo "Running apt-get update"
-    aptget_update
-elif [ "$IS_FLATCAR" -eq 1 ] || [ "$IS_ACL" -eq 1 ]; then
+setup_flatcar_or_acl_ca_refresh_timer() {
     script_path="$(readlink -f "$0")"
-    svc="/etc/systemd/system/azure-ca-refresh.service"
-    tmr="/etc/systemd/system/azure-ca-refresh.timer"
+    svc="${SYSTEMD_SYSTEM_DIR}/azure-ca-refresh.service"
+    tmr="${SYSTEMD_SYSTEM_DIR}/azure-ca-refresh.timer"
 
     cat >"$svc" <<EOF
 [Unit]
@@ -341,6 +341,42 @@ EOF
 
     systemctl daemon-reload
     systemctl enable --now azure-ca-refresh.timer
-fi
+}
+
+init_ubuntu_repo_depot() {
+    cloud-init status --wait
+    rootRepoDepotEndpoint="$(echo "${REPO_DEPOT_ENDPOINT}" | sed 's/\/ubuntu//')"
+    # logic taken from https://repodepot.azure.com/scripts/cloud-init/setup_repodepot.sh
+    ubuntuRel=$(lsb_release --release | awk '{print $2}')
+    ubuntuDist=$(lsb_release -c | awk '{print $2}')
+    # initialize archive.ubuntu.com repo
+    init_ubuntu_main_repo_depot ${rootRepoDepotEndpoint}
+    init_ubuntu_pmc_repo_depot ${rootRepoDepotEndpoint}
+    # update apt list
+    echo "Running apt-get update"
+    aptget_update
+}
+
+main() {
+    detect_distro
+    fetch_and_install_ca_certs
+
+    # This section creates a cron job to poll for refreshed CA certs daily
+    # It can be removed if not needed or desired
+    action=${1:-init}
+    if [ "$action" = "ca-refresh" ]; then
+        exit
+    fi
+
+    if [ "$IS_UBUNTU" -eq 1 ]; then
+        setup_ubuntu_ca_refresh_cron
+        init_ubuntu_repo_depot
+    elif [ "$IS_FLATCAR" -eq 1 ] || [ "$IS_ACL" -eq 1 ]; then
+        setup_flatcar_or_acl_ca_refresh_timer
+    fi
+}
+
+${__SOURCED__:+return}
+main "$@"
 
 #EOF

--- a/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests.sh
+++ b/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+[ -n "${__SOURCED__:-}" ] || set -x
 
 # Path constants — overridable for testing via env vars; defaults preserve
 # production behavior. functions defined until "${__SOURCED__:+return}" are
@@ -41,7 +41,6 @@ detect_distro() {
         exit 1
     fi
 
-    echo "distribution is $distribution"
     echo "Running on $NAME"
 }
 

--- a/parts/linux/cloud-init/artifacts/init-aks-custom-cloud.sh
+++ b/parts/linux/cloud-init/artifacts/init-aks-custom-cloud.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+[ -n "${__SOURCED__:-}" ] || set -x
 
 # Path constants — overridable for testing via env vars; defaults preserve
 # production behavior. functions defined until "${__SOURCED__:+return}" are
@@ -42,7 +42,6 @@ detect_distro() {
         exit 1
     fi
 
-    echo "distribution is $distribution"
     echo "Running on $NAME"
 }
 

--- a/parts/linux/cloud-init/artifacts/init-aks-custom-cloud.sh
+++ b/parts/linux/cloud-init/artifacts/init-aks-custom-cloud.sh
@@ -1,95 +1,109 @@
 #!/bin/bash
 set -x
-mkdir -p /root/AzureCACertificates
 
-IS_FLATCAR=0
-IS_UBUNTU=0
-IS_ACL=0
-# shellcheck disable=SC3010
-if [[ -f /etc/os-release ]]; then
-    . /etc/os-release
+# Path constants — overridable for testing via env vars; defaults preserve
+# production behavior. functions defined until "${__SOURCED__:+return}" are
+# sourced and tested in spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_spec.sh.
+: "${OS_RELEASE_FILE:=/etc/os-release}"
+: "${AZURE_CA_CERTS_DIR:=/root/AzureCACertificates}"
+: "${CA_TRUST_ANCHORS_DIR:=/etc/pki/ca-trust/source/anchors}"
+: "${SSL_CERTS_DIR:=/etc/ssl/certs}"
+: "${LOCAL_SHARE_CA_CERTS_DIR:=/usr/local/share/ca-certificates}"
+: "${OPENSSL_CERT_FILE:=/usr/lib/ssl/cert.pem}"
+: "${APT_SOURCES_LIST:=/etc/apt/sources.list}"
+: "${APT_SOURCES_LIST_D_DIR:=/etc/apt/sources.list.d}"
+: "${APT_KEYRINGS_DIR:=/etc/apt/keyrings}"
+: "${APT_BACKUP_DIR:=/etc/apt/backup}"
+: "${SYSTEMD_SYSTEM_DIR:=/etc/systemd/system}"
+: "${CHRONY_CONF_FILE:=/etc/chrony/chrony.conf}"
+# http://168.63.129.16 is a constant for the host's wireserver endpoint
+: "${WIRESERVER_ENDPOINT:=http://168.63.129.16}"
+
+detect_distro() {
+    IS_FLATCAR=0
+    IS_UBUNTU=0
+    IS_ACL=0
     # shellcheck disable=SC3010
-    if [[ $NAME == *"Ubuntu"* ]]; then
-        IS_UBUNTU=1
-    elif [[ $ID == *"flatcar"* ]]; then
-        IS_FLATCAR=1
-    elif [[ $ID == "azurecontainerlinux" ]] || { [[ $ID == "azurelinux" ]] && [[ ${VARIANT_ID:-} == "azurecontainerlinux" ]]; }; then
-        IS_ACL=1
+    if [[ -f "${OS_RELEASE_FILE}" ]]; then
+        . "${OS_RELEASE_FILE}"
+        # shellcheck disable=SC3010
+        if [[ $NAME == *"Ubuntu"* ]]; then
+            IS_UBUNTU=1
+        elif [[ $ID == *"flatcar"* ]]; then
+            IS_FLATCAR=1
+        elif [[ $ID == "azurecontainerlinux" ]] || { [[ $ID == "azurelinux" ]] && [[ ${VARIANT_ID:-} == "azurecontainerlinux" ]]; }; then
+            IS_ACL=1
+        else
+            echo "Unknown Linux distribution"
+            exit 1
+        fi
     else
-        echo "Unknown Linux distribution"
+        echo "Unsupported operating system"
         exit 1
     fi
-else
-    echo "Unsupported operating system"
-    exit 1
-fi
 
-echo "distribution is $distribution"
-echo "Running on $NAME"
+    echo "distribution is $distribution"
+    echo "Running on $NAME"
+}
 
-# http://168.63.129.16 is a constant for the host's wireserver endpoint
-certs=$(curl "http://168.63.129.16/machine?comp=acmspackage&type=cacertificates&ext=json")
-IFS_backup=$IFS
-IFS=$'\r\n'
-certNames=($(echo $certs | grep -oP '(?<=Name\": \")[^\"]*'))
-certBodies=($(echo $certs | grep -oP '(?<=CertBody\": \")[^\"]*'))
-ext=".crt"
-if [ "$IS_FLATCAR" -eq 1 ]; then
-    ext=".pem"
-fi
-for i in ${!certBodies[@]}; do
-    echo ${certBodies[$i]}  | sed 's/\\r\\n/\n/g' | sed 's/\\//g' > "/root/AzureCACertificates/$(echo ${certNames[$i]} | sed "s/.cer/.${ext}/g")"
-done
-IFS=$IFS_backup
+fetch_and_install_ca_certs() {
+    mkdir -p "${AZURE_CA_CERTS_DIR}"
+    certs=$(curl "${WIRESERVER_ENDPOINT}/machine?comp=acmspackage&type=cacertificates&ext=json")
+    IFS_backup=$IFS
+    IFS=$'\r\n'
+    certNames=($(echo $certs | grep -oP '(?<=Name\": \")[^\"]*'))
+    certBodies=($(echo $certs | grep -oP '(?<=CertBody\": \")[^\"]*'))
+    ext=".crt"
+    if [ "$IS_FLATCAR" -eq 1 ]; then
+        ext=".pem"
+    fi
+    for i in ${!certBodies[@]}; do
+        echo ${certBodies[$i]}  | sed 's/\\r\\n/\n/g' | sed 's/\\//g' > "${AZURE_CA_CERTS_DIR}/$(echo ${certNames[$i]} | sed "s/.cer/.${ext}/g")"
+    done
+    IFS=$IFS_backup
 
-if [ "$IS_ACL" -eq 1 ]; then
-    cp /root/AzureCACertificates/*.crt /etc/pki/ca-trust/source/anchors/
-    update-ca-trust
-elif [ "$IS_FLATCAR" -eq 1 ]; then
-    cp /root/AzureCACertificates/*.pem /etc/ssl/certs/
-    update-ca-certificates
-else
-    cp /root/AzureCACertificates/*.crt /usr/local/share/ca-certificates/
-    update-ca-certificates
+    if [ "$IS_ACL" -eq 1 ]; then
+        cp "${AZURE_CA_CERTS_DIR}"/*.crt "${CA_TRUST_ANCHORS_DIR}/"
+        update-ca-trust
+    elif [ "$IS_FLATCAR" -eq 1 ]; then
+        cp "${AZURE_CA_CERTS_DIR}"/*.pem "${SSL_CERTS_DIR}/"
+        update-ca-certificates
+    else
+        cp "${AZURE_CA_CERTS_DIR}"/*.crt "${LOCAL_SHARE_CA_CERTS_DIR}/"
+        update-ca-certificates
 
-    # This copies the updated bundle to the location used by OpenSSL which is commonly used
-    cp /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl/cert.pem
-fi
+        # This copies the updated bundle to the location used by OpenSSL which is commonly used
+        cp "${SSL_CERTS_DIR}/ca-certificates.crt" "${OPENSSL_CERT_FILE}"
+    fi
+}
 
-# This section creates a cron job to poll for refreshed CA certs daily
-# It can be removed if not needed or desired
-action=${1:-init}
-if [ "$action" = "ca-refresh" ]; then
-    exit
-fi
-
-function init_ubuntu_main_repo_depot {
+init_ubuntu_main_repo_depot() {
     local repodepot_endpoint="$1"
     # Initialize directory for keys
-    mkdir -p /etc/apt/keyrings
+    mkdir -p "${APT_KEYRINGS_DIR}"
 
     # This copies the updated bundle to the location used by OpenSSL which is commonly used
     echo "Copying updated bundle to OpenSSL .pem file..."
-    cp /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl/cert.pem
+    cp "${SSL_CERTS_DIR}/ca-certificates.crt" "${OPENSSL_CERT_FILE}"
     echo "Updated bundle copied."
 
     # Back up sources.list and sources.list.d contents
-    mkdir -p /etc/apt/backup/
-    if [ -f "/etc/apt/sources.list" ]; then
-        mv /etc/apt/sources.list /etc/apt/backup/
+    mkdir -p "${APT_BACKUP_DIR}/"
+    if [ -f "${APT_SOURCES_LIST}" ]; then
+        mv "${APT_SOURCES_LIST}" "${APT_BACKUP_DIR}/"
     fi
-    for sources_file in /etc/apt/sources.list.d/*; do
+    for sources_file in "${APT_SOURCES_LIST_D_DIR}"/*; do
         if [ -f "$sources_file" ]; then
-            mv "$sources_file" /etc/apt/backup/
+            mv "$sources_file" "${APT_BACKUP_DIR}/"
         fi
     done
 
     # Set location of sources file
-    . /etc/os-release
-    aptSourceFile="/etc/apt/sources.list.d/ubuntu.sources"
+    . "${OS_RELEASE_FILE}"
+    aptSourceFile="${APT_SOURCES_LIST_D_DIR}/ubuntu.sources"
 
     # Create main sources file
-    cat <<EOF > /etc/apt/sources.list.d/ubuntu.sources
+    cat <<EOF > "${aptSourceFile}"
 
 Types: deb
 URIs: ${repodepot_endpoint}/ubuntu
@@ -111,7 +125,7 @@ EOF
     echo ""
 }
 
-function check_url {
+check_url() {
     local url=$1
     echo "Checking url: $url"
 
@@ -125,13 +139,13 @@ function check_url {
     fi
 }
 
-function write_to_sources_file {
+write_to_sources_file() {
     local sources_list_d_file=$1
     local source_uri=$2
     shift 2
     local key_paths=("$@")
 
-    sources_file_path="/etc/apt/sources.list.d/${sources_list_d_file}.sources"
+    sources_file_path="${APT_SOURCES_LIST_D_DIR}/${sources_list_d_file}.sources"
     ubuntuDist=$(lsb_release -c | awk '{print $2}')
 
     tee -a $sources_file_path <<EOF
@@ -145,7 +159,7 @@ Signed-By: ${key_paths[*]}
 EOF
 }
 
-function add_key_ubuntu {
+add_key_ubuntu() {
     local key_name=$1
 
     key_url="${repodepot_endpoint}/keys/${key_name}"
@@ -157,18 +171,18 @@ function add_key_ubuntu {
     echo "$key_name key added to keyring."
 }
 
-function derive_key_paths {
+derive_key_paths() {
     local key_names=("$@")
     local key_paths=()
 
     for key_name in "${key_names[@]}"; do
-        key_paths+=("/etc/apt/keyrings/${key_name}.gpg")
+        key_paths+=("${APT_KEYRINGS_DIR}/${key_name}.gpg")
     done
 
     echo "${key_paths[*]}"
 }
 
-function add_ms_keys {
+add_ms_keys() {
     # Add the Microsoft package server keys to keyring.
     echo "Adding Microsoft keys to keyring..."
 
@@ -176,7 +190,7 @@ function add_ms_keys {
     add_key_ubuntu msopentech.asc
 }
 
-function aptget_update {
+aptget_update() {
     echo "apt-get updating..."
     echo "note: depending on how many sources have been added this may take a couple minutes..."
     if apt-get update | grep -q "404 Not Found"; then
@@ -187,7 +201,7 @@ function aptget_update {
     fi
 }
 
-function init_ubuntu_pmc_repo_depot {
+init_ubuntu_pmc_repo_depot() {
     local repodepot_endpoint="$1"
     # Add Microsoft packages source to the azure specific sources.list.
     echo "Adding the packages.microsoft.com Ubuntu-$ubuntuRel repo..."
@@ -201,7 +215,7 @@ function init_ubuntu_pmc_repo_depot {
     add_ms_keys $repodepot_endpoint
 }
 
-if [ "$IS_UBUNTU" -eq 1 ]; then
+setup_ubuntu_ca_refresh_cron() {
     scriptPath=$0
     # Determine an absolute, canonical path to this script for use in cron.
     if command -v readlink >/dev/null 2>&1; then
@@ -215,22 +229,12 @@ if [ "$IS_UBUNTU" -eq 1 ]; then
             echo "Failed to install ca-refresh cron job via crontab" >&2
         fi
     fi
+}
 
-    cloud-init status --wait
-    rootRepoDepotEndpoint="$(echo "${REPO_DEPOT_ENDPOINT}" | sed 's/\/ubuntu//')"
-    # logic taken from https://repodepot.azure.com/scripts/cloud-init/setup_repodepot.sh
-    ubuntuRel=$(lsb_release --release | awk '{print $2}')
-    ubuntuDist=$(lsb_release -c | awk '{print $2}')
-    # initialize archive.ubuntu.com repo
-    init_ubuntu_main_repo_depot ${rootRepoDepotEndpoint}
-    init_ubuntu_pmc_repo_depot ${rootRepoDepotEndpoint}
-    # update apt list
-    echo "Running apt-get update"
-    aptget_update
-elif [ "$IS_FLATCAR" -eq 1 ] || [ "$IS_ACL" -eq 1 ]; then
+setup_flatcar_or_acl_ca_refresh_timer() {
     script_path="$(readlink -f "$0")"
-    svc="/etc/systemd/system/azure-ca-refresh.service"
-    tmr="/etc/systemd/system/azure-ca-refresh.timer"
+    svc="${SYSTEMD_SYSTEM_DIR}/azure-ca-refresh.service"
+    tmr="${SYSTEMD_SYSTEM_DIR}/azure-ca-refresh.timer"
 
     cat >"$svc" <<EOF
 [Unit]
@@ -258,28 +262,44 @@ EOF
 
     systemctl daemon-reload
     systemctl enable --now azure-ca-refresh.timer
-fi
+}
 
-# Disable systemd-timesyncd and install chrony and uses local time source
-# ACL has PTP clock config compiled into chronyd with no config file or sourcedir directives,
-# so it uses only the local PTP clock and has no DHCP-injectable NTP sources.
-if [ "$IS_ACL" -eq 1 ]; then
-    echo "Skipping chrony configuration for ACL (PTP clock baked into chronyd, no external NTP sources)"
-else
-chrony_conf="/etc/chrony/chrony.conf"
-if [ "$IS_UBUNTU" -eq 1 ]; then
-    systemctl stop systemd-timesyncd
-    systemctl disable systemd-timesyncd
+init_ubuntu_repo_depot() {
+    cloud-init status --wait
+    rootRepoDepotEndpoint="$(echo "${REPO_DEPOT_ENDPOINT}" | sed 's/\/ubuntu//')"
+    # logic taken from https://repodepot.azure.com/scripts/cloud-init/setup_repodepot.sh
+    ubuntuRel=$(lsb_release --release | awk '{print $2}')
+    ubuntuDist=$(lsb_release -c | awk '{print $2}')
+    # initialize archive.ubuntu.com repo
+    init_ubuntu_main_repo_depot ${rootRepoDepotEndpoint}
+    init_ubuntu_pmc_repo_depot ${rootRepoDepotEndpoint}
+    # update apt list
+    echo "Running apt-get update"
+    aptget_update
+}
 
-    if [ ! -e "$chrony_conf" ]; then
-        apt-get update
-        apt-get install chrony -y
+write_chrony_config() {
+    # Disable systemd-timesyncd and install chrony and uses local time source
+    # ACL has PTP clock config compiled into chronyd with no config file or sourcedir directives,
+    # so it uses only the local PTP clock and has no DHCP-injectable NTP sources.
+    if [ "$IS_ACL" -eq 1 ]; then
+        echo "Skipping chrony configuration for ACL (PTP clock baked into chronyd, no external NTP sources)"
+        return
     fi
-elif [ "$IS_FLATCAR" -eq 1 ]; then
-    rm -f ${chrony_conf}
-fi
 
-cat > $chrony_conf <<EOF
+    if [ "$IS_UBUNTU" -eq 1 ]; then
+        systemctl stop systemd-timesyncd
+        systemctl disable systemd-timesyncd
+
+        if [ ! -e "${CHRONY_CONF_FILE}" ]; then
+            apt-get update
+            apt-get install chrony -y
+        fi
+    elif [ "$IS_FLATCAR" -eq 1 ]; then
+        rm -f "${CHRONY_CONF_FILE}"
+    fi
+
+    cat > "${CHRONY_CONF_FILE}" <<EOF
 # Welcome to the chrony configuration file. See chrony.conf(5) for more
 # information about usuable directives.
 
@@ -327,11 +347,35 @@ refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
 makestep 1.0 -1
 EOF
 
-if [ "$IS_UBUNTU" -eq 1 ]; then
-    systemctl restart chrony
-elif [ "$IS_FLATCAR" -eq 1 ]; then
-    systemctl restart chronyd
-fi
-fi # end of IS_ACL skip block
+    if [ "$IS_UBUNTU" -eq 1 ]; then
+        systemctl restart chrony
+    elif [ "$IS_FLATCAR" -eq 1 ]; then
+        systemctl restart chronyd
+    fi
+}
+
+main() {
+    detect_distro
+    fetch_and_install_ca_certs
+
+    # This section creates a cron job to poll for refreshed CA certs daily
+    # It can be removed if not needed or desired
+    action=${1:-init}
+    if [ "$action" = "ca-refresh" ]; then
+        exit
+    fi
+
+    if [ "$IS_UBUNTU" -eq 1 ]; then
+        setup_ubuntu_ca_refresh_cron
+        init_ubuntu_repo_depot
+    elif [ "$IS_FLATCAR" -eq 1 ] || [ "$IS_ACL" -eq 1 ]; then
+        setup_flatcar_or_acl_ca_refresh_timer
+    fi
+
+    write_chrony_config
+}
+
+${__SOURCED__:+return}
+main "$@"
 
 #EOF

--- a/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_mariner_spec.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# Tests for parts/linux/cloud-init/artifacts/init-aks-custom-cloud-mariner.sh
+#
+# Custom-cloud (Bleu, AGC, etc. — clouds that aren't Mooncake/Fairfax) provision-time
+# script for Mariner/AzureLinux. We assert that after the repo-depot rewrite:
+#   1. All baseurl entries point at the mocked depot, not packages.microsoft.com.
+#   2. No third-party (e.g. developer.download.nvidia.com) URLs leak into the repo files.
+#
+# This is the regression class that caused IcM 725845756 (Bleu) — stale repo URLs on
+# the booted VHD caused AzSecPack tdnf calls to hang on unreachable endpoints.
+
+Describe 'init-aks-custom-cloud-mariner.sh'
+    Include "./parts/linux/cloud-init/artifacts/init-aks-custom-cloud-mariner.sh"
+    set +x
+
+    setup() {
+        TEST_DIR="$(mktemp -d)"
+        export OS_RELEASE_FILE="${TEST_DIR}/os-release"
+        export AZURE_CA_CERTS_DIR="${TEST_DIR}/AzureCACertificates"
+        export CA_TRUST_ANCHORS_DIR="${TEST_DIR}/ca-trust-anchors"
+        export YUM_REPOS_D_DIR="${TEST_DIR}/yum.repos.d"
+        export CHRONY_CONF_FILE="${TEST_DIR}/chrony.conf"
+        export WIRESERVER_ENDPOINT="http://wireserver.local"
+        mkdir -p "${AZURE_CA_CERTS_DIR}" "${CA_TRUST_ANCHORS_DIR}" "${YUM_REPOS_D_DIR}"
+    }
+    cleanup() {
+        rm -rf "${TEST_DIR}"
+    }
+
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    Describe 'init_mariner_repo_depot'
+        write_mariner_extras_repo() {
+            cat > "${YUM_REPOS_D_DIR}/mariner-extras.repo" <<'EOF'
+[mariner-official-extras]
+name=CBL-Mariner Official Extras $releasever $basearch
+baseurl=https://packages.microsoft.com/cbl-mariner/$releasever/prod/extras/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY
+gpgcheck=1
+enabled=1
+EOF
+        }
+
+        It 'rewrites Mariner repo baseurls to the depot endpoint and creates extended/nvidia/cloud-native repos'
+            write_mariner_extras_repo
+            When call init_mariner_repo_depot "https://repodepot.bleu.example.com"
+            The status should be success
+            The path "${YUM_REPOS_D_DIR}/mariner-extended.repo" should be exist
+            The path "${YUM_REPOS_D_DIR}/mariner-nvidia.repo" should be exist
+            The path "${YUM_REPOS_D_DIR}/mariner-cloud-native.repo" should be exist
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-extras.repo" should include "https://repodepot.bleu.example.com/mariner/packages.microsoft.com"
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-extras.repo" should not include "https://packages.microsoft.com"
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-nvidia.repo" should include "https://repodepot.bleu.example.com/mariner/packages.microsoft.com"
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-nvidia.repo" should not include "https://packages.microsoft.com"
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-nvidia.repo" should not include "developer.download.nvidia.com"
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-cloud-native.repo" should include "https://repodepot.bleu.example.com/mariner/packages.microsoft.com"
+        End
+
+        It 'derives the nvidia repo from extras with case-preserving section/name updates'
+            write_mariner_extras_repo
+            When call init_mariner_repo_depot "https://repodepot.bleu.example.com"
+            The status should be success
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-nvidia.repo" should include "[mariner-official-nvidia]"
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-nvidia.repo" should include "name=CBL-Mariner Official Nvidia"
+        End
+    End
+
+    Describe 'init_azurelinux_repo_depot'
+        It 'creates all seven azurelinux repo files pointing at the depot'
+            When call init_azurelinux_repo_depot "https://repodepot.bleu.example.com"
+            The status should be success
+            The path "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should be exist
+            The path "${YUM_REPOS_D_DIR}/azurelinux-cloud-native.repo" should be exist
+            The path "${YUM_REPOS_D_DIR}/azurelinux-nvidia.repo" should be exist
+            The path "${YUM_REPOS_D_DIR}/azurelinux-amd.repo" should be exist
+            The path "${YUM_REPOS_D_DIR}/azurelinux-extended.repo" should be exist
+            The path "${YUM_REPOS_D_DIR}/azurelinux-ms-non-oss.repo" should be exist
+            The path "${YUM_REPOS_D_DIR}/azurelinux-ms-oss.repo" should be exist
+        End
+
+        It 'writes baseurls that point at the depot and never at packages.microsoft.com'
+            When call init_azurelinux_repo_depot "https://repodepot.bleu.example.com"
+            The status should be success
+            The contents of file "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should include "baseurl=https://repodepot.bleu.example.com/azurelinux/"
+            The contents of file "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should not include "packages.microsoft.com"
+            The contents of file "${YUM_REPOS_D_DIR}/azurelinux-nvidia.repo" should include "baseurl=https://repodepot.bleu.example.com/azurelinux/"
+            The contents of file "${YUM_REPOS_D_DIR}/azurelinux-nvidia.repo" should not include "developer.download.nvidia.com"
+            The contents of file "${YUM_REPOS_D_DIR}/azurelinux-nvidia.repo" should not include "packages.microsoft.com"
+        End
+
+        It 'removes any pre-existing azurelinux*.repo files before creating new ones'
+            echo "stale" > "${YUM_REPOS_D_DIR}/azurelinux-leftover.repo"
+            When call init_azurelinux_repo_depot "https://repodepot.bleu.example.com"
+            The status should be success
+            The path "${YUM_REPOS_D_DIR}/azurelinux-leftover.repo" should not be exist
+        End
+    End
+
+    Describe 'init_repo_depot dispatch'
+        setup_mariner_os_release() {
+            cat > "${OS_RELEASE_FILE}" <<EOF
+NAME="Common Base Linux Mariner"
+VERSION="2.0.20250701"
+ID=mariner
+VERSION_ID="2.0"
+PRETTY_NAME="CBL-Mariner/Linux"
+EOF
+        }
+        setup_azurelinux_os_release() {
+            cat > "${OS_RELEASE_FILE}" <<EOF
+NAME="Microsoft Azure Linux"
+VERSION="3.0.20250702"
+ID=azurelinux
+VERSION_ID="3.0"
+PRETTY_NAME="Microsoft Azure Linux 3.0"
+EOF
+        }
+        write_mariner_extras_repo() {
+            cat > "${YUM_REPOS_D_DIR}/mariner-extras.repo" <<'EOF'
+[mariner-official-extras]
+baseurl=https://packages.microsoft.com/cbl-mariner/$releasever/prod/extras/$basearch
+EOF
+        }
+
+        Mock dnf_makecache
+            true
+        End
+
+        It 'strips trailing /ubuntu from REPO_DEPOT_ENDPOINT and runs Mariner path'
+            setup_mariner_os_release
+            write_mariner_extras_repo
+            detect_distro
+            REPO_DEPOT_ENDPOINT="https://repodepot.bleu.example.com/ubuntu"
+            When call init_repo_depot
+            The status should be success
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-extras.repo" should include "https://repodepot.bleu.example.com/mariner/packages.microsoft.com"
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-extras.repo" should not include "https://packages.microsoft.com"
+        End
+
+        It 'runs AzureLinux path and writes only depot URLs'
+            setup_azurelinux_os_release
+            detect_distro
+            REPO_DEPOT_ENDPOINT="https://repodepot.bleu.example.com/ubuntu"
+            When call init_repo_depot
+            The status should be success
+            The contents of file "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should include "https://repodepot.bleu.example.com/azurelinux/"
+        End
+
+        It 'warns when REPO_DEPOT_ENDPOINT is empty'
+            setup_mariner_os_release
+            detect_distro
+            REPO_DEPOT_ENDPOINT=""
+            When call init_repo_depot
+            The status should be success
+            The stderr should include "repo depot endpoint empty"
+        End
+    End
+End

--- a/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_mariner_spec.sh
@@ -46,6 +46,7 @@ EOF
         It 'rewrites Mariner repo baseurls to the depot endpoint and creates extended/nvidia/cloud-native repos'
             write_mariner_extras_repo
             When call init_mariner_repo_depot "https://repodepot.bleu.example.com"
+            The output should be present
             The status should be success
             The path "${YUM_REPOS_D_DIR}/mariner-extended.repo" should be exist
             The path "${YUM_REPOS_D_DIR}/mariner-nvidia.repo" should be exist
@@ -61,6 +62,7 @@ EOF
         It 'derives the nvidia repo from extras with case-preserving section/name updates'
             write_mariner_extras_repo
             When call init_mariner_repo_depot "https://repodepot.bleu.example.com"
+            The output should be present
             The status should be success
             The contents of file "${YUM_REPOS_D_DIR}/mariner-nvidia.repo" should include "[mariner-official-nvidia]"
             The contents of file "${YUM_REPOS_D_DIR}/mariner-nvidia.repo" should include "name=CBL-Mariner Official Nvidia"
@@ -70,6 +72,7 @@ EOF
     Describe 'init_azurelinux_repo_depot'
         It 'creates all seven azurelinux repo files pointing at the depot'
             When call init_azurelinux_repo_depot "https://repodepot.bleu.example.com"
+            The output should be present
             The status should be success
             The path "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should be exist
             The path "${YUM_REPOS_D_DIR}/azurelinux-cloud-native.repo" should be exist
@@ -82,6 +85,7 @@ EOF
 
         It 'writes baseurls that point at the depot and never at packages.microsoft.com'
             When call init_azurelinux_repo_depot "https://repodepot.bleu.example.com"
+            The output should be present
             The status should be success
             The contents of file "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should include "baseurl=https://repodepot.bleu.example.com/azurelinux/"
             The contents of file "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should not include "packages.microsoft.com"
@@ -93,6 +97,7 @@ EOF
         It 'removes any pre-existing azurelinux*.repo files before creating new ones'
             echo "stale" > "${YUM_REPOS_D_DIR}/azurelinux-leftover.repo"
             When call init_azurelinux_repo_depot "https://repodepot.bleu.example.com"
+            The output should be present
             The status should be success
             The path "${YUM_REPOS_D_DIR}/azurelinux-leftover.repo" should not be exist
         End
@@ -134,6 +139,7 @@ EOF
             detect_distro
             REPO_DEPOT_ENDPOINT="https://repodepot.bleu.example.com/ubuntu"
             When call init_repo_depot
+            The output should be present
             The status should be success
             The contents of file "${YUM_REPOS_D_DIR}/mariner-extras.repo" should include "https://repodepot.bleu.example.com/mariner/packages.microsoft.com"
             The contents of file "${YUM_REPOS_D_DIR}/mariner-extras.repo" should not include "https://packages.microsoft.com"
@@ -144,6 +150,7 @@ EOF
             detect_distro
             REPO_DEPOT_ENDPOINT="https://repodepot.bleu.example.com/ubuntu"
             When call init_repo_depot
+            The output should be present
             The status should be success
             The contents of file "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should include "https://repodepot.bleu.example.com/azurelinux/"
         End

--- a/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_operation_requests_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_operation_requests_mariner_spec.sh
@@ -45,6 +45,7 @@ EOF
         It 'rewrites Mariner repo baseurls to the depot endpoint with no PMC leakage'
             write_mariner_extras_repo
             When call init_mariner_repo_depot "https://repodepot.bleu.example.com"
+            The output should be present
             The status should be success
             The path "${YUM_REPOS_D_DIR}/mariner-extended.repo" should be exist
             The path "${YUM_REPOS_D_DIR}/mariner-nvidia.repo" should be exist
@@ -59,6 +60,7 @@ EOF
     Describe 'init_azurelinux_repo_depot'
         It 'creates azurelinux repo files all pointing at the depot, no PMC, no NVIDIA URLs'
             When call init_azurelinux_repo_depot "https://repodepot.bleu.example.com"
+            The output should be present
             The status should be success
             The path "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should be exist
             The path "${YUM_REPOS_D_DIR}/azurelinux-nvidia.repo" should be exist
@@ -103,6 +105,7 @@ EOF
             detect_distro
             REPO_DEPOT_ENDPOINT="https://repodepot.bleu.example.com/ubuntu"
             When call init_repo_depot
+            The output should be present
             The status should be success
             The contents of file "${YUM_REPOS_D_DIR}/mariner-extras.repo" should include "https://repodepot.bleu.example.com/mariner/packages.microsoft.com"
             The contents of file "${YUM_REPOS_D_DIR}/mariner-extras.repo" should not include "https://packages.microsoft.com"
@@ -113,6 +116,7 @@ EOF
             detect_distro
             REPO_DEPOT_ENDPOINT="https://repodepot.bleu.example.com/ubuntu"
             When call init_repo_depot
+            The output should be present
             The status should be success
             The contents of file "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should include "https://repodepot.bleu.example.com/azurelinux/"
             The contents of file "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should not include "packages.microsoft.com"

--- a/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_operation_requests_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_operation_requests_mariner_spec.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# Tests for parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests-mariner.sh
+#
+# This is the script that runs in Bleu (and other public-custom clouds that go through
+# the operation-requests wireserver API) on Mariner / AzureLinux nodes. It is the script
+# whose repo-depot rewrite must succeed to prevent IcM 725845756.
+#
+# Repo-depot rewrite logic is identical to init-aks-custom-cloud-mariner.sh but the
+# cert-fetch path is different (rate-limited operation-requests API). We assert the same
+# invariants on the repo files.
+
+Describe 'init-aks-custom-cloud-operation-requests-mariner.sh'
+    Include "./parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests-mariner.sh"
+    set +x
+
+    setup() {
+        TEST_DIR="$(mktemp -d)"
+        export OS_RELEASE_FILE="${TEST_DIR}/os-release"
+        export AZURE_CA_CERTS_DIR="${TEST_DIR}/AzureCACertificates"
+        export CA_TRUST_ANCHORS_DIR="${TEST_DIR}/ca-trust-anchors"
+        export YUM_REPOS_D_DIR="${TEST_DIR}/yum.repos.d"
+        export WIRESERVER_ENDPOINT="http://wireserver.local"
+        mkdir -p "${AZURE_CA_CERTS_DIR}" "${CA_TRUST_ANCHORS_DIR}" "${YUM_REPOS_D_DIR}"
+    }
+    cleanup() {
+        rm -rf "${TEST_DIR}"
+    }
+
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    Describe 'init_mariner_repo_depot'
+        write_mariner_extras_repo() {
+            cat > "${YUM_REPOS_D_DIR}/mariner-extras.repo" <<'EOF'
+[mariner-official-extras]
+name=CBL-Mariner Official Extras $releasever $basearch
+baseurl=https://packages.microsoft.com/cbl-mariner/$releasever/prod/extras/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY
+gpgcheck=1
+enabled=1
+EOF
+        }
+
+        It 'rewrites Mariner repo baseurls to the depot endpoint with no PMC leakage'
+            write_mariner_extras_repo
+            When call init_mariner_repo_depot "https://repodepot.bleu.example.com"
+            The status should be success
+            The path "${YUM_REPOS_D_DIR}/mariner-extended.repo" should be exist
+            The path "${YUM_REPOS_D_DIR}/mariner-nvidia.repo" should be exist
+            The path "${YUM_REPOS_D_DIR}/mariner-cloud-native.repo" should be exist
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-extras.repo" should include "https://repodepot.bleu.example.com/mariner/packages.microsoft.com"
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-extras.repo" should not include "https://packages.microsoft.com"
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-nvidia.repo" should not include "developer.download.nvidia.com"
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-nvidia.repo" should not include "https://packages.microsoft.com"
+        End
+    End
+
+    Describe 'init_azurelinux_repo_depot'
+        It 'creates azurelinux repo files all pointing at the depot, no PMC, no NVIDIA URLs'
+            When call init_azurelinux_repo_depot "https://repodepot.bleu.example.com"
+            The status should be success
+            The path "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should be exist
+            The path "${YUM_REPOS_D_DIR}/azurelinux-nvidia.repo" should be exist
+            The contents of file "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should include "baseurl=https://repodepot.bleu.example.com/azurelinux/"
+            The contents of file "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should not include "packages.microsoft.com"
+            The contents of file "${YUM_REPOS_D_DIR}/azurelinux-nvidia.repo" should not include "developer.download.nvidia.com"
+            The contents of file "${YUM_REPOS_D_DIR}/azurelinux-nvidia.repo" should not include "packages.microsoft.com"
+        End
+    End
+
+    Describe 'init_repo_depot dispatch'
+        setup_mariner_os_release() {
+            cat > "${OS_RELEASE_FILE}" <<EOF
+NAME="Common Base Linux Mariner"
+VERSION="2.0.20250701"
+ID=mariner
+VERSION_ID="2.0"
+EOF
+        }
+        setup_azurelinux_os_release() {
+            cat > "${OS_RELEASE_FILE}" <<EOF
+NAME="Microsoft Azure Linux"
+VERSION="3.0.20250702"
+ID=azurelinux
+VERSION_ID="3.0"
+EOF
+        }
+        write_mariner_extras_repo() {
+            cat > "${YUM_REPOS_D_DIR}/mariner-extras.repo" <<'EOF'
+[mariner-official-extras]
+baseurl=https://packages.microsoft.com/cbl-mariner/$releasever/prod/extras/$basearch
+EOF
+        }
+
+        Mock dnf_makecache
+            true
+        End
+
+        It 'rewrites Mariner repos under a Bleu-shaped depot URL'
+            setup_mariner_os_release
+            write_mariner_extras_repo
+            detect_distro
+            REPO_DEPOT_ENDPOINT="https://repodepot.bleu.example.com/ubuntu"
+            When call init_repo_depot
+            The status should be success
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-extras.repo" should include "https://repodepot.bleu.example.com/mariner/packages.microsoft.com"
+            The contents of file "${YUM_REPOS_D_DIR}/mariner-extras.repo" should not include "https://packages.microsoft.com"
+        End
+
+        It 'rewrites AzureLinux repos under a Bleu-shaped depot URL'
+            setup_azurelinux_os_release
+            detect_distro
+            REPO_DEPOT_ENDPOINT="https://repodepot.bleu.example.com/ubuntu"
+            When call init_repo_depot
+            The status should be success
+            The contents of file "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should include "https://repodepot.bleu.example.com/azurelinux/"
+            The contents of file "${YUM_REPOS_D_DIR}/azurelinux-base.repo" should not include "packages.microsoft.com"
+        End
+
+        It 'warns when REPO_DEPOT_ENDPOINT is empty'
+            setup_mariner_os_release
+            detect_distro
+            REPO_DEPOT_ENDPOINT=""
+            When call init_repo_depot
+            The status should be success
+            The stderr should include "repo depot endpoint empty"
+        End
+    End
+End

--- a/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_operation_requests_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_operation_requests_spec.sh
@@ -55,6 +55,7 @@ EOF
         It 'writes a ubuntu.sources file pointing at the Bleu-shaped depot only'
             write_ubuntu_os_release
             When call init_ubuntu_main_repo_depot "https://repodepot.bleu.example.com"
+            The output should be present
             The status should be success
             The path "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should be exist
             The contents of file "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should include "URIs: https://repodepot.bleu.example.com/ubuntu"
@@ -69,6 +70,7 @@ EOF
             echo "deb http://archive.ubuntu.com/ubuntu jammy main" > "${APT_SOURCES_LIST}"
             echo "deb http://packages.microsoft.com/repos/azure-cli/ jammy main" > "${APT_SOURCES_LIST_D_DIR}/azure-cli.list"
             When call init_ubuntu_main_repo_depot "https://repodepot.bleu.example.com"
+            The output should be present
             The status should be success
             The path "${APT_BACKUP_DIR}/sources.list" should be exist
             The path "${APT_BACKUP_DIR}/azure-cli.list" should be exist
@@ -95,6 +97,7 @@ EOF
             ubuntuRel=22.04
             repodepot_endpoint="https://repodepot.bleu.example.com"
             When call init_ubuntu_pmc_repo_depot "${repodepot_endpoint}"
+            The output should be present
             The status should be success
             The path "${APT_SOURCES_LIST_D_DIR}/microsoft-prod.sources" should be exist
             The path "${APT_SOURCES_LIST_D_DIR}/microsoft-prod-testing.sources" should be exist

--- a/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_operation_requests_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_operation_requests_spec.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Tests for parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests.sh
+#
+# This is the script that runs in Bleu (and other public-custom clouds that go through
+# the operation-requests wireserver API) on Ubuntu / Flatcar / ACL nodes. It is the script
+# whose repo-depot rewrite must succeed to prevent IcM 725845756.
+#
+# Repo-depot rewrite logic is identical to init-aks-custom-cloud.sh but the cert-fetch
+# path is different (rate-limited operation-requests API). We assert the same invariants
+# on the apt sources files.
+
+Describe 'init-aks-custom-cloud-operation-requests.sh'
+    Include "./parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests.sh"
+    set +x
+
+    setup() {
+        TEST_DIR="$(mktemp -d)"
+        export OS_RELEASE_FILE="${TEST_DIR}/os-release"
+        export AZURE_CA_CERTS_DIR="${TEST_DIR}/AzureCACertificates"
+        export CA_TRUST_ANCHORS_DIR="${TEST_DIR}/ca-trust-anchors"
+        export SSL_CERTS_DIR="${TEST_DIR}/ssl-certs"
+        export LOCAL_SHARE_CA_CERTS_DIR="${TEST_DIR}/local-share-ca-certs"
+        export OPENSSL_CERT_FILE="${TEST_DIR}/openssl-cert.pem"
+        export APT_SOURCES_LIST="${TEST_DIR}/apt/sources.list"
+        export APT_SOURCES_LIST_D_DIR="${TEST_DIR}/apt/sources.list.d"
+        export APT_KEYRINGS_DIR="${TEST_DIR}/apt/keyrings"
+        export APT_BACKUP_DIR="${TEST_DIR}/apt/backup"
+        export SYSTEMD_SYSTEM_DIR="${TEST_DIR}/systemd"
+        export WIRESERVER_ENDPOINT="http://wireserver.local"
+        mkdir -p "${AZURE_CA_CERTS_DIR}" "${CA_TRUST_ANCHORS_DIR}" "${SSL_CERTS_DIR}" \
+                 "${LOCAL_SHARE_CA_CERTS_DIR}" "${APT_SOURCES_LIST_D_DIR}" \
+                 "${APT_KEYRINGS_DIR}" "${APT_BACKUP_DIR}" "${SYSTEMD_SYSTEM_DIR}" \
+                 "$(dirname "${APT_SOURCES_LIST}")"
+        echo "fake-bundle" > "${SSL_CERTS_DIR}/ca-certificates.crt"
+    }
+    cleanup() {
+        rm -rf "${TEST_DIR}"
+    }
+
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    write_ubuntu_os_release() {
+        cat > "${OS_RELEASE_FILE}" <<EOF
+NAME="Ubuntu"
+VERSION="22.04.5 LTS (Jammy Jellyfish)"
+ID=ubuntu
+VERSION_ID="22.04"
+VERSION_CODENAME=jammy
+EOF
+    }
+
+    Describe 'init_ubuntu_main_repo_depot'
+        It 'writes a ubuntu.sources file pointing at the Bleu-shaped depot only'
+            write_ubuntu_os_release
+            When call init_ubuntu_main_repo_depot "https://repodepot.bleu.example.com"
+            The status should be success
+            The path "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should be exist
+            The contents of file "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should include "URIs: https://repodepot.bleu.example.com/ubuntu"
+            The contents of file "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should include "jammy jammy-updates jammy-backports jammy-security"
+            The contents of file "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should not include "archive.ubuntu.com"
+            The contents of file "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should not include "security.ubuntu.com"
+            The contents of file "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should not include "packages.microsoft.com"
+        End
+
+        It 'backs up the existing sources.list and sources.list.d files'
+            write_ubuntu_os_release
+            echo "deb http://archive.ubuntu.com/ubuntu jammy main" > "${APT_SOURCES_LIST}"
+            echo "deb http://packages.microsoft.com/repos/azure-cli/ jammy main" > "${APT_SOURCES_LIST_D_DIR}/azure-cli.list"
+            When call init_ubuntu_main_repo_depot "https://repodepot.bleu.example.com"
+            The status should be success
+            The path "${APT_BACKUP_DIR}/sources.list" should be exist
+            The path "${APT_BACKUP_DIR}/azure-cli.list" should be exist
+            The path "${APT_SOURCES_LIST}" should not be exist
+            The path "${APT_SOURCES_LIST_D_DIR}/azure-cli.list" should not be exist
+        End
+    End
+
+    Describe 'init_ubuntu_pmc_repo_depot'
+        Mock curl
+            printf 'HTTP/1.1 200 OK\n'
+        End
+        Mock wget
+            echo 'fake-key-data'
+        End
+        Mock gpg
+            cat
+        End
+        Mock lsb_release
+            echo "Codename:	jammy"
+        End
+
+        It 'writes microsoft-prod sources files pointing at the Bleu-shaped depot only'
+            ubuntuRel=22.04
+            repodepot_endpoint="https://repodepot.bleu.example.com"
+            When call init_ubuntu_pmc_repo_depot "${repodepot_endpoint}"
+            The status should be success
+            The path "${APT_SOURCES_LIST_D_DIR}/microsoft-prod.sources" should be exist
+            The path "${APT_SOURCES_LIST_D_DIR}/microsoft-prod-testing.sources" should be exist
+            The contents of file "${APT_SOURCES_LIST_D_DIR}/microsoft-prod.sources" should include "URIs: https://repodepot.bleu.example.com/microsoft/ubuntu/22.04/prod"
+            The contents of file "${APT_SOURCES_LIST_D_DIR}/microsoft-prod.sources" should not include "https://packages.microsoft.com"
+            The path "${APT_KEYRINGS_DIR}/microsoft.asc.gpg" should be exist
+            The path "${APT_KEYRINGS_DIR}/msopentech.asc.gpg" should be exist
+        End
+    End
+End

--- a/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_spec.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+# Tests for parts/linux/cloud-init/artifacts/init-aks-custom-cloud.sh
+#
+# Custom-cloud provision-time script for Ubuntu / Flatcar / ACL on USSecCloud / USNatCloud
+# (Mooncake / Fairfax). Asserts that after the repo-depot rewrite:
+#   1. Generated apt sources files point at the mocked depot, not packages.microsoft.com /
+#      archive.ubuntu.com / security.ubuntu.com / etc.
+#   2. No third-party (e.g. developer.download.nvidia.com) URLs leak in.
+#   3. Old/baked sources.list[.d] entries are backed up rather than left in place.
+# This is the regression class behind IcM 725845756: stale repo URLs on a booted VHD
+# cause downstream tdnf/apt operations to hang.
+
+Describe 'init-aks-custom-cloud.sh'
+    Include "./parts/linux/cloud-init/artifacts/init-aks-custom-cloud.sh"
+    set +x
+
+    setup() {
+        TEST_DIR="$(mktemp -d)"
+        export OS_RELEASE_FILE="${TEST_DIR}/os-release"
+        export AZURE_CA_CERTS_DIR="${TEST_DIR}/AzureCACertificates"
+        export CA_TRUST_ANCHORS_DIR="${TEST_DIR}/ca-trust-anchors"
+        export SSL_CERTS_DIR="${TEST_DIR}/ssl-certs"
+        export LOCAL_SHARE_CA_CERTS_DIR="${TEST_DIR}/local-share-ca-certs"
+        export OPENSSL_CERT_FILE="${TEST_DIR}/openssl-cert.pem"
+        export APT_SOURCES_LIST="${TEST_DIR}/apt/sources.list"
+        export APT_SOURCES_LIST_D_DIR="${TEST_DIR}/apt/sources.list.d"
+        export APT_KEYRINGS_DIR="${TEST_DIR}/apt/keyrings"
+        export APT_BACKUP_DIR="${TEST_DIR}/apt/backup"
+        export SYSTEMD_SYSTEM_DIR="${TEST_DIR}/systemd"
+        export CHRONY_CONF_FILE="${TEST_DIR}/chrony.conf"
+        export WIRESERVER_ENDPOINT="http://wireserver.local"
+        mkdir -p "${AZURE_CA_CERTS_DIR}" "${CA_TRUST_ANCHORS_DIR}" "${SSL_CERTS_DIR}" \
+                 "${LOCAL_SHARE_CA_CERTS_DIR}" "${APT_SOURCES_LIST_D_DIR}" \
+                 "${APT_KEYRINGS_DIR}" "${APT_BACKUP_DIR}" "${SYSTEMD_SYSTEM_DIR}" \
+                 "$(dirname "${APT_SOURCES_LIST}")"
+        # ca-certificates.crt is referenced when copying the bundle to OPENSSL_CERT_FILE
+        echo "fake-bundle" > "${SSL_CERTS_DIR}/ca-certificates.crt"
+    }
+    cleanup() {
+        rm -rf "${TEST_DIR}"
+    }
+
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    write_ubuntu_os_release() {
+        cat > "${OS_RELEASE_FILE}" <<EOF
+NAME="Ubuntu"
+VERSION="22.04.5 LTS (Jammy Jellyfish)"
+ID=ubuntu
+ID_LIKE=debian
+VERSION_ID="22.04"
+VERSION_CODENAME=jammy
+EOF
+    }
+
+    Describe 'init_ubuntu_main_repo_depot'
+        It 'writes a ubuntu.sources file pointing at the depot, with no upstream URLs'
+            write_ubuntu_os_release
+            When call init_ubuntu_main_repo_depot "https://repodepot.bleu.example.com"
+            The status should be success
+            The path "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should be exist
+            The contents of file "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should include "URIs: https://repodepot.bleu.example.com/ubuntu"
+            The contents of file "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should include "jammy jammy-updates jammy-backports jammy-security"
+            The contents of file "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should not include "archive.ubuntu.com"
+            The contents of file "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should not include "security.ubuntu.com"
+            The contents of file "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should not include "packages.microsoft.com"
+        End
+
+        It 'backs up the existing sources.list and sources.list.d files'
+            write_ubuntu_os_release
+            echo "deb http://archive.ubuntu.com/ubuntu jammy main" > "${APT_SOURCES_LIST}"
+            echo "deb http://packages.microsoft.com/repos/azure-cli/ jammy main" > "${APT_SOURCES_LIST_D_DIR}/azure-cli.list"
+            When call init_ubuntu_main_repo_depot "https://repodepot.bleu.example.com"
+            The status should be success
+            The path "${APT_BACKUP_DIR}/sources.list" should be exist
+            The path "${APT_BACKUP_DIR}/azure-cli.list" should be exist
+            The path "${APT_SOURCES_LIST}" should not be exist
+            The path "${APT_SOURCES_LIST_D_DIR}/azure-cli.list" should not be exist
+        End
+    End
+
+    Describe 'init_ubuntu_pmc_repo_depot'
+        Mock curl
+            printf 'HTTP/1.1 200 OK\n'
+        End
+        Mock wget
+            echo 'fake-key-data'
+        End
+        Mock gpg
+            cat
+        End
+        Mock lsb_release
+            echo "Codename:	jammy"
+        End
+
+        It 'writes microsoft-prod sources files pointing at the depot only'
+            ubuntuRel=22.04
+            repodepot_endpoint="https://repodepot.bleu.example.com"
+            When call init_ubuntu_pmc_repo_depot "${repodepot_endpoint}"
+            The status should be success
+            The path "${APT_SOURCES_LIST_D_DIR}/microsoft-prod.sources" should be exist
+            The path "${APT_SOURCES_LIST_D_DIR}/microsoft-prod-testing.sources" should be exist
+            The contents of file "${APT_SOURCES_LIST_D_DIR}/microsoft-prod.sources" should include "URIs: https://repodepot.bleu.example.com/microsoft/ubuntu/22.04/prod"
+            The contents of file "${APT_SOURCES_LIST_D_DIR}/microsoft-prod.sources" should not include "https://packages.microsoft.com"
+            The path "${APT_KEYRINGS_DIR}/microsoft.asc.gpg" should be exist
+            The path "${APT_KEYRINGS_DIR}/msopentech.asc.gpg" should be exist
+        End
+    End
+
+    Describe 'check_url'
+        Mock curl
+            printf 'HTTP/1.1 200 OK\n'
+        End
+
+        It 'passes for a 200 response'
+            When call check_url "https://repodepot.bleu.example.com/ubuntu/dists/jammy/Release"
+            The status should be success
+            The stdout should include "Checking url"
+        End
+    End
+End

--- a/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/init_aks_custom_cloud_spec.sh
@@ -59,6 +59,7 @@ EOF
         It 'writes a ubuntu.sources file pointing at the depot, with no upstream URLs'
             write_ubuntu_os_release
             When call init_ubuntu_main_repo_depot "https://repodepot.bleu.example.com"
+            The output should be present
             The status should be success
             The path "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should be exist
             The contents of file "${APT_SOURCES_LIST_D_DIR}/ubuntu.sources" should include "URIs: https://repodepot.bleu.example.com/ubuntu"
@@ -73,6 +74,7 @@ EOF
             echo "deb http://archive.ubuntu.com/ubuntu jammy main" > "${APT_SOURCES_LIST}"
             echo "deb http://packages.microsoft.com/repos/azure-cli/ jammy main" > "${APT_SOURCES_LIST_D_DIR}/azure-cli.list"
             When call init_ubuntu_main_repo_depot "https://repodepot.bleu.example.com"
+            The output should be present
             The status should be success
             The path "${APT_BACKUP_DIR}/sources.list" should be exist
             The path "${APT_BACKUP_DIR}/azure-cli.list" should be exist
@@ -99,6 +101,7 @@ EOF
             ubuntuRel=22.04
             repodepot_endpoint="https://repodepot.bleu.example.com"
             When call init_ubuntu_pmc_repo_depot "${repodepot_endpoint}"
+            The output should be present
             The status should be success
             The path "${APT_SOURCES_LIST_D_DIR}/microsoft-prod.sources" should be exist
             The path "${APT_SOURCES_LIST_D_DIR}/microsoft-prod-testing.sources" should be exist


### PR DESCRIPTION
## Context

The `init-aks-custom-cloud*.sh` scripts run at node boot in custom-cloud environments and rewrite the system package repository URLs to point at the internal RepoDepot mirror (since those nodes cannot reach the public internet). A misconfiguration here — e.g. a leftover public URL that does not get rewritten — can cause package operations to hang during provisioning. There was previously no automated test exercising these scripts, so a regression in the repo-URL rewrite could slip through.

This PR adds that missing test coverage.

## What this PR does

> **No script logic is changed.** This PR only adds ShellSpec unit-test coverage and makes the scripts/functions testable. The runtime behavior of all four scripts is preserved — `main()` invokes the same functions in the same order with the same arguments as before.

### 1. Makes all 4 `init-aks-custom-cloud*.sh` scripts testable (no behavior change)

- `init-aks-custom-cloud.sh` (Ubuntu/Flatcar/ACL)
- `init-aks-custom-cloud-mariner.sh` (Mariner/AzureLinux)
- `init-aks-custom-cloud-operation-requests.sh` (Ubuntu/Flatcar/ACL)
- `init-aks-custom-cloud-operation-requests-mariner.sh` (Mariner/AzureLinux)

Refactor pattern (matches existing repo convention, e.g. `mariner-package-update.sh`):
- Lift hardcoded paths (apt sources, yum.repos.d, ssl certs, chrony, wireserver) into `: "${VAR:=default}"` env-overridable constants. Defaults are identical to the previous hardcoded values, so production behavior is unchanged.
- Add `${__SOURCED__:+return}` guard so ShellSpec's `Include` can source the script without running `main` at source time.
- Wrap existing inline logic into named functions (`detect_distro`, `fetch_and_install_ca_certs`, `init_*_repo_depot`, `write_chrony_config`, etc.) — the same commands, just grouped into callable units.

### 2. Adds ShellSpec tests (20 examples across 4 spec files)

Drives each script with a mocked `REPO_DEPOT_ENDPOINT` and asserts:
- All rewritten repo files point at the mocked depot.
- No leftover `packages.microsoft.com` URLs remain.
- No third-party (e.g. `developer.download.nvidia.com`) URLs leak in.
- Existing `/etc/apt/sources.list[.d]` entries are backed up, not left in place.
- `init_repo_depot` strips the trailing `/ubuntu` and dispatches the Mariner / AzureLinux / Ubuntu paths correctly.

## Verification

- All 20 new ShellSpec examples pass locally (pinned to the CI shellspec version 0.28.1).
- `make validate-shell` (shellcheck gate) passes.
- No snapshot/testdata changes — the refactor preserves embedded-script behavior.