### PR TITLE
feat(gpu): tear down prebaked CUDA driver on non-GPU nodes (shared VHD)

### DIFF
--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
@@ -223,12 +223,50 @@ removeNvidiaRepos() {
     fi
 }
 
+# cleanUpPrebakedGPUDriver tears down a CUDA driver that was pre-baked into a shared Ubuntu VHD
+# when this node is NOT a GPU node. On a non-GPU node the installed driver is dead weight: it
+# wastes disk and, because it stays DKMS-registered, forces an nvidia.ko rebuild on every kernel
+# patch. The nvidia module is never loaded on a non-GPU node, so deregistration cannot hit
+# "module in use". It is a no-op unless the aks-gpu prebake marker is present, so today's
+# non-prebaked VHDs are completely unaffected. Idempotent and safe to re-run.
+# NOTE: this runs synchronously on the (non-GPU) provisioning path; the teardown is light
+# (deregister + rm + ldconfig, no initramfs rebuild). To move it fully off the critical path it
+# can be launched via a transient systemd unit (systemd-run --no-block) instead -- see the PR
+# description for that variant and its trade-offs.
+cleanUpPrebakedGPUDriver() {
+    local marker="${GPU_DKMS_MARKER_FILE:-/opt/azure/aks-gpu/dkms-marker}"
+    if [ ! -f "${marker}" ]; then
+        return 0
+    fi
+    echo "Removing pre-baked NVIDIA driver inherited from shared VHD on non-GPU node"
+
+    # Deregister the nvidia DKMS module so future kernel upgrades stop rebuilding it. Parsing stops
+    # at the first ',', ':' or space so "nvidia/<ver>: added" and "nvidia/<ver>, <kernel>: installed"
+    # both yield just <ver>.
+    if command -v dkms >/dev/null 2>&1; then
+        dkms status 2>/dev/null | sed -n 's#^nvidia/\([^,: ]*\).*#\1#p' | sort -u | while read -r nvidiaVersion; do
+            [ -n "${nvidiaVersion}" ] && dkms remove "nvidia/${nvidiaVersion}" --all || true
+        done
+    fi
+    rm -rf /var/lib/dkms/nvidia || true
+    # aks-gpu relocates the userspace libs under GPU_DEST/lib64; on Ubuntu GPU_DEST=/usr/bin.
+    rm -rf /usr/bin/lib64 || true
+    rm -f /etc/ld.so.conf.d/nvidia.conf || true
+    ldconfig || true
+    rm -f "${marker}" || true
+}
+
 cleanUpGPUDrivers() {
     rm -Rf $GPU_DEST /opt/gpu
 
     for packageName in $(managedGPUPackageList); do
         rm -rf "/opt/${packageName}"
     done
+
+    # A CUDA driver pre-baked into a shared Ubuntu VHD is dead weight on a non-GPU node, and while
+    # DKMS-registered it forces an nvidia.ko rebuild on every kernel patch. Tear it down here.
+    # No-op on VHDs without the aks-gpu prebake marker.
+    cleanUpPrebakedGPUDriver
 }
 
 installCriCtlPackage() {

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+Describe 'cse_install_ubuntu.sh'
+    Include "./parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh"
+
+    Describe 'cleanUpPrebakedGPUDriver'
+        It 'is a no-op when the prebake marker is absent'
+            GPU_DKMS_MARKER_FILE="/tmp/aks-gpu-marker-absent-$$"
+            When call cleanUpPrebakedGPUDriver
+            The status should be success
+            The output should equal ""
+        End
+
+        It 'deregisters the nvidia DKMS module and removes baked artifacts when the marker is present'
+            marker="$(mktemp)"
+            GPU_DKMS_MARKER_FILE="${marker}"
+            # mock dkms so `command -v dkms` succeeds and `dkms status` returns the installed form
+            dkms() {
+                if [ "$1" = "status" ]; then
+                    echo "nvidia/580.126.09, 6.8.0-1029-azure, x86_64: installed"
+                else
+                    echo "mock dkms $*"
+                fi
+            }
+            rm() { echo "mock rm $*"; }
+            ldconfig() { echo "mock ldconfig"; }
+            When call cleanUpPrebakedGPUDriver
+            The status should be success
+            The output should include "Removing pre-baked NVIDIA driver"
+            The output should include "mock dkms remove nvidia/580.126.09 --all"
+            The output should include "mock rm -rf /var/lib/dkms/nvidia"
+            The output should include "mock rm -rf /usr/bin/lib64"
+            The output should include "mock ldconfig"
+        End
+
+        It 'parses the bare "nvidia/<ver>: added" dkms status form to a clean version'
+            marker="$(mktemp)"
+            GPU_DKMS_MARKER_FILE="${marker}"
+            dkms() {
+                if [ "$1" = "status" ]; then
+                    echo "nvidia/570.86.15: added"
+                else
+                    echo "mock dkms $*"
+                fi
+            }
+            rm() { echo "mock rm $*"; }
+            ldconfig() { echo "mock ldconfig"; }
+            When call cleanUpPrebakedGPUDriver
+            The status should be success
+            The output should include "mock dkms remove nvidia/570.86.15 --all"
+        End
+    End
+End


### PR DESCRIPTION
Draft, stacked on #8661 (base = `gpu-prebake-cuda-driver`) so the diff shows only the teardown. Closes the shared-VHD gap in the CUDA prebake.

## Problem
Regular x86 CUDA GPU nodes share their Ubuntu VHD with **non-GPU** nodes (there is no x86 GPU-dedicated VHD; only GB200 is dedicated). When #8661 pre-bakes the CUDA driver into that shared image, every **non-GPU** node inherits a fully *installed* driver — yet non-GPU nodes never run the aks-gpu installer. The existing `cleanUpGPUDrivers` was written for the "driver only ever cached, never installed" world (`rm -Rf /usr/local/nvidia /opt/gpu`) and does **not** remove an installed driver.

Left in place on a non-GPU node, the baked driver:
- wastes disk (hundreds of MB), and
- stays **DKMS-registered**, so it recompiles `nvidia.ko` on **every kernel patch** — re-introducing the ~100s compile prebake set out to remove, on nodes that have no GPU, and adding a failure point to the patch path.

## Fix
`cleanUpGPUDrivers` (Ubuntu) now calls `cleanUpPrebakedGPUDriver`, which:
- **no-ops unless** the aks-gpu prebake marker (`/opt/azure/aks-gpu/dkms-marker`, overridable via `GPU_DKMS_MARKER_FILE`) is present, so today's non-prebaked VHDs are untouched (backward compatible);
- runs `dkms remove nvidia/<ver> --all` to stop future kernel-patch rebuilds (the high-value step);
- removes the relocated libs (`/usr/bin/lib64`), `ld.so.conf.d/nvidia.conf` (+ `ldconfig`), `/var/lib/dkms/nvidia`, and the marker.

The nvidia module is **never loaded** on a non-GPU node, so deregistration cannot hit "module in use" — strictly simpler/safer than the GPU-side stale-driver path.

## Sync vs async (open decision)
This wires the **synchronous, minimal** teardown (deregister + `rm` + `ldconfig`, no `update-initramfs`), which is light and runs only when prebake is active. To take it fully **off the non-GPU critical path**, the same body can be launched via a transient unit: `systemd-run --no-block --collect --unit=aks-gpu-prebake-cleanup /bin/bash <launcher>`. Sync is the default for testability/simplicity; happy to switch to the systemd-run variant if non-GPU provisioning-latency measurements warrant it (the async variant needs a small launcher-script artifact to stay shellcheck-clean and unit-testable).

## Tests
- ShellSpec `spec/.../cse_install_ubuntu_spec.sh`: no-op when marker absent; full teardown when present; bare `nvidia/<ver>: added` status parses to a clean version. (3 examples, 0 failures.)
- `make generate-testdata`: clean (cse_install_ubuntu.sh is not snapshot-inlined).
- Generic + POSIX shellcheck gates pass on the changed file. Note: `make validate-shell` has **pre-existing** SC3014 failures in unrelated files (`init-aks-custom-cloud.sh`, `disk_queue.sh`) on the base branch — not introduced here.

## Not addressed (by design)
GB200/300 (dedicated `NVIDIA_GB` arm64 VHD) is unaffected and intentionally untouched. VHD-size bloat from prebaking into the shared image is inherent to the shared-VHD approach and out of scope here.
