### PR TITLE
feat(anc): support a base-to-version hotfix map in downloadHotfix

### DIFF
--- a/aks-node-controller/hotfix.go
+++ b/aks-node-controller/hotfix.go
@@ -148,17 +148,6 @@ func readHotfixConfig(path string) (hotfixConfig, error) {
 	return cfg, nil
 }
 
-// readHotfixVersion reads the legacy single-version field from the hotfix config.
-// Retained for backward compatibility; map-aware callers should use readHotfixConfig
-// together with hotfixConfig.resolveVersion.
-func readHotfixVersion(path string) (string, error) {
-	cfg, err := readHotfixConfig(path)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(cfg.Version), nil
-}
-
 // packageManager represents a supported system package manager.
 type packageManager string
 

--- a/aks-node-controller/hotfix.go
+++ b/aks-node-controller/hotfix.go
@@ -38,7 +38,11 @@ func (a *App) downloadHotfix(ctx context.Context) error {
 	}
 	cfg, err := readHotfixConfig(hotfixPath)
 	if err != nil {
-		return fmt.Errorf("read hotfix config from %s: %w", hotfixPath, err)
+		// Fail-open: an unreadable or malformed hotfix config must never block
+		// provisioning. Log and skip so the node boots on its VHD-baked binary.
+		slog.Warn("failed to read hotfix config, skipping hotfix download",
+			"path", hotfixPath, "error", err)
+		return nil
 	}
 	hotfixVersion := cfg.resolveVersion(Version)
 
