### PR TITLE
test: add DISABLE_SCRIPTLESS variable for local e2e testing

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -188,7 +188,7 @@ sequenceDiagram
 ## Running Locally
 
 **Note: if you have changed code or artifacts used to generate custom data or custom script extension payloads, you
-should first run `make generate` from the root of the AgentBaker repository.**
+should set `DISABLE_SCRIPTLESS=true` in `.env`. Otherwise scriptless provisioning only uses scripts that are built into VHD.**
 
 To run the E2E test suite locally, use `e2e-local.sh`. This script sets up the `go test` command.
 

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -60,6 +60,7 @@ type Configuration struct {
 	DefaultPollInterval                    time.Duration `env:"DEFAULT_POLL_INTERVAL" envDefault:"1s"`
 	DefaultSubnetName                      string        `env:"DEFAULT_SUBNET_NAME" envDefault:"aks-subnet"`
 	DefaultVMSKU                           string        `env:"DEFAULT_VM_SKU" envDefault:"Standard_D2ds_v5"`
+	DisableScriptless                      bool          `env:"DISABLE_SCRIPTLESS"`
 	DisableScriptLessCompilation           bool          `env:"DISABLE_SCRIPTLESS_COMPILATION"`
 	E2ELoggingDir                          string        `env:"LOGGING_DIR" envDefault:"scenario-logs"`
 	EnableSecureTLSBootstrapping           bool          `env:"ENABLE_SECURE_TLS_BOOTSTRAPPING" envDefault:"true"`

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -275,7 +275,9 @@ func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 	nbc, err := getBaseNBC(ctx, s.T, s.Runtime.Cluster, s.VHD)
 	require.NoError(s.T, err)
 
-	nbc.EnableScriptlessCSECmd = true
+	if !config.Config.DisableScriptless {
+		nbc.EnableScriptlessCSECmd = true
+	}
 	if s.Runtime != nil && s.Runtime.EnableScriptlessNBCCSECmd {
 		nbc.EnableScriptlessNBCCSECmd = true
 		nbc.EnableScriptlessCSECmd = false


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
To allow testing customdata and cse changes locally, add variable to disable scriptless in e2e config.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
