### PR TITLE
fix: check if any node exists and cleanup nsg resources if in RG

### DIFF
--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -471,14 +471,35 @@ func isUsableNodeResourceGroup(ctx context.Context, location, clusterName, resou
 	}
 
 	if rg.Properties != nil && rg.Properties.ProvisioningState != nil && strings.EqualFold(*rg.Properties.ProvisioningState, "Deleting") {
-		if err := detachRouteTableFromClusterSubnet(ctx, location, clusterName, resourceGroupName); err != nil {
-			toolkit.Logf(ctx, "warning: failed to detach route table for deleting node resource group %q: %v", resourceGroupName, err)
+		if err := detachNodeResourceGroupReferencesFromClusterSubnet(ctx, location, clusterName, resourceGroupName); err != nil {
+			toolkit.Logf(ctx, "warning: failed to detach subnet references for deleting node resource group %q: %v", resourceGroupName, err)
 		}
 		toolkit.Logf(ctx, "node resource group %q is deleting; recreating cluster %q", resourceGroupName, clusterName)
 		return false, nil
 	}
 
+	hasVMSS, err := hasVMSSInResourceGroup(ctx, resourceGroupName)
+	if err != nil {
+		return false, err
+	}
+	if !hasVMSS {
+		toolkit.Logf(ctx, "node resource group %q has no VMSS; recreating cluster %q", resourceGroupName, clusterName)
+		return false, nil
+	}
+
 	return true, nil
+}
+
+func hasVMSSInResourceGroup(ctx context.Context, resourceGroupName string) (bool, error) {
+	pager := config.Azure.VMSS.NewListPager(resourceGroupName, nil)
+	if !pager.More() {
+		return false, nil
+	}
+	page, err := pager.NextPage(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to list VMSS in node resource group %q: %w", resourceGroupName, err)
+	}
+	return len(page.Value) > 0, nil
 }
 
 func createNewAKSCluster(ctx context.Context, cluster *armcontainerservice.ManagedCluster) (*armcontainerservice.ManagedCluster, error) {
@@ -538,8 +559,8 @@ func createNewAKSClusterWithRetry(ctx context.Context, cluster *armcontainerserv
 				if cluster.Properties != nil && cluster.Properties.NodeResourceGroup != nil {
 					nodeResourceGroup = *cluster.Properties.NodeResourceGroup
 				}
-				if cleanupErr := detachRouteTableFromClusterSubnet(ctx, *cluster.Location, *cluster.Name, nodeResourceGroup); cleanupErr != nil {
-					toolkit.Logf(ctx, "warning: failed to detach route table for deleting node resource group %q: %v", nodeResourceGroup, cleanupErr)
+				if cleanupErr := detachNodeResourceGroupReferencesFromClusterSubnet(ctx, *cluster.Location, *cluster.Name, nodeResourceGroup); cleanupErr != nil {
+					toolkit.Logf(ctx, "warning: failed to detach subnet references for deleting node resource group %q: %v", nodeResourceGroup, cleanupErr)
 				}
 				if deleteErr := deleteCluster(ctx, *cluster.Name, config.ResourceGroupName(*cluster.Location)); deleteErr != nil {
 					return nil, fmt.Errorf("deleting cluster with deleting node resource group %q: %w", nodeResourceGroup, deleteErr)

--- a/e2e/shared_infra.go
+++ b/e2e/shared_infra.go
@@ -461,11 +461,11 @@ func clusterSubnetName(clusterName string) string {
 	return "aks-subnet-" + clusterName
 }
 
-func detachRouteTableFromClusterSubnet(ctx context.Context, location, clusterName, routeTableResourceGroup string) error {
+func detachNodeResourceGroupReferencesFromClusterSubnet(ctx context.Context, location, clusterName, nodeResourceGroup string) error {
 	rg := config.ResourceGroupName(location)
 	subnetName := clusterSubnetName(clusterName)
 
-	return retryOn409(ctx, fmt.Sprintf("detaching route table from subnet %s", subnetName), func() error {
+	return retryOn409(ctx, fmt.Sprintf("detaching node resource group references from subnet %s", subnetName), func() error {
 		subnetResp, err := config.Azure.Subnet.Get(ctx, rg, SharedVNetName, subnetName, nil)
 		if err != nil {
 			if isNotFoundError(err) {
@@ -473,37 +473,62 @@ func detachRouteTableFromClusterSubnet(ctx context.Context, location, clusterNam
 			}
 			return fmt.Errorf("getting subnet %s: %w", subnetName, err)
 		}
-		shouldDetach, err := subnetRouteTableInResourceGroup(subnetResp.Subnet, routeTableResourceGroup)
+
+		shouldDetachRouteTable, err := subnetResourceIDInResourceGroup(routeTableID(subnetResp.Properties.RouteTable), nodeResourceGroup)
 		if err != nil {
 			return err
 		}
-		if !shouldDetach {
+		shouldDetachNSG, err := subnetResourceIDInResourceGroup(networkSecurityGroupID(subnetResp.Properties.NetworkSecurityGroup), nodeResourceGroup)
+		if err != nil {
+			return err
+		}
+
+		if shouldDetachRouteTable {
+			routeTableID := *subnetResp.Properties.RouteTable.ID
+			toolkit.Logf(ctx, "detaching route table %q from shared subnet %q because resource group %q is deleting", routeTableID, subnetName, nodeResourceGroup)
+			subnetResp.Subnet.Properties.RouteTable = nil
+		}
+		if shouldDetachNSG {
+			nsgID := *subnetResp.Properties.NetworkSecurityGroup.ID
+			toolkit.Logf(ctx, "detaching network security group %q from shared subnet %q because resource group %q is deleting", nsgID, subnetName, nodeResourceGroup)
+			subnetResp.Subnet.Properties.NetworkSecurityGroup = nil
+		}
+		if !shouldDetachRouteTable && !shouldDetachNSG {
 			return nil
 		}
 
-		routeTableID := *subnetResp.Properties.RouteTable.ID
-
-		toolkit.Logf(ctx, "detaching route table %q from shared subnet %q because resource group %q is deleting", routeTableID, subnetName, routeTableResourceGroup)
-		subnetResp.Subnet.Properties.RouteTable = nil
 		poller, err := config.Azure.Subnet.BeginCreateOrUpdate(ctx, rg, SharedVNetName, subnetName, subnetResp.Subnet, nil)
 		if err != nil {
-			return fmt.Errorf("detaching route table from subnet %s: %w", subnetName, err)
+			return fmt.Errorf("detaching node resource group references from subnet %s: %w", subnetName, err)
 		}
 		_, err = poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
 		return err
 	})
 }
 
-func subnetRouteTableInResourceGroup(subnet armnetwork.Subnet, routeTableResourceGroup string) (bool, error) {
-	if subnet.Properties == nil || subnet.Properties.RouteTable == nil || subnet.Properties.RouteTable.ID == nil {
+func routeTableID(routeTable *armnetwork.RouteTable) *string {
+	if routeTable == nil {
+		return nil
+	}
+	return routeTable.ID
+}
+
+func networkSecurityGroupID(nsg *armnetwork.SecurityGroup) *string {
+	if nsg == nil {
+		return nil
+	}
+	return nsg.ID
+}
+
+func subnetResourceIDInResourceGroup(resourceID *string, resourceGroup string) (bool, error) {
+	if resourceID == nil {
 		return false, nil
 	}
-	routeTableID := *subnet.Properties.RouteTable.ID
-	parsedRouteTable, err := arm.ParseResourceID(routeTableID)
+	parsedResource, err := arm.ParseResourceID(*resourceID)
 	if err != nil {
-		return false, fmt.Errorf("parsing route table ID %q: %w", routeTableID, err)
+		return false, fmt.Errorf("parsing subnet resource ID %q: %w", *resourceID, err)
 	}
-	return strings.EqualFold(parsedRouteTable.ResourceGroupName, routeTableResourceGroup), nil
+	return strings.EqualFold(parsedResource.ResourceGroupName, resourceGroup), nil
 }
 
 const totalSubnetSlots = 4080


### PR DESCRIPTION
- Updated E2E cluster reuse cleanup to treat an existing MC_ node resource group with no VMSS as unusable, forcing cluster recreation instead of later proxy/VMSS failures.
- Also renamed and expanded the subnet cleanup helper to detach both route table and NSG references from the shared subnet when they point to a deleting node resource group.