@@ -95,9 +99,11 @@ type hotfixConfig struct {
 // the form "YYYYMM.DD.PATCH". It splits on "." rather than parsing semver so the literal
 // day segment — including any leading zero such as "01" — is preserved to match map keys
 // exactly (semver parsing would drop the leading zero, e.g. "202604.01" -> minor 1).
+// All three segments must be non-empty; a present-but-empty patch (e.g. "202604.01.")
+// is rejected so an obviously malformed current version never selects a map entry.
 func hotfixBaseFromVersion(version string) (string, error) {
 	parts := strings.SplitN(strings.TrimSpace(version), ".", 3)
-	if len(parts) < 3 || parts[0] == "" || parts[1] == "" {
+	if len(parts) < 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
 		return "", fmt.Errorf("version %q is not in YYYYMM.DD.PATCH form", version)
 	}
 	return parts[0] + "." + parts[1], nil

--- a/aks-node-controller/hotfix.go
+++ b/aks-node-controller/hotfix.go
@@ -97,7 +97,7 @@ type hotfixConfig struct {
 
 // hotfixBaseFromVersion extracts the "YYYYMM.DD" base from an ANC version string of
 // the form "YYYYMM.DD.PATCH". It splits on "." rather than parsing semver so the literal
-// day segment — including any leading zero such as "01" — is preserved to match map keys
+// day segment - including any leading zero such as "01" - is preserved to match map keys
 // exactly (semver parsing would drop the leading zero, e.g. "202604.01" -> minor 1).
 // All three segments must be non-empty; a present-but-empty patch (e.g. "202604.01.")
 // is rejected so an obviously malformed current version never selects a map entry.
@@ -345,10 +345,10 @@ func copyBinaryAlongside(src, dst, refPath string) error {
 // ANC versions use the format YYYYMM.DD.PATCH which is valid semver (Major.Minor.Patch).
 //
 // This ensures the hotfix only targets the specific VHD it was built for:
-//   - Older VHDs (different base) are skipped — remediated via VHD republish
-//   - Newer VHDs (different base) are skipped — fix is already baked in
-//   - Same version is skipped — already at hotfix
-//   - Unparseable versions (e.g. "dev") return an error — caller should skip
+//   - Older VHDs (different base) are skipped - remediated via VHD republish
+//   - Newer VHDs (different base) are skipped - fix is already baked in
+//   - Same version is skipped - already at hotfix
+//   - Unparseable versions (e.g. "dev") return an error - caller should skip
 func shouldUpgradeToHotfix(current, hotfix string) (bool, error) {
 	cv, err := semver.NewVersion(strings.TrimSpace(current))
 	if err != nil {

--- a/aks-node-controller/hotfix.go
+++ b/aks-node-controller/hotfix.go
@@ -36,13 +36,15 @@ func (a *App) downloadHotfix(ctx context.Context) error {
 	if hotfixPath == "" {
 		hotfixPath = defaultHotfixVersionPath
 	}
-	hotfixVersion, err := readHotfixVersion(hotfixPath)
+	cfg, err := readHotfixConfig(hotfixPath)
 	if err != nil {
-		return fmt.Errorf("read hotfix version from %s: %w", hotfixPath, err)
+		return fmt.Errorf("read hotfix config from %s: %w", hotfixPath, err)
 	}
+	hotfixVersion := cfg.resolveVersion(Version)
 
 	if hotfixVersion == "" {
-		slog.Info("hotfix config does not request a version, skipping download", "path", hotfixPath)
+		slog.Info("hotfix config does not request a version for this base, skipping download",
+			"path", hotfixPath, "current", Version)
 		return nil
 	}
 
@@ -77,25 +79,76 @@ func (a *App) downloadHotfix(ctx context.Context) error {
 // hotfixConfig is the JSON structure of the hotfix configuration file.
 // Using JSON allows future extension (e.g., adding checksum, source URL) without format changes.
 type hotfixConfig struct {
-	Version string `json:"version"`
+	// Version is the legacy single-version pointer. It is still honored when Hotfixes
+	// is empty, preserving backward compatibility with the original config shape.
+	Version string `json:"version,omitempty"`
+
+	// Hotfixes maps an ANC version base ("YYYYMM.DD") to the hotfix version
+	// ("YYYYMM.DD.PATCH") to apply to nodes whose baked ANC version shares that base.
+	// A single config can thus pin hotfixes for multiple VHD bases at once; a base
+	// whose key is absent gets no hotfix (default deny). When non-empty, this map
+	// takes precedence over Version.
+	Hotfixes map[string]string `json:"hotfixes,omitempty"`
 }
 
-// readHotfixVersion reads and parses the JSON hotfix config from the given path.
-// Returns empty string if the file doesn't exist or contains an empty version.
-func readHotfixVersion(path string) (string, error) {
+// hotfixBaseFromVersion extracts the "YYYYMM.DD" base from an ANC version string of
+// the form "YYYYMM.DD.PATCH". It splits on "." rather than parsing semver so the literal
+// day segment — including any leading zero such as "01" — is preserved to match map keys
+// exactly (semver parsing would drop the leading zero, e.g. "202604.01" -> minor 1).
+func hotfixBaseFromVersion(version string) (string, error) {
+	parts := strings.SplitN(strings.TrimSpace(version), ".", 3)
+	if len(parts) < 3 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("version %q is not in YYYYMM.DD.PATCH form", version)
+	}
+	return parts[0] + "." + parts[1], nil
+}
+
+// resolveVersion picks the hotfix version that applies to the given current ANC version.
+// When the base->version map is populated it takes precedence: the entry matching the
+// current version's "YYYYMM.DD" base is returned, while an absent base (or an unparseable
+// current version) yields "" so provisioning proceeds with no hotfix. When the map is
+// empty it falls back to the legacy single Version field. The returned version is still
+// subject to shouldUpgradeToHotfix's patch-only-strictly-higher gating in the caller.
+func (cfg hotfixConfig) resolveVersion(current string) string {
+	if len(cfg.Hotfixes) > 0 {
+		base, err := hotfixBaseFromVersion(current)
+		if err != nil {
+			slog.Warn("cannot derive hotfix base from current version, skipping hotfix",
+				"current", current, "error", err)
+			return ""
+		}
+		return strings.TrimSpace(cfg.Hotfixes[base])
+	}
+	return strings.TrimSpace(cfg.Version)
+}
+
+// readHotfixConfig reads and parses the JSON hotfix config from the given path.
+// Returns a zero-value config if the file doesn't exist or is empty.
+func readHotfixConfig(path string) (hotfixConfig, error) {
+	var cfg hotfixConfig
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", nil
+			return cfg, nil
 		}
-		return "", err
+		return cfg, err
 	}
 	if len(strings.TrimSpace(string(data))) == 0 {
-		return "", nil
+		return cfg, nil
 	}
-	var cfg hotfixConfig
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		return "", fmt.Errorf("parsing hotfix config %s: %w", path, err)
+		return cfg, fmt.Errorf("parsing hotfix config %s: %w", path, err)
+	}
+	return cfg, nil
+}
+
+// readHotfixVersion reads the legacy single-version field from the hotfix config.
+// Retained for backward compatibility; map-aware callers should use readHotfixConfig
+// together with hotfixConfig.resolveVersion.
+func readHotfixVersion(path string) (string, error) {
+	cfg, err := readHotfixConfig(path)
+	if err != nil {
+		return "", err
 	}
 	return strings.TrimSpace(cfg.Version), nil
 }

--- a/aks-node-controller/hotfix_test.go
+++ b/aks-node-controller/hotfix_test.go
@@ -387,6 +387,30 @@ func TestDownloadHotfix_MapPatchNotHigherSkips(t *testing.T) {
 	assert.False(t, installCalled, "should skip when resolved hotfix patch is not strictly higher")
 }
 
+func TestDownloadHotfix_MapMisconfiguredValueBaseSkips(t *testing.T) {
+	origVersion := Version
+	Version = "202604.01.0"
+	defer func() { Version = origVersion }()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hotfix-config.json")
+	// Misconfigured entry: the value's base (202605.30) does not match its key (202604.01).
+	// resolveVersion selects it by key for a node on base 202604.01, but shouldUpgradeToHotfix
+	// must reject it because the YYYYMM.DD bases differ, so no wrong-base binary is installed.
+	require.NoError(t, os.WriteFile(path, []byte(`{"hotfixes": {"202604.01": "202605.30.2"}}`), 0o644))
+
+	installCalled := false
+	tt := NewTestApp(t, TestAppConfig{
+		RunFunc: func(cmd *exec.Cmd) error {
+			installCalled = true
+			return nil
+		},
+	})
+	tt.App.hotfixVersionPath = path
+	require.NoError(t, tt.App.downloadHotfix(context.Background()))
+	assert.False(t, installCalled, "should skip when the map value's base does not match the node's base")
+}
+
 func TestRetryCommand_SuccessOnFirstAttempt(t *testing.T) {
 	callCount := 0
 	tt := NewTestApp(t, TestAppConfig{

--- a/aks-node-controller/hotfix_test.go
+++ b/aks-node-controller/hotfix_test.go
@@ -12,54 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReadHotfixVersion(t *testing.T) {
-	t.Run("file does not exist", func(t *testing.T) {
-		version, err := readHotfixVersion("/nonexistent/path")
-		assert.NoError(t, err)
-		assert.Equal(t, "", version)
-	})
-
-	t.Run("file is empty", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "hotfix-config.json")
-		require.NoError(t, os.WriteFile(path, []byte(""), 0644))
-		version, err := readHotfixVersion(path)
-		assert.NoError(t, err)
-		assert.Equal(t, "", version)
-	})
-
-	t.Run("file has version", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "hotfix-config.json")
-		require.NoError(t, os.WriteFile(path, []byte(`{"version": "202603.30.0-hotfix1"}`), 0644))
-		version, err := readHotfixVersion(path)
-		assert.NoError(t, err)
-		assert.Equal(t, "202603.30.0-hotfix1", version)
-	})
-
-	t.Run("file has empty version field", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "hotfix-config.json")
-		require.NoError(t, os.WriteFile(path, []byte(`{"version": ""}`), 0644))
-		version, err := readHotfixVersion(path)
-		assert.NoError(t, err)
-		assert.Equal(t, "", version)
-	})
-
-	t.Run("file has invalid JSON", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "hotfix-config.json")
-		require.NoError(t, os.WriteFile(path, []byte("not json"), 0644))
-		_, err := readHotfixVersion(path)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "parsing hotfix config")
-	})
-
-	t.Run("file has extra fields (forward compat)", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "hotfix-config.json")
-		require.NoError(t, os.WriteFile(path, []byte(`{"version": "1.0.0", "sha256": "abc123"}`), 0644))
-		version, err := readHotfixVersion(path)
-		assert.NoError(t, err)
-		assert.Equal(t, "1.0.0", version)
-	})
-}
-
 func TestReadHotfixConfig(t *testing.T) {
 	t.Run("file does not exist returns zero config", func(t *testing.T) {
 		cfg, err := readHotfixConfig("/nonexistent/path")
@@ -98,6 +50,14 @@ func TestReadHotfixConfig(t *testing.T) {
 		_, err := readHotfixConfig(path)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "parsing hotfix config")
+	})
+
+	t.Run("ignores extra fields (forward compat)", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "hotfix-config.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"version": "202604.01.1", "sha256": "abc123"}`), 0644))
+		cfg, err := readHotfixConfig(path)
+		require.NoError(t, err)
+		assert.Equal(t, "202604.01.1", cfg.Version)
 	})
 }
 

