### PR TITLE
feat: enable GPU on vanilla arm64 VHD for GB300 (aks-gpu + fabric manager)

### DIFF
--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -992,8 +992,11 @@ var _ = Describe("GPUNeedsFabricManager", func() {
 	It("should be true for multi-GPU NVLink SKUs already in the list", func() {
 		Expect(GPUNeedsFabricManager("standard_nd96isr_h200_v5")).To(BeTrue())
 	})
-	It("should be case-insensitive", func() {
+	It("should be case-insensitive (matches RP-provided mixed-case VM sizes)", func() {
+		// Mixed-case exactly as the RP passes the VM size; a typo here would silently
+		// skip starting nvidia-fabricmanager, the core behavior this change enables.
 		Expect(GPUNeedsFabricManager("Standard_ND128isr_GB300_v6")).To(BeTrue())
+		Expect(GPUNeedsFabricManager("Standard_ND128isr_NDR_GB200_v6")).To(BeTrue())
 	})
 	It("should be false for A100 oddballs that fail to start fabricmanager", func() {
 		Expect(GPUNeedsFabricManager("standard_nc24ads_a100_v4")).To(BeFalse())

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -984,6 +984,25 @@ var _ = Describe("GetGPUDriverType", func() {
 	})
 })
 
+var _ = Describe("GPUNeedsFabricManager", func() {
+	It("should be true for GB200/GB300 (Grace-Blackwell NVL)", func() {
+		Expect(GPUNeedsFabricManager("standard_nd128isr_ndr_gb200_v6")).To(BeTrue())
+		Expect(GPUNeedsFabricManager("standard_nd128isr_gb300_v6")).To(BeTrue())
+	})
+	It("should be true for multi-GPU NVLink SKUs already in the list", func() {
+		Expect(GPUNeedsFabricManager("standard_nd96isr_h200_v5")).To(BeTrue())
+	})
+	It("should be case-insensitive", func() {
+		Expect(GPUNeedsFabricManager("Standard_ND128isr_GB300_v6")).To(BeTrue())
+	})
+	It("should be false for A100 oddballs that fail to start fabricmanager", func() {
+		Expect(GPUNeedsFabricManager("standard_nc24ads_a100_v4")).To(BeFalse())
+	})
+	It("should be false for SKUs not in the list", func() {
+		Expect(GPUNeedsFabricManager("standard_nc6_v3")).To(BeFalse())
+	})
+})
+
 var _ = Describe("GetAKSGPUImageSHA", func() {
 	It("should use newest AKSGPUGridVersionSuffix with nv v5", func() {
 		Expect(GetAKSGPUImageSHA("standard_nv6ads_a10_v5")).To(Equal(datamodel.AKSGPUGridVersionSuffix))

--- a/pkg/agent/datamodel/gpu_components.go
+++ b/pkg/agent/datamodel/gpu_components.go
@@ -159,6 +159,9 @@ var FabricManagerGPUSizes = map[string]bool{
 	"standard_nd96is_h200_v5":   true,
 	"standard_nd96isr_h200_v5":  true,
 	"standard_nd96isrf_h200_v5": true,
+	// GB200 / GB300 (Grace-Blackwell NVL) need fabric manager for NVLink/NVSwitch.
+	"standard_nd128isr_ndr_gb200_v6": true,
+	"standard_nd128isr_gb300_v6":     true,
 	// A100 oddballs.
 	"standard_nc24ads_a100_v4": false, // NCads_v4 will fail to start fabricmanager.
 	"standard_nc48ads_a100_v4": false,

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -707,8 +707,10 @@ while IFS= read -r imageToBePulled; do
   fi
 done <<< "$GPUContainerImages"
 
-# For Ubuntu, pre-pull the CUDA driver image
-if [ $OS = $UBUNTU_OS_NAME ] && [ "$(isARM64)" -ne 1 ]; then  # No ARM64 SKU with GPU now
+# For Ubuntu, pre-pull the CUDA driver image.
+# Skip GB images: they bake the GPU driver via apt in the NVIDIA_GB block below. All other Ubuntu
+# images (amd64 and arm64) cache aks-gpu-cuda so CSE can install the driver at node boot.
+if [ $OS = $UBUNTU_OS_NAME ] && ! grep -q "NVIDIA_GB" <<< "$FEATURE_FLAGS"; then  # incl. ARM64 (e.g. GB300 on vanilla)
   gpu_action="copy"
 
   while IFS= read -r imageToBePulled; do

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -710,7 +710,7 @@ done <<< "$GPUContainerImages"
 # For Ubuntu, pre-pull the CUDA driver image.
 # Skip GB images: they bake the GPU driver via apt in the NVIDIA_GB block below. All other Ubuntu
 # images (amd64 and arm64) cache aks-gpu-cuda so CSE can install the driver at node boot.
-if [ $OS = $UBUNTU_OS_NAME ] && ! grep -q "NVIDIA_GB" <<< "$FEATURE_FLAGS"; then  # incl. ARM64 (e.g. GB300 on vanilla)
+if [ $OS = $UBUNTU_OS_NAME ] && ! grep -q "NVIDIA_GB" <<< "$FEATURE_FLAGS"; then  # incl. ARM64 (e.g. GB200/300 on vanilla)
   gpu_action="copy"
 
   while IFS= read -r imageToBePulled; do

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -710,7 +710,7 @@ done <<< "$GPUContainerImages"
 # For Ubuntu, pre-pull the CUDA driver image.
 # Skip GB images: they bake the GPU driver via apt in the NVIDIA_GB block below. All other Ubuntu
 # images (amd64 and arm64) cache aks-gpu-cuda so CSE can install the driver at node boot.
-if [ $OS = $UBUNTU_OS_NAME ] && ! grep -q "NVIDIA_GB" <<< "$FEATURE_FLAGS"; then  # incl. ARM64 (e.g. GB200/300 on vanilla)
+if [ "$OS" = "$UBUNTU_OS_NAME" ] && ! grep -q "NVIDIA_GB" <<< "$FEATURE_FLAGS"; then  # incl. ARM64 (e.g. GB200/300 on vanilla)
   gpu_action="copy"
 
   while IFS= read -r imageToBePulled; do


### PR DESCRIPTION
**What this PR does / why we need it**:

⚠️ **Experimental / for discussion.** Exploring whether GB300 (`Standard_ND128isr_GB300_v6`) can run on the vanilla `2404gen2arm64containerd` VHD via the **aks-gpu** container path, instead of the dedicated GB image.

Two changes:
1. **`vhdbuilder/packer/install-dependencies.sh`** — pre-pull (bake) `aks-gpu-cuda` for **all non-GB Ubuntu images (amd64 + arm64)** instead of amd64 only. `aks-gpu-cuda` is multi-arch (`linux/arm64` exists), so CSE can install the driver at node boot on arm64. GB images stay excluded (they bake the driver via apt in the `NVIDIA_GB` block).
2. **`pkg/agent/datamodel/gpu_components.go`** — add GB200/GB300 (`standard_nd128isr_ndr_gb200_v6`, `standard_nd128isr_gb300_v6`) to `FabricManagerGPUSizes` so `GPUNeedsFabricManager` is true and CSE starts `nvidia-fabricmanager` for NVLink/NVSwitch.

**Known gap (intentionally not in this PR):** full GB300 NVL also needs **IMEX** and **DOCA/OFED RDMA**, which `aks-gpu` does **not** install (verified against `Azure/aks-gpu` source). With this PR alone you get driver + container-toolkit + fabric manager (single-node multi-GPU NVLink), but **not** multi-node NVL / GPUDirect RDMA. Opening for discussion on whether this direction is worth pursuing vs. the dedicated GB image.

**Which issue(s) this PR fixes**:
N/A — exploratory.
