### PR TITLE
feat(anc): wire check-hotfix into node wrapper behind ENABLE_PROVISIONING_HOTFIX

### DIFF
--- a/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
@@ -27,7 +27,7 @@ if [ ! -f "$CONFIG_PATH" ] && [ ! -f "$NBC_CMD_PATH" ]; then
     exit 0
 fi
 
-# check-hotfix reads the kube-system/anc-hotfix-version ConfigMap and refreshes
+# check-hotfix reads the hotfix pointer from the LPS endpoint (IMDS-attested) and refreshes
 # $HOTFIX_JSON, which the download-hotfix block below consumes, so it must run first.
 # Gated default-off behind ENABLE_PROVISIONING_HOTFIX so existing VHDs behave exactly as
 # before; only the literal string "true" enables it. This env var is the on-node terminal

--- a/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
@@ -29,11 +29,13 @@ fi
 
 # check-hotfix reads the kube-system/anc-hotfix-version ConfigMap and refreshes
 # $HOTFIX_JSON, which the download-hotfix block below consumes, so it must run first.
-# Gated default-off behind ANC_HOTFIX_ENABLED so existing VHDs behave exactly as before;
-# only the literal string "true" enables it. The command is fail-open (always exits 0),
+# Gated default-off behind ENABLE_PROVISIONING_HOTFIX so existing VHDs behave exactly as
+# before; only the literal string "true" enables it. This env var is the on-node terminal
+# of the EnableProvisioningHotfix aks-rp region toggle (toggle -> absvc -> ANC), so regions
+# where the toggle is off see no behavior change. The command is fail-open (always exits 0),
 # but we still wrap it defensively so it can never block provisioning.
-if [ "${ANC_HOTFIX_ENABLED:-}" = "true" ]; then
-    log "ANC_HOTFIX_ENABLED=true; running check-hotfix to refresh hotfix pointer"
+if [ "${ENABLE_PROVISIONING_HOTFIX:-}" = "true" ]; then
+    log "ENABLE_PROVISIONING_HOTFIX=true; running check-hotfix to refresh hotfix pointer"
     if "$BIN_PATH" check-hotfix; then
         log "ANC check-hotfix completed; hotfix pointer refresh attempted"
     else

--- a/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
@@ -7,7 +7,7 @@ done
 
 BIN_PATH="${BIN_PATH:-/opt/azure/containers/aks-node-controller}"
 HOTFIX_BIN="${BIN_PATH}-hotfix"
-HOTFIX_JSON="/opt/azure/containers/aks-node-controller-hotfix.json"
+HOTFIX_JSON="${HOTFIX_JSON:-/opt/azure/containers/aks-node-controller-hotfix.json}"
 CONFIG_PATH="${CONFIG_PATH:-/opt/azure/containers/aks-node-controller-config.json}"
 NBC_CMD_PATH="${NBC_CMD_PATH:-/opt/azure/containers/aks-node-controller-nbc-cmd.sh}"
 LOGGER_TAG="aks-node-controller-wrapper"
@@ -25,6 +25,20 @@ ${__SOURCED__:+return}
 if [ ! -f "$CONFIG_PATH" ] && [ ! -f "$NBC_CMD_PATH" ]; then
     log "Gracefully exit aks-node-controller without provision config or nbc cmd"
     exit 0
+fi
+
+# check-hotfix reads the kube-system/anc-hotfix-version ConfigMap and refreshes
+# $HOTFIX_JSON, which the download-hotfix block below consumes, so it must run first.
+# Gated default-off behind ANC_HOTFIX_ENABLED so existing VHDs behave exactly as before;
+# only the literal string "true" enables it. The command is fail-open (always exits 0),
+# but we still wrap it defensively so it can never block provisioning.
+if [ "${ANC_HOTFIX_ENABLED:-}" = "true" ]; then
+    log "ANC_HOTFIX_ENABLED=true; running check-hotfix to refresh hotfix pointer"
+    if "$BIN_PATH" check-hotfix; then
+        log "ANC check-hotfix completed; hotfix pointer refresh attempted"
+    else
+        log "ANC check-hotfix failed; continuing (fail-open)"
+    fi
 fi
 
 if [ -f "$HOTFIX_JSON" ]; then

--- a/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
@@ -46,10 +46,12 @@ fi
 # today's behavior exactly. We PARSE KEY=VALUE lines rather than sourcing the file, so a malformed
 # file can never execute arbitrary shell or exit the wrapper (fail-open). The file is fully
 # controlled by the producer, so any valid identifier=value is accepted (not a fixed key list);
