### PR TITLE
chore: upgrade Azure Blob CSI driver image versions

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -582,13 +582,13 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/blob-csi",
-          "latestVersion": "v1.26.12",
-          "previousLatestVersion": "v1.26.11"
+          "latestVersion": "v1.26.14",
+          "previousLatestVersion": "v1.26.12"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/blob-csi",
-          "latestVersion": "v1.27.5",
-          "previousLatestVersion": "v1.27.4"
+          "latestVersion": "v1.27.7",
+          "previousLatestVersion": "v1.27.5"
         }
       ],
       "windowsVersions": []


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
Upgrade Azure Blob CSI driver image versions in `components.json`:

| Component | Previous | New |
|-----------|----------|-----|
| blob-csi (1.26.x) | v1.26.12 (previousLatest: v1.26.11) | v1.26.14 (previousLatest: v1.26.12) |
| blob-csi (1.27.x) | v1.27.5 (previousLatest: v1.27.4) | v1.27.7 (previousLatest: v1.27.5) |

Key fix in both releases:
- fix: allow `--use-adls` mount option for ephemeral volumes

Release notes:
- https://github.com/kubernetes-sigs/blob-csi-driver/releases/tag/v1.26.14
- https://github.com/kubernetes-sigs/blob-csi-driver/releases/tag/v1.27.7

**Which issue(s) this PR fixes**:
N/A
