### PR TITLE
feat: upgrade azurefile-csi-driver to v1.35.4

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -544,8 +544,8 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.35.3",
-          "previousLatestVersion": "v1.35.2"
+          "latestVersion": "v1.35.4",
+          "previousLatestVersion": "v1.35.3"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
@@ -561,8 +561,8 @@
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.35.3-windows-hp",
-          "previousLatestVersion": "v1.35.2-windows-hp"
+          "latestVersion": "v1.35.4-windows-hp",
+          "previousLatestVersion": "v1.35.3-windows-hp"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",


### PR DESCRIPTION
## What this PR does / why we need it

Upgrades Azure File CSI driver from v1.35.3 to v1.35.4.

### Changes in `parts/common/components.json`:
- `multiArchVersionsV2`: v1.35.3 → v1.35.4 (previousLatestVersion: v1.35.3)
- `windowsVersions`: v1.35.3-windows-hp → v1.35.4-windows-hp (previousLatestVersion: v1.35.3-windows-hp)

### Release notes
https://github.com/kubernetes-sigs/azurefile-csi-driver/releases/tag/v1.35.4