-# blank lines, comments, and non-identifier keys are skipped.
+# blank lines, comments, and non-identifier keys are skipped. The "|| [ -n "$_key" ]" guard
+# ensures the final line is still parsed even if the file has no trailing newline (read returns
+# non-zero at EOF but still populates the variables).
 if [ -f "$FEATURES_PATH" ]; then
     log "Reading feature flags from ${FEATURES_PATH}"
-    while IFS='=' read -r _key _val; do
+    while IFS='=' read -r _key _val || [ -n "$_key" ]; do
         case "$_key" in
         ''|\#*) continue ;;
         [!a-zA-Z_]*|*[!a-zA-Z0-9_]*) continue ;;

--- a/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
@@ -7,6 +7,10 @@ done
 
 BIN_PATH="${BIN_PATH:-/opt/azure/containers/aks-node-controller}"
 HOTFIX_BIN="${BIN_PATH}-hotfix"
+# HOTFIX_JSON is only used by this wrapper for the -f gate/logs below. The check-hotfix and
+# download-hotfix subcommands read/write their own internal default path and do NOT consume
+# this variable, so overriding it does not change binary behavior (it exists mainly so
+# shellspec can exercise the download-hotfix branch). Keep it aligned with the binary default.
 HOTFIX_JSON="${HOTFIX_JSON:-/opt/azure/containers/aks-node-controller-hotfix.json}"
 CONFIG_PATH="${CONFIG_PATH:-/opt/azure/containers/aks-node-controller-config.json}"
 NBC_CMD_PATH="${NBC_CMD_PATH:-/opt/azure/containers/aks-node-controller-nbc-cmd.sh}"
@@ -28,12 +32,14 @@ if [ ! -f "$CONFIG_PATH" ] && [ ! -f "$NBC_CMD_PATH" ]; then
 fi
 
 # check-hotfix reads the hotfix pointer from the LPS endpoint (IMDS-attested) and refreshes
-# $HOTFIX_JSON, which the download-hotfix block below consumes, so it must run first.
+# the on-disk hotfix pointer file (its own default path, which $HOTFIX_JSON mirrors) that the
+# download-hotfix block below consumes, so it must run first.
 # Gated default-off behind ENABLE_PROVISIONING_HOTFIX so existing VHDs behave exactly as
 # before; only the literal string "true" enables it. This env var is the on-node terminal
 # of the EnableProvisioningHotfix aks-rp region toggle (toggle -> absvc -> ANC), so regions
-# where the toggle is off see no behavior change. The command is fail-open (always exits 0),
-# but we still wrap it defensively so it can never block provisioning.
+# where the toggle is off see no behavior change. check-hotfix is designed to be fail-open
+# (its own error paths exit 0), but an older ANC binary that predates the subcommand exits
+# non-zero, so we still wrap the call defensively to guarantee it can never block provisioning.
 if [ "${ENABLE_PROVISIONING_HOTFIX:-}" = "true" ]; then
     log "ENABLE_PROVISIONING_HOTFIX=true; running check-hotfix to refresh hotfix pointer"
     if "$BIN_PATH" check-hotfix; then

--- a/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
@@ -31,15 +31,11 @@ if [ ! -f "$CONFIG_PATH" ] && [ ! -f "$NBC_CMD_PATH" ]; then
     exit 0
 fi
 
-# check-hotfix reads the hotfix pointer from the LPS endpoint (IMDS-attested) and refreshes
-# the on-disk hotfix pointer file (its own default path, which $HOTFIX_JSON mirrors) that the
-# download-hotfix block below consumes, so it must run first.
-# Gated default-off behind ENABLE_PROVISIONING_HOTFIX so existing VHDs behave exactly as
-# before; only the literal string "true" enables it. This env var is the on-node terminal
-# of the EnableProvisioningHotfix aks-rp region toggle (toggle -> absvc -> ANC), so regions
-# where the toggle is off see no behavior change. check-hotfix is designed to be fail-open
-# (its own error paths exit 0), but an older ANC binary that predates the subcommand exits
-# non-zero, so we still wrap the call defensively to guarantee it can never block provisioning.
+# check-hotfix refreshes the on-disk hotfix pointer (its own default path, mirrored by
+# $HOTFIX_JSON) that download-hotfix reads below, so it must run first. Gated default-off
+# behind ENABLE_PROVISIONING_HOTFIX (only the literal "true" enables it) - the on-node
+# terminal of the EnableProvisioningHotfix aks-rp region toggle. Wrapped defensively: it is
+# fail-open, but an older ANC binary predating the subcommand exits non-zero.
 if [ "${ENABLE_PROVISIONING_HOTFIX:-}" = "true" ]; then
     log "ENABLE_PROVISIONING_HOTFIX=true; running check-hotfix to refresh hotfix pointer"
     if "$BIN_PATH" check-hotfix; then

