### PR TITLE
chore: bump azure-cloud-node-manager and acr-credential-provider versions

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1762,24 +1762,26 @@
               {
                 "k8sVersion": "1.33",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=24.04",
-                "latestVersion": "1.33.13-ubuntu24.04u1",
-                "previousLatestVersion": "1.33.11-ubuntu24.04u1"
+                "latestVersion": "1.33.14-ubuntu24.04u1",
+                "previousLatestVersion": "1.33.13-ubuntu24.04u1"
               },
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=24.04",
-                "latestVersion": "1.34.10-ubuntu24.04u1",
-                "previousLatestVersion": "1.34.8-ubuntu24.04u1"
+                "latestVersion": "1.34.11-ubuntu24.04u1",
+                "previousLatestVersion": "1.34.10-ubuntu24.04u1"
               },
               {
                 "k8sVersion": "1.35",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=24.04",
-                "latestVersion": "1.35.5-ubuntu24.04u1"
+                "latestVersion": "1.35.6-ubuntu24.04u1",
+                "previousLatestVersion": "1.35.5-ubuntu24.04u1"
               },
               {
                 "k8sVersion": "1.36",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=24.04",
-                "latestVersion": "1.36.1-ubuntu24.04u1"
+                "latestVersion": "1.36.2-ubuntu24.04u1",
+                "previousLatestVersion": "1.36.1-ubuntu24.04u1"
               }
             ]
           },
@@ -1794,24 +1796,26 @@
               {
                 "k8sVersion": "1.33",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "1.33.13-ubuntu22.04u1",
-                "previousLatestVersion": "1.33.11-ubuntu22.04u1"
+                "latestVersion": "1.33.14-ubuntu22.04u1",
+                "previousLatestVersion": "1.33.13-ubuntu22.04u1"
               },
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "1.34.10-ubuntu22.04u1",
-                "previousLatestVersion": "1.34.8-ubuntu22.04u1"
+                "latestVersion": "1.34.11-ubuntu22.04u1",
+                "previousLatestVersion": "1.34.10-ubuntu22.04u1"
               },
               {
                 "k8sVersion": "1.35",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "1.35.5-ubuntu22.04u1"
+                "latestVersion": "1.35.6-ubuntu22.04u1",
+                "previousLatestVersion": "1.35.5-ubuntu22.04u1"
               },
               {
                 "k8sVersion": "1.36",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "1.36.1-ubuntu22.04u1"
+                "latestVersion": "1.36.2-ubuntu22.04u1",
+                "previousLatestVersion": "1.36.1-ubuntu22.04u1"
               }
             ]
           },
@@ -1826,24 +1830,26 @@
               {
                 "k8sVersion": "1.33",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=20.04",
-                "latestVersion": "1.33.13-ubuntu20.04u1",
-                "previousLatestVersion": "1.33.11-ubuntu20.04u1"
+                "latestVersion": "1.33.14-ubuntu20.04u1",
+                "previousLatestVersion": "1.33.13-ubuntu20.04u1"
               },
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=20.04",
-                "latestVersion": "1.34.10-ubuntu20.04u1",
-                "previousLatestVersion": "1.34.8-ubuntu20.04u1"
+                "latestVersion": "1.34.11-ubuntu20.04u1",
+                "previousLatestVersion": "1.34.10-ubuntu20.04u1"
               },
               {
                 "k8sVersion": "1.35",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=20.04",
-                "latestVersion": "1.35.5-ubuntu20.04u1"
+                "latestVersion": "1.35.6-ubuntu20.04u1",
+                "previousLatestVersion": "1.35.5-ubuntu20.04u1"
               },
               {
                 "k8sVersion": "1.36",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=20.04",
-                "latestVersion": "1.36.1-ubuntu20.04u1"
+                "latestVersion": "1.36.2-ubuntu20.04u1",
+                "previousLatestVersion": "1.36.1-ubuntu20.04u1"
               }
             ]
           }
@@ -1860,24 +1866,26 @@
               {
                 "k8sVersion": "1.33",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=azurelinux, release=3.0",
-                "latestVersion": "1.33.13-1.azl3",
-                "previousLatestVersion": "1.33.6-1.azl3"
+                "latestVersion": "1.33.14-1.azl3",
+                "previousLatestVersion": "1.33.13-1.azl3"
               },
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=azurelinux, release=3.0",
-                "latestVersion": "1.34.10-1.azl3",
-                "previousLatestVersion": "1.34.7-1.azl3"
+                "latestVersion": "1.34.11-1.azl3",
+                "previousLatestVersion": "1.34.10-1.azl3"
               },
               {
                 "k8sVersion": "1.35",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=azurelinux, release=3.0",
-                "latestVersion": "1.35.5-1.azl3"
+                "latestVersion": "1.35.6-1.azl3",
+                "previousLatestVersion": "1.35.5-1.azl3"
               },
               {
                 "k8sVersion": "1.36",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=azurelinux, release=3.0",
-                "latestVersion": "1.36.1-1.azl3"
+                "latestVersion": "1.36.2-1.azl3",
+                "previousLatestVersion": "1.36.1-1.azl3"
               }
             ]
           }
