### PR TITLE
fix: vhdbuilder phase 2.5 should still use nbccsecmd hack

### DIFF
--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2670,7 +2670,7 @@ func ValidateScriptlessNBCCSECmd(ctx context.Context, s *Scenario) {
 	nbc := s.Runtime.NBC
 	if nbc != nil && nbc.EnableScriptlessNBCCSECmd && s.VHD.SupportsScriptless() {
 		fileNameToCheck := "/opt/azure/containers/aks-node-controller-nbc-cmd.sh"
-		if s.Runtime.AKSNodeConfig != nil || (!config.Config.DisableScriptLessCompilation && !s.Tags.NetworkIsolated) {
+		if !config.Config.DisableScriptLessCompilation && !s.Tags.NetworkIsolated {
 			fileNameToCheck = "/opt/azure/containers/aks-node-controller-nbc-cmd-hack.sh"
 		}
 		ValidateFileExists(ctx, s, fileNameToCheck)

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2670,7 +2670,7 @@ func ValidateScriptlessNBCCSECmd(ctx context.Context, s *Scenario) {
 	nbc := s.Runtime.NBC
 	if nbc != nil && nbc.EnableScriptlessNBCCSECmd && s.VHD.SupportsScriptless() {
 		fileNameToCheck := "/opt/azure/containers/aks-node-controller-nbc-cmd.sh"
-		if !config.Config.DisableScriptLessCompilation && !s.Tags.NetworkIsolated {
+		if s.Runtime.AKSNodeConfig != nil || (!config.Config.DisableScriptLessCompilation && !s.Tags.NetworkIsolated) {
 			fileNameToCheck = "/opt/azure/containers/aks-node-controller-nbc-cmd-hack.sh"
 		}
 		ValidateFileExists(ctx, s, fileNameToCheck)

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -376,6 +376,17 @@ func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachine
 		}
 
 		customData = func() string {
+			binaryURL, err := CachedCompileAndUploadAKSNodeController(ctx, s.VHD.Arch)
+			require.NoError(s.T, err, "failed to compile and upload aks-node-controller binary")
+			if s.Runtime.NBC.EnableScriptlessNBCCSECmd {
+				customData := nodeBootstrapping.CustomData
+				customData, err = CustomDataWithNBCCmdHack(s, customData, binaryURL)
+				require.NoError(s.T, err, "failed to generate custom data with NBC cmd hack")
+				return customData
+			}
+			data, err := CustomDataWithHack(s, binaryURL)
+			require.NoError(s.T, err, "failed to generate custom data from AKSNodeConfig with hack")
+
 			if config.Config.DisableScriptLessCompilation {
 				var data string
 				var err error
@@ -387,16 +398,6 @@ func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachine
 				require.NoError(s.T, err, "failed to generate custom data from AKSNodeConfig")
 				return data
 			}
-			binaryURL, err := CachedCompileAndUploadAKSNodeController(ctx, s.VHD.Arch)
-			require.NoError(s.T, err, "failed to compile and upload aks-node-controller binary")
-			if s.Runtime.NBC.EnableScriptlessNBCCSECmd {
-				customData := nodeBootstrapping.CustomData
-				customData, err = CustomDataWithNBCCmdHack(s, customData, binaryURL)
-				require.NoError(s.T, err, "failed to generate custom data with NBC cmd hack")
-				return customData
-			}
-			data, err := CustomDataWithHack(s, binaryURL)
-			require.NoError(s.T, err, "failed to generate custom data from AKSNodeConfig with hack")
 			return data
 		}()
 

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -376,9 +376,12 @@ func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachine
 		}
 
 		customData = func() string {
-			if config.Config.DisableScriptLessCompilation && !s.Runtime.NBC.EnableScriptlessNBCCSECmd {
+			if config.Config.DisableScriptLessCompilation {
 				var data string
 				var err error
+				if s.Runtime.NBC.EnableScriptlessNBCCSECmd {
+					return nodeBootstrapping.CustomData
+				}
 				if s.VHD.Flatcar {
 					data, err = nodeconfigutils.CustomDataFlatcar(aksNodeConfig)
 				} else {

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -376,18 +376,7 @@ func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachine
 		}
 
 		customData = func() string {
-			binaryURL, err := CachedCompileAndUploadAKSNodeController(ctx, s.VHD.Arch)
-			require.NoError(s.T, err, "failed to compile and upload aks-node-controller binary")
-			if s.Runtime.NBC.EnableScriptlessNBCCSECmd {
-				customData := nodeBootstrapping.CustomData
-				customData, err = CustomDataWithNBCCmdHack(s, customData, binaryURL)
-				require.NoError(s.T, err, "failed to generate custom data with NBC cmd hack")
-				return customData
-			}
-			data, err := CustomDataWithHack(s, binaryURL)
-			require.NoError(s.T, err, "failed to generate custom data from AKSNodeConfig with hack")
-
-			if config.Config.DisableScriptLessCompilation {
+			if config.Config.DisableScriptLessCompilation && !s.Runtime.NBC.EnableScriptlessNBCCSECmd {
 				var data string
 				var err error
 				if s.VHD.Flatcar {
@@ -398,6 +387,16 @@ func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachine
 				require.NoError(s.T, err, "failed to generate custom data from AKSNodeConfig")
 				return data
 			}
+			binaryURL, err := CachedCompileAndUploadAKSNodeController(ctx, s.VHD.Arch)
+			require.NoError(s.T, err, "failed to compile and upload aks-node-controller binary")
+			if s.Runtime.NBC.EnableScriptlessNBCCSECmd {
+				customData := nodeBootstrapping.CustomData
+				customData, err = CustomDataWithNBCCmdHack(s, customData, binaryURL)
+				require.NoError(s.T, err, "failed to generate custom data with NBC cmd hack")
+				return customData
+			}
+			data, err := CustomDataWithHack(s, binaryURL)
+			require.NoError(s.T, err, "failed to generate custom data from AKSNodeConfig with hack")
 			return data
 		}()
 


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
For phase 2.5, we should still use nbccsecmd hack, not scriptless compilation

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
