### PR TITLE
fix: fix artifact arm64 params, anc hotfix to handle boothook

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -763,7 +763,7 @@ func Test_Ubuntu2204_ANCHotfix_BinarySelection(t *testing.T) {
 				},
 			},
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.EnableScriptlessCSECmd = true
+				nbc.EnableScriptlessNBCCSECmd = true
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				// Wrapper found the pre-seeded hotfix binary and selected it
@@ -1388,6 +1388,11 @@ func Test_Ubuntu2404_ArtifactStreaming_ARM64(t *testing.T) {
 			VHD:     config.VHDUbuntu2404ArmContainerd,
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				vmss.SKU.Name = to.Ptr("Standard_D2pds_V5")
+			},
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.EnableArtifactStreaming = true
+				nbc.AgentPoolProfile.VMSize = "Standard_D2pds_V5"
+				nbc.IsARM64 = true
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateNonEmptyDirectory(ctx, s, "/etc/overlaybd")
@@ -2971,7 +2976,7 @@ func Test_Ubuntu2204Gen2_ImagePullIdentityBinding_Disabled_Scriptless(t *testing
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion = "1.34.0"
 				nbc.ContainerService.Properties.ServiceAccountImagePullProfile = &datamodel.ServiceAccountImagePullProfile{
-					Enabled: false,
+					Enabled:           false,
 					DefaultClientID:   "should-not-appear-client-id",
 					DefaultTenantID:   "should-not-appear-tenant-id",
 					LocalAuthoritySNI: "should.not.appear.sni",

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -1100,6 +1100,10 @@ func injectWriteFilesEntriesToCustomData(customData string, entries []CustomData
 		return "", fmt.Errorf("failed to decode customData: %w", err)
 	}
 
+	if strings.Contains(string(decoded), "#cloud-boothook") {
+		return injectWriteFilesEntriesToBoothookCustomData(decoded, entries)
+	}
+
 	reader, err := gzip.NewReader(bytes.NewReader(decoded))
 	if err != nil {
 		return "", fmt.Errorf("failed to create gzip reader: %w", err)
@@ -1152,6 +1156,57 @@ func injectWriteFilesEntriesToCustomData(customData string, entries []CustomData
 
 	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
 	return encoded, nil
+}
+
+func injectWriteFilesEntriesToBoothookCustomData(decoded []byte, entries []CustomDataWriteFile) (string, error) {
+	boothookStr := string(decoded)
+
+	entryBlock, err := renderBoothookWriteFilesEntries(entries)
+	if err != nil {
+		return "", err
+	}
+
+	const serviceStart = "systemctl start --no-block aks-node-controller.service"
+	insertPos := strings.Index(boothookStr, serviceStart)
+	if insertPos == -1 {
+		return "", fmt.Errorf("cloud-boothook customData missing %q", serviceStart)
+	}
+
+	boothookStr = boothookStr[:insertPos] + entryBlock + boothookStr[insertPos:]
+	return base64.StdEncoding.EncodeToString([]byte(boothookStr)), nil
+}
+
+func renderBoothookWriteFilesEntries(entries []CustomDataWriteFile) (string, error) {
+	var entryBuilder strings.Builder
+	entryBuilder.WriteString("\n")
+	for _, entry := range entries {
+		if entry.Path == "" {
+			return "", fmt.Errorf("cloud-init write_files entry path cannot be empty")
+		}
+
+		permissions := entry.Permissions
+		if permissions == "" {
+			permissions = "0644"
+		}
+
+		owner := entry.Owner
+		if owner == "" {
+			owner = "root"
+		}
+
+		quotedPath := shellSingleQuote(entry.Path)
+		entryBuilder.WriteString(fmt.Sprintf("mkdir -p \"$(dirname %s)\"\n", quotedPath))
+		entryBuilder.WriteString(fmt.Sprintf("cat <<'EOF' | base64 -d > %s\n", quotedPath))
+		entryBuilder.WriteString(base64.StdEncoding.EncodeToString([]byte(entry.Content)))
+		entryBuilder.WriteString("\nEOF\n")
+		entryBuilder.WriteString(fmt.Sprintf("chmod %s %s\n", shellSingleQuote(permissions), quotedPath))
+		entryBuilder.WriteString(fmt.Sprintf("chown %s %s\n\n", shellSingleQuote(owner), quotedPath))
+	}
+	return entryBuilder.String(), nil
+}
+
+func shellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
 func indentYAMLBlock(content, indent string) string {

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -1103,6 +1103,9 @@ func injectWriteFilesEntriesToCustomData(customData string, entries []CustomData
 	if strings.Contains(string(decoded), "#cloud-boothook") {
 		return injectWriteFilesEntriesToBoothookCustomData(decoded, entries)
 	}
+	if strings.Contains(string(decoded), "write_files:") {
+		return injectWriteFilesEntriesToPlainCloudConfig(decoded, entries)
+	}
 
 	reader, err := gzip.NewReader(bytes.NewReader(decoded))
 	if err != nil {
@@ -1114,13 +1117,50 @@ func injectWriteFilesEntriesToCustomData(customData string, entries []CustomData
 		return "", fmt.Errorf("failed to read gzip data: %w", err)
 	}
 
+	yamlStr, err := injectWriteFilesEntriesToCloudConfigYAML(string(yamlBytes), entries)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err = gw.Write([]byte(yamlStr))
+	if err != nil {
+		return "", fmt.Errorf("failed to gzip customData: %w", err)
+	}
+	if err := gw.Close(); err != nil {
+		return "", fmt.Errorf("failed to close gzip writer: %w", err)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+	return encoded, nil
+}
+
+func injectWriteFilesEntriesToPlainCloudConfig(decoded []byte, entries []CustomDataWriteFile) (string, error) {
+	yamlStr, err := injectWriteFilesEntriesToCloudConfigYAML(string(decoded), entries)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString([]byte(yamlStr)), nil
+}
+
+func injectWriteFilesEntriesToCloudConfigYAML(yamlStr string, entries []CustomDataWriteFile) (string, error) {
 	const writeFilesMarker = "write_files:"
-	yamlStr := string(yamlBytes)
 	idx := strings.Index(yamlStr, writeFilesMarker)
 	if idx == -1 {
 		return "", fmt.Errorf("cloud-init customData missing %q section", writeFilesMarker)
 	}
 
+	entryBlock, err := renderCloudConfigWriteFilesEntries(entries)
+	if err != nil {
+		return "", err
+	}
+
+	insertPos := idx + len(writeFilesMarker)
+	return yamlStr[:insertPos] + entryBlock + yamlStr[insertPos:], nil
+}
+
+func renderCloudConfigWriteFilesEntries(entries []CustomDataWriteFile) (string, error) {
 	var entryBuilder strings.Builder
 	for _, entry := range entries {
 		if entry.Path == "" {
@@ -1140,22 +1180,7 @@ func injectWriteFilesEntriesToCustomData(customData string, entries []CustomData
 		indentedContent := indentYAMLBlock(entry.Content, "    ")
 		entryBuilder.WriteString(fmt.Sprintf("\n- path: %s\n  permissions: %q\n  owner: %s\n  content: |\n%s\n", entry.Path, permissions, owner, indentedContent))
 	}
-
-	insertPos := idx + len(writeFilesMarker)
-	yamlStr = yamlStr[:insertPos] + entryBuilder.String() + yamlStr[insertPos:]
-
-	var buf bytes.Buffer
-	gw := gzip.NewWriter(&buf)
-	_, err = gw.Write([]byte(yamlStr))
-	if err != nil {
-		return "", fmt.Errorf("failed to gzip customData: %w", err)
-	}
-	if err := gw.Close(); err != nil {
-		return "", fmt.Errorf("failed to close gzip writer: %w", err)
-	}
-
-	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
-	return encoded, nil
+	return entryBuilder.String(), nil
 }
 
 func injectWriteFilesEntriesToBoothookCustomData(decoded []byte, entries []CustomDataWriteFile) (string, error) {
@@ -1166,10 +1191,12 @@ func injectWriteFilesEntriesToBoothookCustomData(decoded []byte, entries []Custo
 		return "", err
 	}
 
-	const serviceStart = "systemctl start --no-block aks-node-controller.service"
-	insertPos := strings.Index(boothookStr, serviceStart)
+	insertPos := strings.Index(boothookStr, "systemctl start --no-block aks-node-controller.service")
 	if insertPos == -1 {
-		return "", fmt.Errorf("cloud-boothook customData missing %q", serviceStart)
+		insertPos = strings.Index(boothookStr, "systemctl start --no-block aks-node-controller-hack.service")
+	}
+	if insertPos == -1 {
+		return "", fmt.Errorf("cloud-boothook customData missing aks-node-controller service start")
 	}
 
 	boothookStr = boothookStr[:insertPos] + entryBlock + boothookStr[insertPos:]


### PR DESCRIPTION
- Fixed Test_Ubuntu2404_ArtifactStreaming_ARM64 to actually enable artifact streaming for ARM64 nodes, so overlaybd/containerd validators match the scenario intent.
 - Updated customData write file injection to handle #cloud-boothook scriptless NBC customData, not only gzipped write_files: cloud-config.
 - This lets Test_Ubuntu2204_ANCHotfix_BinarySelection pre-seed the ANC hotfix JSON/binary before aks-node-controller.service starts, so wrapper binary selection can detect the hotfix path.
 
 Fixes tests failed here: https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=168054626&view=logs&j=10f66467-59e5-53bc-0c8a-42cc89770de4&t=85db0a6d-4633-56aa-cb86-ea559630d4e6