@@ -1894,24 +1902,26 @@
               {
                 "k8sVersion": "1.33",
                 "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-acr-credential-provider-sysext",
-                "latestVersion": "v1.33.13-1-azlinux3",
-                "previousLatestVersion": "v1.33.6-1-azlinux3"
+                "latestVersion": "v1.33.14-1-azlinux3",
+                "previousLatestVersion": "v1.33.13-1-azlinux3"
               },
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-acr-credential-provider-sysext",
-                "latestVersion": "v1.34.10-1-azlinux3",
-                "previousLatestVersion": "v1.34.7-1-azlinux3"
+                "latestVersion": "v1.34.11-1-azlinux3",
+                "previousLatestVersion": "v1.34.10-1-azlinux3"
               },
               {
                 "k8sVersion": "1.35",
                 "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-acr-credential-provider-sysext",
-                "latestVersion": "v1.35.5-1-azlinux3"
+                "latestVersion": "v1.35.6-1-azlinux3",
+                "previousLatestVersion": "v1.35.5-1-azlinux3"
               },
               {
                 "k8sVersion": "1.36",
                 "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-acr-credential-provider-sysext",
-                "latestVersion": "v1.36.1-1-azlinux3"
+                "latestVersion": "v1.36.2-1-azlinux3",
+                "previousLatestVersion": "v1.36.1-1-azlinux3"
               }
             ],
             "downloadURL": "mcr.microsoft.com/oss/v2/kubernetes/azure-acr-credential-provider-sysext:${version}-${SYSTEMD_ARCH}"

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -439,43 +439,45 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.33.13-1",
-          "previousLatestVersion": "v1.33.11-2"
+          "latestVersion": "v1.33.14-1",
+          "previousLatestVersion": "v1.33.13-1"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.34.10-1",
-          "previousLatestVersion": "v1.34.8-2"
+          "latestVersion": "v1.34.11-1",
+          "previousLatestVersion": "v1.34.10-1"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.35.5-1",
-          "previousLatestVersion": "v1.35.3-2"
+          "latestVersion": "v1.35.6-1",
+          "previousLatestVersion": "v1.35.5-1"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.36.1-1"
+          "latestVersion": "v1.36.2-1",
+          "previousLatestVersion": "v1.36.1-1"
         }
       ],
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.33.13-windows-hpc-1",
-          "previousLatestVersion": "v1.33.11-windows-hpc-1"
+          "latestVersion": "v1.33.14-windows-hpc-1",
+          "previousLatestVersion": "v1.33.13-windows-hpc-1"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.34.10-windows-hpc-1",
-          "previousLatestVersion": "v1.34.8-windows-hpc-1"
+          "latestVersion": "v1.34.11-windows-hpc-1",
+          "previousLatestVersion": "v1.34.10-windows-hpc-1"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.35.5-windows-hpc-1",
-          "previousLatestVersion": "v1.35.3-windows-hpc-1"
+          "latestVersion": "v1.35.6-windows-hpc-1",
+          "previousLatestVersion": "v1.35.5-windows-hpc-1"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.36.1-windows-hpc-1"
+          "latestVersion": "v1.36.2-windows-hpc-1",
+          "previousLatestVersion": "v1.36.1-windows-hpc-1"
         }
       ]
     },


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
Bump cloud-node-manager and acr-credential provider versions:

| Package | Update | Change |
|---|---|---|
| azure-cloud-node-manager (linux) | patch | `v1.33.13-1` → `v1.33.14-1` |
| azure-cloud-node-manager (linux) | patch | `v1.34.10-1` → `v1.34.11-1` |
| azure-cloud-node-manager (linux) | patch | `v1.35.5-1` → `v1.35.6-1` |
| azure-cloud-node-manager (linux) | patch | `v1.36.1-1` → `v1.36.2-1` |
| azure-cloud-node-manager (windows) | patch | `v1.33.13-windows-hpc-1` → `v1.33.14-windows-hpc-1` |
| azure-cloud-node-manager (windows) | patch | `v1.34.10-windows-hpc-1` → `v1.34.11-windows-hpc-1` |
| azure-cloud-node-manager (windows) | patch | `v1.35.5-windows-hpc-1` → `v1.35.6-windows-hpc-1` |
| azure-cloud-node-manager (windows) | patch | `v1.36.1-windows-hpc-1` → `v1.36.2-windows-hpc-1` |
| azure-acr-credential-provider (ubuntu 20.04 / 22.04 / 24.04) | patch | `1.33.13` → `1.33.14` |
| azure-acr-credential-provider (ubuntu 20.04 / 22.04 / 24.04) | patch | `1.34.10` → `1.34.11` |
| azure-acr-credential-provider (ubuntu 20.04 / 22.04 / 24.04) | patch | `1.35.5` → `1.35.6` |
| azure-acr-credential-provider (ubuntu 20.04 / 22.04 / 24.04) | patch | `1.36.1` → `1.36.2` |
| azure-acr-credential-provider (azurelinux 3.0) | patch | `1.33.13-1.azl3` → `1.33.14-1.azl3` |
| azure-acr-credential-provider (azurelinux 3.0) | patch | `1.34.10-1.azl3` → `1.34.11-1.azl3` |
| azure-acr-credential-provider (azurelinux 3.0) | patch | `1.35.5-1.azl3` → `1.35.6-1.azl3` |
| azure-acr-credential-provider (azurelinux 3.0) | patch | `1.36.1-1.azl3` → `1.36.2-1.azl3` |
| azure-acr-credential-provider-sysext (azlinux3) | patch | `v1.33.13-1-azlinux3` → `v1.33.14-1-azlinux3` |
| azure-acr-credential-provider-sysext (azlinux3) | patch | `v1.34.10-1-azlinux3` → `v1.34.11-1-azlinux3` |
| azure-acr-credential-provider-sysext (azlinux3) | patch | `v1.35.5-1-azlinux3` → `v1.35.6-1-azlinux3` |
| azure-acr-credential-provider-sysext (azlinux3) | patch | `v1.36.1-1-azlinux3` → `v1.36.2-1-azlinux3` |

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