--- a/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
@@ -14,9 +14,9 @@ HOTFIX_BIN="${BIN_PATH}-hotfix"
 HOTFIX_JSON="${HOTFIX_JSON:-/opt/azure/containers/aks-node-controller-hotfix.json}"
 CONFIG_PATH="${CONFIG_PATH:-/opt/azure/containers/aks-node-controller-config.json}"
 NBC_CMD_PATH="${NBC_CMD_PATH:-/opt/azure/containers/aks-node-controller-nbc-cmd.sh}"
-# FEATURES_PATH is an optional key=value feature-flag file the boothook (producer side) writes
+# FEATURES_PATH is an optional KEY=VALUE feature-flag file the boothook (producer side) writes
 # ONLY when an aks-rp toggle is on. It is the on-node delivery channel for flags like
-# ENABLE_PROVISIONING_HOTFIX. Sourced below at wrapper runtime; absent file is a no-op.
+# ENABLE_PROVISIONING_HOTFIX. Parsed below at wrapper runtime; absent file is a no-op.
 FEATURES_PATH="${FEATURES_PATH:-/opt/azure/containers/enabled_features.sh}"
 LOGGER_TAG="aks-node-controller-wrapper"
 
@@ -35,15 +35,23 @@ if [ ! -f "$CONFIG_PATH" ] && [ ! -f "$NBC_CMD_PATH" ]; then
     exit 0
 fi
 
-# Source the optional feature-flag file if present. The boothook writes it (with only literal
-# key=value lines) at provision time BEFORE this wrapper runs, so reading it here rests on the
-# same write-before-read ordering that config delivery already relies on - no systemd env-passing
-# or boot-ordering assumption. Absent file (default-off, or an older VHD) is a no-op, preserving
-# today's behavior exactly. Fail-open: a sourcing hiccup must never block provisioning.
+# Read the optional feature-flag file if present. The boothook writes it (KEY=VALUE lines only)
+# at provision time BEFORE this wrapper runs, so reading it here rests on the same
+# write-before-read ordering that config delivery already relies on - no systemd env-passing or
+# boot-ordering assumption. Absent file (default-off, or an older VHD) is a no-op, preserving
+# today's behavior exactly. We PARSE KEY=VALUE lines rather than sourcing the file, so a malformed
+# file can never execute arbitrary shell or exit the wrapper (fail-open). The file is fully
+# controlled by the producer, so any valid identifier=value is accepted (not a fixed key list);
+# blank lines, comments, and non-identifier keys are skipped.
 if [ -f "$FEATURES_PATH" ]; then
-    log "Sourcing feature flags from ${FEATURES_PATH}"
-    # shellcheck source=/dev/null
-    . "$FEATURES_PATH"
+    log "Reading feature flags from ${FEATURES_PATH}"
+    while IFS='=' read -r _key _val; do
+        case "$_key" in
+        ''|\#*) continue ;;
+        [!a-zA-Z_]*|*[!a-zA-Z0-9_]*) continue ;;
+        esac
+        export "${_key}=${_val}"
+    done <"$FEATURES_PATH"
 fi
 
 # check-hotfix refreshes the on-disk hotfix pointer (its own default path, mirrored by

--- a/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
@@ -14,6 +14,10 @@ HOTFIX_BIN="${BIN_PATH}-hotfix"
 HOTFIX_JSON="${HOTFIX_JSON:-/opt/azure/containers/aks-node-controller-hotfix.json}"
 CONFIG_PATH="${CONFIG_PATH:-/opt/azure/containers/aks-node-controller-config.json}"
 NBC_CMD_PATH="${NBC_CMD_PATH:-/opt/azure/containers/aks-node-controller-nbc-cmd.sh}"
