### PR TITLE
fix(e2e): improve e2e test reliability (16 fixes)

### DIFF
--- a/e2e/bastionssh.go
+++ b/e2e/bastionssh.go
@@ -64,7 +64,7 @@ type tunnelSession struct {
 }
 
 func (b *Bastion) NewTunnelSession(ctx context.Context, targetHost string, port uint16) (*tunnelSession, error) {
-	session, err := b.newSessionToken(targetHost, port)
+	session, err := b.newSessionToken(ctx, targetHost, port)
 	if err != nil {
 		return nil, err
 	}
@@ -132,9 +132,9 @@ func (t *tunnelSession) Close() error {
 	return nil
 }
 
-func (b *Bastion) newSessionToken(targetHost string, port uint16) (*sessionToken, error) {
+func (b *Bastion) newSessionToken(ctx context.Context, targetHost string, port uint16) (*sessionToken, error) {
 
-	token, err := b.credential.GetToken(context.Background(), policy.TokenRequestOptions{
+	token, err := b.credential.GetToken(ctx, policy.TokenRequestOptions{
 		Scopes: []string{fmt.Sprintf("%s/.default", cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint)},
 	})
 
@@ -156,6 +156,7 @@ func (b *Bastion) newSessionToken(targetHost string, port uint16) (*sessionToken
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := b.httpClient.Do(req) // TODO client settings
@@ -303,9 +304,7 @@ func DialSSHOverBastion(
 		}
 		toolkit.Logf(ctx, "Attempt %d/%d establishing SSH over bastion to %s", attempt, sshDialAttempts, vmPrivateIP)
 
-		// Intentionally use a background context to prevent cancelling the SSH connection before
-		// we fetch logs during cleanup.
-		tunnel, err := bastion.NewTunnelSession(context.Background(), vmPrivateIP, 22)
+		tunnel, err := bastion.NewTunnelSession(ctx, vmPrivateIP, 22)
 		if err != nil {
 			lastErr = err
 			toolkit.Logf(ctx, "Attempt %d/%d failed to create bastion tunnel: %v", attempt, sshDialAttempts, err)

--- a/e2e/bastionssh.go
+++ b/e2e/bastionssh.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -296,8 +297,9 @@ func DialSSHOverBastion(
 	var lastErr error
 	for attempt := 1; attempt <= sshDialAttempts; attempt++ {
 		if attempt > 1 {
+			backoff := sshDialBackoff + time.Duration(rand.Int63n(int64(sshDialBackoff)))
 			select {
-			case <-time.After(sshDialBackoff):
+			case <-time.After(backoff):
 			case <-ctx.Done():
 				return nil, ctx.Err()
 			}

--- a/e2e/cache.go
+++ b/e2e/cache.go
@@ -13,7 +13,9 @@ import (
 )
 
 // cachedFunc creates a thread-safe memoized version of a function.
-// Results are cached per unique Request key using sync.Once for single execution.
+// Successful results are cached permanently per unique Request key.
+// Errors are NOT cached — a failed call will be retried on the next invocation,
+// preventing a transient failure from poisoning all future callers sharing the key.
 // Request type must be comparable (no slices/maps/pointers).
 // Cache persists for program lifetime with no TTL or invalidation.
 // WARNING: Incorrect keys can cause hard-to-debug cache collisions.

--- a/e2e/cache.go
+++ b/e2e/cache.go
@@ -19,7 +19,8 @@ import (
 // WARNING: Incorrect keys can cause hard-to-debug cache collisions.
 func cachedFunc[Request comparable, Response any](fn func(context.Context, Request) (Response, error)) func(context.Context, Request) (Response, error) {
 	type entry struct {
-		once  sync.Once
+		mu    sync.Mutex
+		done  bool
 		value Response
 		err   error
 	}
@@ -30,9 +31,17 @@ func cachedFunc[Request comparable, Response any](fn func(context.Context, Reque
 		actual, _ := cache.LoadOrStore(key, &entry{})
 		e := actual.(*entry)
 
-		e.once.Do(func() {
-			e.value, e.err = fn(ctx, key)
-		})
+		e.mu.Lock()
+		defer e.mu.Unlock()
+
+		if e.done {
+			return e.value, nil
+		}
+
+		e.value, e.err = fn(ctx, key)
+		if e.err == nil {
+			e.done = true
+		}
 
 		return e.value, e.err
 	}

--- a/e2e/cache_test.go
+++ b/e2e/cache_test.go
@@ -72,7 +72,7 @@ func Test_cachedFunc_different_keys_produce_different_cache_entries(t *testing.T
 	assert.Equal(t, int32(2), callCount.Load(), "underlying function should be called once per unique key")
 }
 
-func Test_cachedFunc_caches_errors(t *testing.T) {
+func Test_cachedFunc_retries_on_error(t *testing.T) {
 	var callCount atomic.Int32
 	expectedErr := fmt.Errorf("something went wrong")
 	fn := cachedFunc(func(ctx context.Context, key string) (string, error) {
@@ -88,7 +88,39 @@ func Test_cachedFunc_caches_errors(t *testing.T) {
 	_, err2 := fn(ctx, "a")
 	require.ErrorIs(t, err2, expectedErr)
 
-	assert.Equal(t, int32(1), callCount.Load(), "underlying function should only be called once even when it returns an error")
+	assert.Equal(t, int32(2), callCount.Load(), "underlying function should be retried after each error, not memoized")
+}
+
+func Test_cachedFunc_caches_after_success_following_error(t *testing.T) {
+	var callCount atomic.Int32
+	shouldFail := true
+	fn := cachedFunc(func(ctx context.Context, key string) (string, error) {
+		callCount.Add(1)
+		if shouldFail {
+			return "", fmt.Errorf("transient error")
+		}
+		return "ok", nil
+	})
+
+	ctx := context.Background()
+
+	// First call fails — not cached
+	_, err := fn(ctx, "a")
+	require.Error(t, err)
+	assert.Equal(t, int32(1), callCount.Load())
+
+	// Second call succeeds — result is now cached
+	shouldFail = false
+	v1, err := fn(ctx, "a")
+	require.NoError(t, err)
+	assert.Equal(t, "ok", v1)
+	assert.Equal(t, int32(2), callCount.Load())
+
+	// Third call hits cache — underlying function not called again
+	v2, err := fn(ctx, "a")
+	require.NoError(t, err)
+	assert.Equal(t, "ok", v2)
+	assert.Equal(t, int32(2), callCount.Load(), "successful result should be cached; underlying function should not be called again")
 }
 
 func Test_cachedFunc_with_struct_key(t *testing.T) {

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -412,6 +412,7 @@ func waitForClusterDeletion(ctx context.Context, clusterName, resourceGroupName 
 func waitUntilClusterReady(ctx context.Context, name, location string) (*armcontainerservice.ManagedCluster, error) {
 	var cluster armcontainerservice.ManagedClustersClientGetResponse
 	var clusterDeleted bool
+	var lastErr error
 	err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
 		var err error
 		cluster, err = config.Azure.AKS.Get(ctx, config.ResourceGroupName(location), name, nil)
@@ -421,7 +422,9 @@ func waitUntilClusterReady(ctx context.Context, name, location string) (*armcont
 				clusterDeleted = true
 				return true, nil
 			}
-			return false, err
+			lastErr = err
+			toolkit.Logf(ctx, "transient error polling cluster %s, will retry: %v", name, err)
+			return false, nil
 		}
 		switch *cluster.ManagedCluster.Properties.ProvisioningState {
 		case "Succeeded":
@@ -435,6 +438,9 @@ func waitUntilClusterReady(ctx context.Context, name, location string) (*armcont
 		}
 	})
 	if err != nil {
+		if lastErr != nil {
+			return nil, fmt.Errorf("failed to wait for cluster %s to be ready after transient polling error: %w", name, lastErr)
+		}
 		return nil, fmt.Errorf("failed to wait for cluster %s to be ready: %w", name, err)
 	}
 	if clusterDeleted {

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net"
 	"net/http"
 	"strings"
@@ -554,10 +555,11 @@ func createNewAKSClusterWithRetry(ctx context.Context, cluster *armcontainerserv
 					return nil, fmt.Errorf("failed waiting for cluster deletion: %w", deleteErr)
 				}
 			}
-			toolkit.Logf(ctx, "Attempt %d failed with retryable error: %v. Retrying in %v...", attempt+1, err, retryInterval)
+			backoff := retryInterval + time.Duration(rand.Int63n(int64(retryInterval)))
+			toolkit.Logf(ctx, "Attempt %d failed with retryable error: %v. Retrying in %v...", attempt+1, err, backoff)
 
 			select {
-			case <-time.After(retryInterval):
+			case <-time.After(backoff):
 			case <-ctx.Done():
 				return nil, fmt.Errorf("context canceled while retrying cluster creation: %w", ctx.Err())
 			}

--- a/e2e/dag/dag.go
+++ b/e2e/dag/dag.go
@@ -28,11 +28,10 @@
 // collected errors. Panics inside task functions are recovered and surfaced
 // as errors; they never crash the process.
 //
-// Note: the package does not perform runtime cycle detection. Dependency
-// cycles created via the untyped [Go]/[Run] API (where a task's closure
-// captures a [Result] that transitively depends on itself) will cause
-// [Group.Wait] to deadlock. The typed variants (Go1–Go3, Run1–Run3) make
-// cycles harder to construct but do not prevent them entirely.
+// Note: the package performs runtime cycle detection for explicit dependency
+// edges declared via [Go]/[Run]/[Go1-3]/[Run1-3]. Hidden cycles created by
+// closures that capture undeclared [Result] values are still outside the
+// scheduler's view and can deadlock [Group.Wait].
 //
 // Example:
 //
@@ -85,13 +84,16 @@ type Group struct {
 	mu   sync.Mutex
 	errs []error
 	wg   sync.WaitGroup
+	deps map[taskNode][]taskNode
 }
+
+type taskNode any
 
 // NewGroup creates a Group whose tasks run under ctx.
 // On the first task error the Group cancels ctx, signalling all other tasks.
 func NewGroup(ctx context.Context) *Group {
 	ctx, cancel := context.WithCancel(ctx)
-	return &Group{ctx: ctx, cancel: cancel}
+	return &Group{ctx: ctx, cancel: cancel, deps: map[taskNode][]taskNode{}}
 }
 
 // Wait blocks until every task in the group has finished.
@@ -116,6 +118,40 @@ func (g *Group) recordError(err error) {
 	g.errs = append(g.errs, err)
 	g.mu.Unlock()
 	g.cancel()
+}
+
+func (g *Group) registerTask(task taskNode, deps []Dep) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	taskDeps := make([]taskNode, len(deps))
+	for i, dep := range deps {
+		taskDeps[i] = dep
+	}
+	g.deps[task] = taskDeps
+	for _, dep := range taskDeps {
+		if g.hasPathLocked(dep, task, map[taskNode]bool{}) {
+			delete(g.deps, task)
+			return fmt.Errorf("dag: dependency cycle detected")
+		}
+	}
+	return nil
+}
+
+func (g *Group) hasPathLocked(current, target taskNode, seen map[taskNode]bool) bool {
+	if current == target {
+		return true
+	}
+	if seen[current] {
+		return false
+	}
+	seen[current] = true
+	for _, dep := range g.deps[current] {
+		if g.hasPathLocked(dep, target, seen) {
+			return true
+		}
+	}
+	return false
 }
 
 // errSkipped is a sentinel set on tasks that were skipped because a
@@ -246,6 +282,12 @@ func (e *Effect) finish(err error) {
 // via [Result.MustGet] inside fn.
 func Go[T any](g *Group, fn func(ctx context.Context) (T, error), deps ...Dep) *Result[T] {
 	r := newResult[T]()
+	if err := g.registerTask(r, deps); err != nil {
+		var zero T
+		r.finish(zero, err)
+		g.recordError(err)
+		return r
+	}
 	g.launch(deps, func() {
 		val, err := fn(g.ctx)
 		if err != nil {
@@ -263,7 +305,14 @@ func Go[T any](g *Group, fn func(ctx context.Context) (T, error), deps ...Dep) *
 // Extra deps are waited on but their values are not passed to fn.
 func Go1[T, D1 any](g *Group, dep *Result[D1], fn func(ctx context.Context, d1 D1) (T, error), extra ...Dep) *Result[T] {
 	r := newResult[T]()
-	g.launch(append([]Dep{dep}, extra...), func() {
+	deps := append([]Dep{dep}, extra...)
+	if err := g.registerTask(r, deps); err != nil {
+		var zero T
+		r.finish(zero, err)
+		g.recordError(err)
+		return r
+	}
+	g.launch(deps, func() {
 		val, err := fn(g.ctx, dep.val)
 		if err != nil {
 			g.recordError(err)
@@ -280,7 +329,14 @@ func Go1[T, D1 any](g *Group, dep *Result[D1], fn func(ctx context.Context, d1 D
 // Extra deps are waited on but their values are not passed to fn.
 func Go2[T, D1, D2 any](g *Group, dep1 *Result[D1], dep2 *Result[D2], fn func(ctx context.Context, d1 D1, d2 D2) (T, error), extra ...Dep) *Result[T] {
 	r := newResult[T]()
-	g.launch(append([]Dep{dep1, dep2}, extra...), func() {
+	deps := append([]Dep{dep1, dep2}, extra...)
+	if err := g.registerTask(r, deps); err != nil {
+		var zero T
+		r.finish(zero, err)
+		g.recordError(err)
+		return r
+	}
+	g.launch(deps, func() {
 		val, err := fn(g.ctx, dep1.val, dep2.val)
 		if err != nil {
 			g.recordError(err)
@@ -297,7 +353,14 @@ func Go2[T, D1, D2 any](g *Group, dep1 *Result[D1], dep2 *Result[D2], fn func(ct
 // Extra deps are waited on but their values are not passed to fn.
 func Go3[T, D1, D2, D3 any](g *Group, dep1 *Result[D1], dep2 *Result[D2], dep3 *Result[D3], fn func(ctx context.Context, d1 D1, d2 D2, d3 D3) (T, error), extra ...Dep) *Result[T] {
 	r := newResult[T]()
-	g.launch(append([]Dep{dep1, dep2, dep3}, extra...), func() {
+	deps := append([]Dep{dep1, dep2, dep3}, extra...)
+	if err := g.registerTask(r, deps); err != nil {
+		var zero T
+		r.finish(zero, err)
+		g.recordError(err)
+		return r
+	}
+	g.launch(deps, func() {
 		val, err := fn(g.ctx, dep1.val, dep2.val, dep3.val)
 		if err != nil {
 			g.recordError(err)
@@ -320,6 +383,11 @@ func Go3[T, D1, D2, D3 any](g *Group, dep1 *Result[D1], dep2 *Result[D2], dep3 *
 // Run launches fn with optional untyped deps.
 func Run(g *Group, fn func(ctx context.Context) error, deps ...Dep) *Effect {
 	e := newEffect()
+	if err := g.registerTask(e, deps); err != nil {
+		e.finish(err)
+		g.recordError(err)
+		return e
+	}
 	g.launch(deps, func() {
 		err := fn(g.ctx)
 		if err != nil {
@@ -334,7 +402,13 @@ func Run(g *Group, fn func(ctx context.Context) error, deps ...Dep) *Effect {
 // Extra deps are waited on but their values are not passed to fn.
 func Run1[D1 any](g *Group, dep *Result[D1], fn func(ctx context.Context, d1 D1) error, extra ...Dep) *Effect {
 	e := newEffect()
-	g.launch(append([]Dep{dep}, extra...), func() {
+	deps := append([]Dep{dep}, extra...)
+	if err := g.registerTask(e, deps); err != nil {
+		e.finish(err)
+		g.recordError(err)
+		return e
+	}
+	g.launch(deps, func() {
 		err := fn(g.ctx, dep.val)
 		if err != nil {
 			g.recordError(err)
@@ -348,7 +422,13 @@ func Run1[D1 any](g *Group, dep *Result[D1], fn func(ctx context.Context, d1 D1)
 // Extra deps are waited on but their values are not passed to fn.
 func Run2[D1, D2 any](g *Group, dep1 *Result[D1], dep2 *Result[D2], fn func(ctx context.Context, d1 D1, d2 D2) error, extra ...Dep) *Effect {
 	e := newEffect()
-	g.launch(append([]Dep{dep1, dep2}, extra...), func() {
+	deps := append([]Dep{dep1, dep2}, extra...)
+	if err := g.registerTask(e, deps); err != nil {
+		e.finish(err)
+		g.recordError(err)
+		return e
+	}
+	g.launch(deps, func() {
 		err := fn(g.ctx, dep1.val, dep2.val)
 		if err != nil {
 			g.recordError(err)
@@ -362,7 +442,13 @@ func Run2[D1, D2 any](g *Group, dep1 *Result[D1], dep2 *Result[D2], fn func(ctx 
 // Extra deps are waited on but their values are not passed to fn.
 func Run3[D1, D2, D3 any](g *Group, dep1 *Result[D1], dep2 *Result[D2], dep3 *Result[D3], fn func(ctx context.Context, d1 D1, d2 D2, d3 D3) error, extra ...Dep) *Effect {
 	e := newEffect()
-	g.launch(append([]Dep{dep1, dep2, dep3}, extra...), func() {
+	deps := append([]Dep{dep1, dep2, dep3}, extra...)
+	if err := g.registerTask(e, deps); err != nil {
+		e.finish(err)
+		g.recordError(err)
+		return e
+	}
+	g.launch(deps, func() {
 		err := fn(g.ctx, dep1.val, dep2.val, dep3.val)
 		if err != nil {
 			g.recordError(err)

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	mrand "math/rand"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -218,8 +219,9 @@ func execOnPod(ctx context.Context, kube *Kubeclient, namespace, podName string,
 
 		// If it's a retryable connection error and we have retries left, retry
 		if isRetryableConnectionError(err) && attempt < maxRetries-1 {
+			backoff := retryDelay + time.Duration(mrand.Int63n(int64(retryDelay)))
 			select {
-			case <-time.After(retryDelay):
+			case <-time.After(backoff):
 				// Continue to next attempt
 			case <-ctx.Done():
 				return nil, fmt.Errorf("context cancelled during retry attempt %d: %w", attempt+1, ctx.Err())

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -144,9 +144,11 @@ func runSSHCommandWithPrivateKeyFile(
 	if err != nil {
 		if exitErr, ok := err.(*ssh.ExitError); ok {
 			exitCode = exitErr.ExitStatus()
-		} else if errors.As(err, &ssh.ExitMissingError{}) {
-			return nil, err
 		} else {
+			var exitMissingErr *ssh.ExitMissingError
+			if errors.As(err, &exitMissingErr) {
+				return nil, fmt.Errorf("ssh command %q closed without exit status: %w", command, exitMissingErr)
+			}
 			return nil, err // real SSH failure
 		}
 	}

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -80,7 +81,7 @@ func copyScriptToRemoteIfRequired(ctx context.Context, client *ssh.Client, comma
 	}
 	defer scpClient.Close()
 
-	copyCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	copyCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	return remoteCommand, scpClient.Copy(copyCtx,
@@ -121,15 +122,29 @@ func runSSHCommandWithPrivateKeyFile(
 	session.Stdout = stdout
 	session.Stderr = stderr
 
-	err = session.Run(command)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- session.Run(command)
+	}()
+
+	select {
+	case err = <-errCh:
+	case <-ctx.Done():
+		_ = session.Signal(ssh.SIGTERM)
+		_ = session.Close()
+		select {
+		case <-errCh:
+		case <-time.After(5 * time.Second):
+		}
+		return nil, ctx.Err()
+	}
 
 	exitCode := 0
 	if err != nil {
 		if exitErr, ok := err.(*ssh.ExitError); ok {
 			exitCode = exitErr.ExitStatus()
-		} else if _, ok := err.(*ssh.ExitMissingError); ok {
-			// Bastion closed channel early – ignore
-			err = nil
+		} else if errors.As(err, &ssh.ExitMissingError{}) {
+			return nil, err
 		} else {
 			return nil, err // real SSH failure
 		}

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -107,6 +107,7 @@ func NewKubeclient(kubeconfigBytes []byte) (*Kubeclient, error) {
 func (k *Kubeclient) WaitUntilPodRunning(ctx context.Context, namespace string, labelSelector string, fieldSelector string) (*corev1.Pod, error) {
 	defer toolkit.LogStepCtxf(ctx, "waiting for pod %s %s in %q namespace", labelSelector, fieldSelector, namespace)()
 	var pod *corev1.Pod
+	var lastErr error
 
 	err := wait.PollUntilContextTimeout(ctx, 3*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		pods, err := k.Typed.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
@@ -114,7 +115,9 @@ func (k *Kubeclient) WaitUntilPodRunning(ctx context.Context, namespace string, 
 			LabelSelector: labelSelector,
 		})
 		if err != nil {
-			return false, err
+			lastErr = err
+			toolkit.Logf(ctx, "transient error polling pods in %q, will retry: %v", namespace, err)
+			return false, nil
 		}
 
 		if len(pods.Items) == 0 {
@@ -152,6 +155,9 @@ func (k *Kubeclient) WaitUntilPodRunning(ctx context.Context, namespace string, 
 			return false, fmt.Errorf("pod %s is in unexpected phase %s", pod.Name, pod.Status.Phase)
 		}
 	})
+	if err != nil && lastErr != nil {
+		return pod, fmt.Errorf("timed out waiting for pod after transient polling error: %w", lastErr)
+	}
 
 	return pod, err
 }

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -105,6 +105,14 @@ func NewKubeclient(kubeconfigBytes []byte) (*Kubeclient, error) {
 }
 
 func (k *Kubeclient) WaitUntilPodRunning(ctx context.Context, namespace string, labelSelector string, fieldSelector string) (*corev1.Pod, error) {
+	return k.waitUntilPod(ctx, namespace, labelSelector, fieldSelector, false)
+}
+
+func (k *Kubeclient) WaitUntilPodCompleted(ctx context.Context, namespace string, labelSelector string, fieldSelector string) (*corev1.Pod, error) {
+	return k.waitUntilPod(ctx, namespace, labelSelector, fieldSelector, true)
+}
+
+func (k *Kubeclient) waitUntilPod(ctx context.Context, namespace string, labelSelector string, fieldSelector string, allowCompleted bool) (*corev1.Pod, error) {
 	defer toolkit.LogStepCtxf(ctx, "waiting for pod %s %s in %q namespace", labelSelector, fieldSelector, namespace)()
 	var pod *corev1.Pod
 	var lastErr error
@@ -141,15 +149,15 @@ func (k *Kubeclient) WaitUntilPodRunning(ctx context.Context, namespace string, 
 		case corev1.PodPending:
 			return false, nil // Keep polling
 		case corev1.PodSucceeded:
-			return true, nil // Pod completed successfully
-		case corev1.PodRunning:
-			// Check if the pod is ready
-			for _, cond := range pod.Status.Conditions {
-				if cond.Type == "Ready" && cond.Status == "True" {
-					return true, nil
-				}
+			if allowCompleted {
+				return true, nil
 			}
-			return false, nil // Running but not ready yet
+			return false, nil
+		case corev1.PodRunning:
+			if !allPodContainersReady(pod) {
+				return false, nil
+			}
+			return true, nil
 		default:
 			logPodDebugInfo(ctx, k, pod)
 			return false, fmt.Errorf("pod %s is in unexpected phase %s", pod.Name, pod.Status.Phase)
@@ -160,6 +168,18 @@ func (k *Kubeclient) WaitUntilPodRunning(ctx context.Context, namespace string, 
 	}
 
 	return pod, err
+}
+
+func allPodContainersReady(pod *corev1.Pod) bool {
+	if pod == nil || len(pod.Status.ContainerStatuses) == 0 {
+		return false
+	}
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if !containerStatus.Ready {
+			return false
+		}
+	}
+	return true
 }
 
 func (k *Kubeclient) WaitUntilNodeReady(ctx context.Context, t testing.TB, vmssName string) string {

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -157,6 +157,9 @@ func (k *Kubeclient) waitUntilPod(ctx context.Context, namespace string, labelSe
 			if !allPodContainersReady(pod) {
 				return false, nil
 			}
+			if !allowCompleted && !isPodReadyCondition(pod) {
+				return false, nil
+			}
 			return true, nil
 		default:
 			logPodDebugInfo(ctx, k, pod)
@@ -180,6 +183,17 @@ func allPodContainersReady(pod *corev1.Pod) bool {
 		}
 	}
 	return true
+}
+
+// isPodReadyCondition checks the pod-level PodReady condition, which reflects
+// readiness gates and minReadySeconds in addition to container readiness.
+func isPodReadyCondition(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 func (k *Kubeclient) WaitUntilNodeReady(ctx context.Context, t testing.TB, vmssName string) string {

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -75,7 +75,6 @@ func newTestCtx(t testing.TB) context.Context {
 }
 
 func RunScenario(t *testing.T, s *Scenario) {
-	t.Parallel()
 	// Special case for testing VHD caching. Not used by default.
 	if config.Config.TestPreProvision || s.VHDCaching {
 		t.Run("VHDCreation", func(t *testing.T) {

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -321,28 +321,31 @@ func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 
 	require.NoError(s.T, err)
 
+	effectiveVMSKU := config.Config.DefaultVMSKU
+
 	gen2Only, err := CachedIsVMSizeGen2Only(ctx, VMSizeSKURequest{
 		Location: s.Location,
-		VMSize:   config.Config.DefaultVMSKU,
+		VMSize:   effectiveVMSKU,
 	})
-	require.NoError(s.T, err, "checking if VM size %q supports only Gen2", config.Config.DefaultVMSKU)
+	require.NoError(s.T, err, "checking if VM size %q supports only Gen2", effectiveVMSKU)
 	if gen2Only && s.Config.VHD.UnsupportedGen2 {
-		s.T.Logf("VM size %q only supports Gen2 hypervisor but image does not, falling back to vm size that supported gen 1 %q", config.Config.DefaultVMSKU, config.DefaultV5VMSKU)
-		config.Config.DefaultVMSKU = config.DefaultV5VMSKU
+		s.T.Logf("VM size %q only supports Gen2 hypervisor but image does not, falling back to vm size that supported gen 1 %q", effectiveVMSKU, config.DefaultV5VMSKU)
+		effectiveVMSKU = config.DefaultV5VMSKU
 	}
 	supportsNVMe, err := CachedVMSizeSupportsNVMe(ctx, VMSizeSKURequest{
 		Location: s.Location,
-		VMSize:   config.Config.DefaultVMSKU,
+		VMSize:   effectiveVMSKU,
 	})
-	require.NoError(s.T, err, "checking if VM size %q supports only NVMe", config.Config.DefaultVMSKU)
+	require.NoError(s.T, err, "checking if VM size %q supports only NVMe", effectiveVMSKU)
 	if supportsNVMe {
 		if s.Config.VHD.UnsupportedNVMe {
-			s.T.Logf("VM size %q supports NVMe disk controller but image does not support NVMe, falling back to vm size that supports SCSI %q", config.Config.DefaultVMSKU, config.DefaultV5VMSKU)
-			config.Config.DefaultVMSKU = config.DefaultV5VMSKU
+			s.T.Logf("VM size %q supports NVMe disk controller but image does not support NVMe, falling back to vm size that supports SCSI %q", effectiveVMSKU, config.DefaultV5VMSKU)
+			effectiveVMSKU = config.DefaultV5VMSKU
 		} else {
 			s.Config.UseNVMe = true
 		}
 	}
+	s.Runtime.VMSize = effectiveVMSKU
 
 	start := time.Now() // Record the start time
 	scenarioVM, err := ConfigureAndCreateVMSS(ctx, s)

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -187,12 +187,54 @@ func runScenarioWithPreProvision(t *testing.T, original *Scenario) {
 	})
 }
 
-// Helper to deep copy a Scenario (implement as needed for your struct)
+// copyScenario creates an isolated copy of Scenario state used by parallel subtests.
 func copyScenario(s *Scenario) *Scenario {
-	// Implement deep copy logic for Scenario and its fields
-	// This is a placeholder; you may need to copy nested structs and slices
 	copied := *s
-	copied.Config = s.Config // If Config is a struct, deep copy its fields as well
+
+	if s.Config.VHD != nil {
+		vhdCopy := *s.Config.VHD
+		if s.Config.VHD.Gallery != nil {
+			galleryCopy := *s.Config.VHD.Gallery
+			vhdCopy.Gallery = &galleryCopy
+		}
+		copied.Config.VHD = &vhdCopy
+	}
+
+	if s.Config.CustomDataWriteFiles != nil {
+		copied.Config.CustomDataWriteFiles = append([]CustomDataWriteFile(nil), s.Config.CustomDataWriteFiles...)
+	}
+
+	if s.Runtime != nil {
+		runtimeCopy := *s.Runtime
+		if s.Runtime.NBC != nil {
+			nbcCopy := *s.Runtime.NBC
+			runtimeCopy.NBC = &nbcCopy
+		}
+		if s.Runtime.AKSNodeConfig != nil {
+			aksNodeConfigCopy := *s.Runtime.AKSNodeConfig
+			runtimeCopy.AKSNodeConfig = &aksNodeConfigCopy
+		}
+		if s.Runtime.Cluster != nil {
+			clusterCopy := *s.Runtime.Cluster
+			runtimeCopy.Cluster = &clusterCopy
+		}
+		if s.Runtime.VM != nil {
+			vmCopy := *s.Runtime.VM
+			runtimeCopy.VM = &vmCopy
+		}
+		if s.Runtime.CSETimingReport != nil {
+			reportCopy := *s.Runtime.CSETimingReport
+			reportCopy.Tasks = append([]CSETaskTiming(nil), s.Runtime.CSETimingReport.Tasks...)
+			if s.Runtime.CSETimingReport.Provision != nil {
+				provisionCopy := *s.Runtime.CSETimingReport.Provision
+				reportCopy.Provision = &provisionCopy
+			}
+			reportCopy.taskIndex = nil
+			runtimeCopy.CSETimingReport = &reportCopy
+		}
+		copied.Runtime = &runtimeCopy
+	}
+
 	return &copied
 }
 

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -158,6 +158,7 @@ type ScenarioRuntime struct {
 	Cluster                   *Cluster
 	Kube                      *Kubeclient // per-test client with independent rate limiter
 	VM                        *ScenarioVM
+	VMSize                    string
 	VMSSName                  string
 	EnableScriptlessNBCCSECmd bool
 	CSETimingReport           *CSETimingReport // eagerly extracted before GA can sweep events

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -43,6 +43,11 @@ func podNameForAttempt(baseName string, attempt int) string {
 	if len(baseName) > maxBaseLen {
 		baseName = strings.TrimRight(baseName[:maxBaseLen], "-")
 	}
+	if baseName == "" {
+		// baseName was empty or trimmed entirely; use a safe fallback that
+		// starts with an alphanumeric character (DNS-1123 requirement).
+		return fmt.Sprintf("pod%s", suffix)
+	}
 	return baseName + suffix
 }
 

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -181,14 +181,22 @@ func waitUntilResourceAvailable(ctx context.Context, s *Scenario, resourceName s
 	nodeName := s.Runtime.VM.KubeName
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
+	var lastErr error
 
 	for {
 		select {
 		case <-ctx.Done():
-			s.T.Fatalf("context cancelled: %v", ctx.Err())
+			if lastErr != nil {
+				s.T.Fatalf("context cancelled while waiting for resource %q: %v (last transient polling error: %v)", resourceName, ctx.Err(), lastErr)
+			}
+			s.T.Fatalf("context cancelled while waiting for resource %q: %v", resourceName, ctx.Err())
 		case <-ticker.C:
 			node, err := s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-			require.NoError(s.T, err, "failed to get node %q", nodeName)
+			if err != nil {
+				lastErr = err
+				s.T.Logf("transient error polling node %q for resource %q, will retry: %v", nodeName, resourceName, err)
+				continue
+			}
 
 			if isResourceAvailable(node, resourceName) {
 				s.T.Logf("resource %q is available", resourceName)

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -21,15 +21,29 @@ import (
 func ValidatePodRunningWithRetry(ctx context.Context, s *Scenario, pod *corev1.Pod, maxRetries int) {
 	var err error
 	for i := range maxRetries {
-		err = validatePodRunning(ctx, s, pod)
+		podAttempt := pod.DeepCopy()
+		podAttempt.Name = podNameForAttempt(pod.Name, i+1)
+		err = validatePodRunning(ctx, s, podAttempt)
 		if err != nil {
 			time.Sleep(1 * time.Second)
-			s.T.Logf("retrying pod %q validation (%d/%d)", pod.Name, i+1, maxRetries)
+			s.T.Logf("retrying pod %q validation (%d/%d)", podAttempt.Name, i+1, maxRetries)
 			continue
 		}
 		break
 	}
 	require.NoErrorf(s.T, err, "failed to validate pod running %q", pod.Name)
+}
+
+func podNameForAttempt(baseName string, attempt int) string {
+	suffix := fmt.Sprintf("-%d", attempt)
+	maxBaseLen := 63 - len(suffix)
+	if maxBaseLen < 0 {
+		maxBaseLen = 0
+	}
+	if len(baseName) > maxBaseLen {
+		baseName = strings.TrimRight(baseName[:maxBaseLen], "-")
+	}
+	return baseName + suffix
 }
 
 func ValidatePodRunning(ctx context.Context, s *Scenario, pod *corev1.Pod) {

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -779,21 +779,27 @@ func ServiceCanRestartValidator(ctx context.Context, s *Scenario, serviceName st
 		fmt.Sprintf("systemctl is-active %s", serviceName),
 
 		// get the PID of the service, so we can check it's changed
-		fmt.Sprintf("INITIAL_PID=`sudo pgrep %s`", serviceName),
+		fmt.Sprintf("INITIAL_PID=$(sudo systemctl show -p MainPID --value %s)", serviceName),
 		"echo INITIAL_PID: $INITIAL_PID",
 
 		// we use systemctl kill rather than kill -9 because container restrictions stop us sending a kill sig to a process
 		fmt.Sprintf("sudo systemctl kill %s", serviceName),
 
-		// sleep for restartTimeoutInSeconds seconds to give the service time tor restart
-		fmt.Sprintf("sleep %d", restartTimeoutInSeconds),
+		fmt.Sprintf(`for _ in $(seq 1 %d); do
+  CURRENT_STATE=$(systemctl is-active %s || true)
+  POST_PID=$(sudo systemctl show -p MainPID --value %s)
+  if [[ "$CURRENT_STATE" == "active" && -n "$POST_PID" && "$POST_PID" != "0" && "$POST_PID" != "$INITIAL_PID" ]]; then
+    break
+  fi
+  sleep 2
+done`, restartTimeoutInSeconds/2, serviceName, serviceName),
 
 		// print the status of the service and then verify it is active.
 		fmt.Sprintf("(systemctl -n 5 status %s || true)", serviceName),
 		fmt.Sprintf("systemctl is-active %s", serviceName),
 
 		// get the PID of the service after restart, so we can check it's changed
-		fmt.Sprintf("POST_PID=`sudo pgrep %s`", serviceName),
+		fmt.Sprintf("POST_PID=$(sudo systemctl show -p MainPID --value %s)", serviceName),
 		"echo POST_PID: $POST_PID",
 
 		// verify the PID has changed.
@@ -1899,6 +1905,7 @@ func ValidateLocalDNSHostsPluginIPv6(ctx context.Context, s *Scenario) {
 
 	s.T.Log("Testing hosts plugin serves IPv6 entries from hosts file")
 
+	// TODO(reliability): replace embedded shell sleeps in this validator with fully polled readiness checks when the shell flow is refactored into Go helpers.
 	script := `set -euo pipefail
 hosts_file="/etc/localdns/hosts"
 
@@ -2354,9 +2361,28 @@ func ValidateGPUWorkloadSchedulable(ctx context.Context, s *Scenario, gpuCount i
 	s.T.Helper()
 	s.T.Logf("validating that GPU workloads can be scheduled")
 
-	// Wait for resources to be available and add delay for device health
+	// Wait for resources to be available and for the allocatable count to stabilize.
 	waitUntilResourceAvailable(ctx, s, resourceName)
-	time.Sleep(20 * time.Second) // Same delay as existing GPU tests
+	gpuReadyCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	err := wait.PollUntilContextCancel(gpuReadyCtx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		node, err := s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
+		if err != nil {
+			s.T.Logf("transient error polling GPU allocatable resource %q, will retry: %v", resourceName, err)
+			return false, nil
+		}
+		quantity, exists := node.Status.Allocatable[corev1.ResourceName(resourceName)]
+		if !exists {
+			s.T.Logf("GPU allocatable resource %q not advertised yet, retrying", resourceName)
+			return false, nil
+		}
+		if quantity.Value() < int64(gpuCount) {
+			s.T.Logf("GPU allocatable resource %q=%d, waiting for at least %d", resourceName, quantity.Value(), gpuCount)
+			return false, nil
+		}
+		return true, nil
+	})
+	require.NoError(s.T, err, "GPU allocatable resource %q did not become ready", resourceName)
 
 	// Create a GPU test pod using the same pattern as podRunNvidiaWorkload
 	pod := &corev1.Pod{

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -1436,9 +1436,11 @@ func ValidateWindowsVersionFromWindowsSettings(ctx context.Context, s *Scenario,
 		"(Get-ItemProperty -Path \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\" -Name BuildLabEx).BuildLabEx",
 	}
 
-	jsonBytes := getWindowsSettingsJson()
+	jsonBytes, err := getWindowsSettingsJson()
+	require.NoError(s.T, err, "failed to read windows settings json")
 	osVersion := gjson.GetBytes(jsonBytes, fmt.Sprintf("WindowsBaseVersions.%s.base_image_version", windowsVersion))
 	versionSliced := strings.Split(osVersion.String(), ".")
+	require.NotEmpty(s.T, versionSliced[0], "expected non-empty Windows base image version for %q", windowsVersion)
 	osMajorVersion := versionSliced[0]
 
 	podExecResult := execScriptOnVMForScenarioValidateExitCode(ctx, s, strings.Join(steps, "\n"), 0, "could not validate command has parameters - might mean file does not have params, might mean something went wrong")
@@ -1476,9 +1478,8 @@ func ValidateWindowsDisplayVersion(ctx context.Context, s *Scenario, displayVers
 	require.Contains(s.T, podExecResultStdout, displayVersion)
 }
 
-func getWindowsSettingsJson() []byte {
-	jsonBytes, _ := os.ReadFile("../vhdbuilder/packer/windows/windows_settings.json")
-	return jsonBytes
+func getWindowsSettingsJson() ([]byte, error) {
+	return os.ReadFile("../vhdbuilder/packer/windows/windows_settings.json")
 }
 
 func ValidateCiliumIsRunningWindows(ctx context.Context, s *Scenario) {

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -788,7 +788,7 @@ func ServiceCanRestartValidator(ctx context.Context, s *Scenario, serviceName st
 		fmt.Sprintf(`for _ in $(seq 1 %d); do
   CURRENT_STATE=$(systemctl is-active %s || true)
   POST_PID=$(sudo systemctl show -p MainPID --value %s)
-  if [[ "$CURRENT_STATE" == "active" && -n "$POST_PID" && "$POST_PID" != "0" && "$POST_PID" != "$INITIAL_PID" ]]; then
+  if [ "$CURRENT_STATE" = "active" ] && [ -n "$POST_PID" ] && [ "$POST_PID" != "0" ] && [ "$POST_PID" != "$INITIAL_PID" ]; then
     break
   fi
   sleep 2
@@ -803,7 +803,7 @@ done`, restartTimeoutInSeconds/2, serviceName, serviceName),
 		"echo POST_PID: $POST_PID",
 
 		// verify the PID has changed.
-		"if [[ \"$INITIAL_PID\" == \"$POST_PID\" ]]; then echo PID did not change after restart, failing validator. ; exit 1; fi",
+		"if [ \"$INITIAL_PID\" = \"$POST_PID\" ]; then echo PID did not change after restart, failing validator. ; exit 1; fi",
 	}
 
 	execScriptOnVMForScenarioValidateExitCode(ctx, s, strings.Join(steps, "\n"), 0, "command to restart service failed")
@@ -1745,6 +1745,11 @@ func ValidateLocalDNSHostsPluginBypass(ctx context.Context, s *Scenario) {
 		if err != nil {
 			lastErr = err
 			s.T.Logf("transient error polling node %q annotation %q, will retry: %v", s.Runtime.VM.KubeName, annotationKey, err)
+			sleepDuration := time.Duration(1<<uint(attempt-1)) * time.Second
+			if sleepDuration > 10*time.Second {
+				sleepDuration = 10 * time.Second
+			}
+			time.Sleep(sleepDuration)
 			continue
 		}
 

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -246,7 +246,7 @@ func ValidateDirectoryContent(ctx context.Context, s *Scenario, path string, fil
 
 func ValidateSysctlConfig(ctx context.Context, s *Scenario, customSysctls map[string]string) {
 	s.T.Helper()
-	keysToCheck := make([]string, len(customSysctls))
+	keysToCheck := make([]string, 0, len(customSysctls))
 	for k := range customSysctls {
 		keysToCheck = append(keysToCheck, k)
 	}

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -1720,13 +1720,18 @@ func ValidateLocalDNSHostsPluginBypass(ctx context.Context, s *Scenario) {
 
 	var node *corev1.Node
 	var err error
+	var lastErr error
 	var annotationValue string
 	var exists bool
 	maxAttempts := 33 // ~5 minutes: first 4 attempts use 1+2+4+8=15s, then ~29 attempts at 10s cap = ~305s
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		node, err = s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
-		require.NoError(s.T, err, "failed to get node %q", s.Runtime.VM.KubeName)
+		if err != nil {
+			lastErr = err
+			s.T.Logf("transient error polling node %q annotation %q, will retry: %v", s.Runtime.VM.KubeName, annotationKey, err)
+			continue
+		}
 
 		annotationValue, exists = node.Annotations[annotationKey]
 		if exists && annotationValue == "enabled" {
@@ -1735,8 +1740,13 @@ func ValidateLocalDNSHostsPluginBypass(ctx context.Context, s *Scenario) {
 		}
 
 		if attempt == maxAttempts {
-			s.T.Logf("WARNING: node %q annotation %q not found or not 'enabled' after %d attempts (~5 minutes). Current value: exists=%v, value=%q. Annotation is best-effort in production, continuing with stronger validators.",
-				s.Runtime.VM.KubeName, annotationKey, maxAttempts, exists, annotationValue)
+			if lastErr != nil {
+				s.T.Logf("WARNING: node %q annotation %q not found or not 'enabled' after %d attempts (~5 minutes). Current value: exists=%v, value=%q. Last transient polling error: %v. Annotation is best-effort in production, continuing with stronger validators.",
+					s.Runtime.VM.KubeName, annotationKey, maxAttempts, exists, annotationValue, lastErr)
+			} else {
+				s.T.Logf("WARNING: node %q annotation %q not found or not 'enabled' after %d attempts (~5 minutes). Current value: exists=%v, value=%q. Annotation is best-effort in production, continuing with stronger validators.",
+					s.Runtime.VM.KubeName, annotationKey, maxAttempts, exists, annotationValue)
+			}
 		}
 
 		// Exponential backoff: 1s, 2s, 4s, 8s, max 10s

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -1167,6 +1167,7 @@ func validateNPDCondition(ctx context.Context, s *Scenario, conditionType, condi
 	s.T.Helper()
 	// Wait for NPD to report initial condition
 	var condition *corev1.NodeCondition
+	var lastObserved *corev1.NodeCondition
 	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 		node, err := s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
 		if err != nil {
@@ -1176,20 +1177,27 @@ func validateNPDCondition(ctx context.Context, s *Scenario, conditionType, condi
 
 		// Check for condition with correct reason
 		for i := range node.Status.Conditions {
-			if string(node.Status.Conditions[i].Type) == conditionType && string(node.Status.Conditions[i].Reason) == conditionReason {
-				condition = &node.Status.Conditions[i] // Found the partial condition we are looking for
+			current := &node.Status.Conditions[i]
+			if string(current.Type) == conditionType {
+				lastObserved = current
 			}
-
-			if strings.Contains(node.Status.Conditions[i].Message, conditionMessage) {
-				condition = &node.Status.Conditions[i]
-				return true, nil // Found the exact condition we are looking for
+			if string(current.Type) == conditionType &&
+				string(current.Reason) == conditionReason &&
+				strings.Contains(current.Message, conditionMessage) {
+				condition = current
+				return true, nil
 			}
 		}
 
 		return false, nil // Continue polling until the condition is found or timeout occurs
 	})
 	if err != nil && condition == nil {
-		require.NoError(s.T, err, "timed out waiting for %s condition with reason %s to appear on node %q", conditionType, conditionReason, s.Runtime.VM.KubeName)
+		if lastObserved != nil {
+			require.NoErrorf(s.T, err, "timed out waiting for %s condition with reason %s and message %q on node %q; last observed condition: type=%s status=%s reason=%s message=%q",
+				conditionType, conditionReason, conditionMessage, s.Runtime.VM.KubeName, lastObserved.Type, lastObserved.Status, lastObserved.Reason, lastObserved.Message)
+		}
+		require.NoErrorf(s.T, err, "timed out waiting for %s condition with reason %s and message %q on node %q",
+			conditionType, conditionReason, conditionMessage, s.Runtime.VM.KubeName)
 	}
 
 	require.NotNil(s.T, condition, "expected to find %s condition with %s reason on node", conditionType, conditionReason)

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -533,6 +533,10 @@ func CreateVMSS(ctx context.Context, s *Scenario, resourceGroupName string) (*Sc
 	if err != nil {
 		return vm, err
 	}
+	s.T.Cleanup(func() {
+		defer cleanupBastionTunnel(vm.SSHClient)
+		cleanupVMSS(ctx, s, vm)
+	})
 	// We want to generate SSH instructions as soon as possible, so we can debug CSE issues
 	// Wait for VMSS VM to appear before extracting the private IP
 	vm.VM, err = waitForVMSSVM(ctx, s)
@@ -544,11 +548,6 @@ func CreateVMSS(ctx context.Context, s *Scenario, resourceGroupName string) (*Sc
 	if err != nil {
 		return vm, fmt.Errorf("failed to get VM private IP address: %w", err)
 	}
-
-	s.T.Cleanup(func() {
-		defer cleanupBastionTunnel(vm.SSHClient)
-		cleanupVMSS(ctx, s, vm)
-	})
 
 	result := "SSH Instructions: (may take a few minutes for the VM to be ready for SSH)\n========================\n"
 	if config.Config.KeepVMSS {
@@ -1025,11 +1024,15 @@ func deleteVMSS(ctx context.Context, s *Scenario) {
 		}
 		return
 	}
-	_, err := config.Azure.VMSS.BeginDelete(ctx, *s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, &armcompute.VirtualMachineScaleSetsClientBeginDeleteOptions{
+	poller, err := config.Azure.VMSS.BeginDelete(ctx, *s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, &armcompute.VirtualMachineScaleSetsClientBeginDeleteOptions{
 		ForceDeletion: to.Ptr(true),
 	})
 	if err != nil {
 		s.T.Logf("failed to delete vmss %q: %s", s.Runtime.VMSSName, err)
+		return
+	}
+	if _, err = poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions); err != nil {
+		s.T.Logf("failed while waiting for vmss %q deletion: %s", s.Runtime.VMSSName, err)
 		return
 	}
 	s.T.Logf("vmss %q deleted successfully", s.Runtime.VMSSName)

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -1166,10 +1166,14 @@ func indentYAMLBlock(content, indent string) string {
 }
 
 func getBaseVMSSModel(s *Scenario, customData, cseCmd string) armcompute.VirtualMachineScaleSet {
+	vmSize := config.Config.DefaultVMSKU
+	if s.Runtime != nil && s.Runtime.VMSize != "" {
+		vmSize = s.Runtime.VMSize
+	}
 	model := armcompute.VirtualMachineScaleSet{
 		Location: to.Ptr(s.Location),
 		SKU: &armcompute.SKU{
-			Name:     to.Ptr(config.Config.DefaultVMSKU),
+			Name:     to.Ptr(vmSize),
 			Capacity: to.Ptr[int64](1),
 		},
 		Properties: &armcompute.VirtualMachineScaleSetProperties{


### PR DESCRIPTION
## E2E Reliability Improvements

This PR implements 16 targeted reliability fixes to the AgentBaker e2e test suite identified through a comprehensive code review.

### Critical fixes
- Do not memoize transient errors in cachedFunc (prevents suite-wide poisoning)
- Avoid mutating global DefaultVMSKU under parallel tests (fixes data race)
- Wait for VMSS deletion and register cleanup immediately after create (prevents orphans)
- Propagate context cancellation through SSH exec and bastion paths

### Systematic flakiness fixes
- Retry transient API errors in wait/poll loops instead of failing immediately
- Replace fixed sleeps with polling loops in validators
- Add jitter to retry delays to prevent synchronized storms
- Fix WaitUntilPodRunning to not accept PodSucceeded; add WaitUntilPodCompleted
- Treat ssh.ExitMissingError as failure, not success

### Correctness & debuggability
- Remove nested t.Parallel() to reduce isolation pressure
- Implement real deep copy in copyScenario
- Generate unique pod names per retry attempt
- Fix sysctl arg slice init (leading empty strings)
- Fail Windows version validator when settings unreadable
- Require full type+reason+message match in validateNPDCondition
- Add cycle detection to DAG

Closes AB#38423358