### PR TITLE
fix: added retry handling for transient azure linux rpm repo metadata failures

### DIFF
--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -579,6 +579,8 @@ getLatestRPMPackageVersion() {
         fi
 
         if ! echo "${dnfListOutput}" | grep -qiE "Failed to download metadata|repomd\\.xml.*GPG signature|Bad GPG signature|GPG signature verification error|Cannot download repomd\\.xml"; then
+            echo "Failed to query ${packageName} versions (non-retryable error):" >&2
+            echo "${dnfListOutput}" >&2
             return 1
         fi
 

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -590,8 +590,8 @@ getLatestRPMPackageVersion() {
             return 1
         fi
 
-        dnf clean metadata >&2 || true
-        dnf_makecache >&2 || true
+        dnf clean metadata >&2 || echo "Warning: dnf clean metadata failed" >&2
+        dnf_makecache >&2 || echo "Warning: dnf_makecache failed" >&2
         sleep "${waitSleep}"
     done
 

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -573,7 +573,7 @@ getLatestRPMPackageVersion() {
     local i
     for i in $(seq 1 "${retries}"); do
         dnfListOutput=$(dnf list "${packageName}" --showduplicates 2>&1)
-        fullPackageVersion=$(printf '%s\n' "${dnfListOutput}" | awk -v dv="${desiredVersion}" '{ver=$2; sub(/^[0-9]+:/,"",ver); if (index(ver, dv "-")==1) print $2}' | sort -V | tail -n 1)
+        fullPackageVersion=$(printf '%s\n' "${dnfListOutput}" | awk -v dv="${desiredVersion}" '{ver=$2; sub(/^[0-9]+:/,"",ver); if (index(ver, dv "-")==1) print ver}' | sort -V | tail -n 1)
         if [ -n "${fullPackageVersion}" ]; then
             echo "${fullPackageVersion}"
             return 0

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -579,7 +579,7 @@ getLatestRPMPackageVersion() {
             return 0
         fi
 
-        if ! echo "${dnfListOutput}" | grep -qiE "Failed to download metadata|repomd\\.xml.*GPG signature|Bad GPG signature|GPG signature verification error|Cannot download repomd\\.xml"; then
+        if ! printf '%s\n' "${dnfListOutput}" | grep -qiE "Failed to download metadata|repomd\\.xml.*GPG signature|Bad GPG signature|GPG signature verification error|Cannot download repomd\\.xml"; then
             echo "Failed to query ${packageName} versions (non-retryable error):" >&2
             echo "${dnfListOutput}" >&2
             return 1

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -572,7 +572,7 @@ getLatestRPMPackageVersion() {
 
     for i in $(seq 1 "${retries}"); do
         dnfListOutput=$(dnf list "${packageName}" --showduplicates 2>&1)
-        fullPackageVersion=$(echo "${dnfListOutput}" | grep "${desiredVersion}-" | awk '{print $2}' | sort -V | tail -n 1)
+        fullPackageVersion=$(printf '%s\n' "${dnfListOutput}" | awk -v dv="${desiredVersion}" 'index($2, dv "-")==1 {print $2}' | sort -V | tail -n 1)
         if [ -n "${fullPackageVersion}" ]; then
             echo "${fullPackageVersion}"
             return 0

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -512,7 +512,7 @@ installRPMPackageFromFile() {
     if [ -z "${rpmFile}" ]; then
         # query all package versions and get the latest version for matching k8s version
         # e.g. 1.34.0-5.azl3
-        fullPackageVersion=$(dnf list ${packageName} --showduplicates | grep ${desiredVersion}- | awk '{print $2}' | sort -V | tail -n 1)
+        fullPackageVersion=$(getLatestRPMPackageVersion "${packageName}" "${desiredVersion}")
         if [ -z "${fullPackageVersion}" ]; then
             echo "Failed to find valid ${packageName} version for ${desiredVersion}"
             return 1
@@ -560,6 +560,40 @@ installPackageFromCache() {
     logs_to_events "AKS.CSE.install${packageName}.extractBinaryFromRPM" "extractBinaryFromRPM ${rpmFile} ${packageName} ${targetPath}" || exit "$ERR_APT_INSTALL_TIMEOUT"
     rm -rf "${downloadDir}"
     rm -f /opt/bin/"${packageName}"-* &
+}
+
+getLatestRPMPackageVersion() {
+    local packageName="${1}"
+    local desiredVersion="${2}"
+    local retries="${3:-5}"
+    local waitSleep="${4:-10}"
+    local dnfListOutput=""
+    local fullPackageVersion=""
+
+    for i in $(seq 1 "${retries}"); do
+        dnfListOutput=$(dnf list "${packageName}" --showduplicates 2>&1)
+        fullPackageVersion=$(echo "${dnfListOutput}" | grep "${desiredVersion}-" | awk '{print $2}' | sort -V | tail -n 1)
+        if [ -n "${fullPackageVersion}" ]; then
+            echo "${fullPackageVersion}"
+            return 0
+        fi
+
+        if ! echo "${dnfListOutput}" | grep -qiE "Failed to download metadata|repomd\\.xml.*GPG signature|Bad GPG signature|GPG signature verification error|Cannot download repomd\\.xml"; then
+            return 1
+        fi
+
+        echo "Attempt ${i}/${retries}: failed to query ${packageName} versions due to repo metadata error" >&2
+        echo "${dnfListOutput}" >&2
+        if [ "${i}" -eq "${retries}" ]; then
+            return 1
+        fi
+
+        dnf clean metadata >&2 || true
+        dnf_makecache >&2 || true
+        sleep "${waitSleep}"
+    done
+
+    return 1
 }
 
 downloadPkgFromVersion() {

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -570,9 +570,10 @@ getLatestRPMPackageVersion() {
     local dnfListOutput=""
     local fullPackageVersion=""
 
+    local i
     for i in $(seq 1 "${retries}"); do
         dnfListOutput=$(dnf list "${packageName}" --showduplicates 2>&1)
-        fullPackageVersion=$(printf '%s\n' "${dnfListOutput}" | awk -v dv="${desiredVersion}" 'index($2, dv "-")==1 {print $2}' | sort -V | tail -n 1)
+        fullPackageVersion=$(printf '%s\n' "${dnfListOutput}" | awk -v dv="${desiredVersion}" '{ver=$2; sub(/^[0-9]+:/,"",ver); if (index(ver, dv "-")==1) print $2}' | sort -V | tail -n 1)
         if [ -n "${fullPackageVersion}" ]; then
             echo "${fullPackageVersion}"
             return 0

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
@@ -99,6 +99,28 @@ Describe 'cse_install_mariner.sh'
             The status should equal 1
         End
 
+        It 'strips RPM epoch before matching and downloading package version'
+            fallbackToKubeBinaryInstall() { return 1; }
+            dnf() {
+                echo "kubelet.x86_64 1:1.34.8-2.azl3 azurelinux-official-cloud-native"
+                return 0
+            }
+            desiredVersion="1.34.8"
+            rpmDir="$RPM_PACKAGE_CACHE_BASE_DIR/kubelet/downloads"
+            kubeletRpm="$rpmDir/kubelet-${desiredVersion}-2.azl3.x86_64.rpm"
+            downloadPkgFromVersion() {
+                echo "downloadPkgFromVersion $1 $2 $3"
+                touch "$kubeletRpm"
+            }
+
+            When call installRPMPackageFromFile kubelet "$desiredVersion"
+
+            The output should include "downloadPkgFromVersion kubelet 1.34.8-2.azl3 $rpmDir"
+            The output should include "extractBinaryFromRPM $kubeletRpm kubelet /opt/bin/kubelet"
+            The output should not include "1:1.34.8-2.azl3"
+            The status should equal 0
+        End
+
         It 'retries dnf list after a transient repo metadata GPG error'
             fallbackToKubeBinaryInstall() { return 1; }
             dnf_makecache() { echo "dnf makecache"; }

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
@@ -95,7 +95,47 @@ Describe 'cse_install_mariner.sh'
             desiredVersion="1.99.0"
             When call installRPMPackageFromFile kubelet "$desiredVersion"
             The output should include "Failed to find valid kubelet version for 1.99.0"
+            The error should include "Failed to query kubelet versions (non-retryable error):"
             The status should equal 1
+        End
+
+        It 'retries dnf list after a transient repo metadata GPG error'
+            fallbackToKubeBinaryInstall() { return 1; }
+            dnf_makecache() { echo "dnf makecache"; }
+            sleep() { echo "sleep $1"; }
+            dnfListCallsFile="$RPM_PACKAGE_CACHE_BASE_DIR/dnf-list-calls"
+            echo 0 > "$dnfListCallsFile"
+            dnf() {
+                if [ "$1" = "clean" ]; then
+                    echo "dnf clean $2"
+                    return 0
+                fi
+
+                if [ "$1" = "list" ]; then
+                    dnfListCalls=$(cat "$dnfListCallsFile")
+                    dnfListCalls=$((dnfListCalls + 1))
+                    echo "$dnfListCalls" > "$dnfListCallsFile"
+                    if [ "$dnfListCalls" -eq 1 ]; then
+                        echo "Error: Failed to download metadata for repo 'azurelinux-official-cloud-native': repomd.xml GPG signature verification error: Bad GPG signature"
+                        return 1
+                    fi
+                    echo "kubelet.x86_64 1.34.8-2.azl3 azurelinux-official-cloud-native"
+                    return 0
+                fi
+            }
+            desiredVersion="1.34.8"
+            rpmDir="$RPM_PACKAGE_CACHE_BASE_DIR/kubelet/downloads"
+            kubeletRpm="$rpmDir/kubelet-${desiredVersion}-2.azl3.x86_64.rpm"
+            downloadPkgFromVersion() { touch "$kubeletRpm"; }
+
+            When call installRPMPackageFromFile kubelet "$desiredVersion"
+
+            The output should include "sleep 10"
+            The error should include "repo metadata error"
+            The error should include "dnf clean metadata"
+            The error should include "dnf makecache"
+            The output should include "extractBinaryFromRPM $kubeletRpm kubelet /opt/bin/kubelet"
+            The status should equal 0
         End
     End
 


### PR DESCRIPTION
Azure Linux 3 nodes using the PMC/RPM install path can fail CSE with  ERR_KUBELET_INSTALL_FAIL  / exit code  121  when  dnf list kubelet --showduplicates  hits a  transient repo metadata issue, e.g.:

Failed to download metadata for repo 'azurelinux-official-cloud-native': repomd.xml GPG signature verification error: Bad GPG signature

Before this change, that transient  dnf list  failure produced an empty package version, which was treated as:

Failed to find valid kubelet version for <version> and CSE exited immediately with  121 .

Introduced  getLatestRPMPackageVersion  in  parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh  and replaced the direct  dnf list ... | grep  ...  pipeline in  installRPMPackageFromFile .

The new helper:

* Runs  dnf list <package> --showduplicates  to discover the latest matching RPM version.
* Retries when output indicates repo metadata/GPG issues such as  Failed to download metadata ,  Bad GPG signature , or  repomd.xml  GPG verification failures. 
* Refreshes local metadata between attempts with  dnf clean metadata  and  dnf_makecache . 
* Keeps GPG validation enabled; it does not disable  gpgcheck  or  repo_gpgcheck . 
* Preserves existing behavior for genuine “package version not found” cases by returning failure when the error is not a retryable metadata issue.

Reduces false CSE provisioning failures caused by transient Azure Linux repo publish/CDN/mirror metadata inconsistency, especially for kubelet/kubectl  install on Azure Linux 3 / Kubernetes >= 1.34. Genuine missing package versions will still fail fast with the existing error path