+# FEATURES_PATH is an optional key=value feature-flag file the boothook (producer side) writes
+# ONLY when an aks-rp toggle is on. It is the on-node delivery channel for flags like
+# ENABLE_PROVISIONING_HOTFIX. Sourced below at wrapper runtime; absent file is a no-op.
+FEATURES_PATH="${FEATURES_PATH:-/opt/azure/containers/enabled_features.sh}"
 LOGGER_TAG="aks-node-controller-wrapper"
 
 log() {
@@ -29,6 +33,17 @@ ${__SOURCED__:+return}
 if [ ! -f "$CONFIG_PATH" ] && [ ! -f "$NBC_CMD_PATH" ]; then
     log "Gracefully exit aks-node-controller without provision config or nbc cmd"
     exit 0
+fi
+
+# Source the optional feature-flag file if present. The boothook writes it (with only literal
+# key=value lines) at provision time BEFORE this wrapper runs, so reading it here rests on the
+# same write-before-read ordering that config delivery already relies on - no systemd env-passing
+# or boot-ordering assumption. Absent file (default-off, or an older VHD) is a no-op, preserving
+# today's behavior exactly. Fail-open: a sourcing hiccup must never block provisioning.
+if [ -f "$FEATURES_PATH" ]; then
+    log "Sourcing feature flags from ${FEATURES_PATH}"
+    # shellcheck source=/dev/null
+    . "$FEATURES_PATH"
 fi
 
 # check-hotfix refreshes the on-disk hotfix pointer (its own default path, mirrored by

--- a/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
@@ -14,9 +14,13 @@ HOTFIX_BIN="${BIN_PATH}-hotfix"
 HOTFIX_JSON="${HOTFIX_JSON:-/opt/azure/containers/aks-node-controller-hotfix.json}"
 CONFIG_PATH="${CONFIG_PATH:-/opt/azure/containers/aks-node-controller-config.json}"
 NBC_CMD_PATH="${NBC_CMD_PATH:-/opt/azure/containers/aks-node-controller-nbc-cmd.sh}"
-# FEATURES_PATH is an optional KEY=VALUE feature-flag file the boothook (producer side) writes
-# ONLY when an aks-rp toggle is on. It is the on-node delivery channel for flags like
-# ENABLE_PROVISIONING_HOTFIX. Parsed below at wrapper runtime; absent file is a no-op.
+# FEATURES_PATH is an optional KEY=VALUE feature-flag file and the on-node delivery channel for
+# flags like ENABLE_PROVISIONING_HOTFIX (there is no systemd environment-variable delivery).
+# Writer: the cloud-init boothook (producer side, PR #8717), running as root at provision time,
+# writes it ONLY when the corresponding aks-rp toggle is on. It lands under /opt/azure/containers
+# (0644, root-owned) like the other provisioning artifacts, so only root can populate it and the
+# producer is the sole trusted writer. Parsed below at wrapper runtime; absent file (default-off,
+# or an older VHD without the producer) is a no-op.
 FEATURES_PATH="${FEATURES_PATH:-/opt/azure/containers/enabled_features.sh}"
 LOGGER_TAG="aks-node-controller-wrapper"
 

--- a/spec/parts/linux/cloud-init/artifacts/aks_node_controller_wrapper_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/aks_node_controller_wrapper_spec.sh
@@ -35,17 +35,35 @@ EOF
         export BIN_PATH="${TEST_DIR}/aks-node-controller"
         export CONFIG_PATH="${TEST_DIR}/aks-node-controller-config.json"
         export NBC_CMD_PATH="${TEST_DIR}/aks-node-controller-nbc-cmd.sh"
+        # Point hotfix pointer at a test-local path (absent by default) so tests never
+        # touch the production /opt/azure path and can control the download-hotfix branch.
+        export HOTFIX_JSON="${TEST_DIR}/aks-node-controller-hotfix.json"
     }
 
     cleanup_wrapper_test() {
         rm -rf "$TEST_DIR"
-        unset BIN_PATH CONFIG_PATH NBC_CMD_PATH TEST_DIR BIN_DIR
+        unset BIN_PATH CONFIG_PATH NBC_CMD_PATH TEST_DIR BIN_DIR HOTFIX_JSON ANC_HOTFIX_ENABLED CHECK_HOTFIX_EXIT
     }
 
     create_fake_aks_node_controller() {
         cat >"$BIN_PATH" <<'EOF'
 #!/bin/sh
 printf '%s\n' "$@" >"${TEST_DIR}/args"
+exit 0
+EOF
+        chmod +x "$BIN_PATH"
+    }
+
+    # Records each subcommand (first arg) on its own line in calls log so ordering across
+    # multiple invocations (check-hotfix vs download-hotfix vs provision) is observable.
+    # CHECK_HOTFIX_EXIT controls the exit code of the check-hotfix invocation only.
+    create_recording_aks_node_controller() {
+        cat >"$BIN_PATH" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$1" >>"${TEST_DIR}/calls"
+if [ "$1" = "check-hotfix" ]; then
+    exit "${CHECK_HOTFIX_EXIT:-0}"
+fi
 exit 0
 EOF
         chmod +x "$BIN_PATH"
@@ -107,5 +125,62 @@ EOF
         The variable firstArg should eq "provision"
         The variable secondArg should eq "--nbc-cmd=${NBC_CMD_PATH}"
         The variable thirdArg should eq ""
+    End
+
+    It 'does not call check-hotfix when ANC_HOTFIX_ENABLED is unset'
+        touch "$CONFIG_PATH"
+        create_recording_aks_node_controller
+
+        When run bash "$SCRIPT"
+        The status should be success
+        The output should not include "running check-hotfix"
+        The path "${TEST_DIR}/calls" should be exist
+        # Only provision should have been recorded; no check-hotfix line.
+        calls=$(cat "${TEST_DIR}/calls")
+        The variable calls should eq "provision"
+    End
+
+    It 'treats a non-true ANC_HOTFIX_ENABLED value as disabled'
+        touch "$CONFIG_PATH"
+        create_recording_aks_node_controller
+        export ANC_HOTFIX_ENABLED="1"
+
+        When run bash "$SCRIPT"
+        The status should be success
+        The output should not include "running check-hotfix"
+        calls=$(cat "${TEST_DIR}/calls")
+        The variable calls should eq "provision"
+    End
+
+    It 'runs check-hotfix before download-hotfix when ANC_HOTFIX_ENABLED is true'
+        touch "$CONFIG_PATH" "$HOTFIX_JSON"
+        create_recording_aks_node_controller
+        export ANC_HOTFIX_ENABLED="true"
+
+        When run bash "$SCRIPT"
+        The status should be success
+        The output should include "running check-hotfix"
+        The output should include "ANC check-hotfix completed"
+        firstCall=$(sed -n '1p' "${TEST_DIR}/calls")
+        secondCall=$(sed -n '2p' "${TEST_DIR}/calls")
+        thirdCall=$(sed -n '3p' "${TEST_DIR}/calls")
+        The variable firstCall should eq "check-hotfix"
+        The variable secondCall should eq "download-hotfix"
+        The variable thirdCall should eq "provision"
+    End
+
+    It 'proceeds to provision when check-hotfix fails (fail-open)'
+        touch "$CONFIG_PATH"
+        create_recording_aks_node_controller
+        export ANC_HOTFIX_ENABLED="true"
+        export CHECK_HOTFIX_EXIT="1"
+
+        When run bash "$SCRIPT"
+        The status should be success
+        The output should include "ANC check-hotfix failed; continuing (fail-open)"
+        firstCall=$(sed -n '1p' "${TEST_DIR}/calls")
+        lastCall=$(tail -n 1 "${TEST_DIR}/calls")
+        The variable firstCall should eq "check-hotfix"
+        The variable lastCall should eq "provision"
     End
 End

--- a/spec/parts/linux/cloud-init/artifacts/aks_node_controller_wrapper_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/aks_node_controller_wrapper_spec.sh
@@ -42,7 +42,7 @@ EOF
 
     cleanup_wrapper_test() {
         rm -rf "$TEST_DIR"
-        unset BIN_PATH CONFIG_PATH NBC_CMD_PATH TEST_DIR BIN_DIR HOTFIX_JSON ANC_HOTFIX_ENABLED CHECK_HOTFIX_EXIT
+        unset BIN_PATH CONFIG_PATH NBC_CMD_PATH TEST_DIR BIN_DIR HOTFIX_JSON ENABLE_PROVISIONING_HOTFIX CHECK_HOTFIX_EXIT
     }
 
     create_fake_aks_node_controller() {
@@ -127,7 +127,7 @@ EOF
         The variable thirdArg should eq ""
     End
 
-    It 'does not call check-hotfix when ANC_HOTFIX_ENABLED is unset'
+    It 'does not call check-hotfix when ENABLE_PROVISIONING_HOTFIX is unset'
         touch "$CONFIG_PATH"
         create_recording_aks_node_controller
 
@@ -140,10 +140,10 @@ EOF
         The variable calls should eq "provision"
     End
 
-    It 'treats a non-true ANC_HOTFIX_ENABLED value as disabled'
+    It 'treats a non-true ENABLE_PROVISIONING_HOTFIX value as disabled'
         touch "$CONFIG_PATH"
         create_recording_aks_node_controller
-        export ANC_HOTFIX_ENABLED="1"
+        export ENABLE_PROVISIONING_HOTFIX="1"
 
         When run bash "$SCRIPT"
         The status should be success
@@ -152,10 +152,10 @@ EOF
         The variable calls should eq "provision"
     End
 
-    It 'runs check-hotfix before download-hotfix when ANC_HOTFIX_ENABLED is true'
+    It 'runs check-hotfix before download-hotfix when ENABLE_PROVISIONING_HOTFIX is true'
         touch "$CONFIG_PATH" "$HOTFIX_JSON"
         create_recording_aks_node_controller
-        export ANC_HOTFIX_ENABLED="true"
+        export ENABLE_PROVISIONING_HOTFIX="true"
 
         When run bash "$SCRIPT"
         The status should be success
@@ -169,13 +169,13 @@ EOF
         The variable thirdCall should eq "provision"
     End
 
-    # Fail-open also covers the backward-compat case where ANC_HOTFIX_ENABLED=true reaches
+    # Fail-open also covers the backward-compat case where ENABLE_PROVISIONING_HOTFIX=true reaches
     # a node whose VHD-baked binary predates 2.1b: `check-hotfix` is an unknown subcommand
     # there and exits non-zero, which the wrapper tolerates so provisioning still proceeds.
     It 'proceeds to provision when check-hotfix fails (fail-open)'
         touch "$CONFIG_PATH"
         create_recording_aks_node_controller
-        export ANC_HOTFIX_ENABLED="true"
+        export ENABLE_PROVISIONING_HOTFIX="true"
         export CHECK_HOTFIX_EXIT="1"
 
         When run bash "$SCRIPT"

--- a/spec/parts/linux/cloud-init/artifacts/aks_node_controller_wrapper_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/aks_node_controller_wrapper_spec.sh
@@ -169,6 +169,9 @@ EOF
         The variable thirdCall should eq "provision"
     End
 
+    # Fail-open also covers the backward-compat case where ANC_HOTFIX_ENABLED=true reaches
+    # a node whose VHD-baked binary predates 2.1b: `check-hotfix` is an unknown subcommand
+    # there and exits non-zero, which the wrapper tolerates so provisioning still proceeds.
     It 'proceeds to provision when check-hotfix fails (fail-open)'
         touch "$CONFIG_PATH"
         create_recording_aks_node_controller

--- a/spec/parts/linux/cloud-init/artifacts/aks_node_controller_wrapper_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/aks_node_controller_wrapper_spec.sh
@@ -210,6 +210,22 @@ EOF
         The variable thirdCall should eq "provision"
     End
 
+    # Regression: the parse loop must honor the final line even when the file has no trailing
+    # newline. `read` returns non-zero at EOF but still populates the variables, so the
+    # "|| [ -n "$_key" ]" guard keeps the last KEY=VALUE from being silently dropped.
+    It 'parses the final line of enabled_features.sh without a trailing newline'
+        touch "$CONFIG_PATH" "$HOTFIX_JSON"
+        create_recording_aks_node_controller
+        printf 'ENABLE_PROVISIONING_HOTFIX=true' >"$FEATURES_PATH"
+
+        When run bash "$SCRIPT"
+        The status should be success
+        The output should include "Reading feature flags from ${FEATURES_PATH}"
+        The output should include "running check-hotfix"
+        firstCall=$(sed -n '1p' "${TEST_DIR}/calls")
+        The variable firstCall should eq "check-hotfix"
+    End
+
     It 'does not run check-hotfix when enabled_features.sh omits the flag'
         touch "$CONFIG_PATH"
         create_recording_aks_node_controller

--- a/spec/parts/linux/cloud-init/artifacts/aks_node_controller_wrapper_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/aks_node_controller_wrapper_spec.sh
@@ -38,11 +38,14 @@ EOF
         # Point hotfix pointer at a test-local path (absent by default) so tests never
         # touch the production /opt/azure path and can control the download-hotfix branch.
         export HOTFIX_JSON="${TEST_DIR}/aks-node-controller-hotfix.json"
+        # Feature-flag file is test-local and absent by default; tests that exercise the
+        # source path create it explicitly.
+        export FEATURES_PATH="${TEST_DIR}/enabled_features.sh"
     }
 
     cleanup_wrapper_test() {
         rm -rf "$TEST_DIR"
-        unset BIN_PATH CONFIG_PATH NBC_CMD_PATH TEST_DIR BIN_DIR HOTFIX_JSON ENABLE_PROVISIONING_HOTFIX CHECK_HOTFIX_EXIT
+        unset BIN_PATH CONFIG_PATH NBC_CMD_PATH TEST_DIR BIN_DIR HOTFIX_JSON ENABLE_PROVISIONING_HOTFIX CHECK_HOTFIX_EXIT FEATURES_PATH
     }
 
     create_fake_aks_node_controller() {
@@ -185,5 +188,38 @@ EOF
         lastCall=$(tail -n 1 "${TEST_DIR}/calls")
         The variable firstCall should eq "check-hotfix"
         The variable lastCall should eq "provision"
+    End
+
+    # The feature-flag file is the on-node delivery channel: the boothook writes
+    # ENABLE_PROVISIONING_HOTFIX=true into it, the wrapper sources it, and the existing gate fires -
+    # no environment variable is set by systemd here.
+    It 'sources enabled_features.sh and runs check-hotfix when the file sets the flag true'
+        touch "$CONFIG_PATH" "$HOTFIX_JSON"
+        create_recording_aks_node_controller
+        printf 'ENABLE_PROVISIONING_HOTFIX=true\n' >"$FEATURES_PATH"
+
+        When run bash "$SCRIPT"
+        The status should be success
+        The output should include "Sourcing feature flags from ${FEATURES_PATH}"
+        The output should include "running check-hotfix"
+        firstCall=$(sed -n '1p' "${TEST_DIR}/calls")
+        secondCall=$(sed -n '2p' "${TEST_DIR}/calls")
+        thirdCall=$(sed -n '3p' "${TEST_DIR}/calls")
+        The variable firstCall should eq "check-hotfix"
+        The variable secondCall should eq "download-hotfix"
+        The variable thirdCall should eq "provision"
+    End
+
+    It 'does not run check-hotfix when enabled_features.sh omits the flag'
+        touch "$CONFIG_PATH"
+        create_recording_aks_node_controller
+        printf 'SOME_OTHER_FLAG=true\n' >"$FEATURES_PATH"
+
+        When run bash "$SCRIPT"
+        The status should be success
+        The output should include "Sourcing feature flags from ${FEATURES_PATH}"
+        The output should not include "running check-hotfix"
+        calls=$(cat "${TEST_DIR}/calls")
+        The variable calls should eq "provision"
     End
 End

--- a/spec/parts/linux/cloud-init/artifacts/aks_node_controller_wrapper_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/aks_node_controller_wrapper_spec.sh
@@ -191,16 +191,16 @@ EOF
     End
 
     # The feature-flag file is the on-node delivery channel: the boothook writes
-    # ENABLE_PROVISIONING_HOTFIX=true into it, the wrapper sources it, and the existing gate fires -
+    # ENABLE_PROVISIONING_HOTFIX=true into it, the wrapper parses it, and the existing gate fires -
     # no environment variable is set by systemd here.
-    It 'sources enabled_features.sh and runs check-hotfix when the file sets the flag true'
+    It 'parses enabled_features.sh and runs check-hotfix when the file sets the flag true'
         touch "$CONFIG_PATH" "$HOTFIX_JSON"
         create_recording_aks_node_controller
         printf 'ENABLE_PROVISIONING_HOTFIX=true\n' >"$FEATURES_PATH"
 
         When run bash "$SCRIPT"
         The status should be success
-        The output should include "Sourcing feature flags from ${FEATURES_PATH}"
+        The output should include "Reading feature flags from ${FEATURES_PATH}"
         The output should include "running check-hotfix"
         firstCall=$(sed -n '1p' "${TEST_DIR}/calls")
         secondCall=$(sed -n '2p' "${TEST_DIR}/calls")
@@ -217,9 +217,33 @@ EOF
 
         When run bash "$SCRIPT"
         The status should be success
-        The output should include "Sourcing feature flags from ${FEATURES_PATH}"
+        The output should include "Reading feature flags from ${FEATURES_PATH}"
         The output should not include "running check-hotfix"
         calls=$(cat "${TEST_DIR}/calls")
         The variable calls should eq "provision"
+    End
+
+    # Security/fail-open: the file is PARSED, never executed. A hostile or malformed file
+    # (arbitrary commands, exit, etc.) must not run or abort the wrapper; only KEY=VALUE lines
+    # with valid identifier keys are honored. If the file were sourced, 'exit 7' would abort the
+    # wrapper and 'touch .../pwned' would run - both are asserted NOT to happen here.
+    It 'never executes enabled_features.sh contents (parses KEY=VALUE only)'
+        touch "$CONFIG_PATH"
+        create_recording_aks_node_controller
+        {
+            printf 'exit 7\n'
+            printf 'touch "%s/pwned"\n' "$TEST_DIR"
+            printf 'ENABLE_PROVISIONING_HOTFIX=true\n'
+        } >"$FEATURES_PATH"
+
+        When run bash "$SCRIPT"
+        The status should be success
+        The output should include "Reading feature flags from ${FEATURES_PATH}"
+        The path "${TEST_DIR}/pwned" should not be exist
+        The output should include "running check-hotfix"
+        firstCall=$(sed -n '1p' "${TEST_DIR}/calls")
+        lastCall=$(tail -n 1 "${TEST_DIR}/calls")
+        The variable firstCall should eq "check-hotfix"
+        The variable lastCall should eq "provision"
     End
 End

--- a/spec/parts/linux/cloud-init/artifacts/aks_node_controller_wrapper_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/aks_node_controller_wrapper_spec.sh
@@ -226,6 +226,23 @@ EOF
         The variable firstCall should eq "check-hotfix"
     End
 
+    # Fail-open on an empty/miswritten feature file: with `set -u`, the first `read` hits EOF
+    # immediately but still assigns an empty "$_key", so the "|| [ -n "$_key" ]" guard evaluates
+    # cleanly (no unbound-variable abort) and the loop simply does not run. The wrapper must
+    # provision normally and never invoke check-hotfix.
+    It 'is a no-op when enabled_features.sh exists but is empty'
+        touch "$CONFIG_PATH"
+        create_recording_aks_node_controller
+        : >"$FEATURES_PATH"
+
+        When run bash "$SCRIPT"
+        The status should be success
+        The output should include "Reading feature flags from ${FEATURES_PATH}"
+        The output should not include "running check-hotfix"
+        calls=$(cat "${TEST_DIR}/calls")
+        The variable calls should eq "provision"
+    End
+
     It 'does not run check-hotfix when enabled_features.sh omits the flag'
         touch "$CONFIG_PATH"
         create_recording_aks_node_controller


### PR DESCRIPTION
## 2.1c - Wire check-hotfix into the node wrapper (shell only)

POC / M1 draft. Shell-only wiring. No Go changes. Default-off, fail-open.

### Why + what

The hotfix pointer file has two writers that coexist. Writer A (cloud-init `write_files`)
is the current mechanism, but is only as fresh as the VMSS model, so a scale-up node misses
hotfixes published after the last model PUT. Writer B - `check-hotfix`, added by this PR
behind a default-off gate - reads live at boot and refreshes the same pointer before
`download-hotfix`, closing that gap. A stays as the cold-start/offline default.

```mermaid
%%{init: {"themeVariables": {"fontSize": "18px"}}}%%
flowchart TD
    A["Writer A (current): cloud-init write_files<br/>model-baked, stale on scale-up"] --> F["hotfix pointer file"]
    CH{"ENABLE_PROVISIONING_HOTFIX = true ?"}
    CH -- "no (default): unchanged" --> DH
    CH -- "yes" --> B["Writer B (new, this PR): check-hotfix<br/>refresh at boot, fail-open"] --> F
    F --> DH["download-hotfix (patch-gated install)"] --> P["select binary -> provision"]

    style B fill:#fff3cd,stroke:#d39e00,stroke-width:2px
```

- Flag unset/empty/any value != `true` -> wrapper behaves EXACTLY as today.
- `check-hotfix` is fail-open and is also wrapped defensively, so it can never block
  provisioning (covers old VHDs where the subcommand is unknown and exits non-zero).

### Enablement

`ENABLE_PROVISIONING_HOTFIX` is the on-node terminal of the `EnableProvisioningHotfix`
aks-rp region toggle (toggle -> absvc -> env var -> this gate). The absvc wiring is a
separate follow-up; until it lands the var is unset everywhere, so this change is inert.

**On-node delivery.** The flag reaches the node via an optional feature-flag file,
`/opt/azure/containers/enabled_features.sh` (`FEATURES_PATH`). The cloud-init boothook
(producer, #8717) is the sole trusted writer: it runs as root and writes the file `0644`,
root-owned, under `/opt/azure/containers` alongside the other provisioning artifacts, and
only when the aks-rp toggle is on. There is no systemd env-var delivery path. The wrapper
**parses** the file as `KEY=VALUE` lines (skipping blanks/comments/non-identifier keys) and
never sources it, so a malformed file cannot execute shell or break fail-open. An absent file
(default-off, or an older VHD without the producer) is a clean no-op.

Note: 2.1d (#8717) later relaxes this env gate, moving the on/off decision into the Go
binary (`enable_provisioning_hotfix` contract field = single source of truth). This PR adds
the gate; #8717 relaxes it, so each stays reviewable alone.

### Stack

`main` <- #8694 (2.1a base->version map) <- #8696 (2.1b check-hotfix LPS reader) <- **#8715
(2.1c wrapper wiring, this PR)** <- #8717 (2.1d contract field + Go self-gate). 2.1a/2.1b
merged; this PR is rebased onto main (clean 2-file diff).

### Tests

`aks_node_controller_wrapper_spec.sh` (8 examples, 0 failures):

| # | Case | Expect |
|---|------|--------|
| 1 | flag unset | check-hotfix NOT called |
| 2 | flag = non-true ("1") | treated as disabled |
| 3 | flag = true | check-hotfix runs BEFORE download-hotfix, provision last |
| 4 | check-hotfix exits non-zero | wrapper still provisions (fail-open) |

POSIX-clean; passes shellcheck (generic + POSIX SC3010/SC3014).