### PR TITLE
fix: prevent CSE hang when curl verbose output blocks on unstable disks

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -679,6 +679,36 @@ func Test_Ubuntu2204_Early_Failure_Scriptless(t *testing.T) {
 	})
 }
 
+// Test_Ubuntu2204_CSETimeoutOnUnreachableDownload validates that the per-curl timeout (-k 5)
+// in cse_helpers.sh _retry_file_curl_internal properly kills hung download attempts.
+// It sets CustomKubeBinaryURL to a non-routable IP (RFC 5737 TEST-NET-1) which causes curl
+// to hang until the timeout fires, and sets a short CSETimeout so the test completes quickly.
+// The global timeout in cse_start.sh (timeout -k5s) kills the entire provisioning script.
+func Test_Ubuntu2204_CSETimeoutOnUnreachableDownload(t *testing.T) {
+	// 192.0.2.1 is a non-routable IP (RFC 5737 TEST-NET-1) that causes connections to hang
+	unreachableURL := "http://192.0.2.1:9999/fake-kubernetes-node-linux-amd64.tar.gz"
+	RunScenario(t, &Scenario{
+		Description: "Tests that CSE properly times out and exits when a download endpoint is unreachable, " +
+			"validating the timeout -k behavior in cse_helpers.sh",
+		Config: Config{
+			Cluster:           ClusterKubenet,
+			VHD:               config.VHDUbuntu2204Gen2Containerd,
+			SkipScriptlessNBC: true,
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.CustomKubeBinaryURL = unreachableURL
+				nbc.AgentPoolProfile.KubernetesConfig.CustomKubeBinaryURL = unreachableURL
+				// Short CSE timeout (90s) so the test doesn't wait 15 minutes.
+				// The first curl attempt hangs for 60s (--max-time in retrycmd_get_tarball),
+				// gets killed by timeout -k 5 60, then the global timeout -k5s 90 fires
+				// and kills the entire provisioning script.
+				nbc.CSETimeout = 90
+			},
+			// Exit code 124 = killed by timeout(1) SIGTERM from the global CSE timeout wrapper
+			ExpectedError: "vmssCSE 124",
+		},
+	})
+}
+
 func Test_Ubuntu2404_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "testing that a new ubuntu 2404 node using self contained installer can be properly bootstrapped",

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -399,7 +399,7 @@ _retry_file_curl_internal() {
             fi
         fi
 
-        timeout $effectiveTimeout curl -fsSLv $url -o $filePath > $CURL_OUTPUT 2>&1
+        timeout -k 5 $effectiveTimeout curl --max-time $effectiveTimeout -fsSLv $url -o $filePath > $CURL_OUTPUT 2>&1
         if [ "$?" -ne 0 ]; then
             cat $CURL_OUTPUT
         fi

--- a/spec/parts/linux/cloud-init/artifacts/cse_retry_helpers_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_retry_helpers_spec.sh
@@ -262,6 +262,19 @@ Describe 'long running cse helper functions'
                     The stdout should include "5 file curl retries"
                     The stderr should include "Operation budget of 1s exceeded"
                 End
+                Describe 'timeout flags'
+                    It "passes -k 5 and --max-time to timeout and curl"
+                        timeout() {
+                            # Capture the args passed to timeout for verification
+                            echo "timeout_args: $*" >> $CURL_OUTPUT
+                            return 0
+                        }
+                        When call _retry_file_curl_internal 1 1 30 0 "/tmp/nonexistent" "https://dummy.url/file" "[ -f /tmp/curl_flag_test_done ]"
+                        The status should eq 1
+                        The stdout should include "1 file curl retries"
+                        The contents of file "$CURL_OUTPUT" should include "timeout_args: -k 5 30 curl --max-time 30"
+                    End
+                End
             End
         End
 


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
- Redirect CURL_OUTPUT to /dev/shm (tmpfs) instead of /tmp to avoid blocking on unstable OS disks. /dev/shm is kernel-mounted tmpfs (CONFIG_TMPFS=y on all Azure images) across all VM SKUs including CVM and ARM64.
- Add --max-time to curl in _retry_file_curl_internal so curl enforces its own deadline even if shell timeout cannot deliver signals.
- Add -k 5 to timeout in _retrycmd_internal and _retry_file_curl_internal to escalate to SIGKILL if SIGTERM is ignored (e.g. process in D-state).

**Which issue(s) this PR fixes**:
[Bug 36680094](https://msazure.visualstudio.com/CloudNativeCompute/_workitems/edit/36680094): [Repair Item] Improve CSE script to handle curl timeouts and prevent blocking by redirecting verbose output away from unstable disks and enforcing strict timeout with forced kill signals.
Fixes #
