### PR TITLE
fix: revert runc to 1.4.1 for ubuntu 2004

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1027,7 +1027,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=moby-runc, repository=production, os=ubuntu, release=20.04",
-                "latestVersion": "1.4.3-ubuntu20.04u1"
+                "latestVersion": "1.4.1-ubuntu20.04u1"
               }
             ]
           },


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes failing abe2es for ubuntu 2004 fips VHDs by reverting to last known good version for runc

**Which issue(s) this PR fixes**:

This PR fixes failing abe2es for ubuntu 2004 fips VHDs by reverting to last known good version for runc

Fixes #