--- a/aks-node-controller/hotfix_test.go
+++ b/aks-node-controller/hotfix_test.go
@@ -305,11 +305,23 @@ func TestDownloadHotfix_MatchingBaseUpgrades(t *testing.T) {
 }
 
 func TestDownloadHotfix_UnreadableFileFailsOpen(t *testing.T) {
+	origVersion := Version
+	Version = "202604.01.0"
+	defer func() { Version = origVersion }()
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hotfix-config.json")
-	require.NoError(t, os.WriteFile(path, []byte(`{"version": "1.0.0"}`), 0o644))
+	require.NoError(t, os.WriteFile(path, []byte(`{"version": "202604.01.1"}`), 0o644))
 	require.NoError(t, os.Chmod(path, 0o000))
 	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+	if _, err := os.ReadFile(path); err == nil {
+		require.NoError(t, os.Remove(path))
+		require.NoError(t, os.Mkdir(path, 0o755))
+	}
+
+	aptDir := filepath.Join(dir, "sources.list.d")
+	require.NoError(t, os.MkdirAll(aptDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(aptDir, "microsoft-prod.list"), []byte("deb ..."), 0o644))
 
 	installCalled := false
 	tt := NewTestApp(t, TestAppConfig{
@@ -319,6 +331,7 @@ func TestDownloadHotfix_UnreadableFileFailsOpen(t *testing.T) {
 		},
 	})
 	tt.App.hotfixVersionPath = path
+	tt.App.aptSourcesDir = aptDir
 	// Fail-open: an unreadable config must skip the hotfix without erroring,
 	// so download-hotfix never blocks provisioning.
 	require.NoError(t, tt.App.downloadHotfix(context.Background()))
@@ -326,9 +339,17 @@ func TestDownloadHotfix_UnreadableFileFailsOpen(t *testing.T) {
 }
 
 func TestDownloadHotfix_InvalidJSONFailsOpen(t *testing.T) {
+	origVersion := Version
+	Version = "202604.01.0"
+	defer func() { Version = origVersion }()
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hotfix-config.json")
 	require.NoError(t, os.WriteFile(path, []byte("not json"), 0o644))
+
+	aptDir := filepath.Join(dir, "sources.list.d")
+	require.NoError(t, os.MkdirAll(aptDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(aptDir, "microsoft-prod.list"), []byte("deb ..."), 0o644))
 
 	installCalled := false
 	tt := NewTestApp(t, TestAppConfig{
@@ -338,6 +359,7 @@ func TestDownloadHotfix_InvalidJSONFailsOpen(t *testing.T) {
 		},
 	})
 	tt.App.hotfixVersionPath = path
+	tt.App.aptSourcesDir = aptDir
 	// Fail-open: malformed JSON must skip the hotfix without erroring.
 	require.NoError(t, tt.App.downloadHotfix(context.Background()))
 	assert.False(t, installCalled, "should skip install when the config is invalid JSON")

--- a/aks-node-controller/hotfix_test.go
+++ b/aks-node-controller/hotfix_test.go
@@ -554,9 +554,9 @@ func TestShouldUpgradeToHotfix(t *testing.T) {
 		wantErr bool
 	}{
 		// Positive: same base, hotfix has higher patch
-		{"base .0 → hotfix .1", "202604.01.0", "202604.01.1", true, false},
-		{"base .0 → hotfix .2", "202604.01.0", "202604.01.2", true, false},
-		{"hotfix .1 → hotfix .2", "202604.01.1", "202604.01.2", true, false},
+		{"base .0 -> hotfix .1", "202604.01.0", "202604.01.1", true, false},
+		{"base .0 -> hotfix .2", "202604.01.0", "202604.01.2", true, false},
+		{"hotfix .1 -> hotfix .2", "202604.01.1", "202604.01.2", true, false},
 
 		// Negative: same version
 		{"same version .0", "202604.01.0", "202604.01.0", false, false},

--- a/aks-node-controller/hotfix_test.go
+++ b/aks-node-controller/hotfix_test.go
@@ -113,6 +113,7 @@ func TestHotfixBaseFromVersion(t *testing.T) {
 		{"two-digit day", "202605.30.2", "202605.30", false},
 		{"trims whitespace", "  202604.01.1  ", "202604.01", false},
 		{"too few segments", "202604.01", "", true},
+		{"empty patch segment", "202604.01.", "", true},
 		{"single segment", "dev", "", true},
 		{"empty", "", "", true},
 	}
@@ -303,16 +304,43 @@ func TestDownloadHotfix_MatchingBaseUpgrades(t *testing.T) {
 	assert.True(t, installCalled, "should proceed when base matches and hotfix patch is higher")
 }
 
-func TestDownloadHotfix_UnreadableFile(t *testing.T) {
+func TestDownloadHotfix_UnreadableFileFailsOpen(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hotfix-config.json")
 	require.NoError(t, os.WriteFile(path, []byte(`{"version": "1.0.0"}`), 0o644))
 	require.NoError(t, os.Chmod(path, 0o000))
 	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
 
-	tt := NewTestApp(t, TestAppConfig{})
+	installCalled := false
+	tt := NewTestApp(t, TestAppConfig{
+		RunFunc: func(*exec.Cmd) error {
+			installCalled = true
+			return nil
+		},
+	})
 	tt.App.hotfixVersionPath = path
-	require.Error(t, tt.App.downloadHotfix(context.Background()))
+	// Fail-open: an unreadable config must skip the hotfix without erroring,
+	// so download-hotfix never blocks provisioning.
+	require.NoError(t, tt.App.downloadHotfix(context.Background()))
+	assert.False(t, installCalled, "should skip install when the config cannot be read")
+}
+
+func TestDownloadHotfix_InvalidJSONFailsOpen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hotfix-config.json")
+	require.NoError(t, os.WriteFile(path, []byte("not json"), 0o644))
+
+	installCalled := false
+	tt := NewTestApp(t, TestAppConfig{
+		RunFunc: func(*exec.Cmd) error {
+			installCalled = true
+			return nil
+		},
+	})
+	tt.App.hotfixVersionPath = path
+	// Fail-open: malformed JSON must skip the hotfix without erroring.
+	require.NoError(t, tt.App.downloadHotfix(context.Background()))
+	assert.False(t, installCalled, "should skip install when the config is invalid JSON")
 }
 
 func TestDownloadHotfix_MapBaseNotPresentSkips(t *testing.T) {

--- a/aks-node-controller/hotfix_test.go
+++ b/aks-node-controller/hotfix_test.go
@@ -60,6 +60,119 @@ func TestReadHotfixVersion(t *testing.T) {
 	})
 }
 
+func TestReadHotfixConfig(t *testing.T) {
+	t.Run("file does not exist returns zero config", func(t *testing.T) {
+		cfg, err := readHotfixConfig("/nonexistent/path")
+		assert.NoError(t, err)
+		assert.Equal(t, hotfixConfig{}, cfg)
+	})
+
+	t.Run("empty file returns zero config", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "hotfix-config.json")
+		require.NoError(t, os.WriteFile(path, []byte("  \n"), 0644))
+		cfg, err := readHotfixConfig(path)
+		assert.NoError(t, err)
+		assert.Equal(t, hotfixConfig{}, cfg)
+	})
+
+	t.Run("parses legacy version field", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "hotfix-config.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"version": "202604.01.1"}`), 0644))
+		cfg, err := readHotfixConfig(path)
+		require.NoError(t, err)
+		assert.Equal(t, "202604.01.1", cfg.Version)
+		assert.Empty(t, cfg.Hotfixes)
+	})
+
+	t.Run("parses base->version map", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "hotfix-config.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"hotfixes": {"202604.01": "202604.01.1", "202605.30": "202605.30.2"}}`), 0644))
+		cfg, err := readHotfixConfig(path)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"202604.01": "202604.01.1", "202605.30": "202605.30.2"}, cfg.Hotfixes)
+	})
+
+	t.Run("invalid JSON errors", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "hotfix-config.json")
+		require.NoError(t, os.WriteFile(path, []byte("not json"), 0644))
+		_, err := readHotfixConfig(path)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "parsing hotfix config")
+	})
+}
+
+func TestHotfixBaseFromVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+		wantErr bool
+	}{
+		{"standard version", "202604.01.1", "202604.01", false},
+		{"preserves leading zero day", "202604.01.0", "202604.01", false},
+		{"two-digit day", "202605.30.2", "202605.30", false},
+		{"trims whitespace", "  202604.01.1  ", "202604.01", false},
+		{"too few segments", "202604.01", "", true},
+		{"single segment", "dev", "", true},
+		{"empty", "", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := hotfixBaseFromVersion(tc.version)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestHotfixConfigResolveVersion(t *testing.T) {
+	t.Run("empty map falls back to legacy Version field", func(t *testing.T) {
+		cfg := hotfixConfig{Version: "202604.01.1"}
+		assert.Equal(t, "202604.01.1", cfg.resolveVersion("202604.01.0"))
+	})
+
+	t.Run("empty config resolves to empty", func(t *testing.T) {
+		cfg := hotfixConfig{}
+		assert.Equal(t, "", cfg.resolveVersion("202604.01.0"))
+	})
+
+	t.Run("map hit returns matching base entry", func(t *testing.T) {
+		cfg := hotfixConfig{Hotfixes: map[string]string{
+			"202604.01": "202604.01.1",
+			"202605.30": "202605.30.2",
+		}}
+		assert.Equal(t, "202604.01.1", cfg.resolveVersion("202604.01.0"))
+		assert.Equal(t, "202605.30.2", cfg.resolveVersion("202605.30.0"))
+	})
+
+	t.Run("map miss returns empty (default deny for unlisted base)", func(t *testing.T) {
+		cfg := hotfixConfig{Hotfixes: map[string]string{"202604.01": "202604.01.1"}}
+		assert.Equal(t, "", cfg.resolveVersion("202606.09.0"))
+	})
+
+	t.Run("map preserves leading-zero day matching", func(t *testing.T) {
+		cfg := hotfixConfig{Hotfixes: map[string]string{"202604.01": "202604.01.1"}}
+		assert.Equal(t, "202604.01.1", cfg.resolveVersion("202604.01.0"))
+	})
+
+	t.Run("map takes precedence over legacy Version field", func(t *testing.T) {
+		cfg := hotfixConfig{
+			Version:  "202604.01.9",
+			Hotfixes: map[string]string{"202604.01": "202604.01.1"},
+		}
+		assert.Equal(t, "202604.01.1", cfg.resolveVersion("202604.01.0"))
+	})
+
+	t.Run("unparseable current version with map returns empty (fail-open)", func(t *testing.T) {
+		cfg := hotfixConfig{Hotfixes: map[string]string{"202604.01": "202604.01.1"}}
+		assert.Equal(t, "", cfg.resolveVersion("dev"))
+	})
+}
+
 func TestDetectPackageManager(t *testing.T) {
 	// This test reads the real /etc/os-release so it's OS-dependent.
 	// We just verify it doesn't error on the current host.
@@ -200,6 +313,78 @@ func TestDownloadHotfix_UnreadableFile(t *testing.T) {
 	tt := NewTestApp(t, TestAppConfig{})
 	tt.App.hotfixVersionPath = path
 	require.Error(t, tt.App.downloadHotfix(context.Background()))
+}
+
+func TestDownloadHotfix_MapBaseNotPresentSkips(t *testing.T) {
+	origVersion := Version
+	Version = "202606.09.0"
+	defer func() { Version = origVersion }()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hotfix-config.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"hotfixes": {"202604.01": "202604.01.1"}}`), 0o644))
+
+	installCalled := false
+	tt := NewTestApp(t, TestAppConfig{
+		RunFunc: func(cmd *exec.Cmd) error {
+			installCalled = true
+			return nil
+		},
+	})
+	tt.App.hotfixVersionPath = path
+	require.NoError(t, tt.App.downloadHotfix(context.Background()))
+	assert.False(t, installCalled, "should skip when VHD base is not a key in the hotfixes map")
+}
+
+func TestDownloadHotfix_MapMatchingBaseUpgrades(t *testing.T) {
+	origVersion := Version
+	Version = "202604.01.0"
+	defer func() { Version = origVersion }()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hotfix-config.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"hotfixes": {"202604.01": "202604.01.1", "202605.30": "202605.30.2"}}`), 0o644))
+
+	aptDir := filepath.Join(dir, "sources.list.d")
+	require.NoError(t, os.MkdirAll(aptDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(aptDir, "microsoft-prod.list"), []byte("deb ..."), 0o644))
+
+	installCalled := false
+	tt := NewTestApp(t, TestAppConfig{
+		RunFunc: func(cmd *exec.Cmd) error {
+			installCalled = true
+			return nil
+		},
+	})
+	tt.App.hotfixVersionPath = path
+	tt.App.aptSourcesDir = aptDir
+	// Will fail at copyBinaryAlongside since pkgBinaryPath doesn't exist in test,
+	// but install should have been called for the matching base entry.
+	err := tt.App.downloadHotfix(context.Background())
+	require.Error(t, err)
+	assert.True(t, installCalled, "should install the hotfix for the matching base entry")
+}
+
+func TestDownloadHotfix_MapPatchNotHigherSkips(t *testing.T) {
+	origVersion := Version
+	Version = "202604.01.2"
+	defer func() { Version = origVersion }()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hotfix-config.json")
+	// Map entry resolves for this base, but patch (1) is not strictly higher than baked (2).
+	require.NoError(t, os.WriteFile(path, []byte(`{"hotfixes": {"202604.01": "202604.01.1"}}`), 0o644))
+
+	installCalled := false
+	tt := NewTestApp(t, TestAppConfig{
+		RunFunc: func(cmd *exec.Cmd) error {
+			installCalled = true
+			return nil
+		},
+	})
+	tt.App.hotfixVersionPath = path
+	require.NoError(t, tt.App.downloadHotfix(context.Background()))
+	assert.False(t, installCalled, "should skip when resolved hotfix patch is not strictly higher")
 }
 
 func TestRetryCommand_SuccessOnFirstAttempt(t *testing.T) {


### PR DESCRIPTION
## Provisioning-Hotfix groundwork - Milestone 1 (POC draft)

> **POC / M1 DRAFT.** This PR contains **2.1a only**. The `check-hotfix` subcommand (2.1b) is implemented separately and stacked on top of this branch.

### Background

A "hotfix" is a small change to the ANC binary or a few `/opt/azure/containers/*.sh` scripts, shipped as one PMC package and applied at node provisioning time on top of VHD-baked content. VMSS model customdata can go stale on scale-out, autoscaler, or reimage, so new VMs may boot with buggy code. The broader design adds a second pointer channel the node reads at boot; this PR lays the AgentBaker (Node SIG) groundwork.

### What 2.1a does

Extends `aks-node-controller/hotfix.go`:

- `hotfixConfig` gains `Hotfixes map[string]string` mapping an ANC version base (`YYYYMM.DD`) to a hotfix version (`YYYYMM.DD.PATCH`), so one config can pin hotfixes for multiple VHD bases at once, with **default-deny** for any base not listed.
- `resolveVersion()` applies the map first, then falls back to the legacy single `version` field when the map is empty (full backward compatibility).
- `hotfixBaseFromVersion()` splits on `.` (not semver) to preserve the leading-zero day so map keys match exactly (e.g. `202604.01`).
- `readHotfixConfig()` parses the shared config shape.
- `downloadHotfix()` resolves via the map and still gates through the **unchanged** `shouldUpgradeToHotfix()` "same base, patch strictly higher" semantics.
- All resolution paths **fail open**: an unreadable/invalid config, an unparseable current version, or a non-matching base results in **no hotfix applied** rather than a provisioning failure.

### Net effect (examples)

The node's baked-in ANC reports its own version (e.g. `202604.01.0`). `downloadHotfix` resolves the config against that version and only upgrades when there is a higher patch for the **same** base.

**Example 1 - map targets this node's base, higher patch -> upgrade**
```jsonc
// config
{ "hotfixes": { "202604.01": "202604.01.3", "202605.30": "202605.30.1" } }
```
| Baked ANC | Matched entry | Action |
|-----------|---------------|--------|
| `202604.01.0` | `202604.01` -> `202604.01.3` | download + install `202604.01.3` |

**Example 2 - base not listed -> no-op (default-deny)**
```jsonc
{ "hotfixes": { "202605.30": "202605.30.1" } }
```
| Baked ANC | Matched entry | Action |
|-----------|---------------|--------|
| `202604.01.0` | none | skip (no hotfix) |

**Example 3 - patch not higher -> no-op**
```jsonc
{ "hotfixes": { "202604.01": "202604.01.0" } }
```
| Baked ANC | Matched entry | Action |
|-----------|---------------|--------|
| `202604.01.0` | `202604.01` -> `202604.01.0` | skip (not strictly higher) |

**Example 4 - legacy single-version config (unchanged behavior)**
```jsonc
{ "version": "202604.01.3" }
```
Resolves exactly as before: upgrade only if `202604.01.3` is a higher patch of the same base as the baked ANC.

### Files changed
- `aks-node-controller/hotfix.go`
- `aks-node-controller/hotfix_test.go`

### Test results
`go build ./...` passes; all pure-logic unit tests pass. Two tests (`TestDownloadHotfix_MatchingBaseUpgrades`, `TestDownloadHotfix_MapMatchingBaseUpgrades`) fail **on Windows only** because they exercise package-manager detection that needs `/etc/os-release`, `bash`, and unix file permissions. They pass in Linux CI and are unrelated to this change.


### Stack
This is the base of a four-PR stack:
```
main
 \- #8694  2.1a  base->version hotfix map (Go)            <- this PR
     \- #8696  2.1b  check-hotfix ConfigMap reader (Go)
         \- #8715  2.1c  wire check-hotfix into wrapper (shell)
             \- #8717  2.1d  enable_provisioning_hotfix contract field + Go self-gate
```
2.1a is the groundwork: it only teaches `downloadHotfix` the base->version map. The later
PRs add the ConfigMap reader (2.1b), wire it into the boot wrapper (2.1c), and gate the
whole thing on the `enable_provisioning_hotfix` AKSNodeConfig contract field (2.1d).
