### PR TITLE
docs(kubelet): clarify config file generation precedence with tests and variable naming

### DIFF
--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -577,23 +577,23 @@ func GetKubeletConfigFileContent(kc map[string]string, customKc *datamodel.Custo
 	if kc == nil {
 		return ""
 	}
-	// translate simple values.
-	kubeletConfig := getAKSKubeletConfiguration(kc)
+	// Build flag-derived config first.
+	flagConfig := getAKSKubeletConfiguration(kc)
 
 	// Authentication.
-	kubeletConfig.Authentication = datamodel.KubeletAuthentication{}
+	flagConfig.Authentication = datamodel.KubeletAuthentication{}
 	if ca := kc["--client-ca-file"]; ca != "" {
-		kubeletConfig.Authentication.X509 = datamodel.KubeletX509Authentication{
+		flagConfig.Authentication.X509 = datamodel.KubeletX509Authentication{
 			ClientCAFile: ca,
 		}
 	}
 	if aw := kc["--authentication-token-webhook"]; aw != "" {
-		kubeletConfig.Authentication.Webhook = datamodel.KubeletWebhookAuthentication{
+		flagConfig.Authentication.Webhook = datamodel.KubeletWebhookAuthentication{
 			Enabled: strToBool(aw),
 		}
 	}
 	if aa := kc["--anonymous-auth"]; aa != "" {
-		kubeletConfig.Authentication.Anonymous = datamodel.KubeletAnonymousAuthentication{
+		flagConfig.Authentication.Anonymous = datamodel.KubeletAnonymousAuthentication{
 			Enabled: strToBool(aa),
 		}
 	}
@@ -601,37 +601,41 @@ func GetKubeletConfigFileContent(kc map[string]string, customKc *datamodel.Custo
 	// EvictionHard.
 	// default: "memory.available<750Mi,nodefs.available<10%,nodefs.inodesFree<5%".
 	if eh, ok := kc["--eviction-hard"]; ok && eh != "" {
-		kubeletConfig.EvictionHard = filterEvictionSignals(strKeyValToMap(eh, "<"))
+		flagConfig.EvictionHard = filterEvictionSignals(strKeyValToMap(eh, "<"))
 	}
 
 	// EvictionSoft (e.g. "memory.available<500Mi,nodefs.available<15%,imagefs.available<20%").
 	if es, ok := kc["--eviction-soft"]; ok && es != "" {
-		kubeletConfig.EvictionSoft = filterEvictionSignals(strKeyValToMap(es, "<"))
+		flagConfig.EvictionSoft = filterEvictionSignals(strKeyValToMap(es, "<"))
 	}
 
 	// EvictionSoftGracePeriod (e.g. "memory.available=30s,nodefs.available=2m,imagefs.available=2m").
 	if esg, ok := kc["--eviction-soft-grace-period"]; ok && esg != "" {
-		kubeletConfig.EvictionSoftGracePeriod = filterEvictionSignals(strKeyValToMap(esg, "="))
+		flagConfig.EvictionSoftGracePeriod = filterEvictionSignals(strKeyValToMap(esg, "="))
 	}
 
 	// EvictionMaxPodGracePeriod (integer seconds, e.g. "60").
 	if v, ok := kc["--eviction-max-pod-grace-period"]; ok && v != "" {
-		kubeletConfig.EvictionMaxPodGracePeriod = strToInt32(v)
+		flagConfig.EvictionMaxPodGracePeriod = strToInt32(v)
 	}
 
 	// feature gates.
 	// look like "f1=true,f2=true".
-	kubeletConfig.FeatureGates = strKeyValToMapBool(kc["--feature-gates"], ",", "=")
+	flagConfig.FeatureGates = strKeyValToMapBool(kc["--feature-gates"], ",", "=")
 
 	// system reserve and kube reserve.
 	// looks like "cpu=100m,memory=1638Mi".
-	kubeletConfig.SystemReserved = strKeyValToMap(kc["--system-reserved"], "=")
-	kubeletConfig.KubeReserved = strKeyValToMap(kc["--kube-reserved"], "=")
+	flagConfig.SystemReserved = strKeyValToMap(kc["--system-reserved"], "=")
+	flagConfig.KubeReserved = strKeyValToMap(kc["--kube-reserved"], "=")
 
-	// Settings from customKubeletConfig, only take if it's set.
-	setCustomKubeletConfig(customKc, kubeletConfig)
+	// Apply CustomKubeletConfig on top of flag-derived config.
+	// CustomKubeletConfig (user-specified values) takes precedence over flag defaults.
+	setCustomKubeletConfig(customKc, flagConfig)
 
-	configStringByte, _ := json.MarshalIndent(kubeletConfig, "", "    ")
+	configStringByte, err := json.MarshalIndent(flagConfig, "", "    ")
+	if err != nil {
+		return ""
+	}
 	return string(configStringByte)
 }
 

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -577,23 +577,23 @@ func GetKubeletConfigFileContent(kc map[string]string, customKc *datamodel.Custo
 	if kc == nil {
 		return ""
 	}
-	// Build flag-derived config first.
-	flagConfig := getAKSKubeletConfiguration(kc)
+	// translate simple values.
+	kubeletConfig := getAKSKubeletConfiguration(kc)
 
 	// Authentication.
-	flagConfig.Authentication = datamodel.KubeletAuthentication{}
+	kubeletConfig.Authentication = datamodel.KubeletAuthentication{}
 	if ca := kc["--client-ca-file"]; ca != "" {
-		flagConfig.Authentication.X509 = datamodel.KubeletX509Authentication{
+		kubeletConfig.Authentication.X509 = datamodel.KubeletX509Authentication{
 			ClientCAFile: ca,
 		}
 	}
 	if aw := kc["--authentication-token-webhook"]; aw != "" {
-		flagConfig.Authentication.Webhook = datamodel.KubeletWebhookAuthentication{
+		kubeletConfig.Authentication.Webhook = datamodel.KubeletWebhookAuthentication{
 			Enabled: strToBool(aw),
 		}
 	}
 	if aa := kc["--anonymous-auth"]; aa != "" {
-		flagConfig.Authentication.Anonymous = datamodel.KubeletAnonymousAuthentication{
+		kubeletConfig.Authentication.Anonymous = datamodel.KubeletAnonymousAuthentication{
 			Enabled: strToBool(aa),
 		}
 	}
@@ -601,38 +601,37 @@ func GetKubeletConfigFileContent(kc map[string]string, customKc *datamodel.Custo
 	// EvictionHard.
 	// default: "memory.available<750Mi,nodefs.available<10%,nodefs.inodesFree<5%".
 	if eh, ok := kc["--eviction-hard"]; ok && eh != "" {
-		flagConfig.EvictionHard = filterEvictionSignals(strKeyValToMap(eh, "<"))
+		kubeletConfig.EvictionHard = filterEvictionSignals(strKeyValToMap(eh, "<"))
 	}
 
 	// EvictionSoft (e.g. "memory.available<500Mi,nodefs.available<15%,imagefs.available<20%").
 	if es, ok := kc["--eviction-soft"]; ok && es != "" {
-		flagConfig.EvictionSoft = filterEvictionSignals(strKeyValToMap(es, "<"))
+		kubeletConfig.EvictionSoft = filterEvictionSignals(strKeyValToMap(es, "<"))
 	}
 
 	// EvictionSoftGracePeriod (e.g. "memory.available=30s,nodefs.available=2m,imagefs.available=2m").
 	if esg, ok := kc["--eviction-soft-grace-period"]; ok && esg != "" {
-		flagConfig.EvictionSoftGracePeriod = filterEvictionSignals(strKeyValToMap(esg, "="))
+		kubeletConfig.EvictionSoftGracePeriod = filterEvictionSignals(strKeyValToMap(esg, "="))
 	}
 
 	// EvictionMaxPodGracePeriod (integer seconds, e.g. "60").
 	if v, ok := kc["--eviction-max-pod-grace-period"]; ok && v != "" {
-		flagConfig.EvictionMaxPodGracePeriod = strToInt32(v)
+		kubeletConfig.EvictionMaxPodGracePeriod = strToInt32(v)
 	}
 
 	// feature gates.
 	// look like "f1=true,f2=true".
-	flagConfig.FeatureGates = strKeyValToMapBool(kc["--feature-gates"], ",", "=")
+	kubeletConfig.FeatureGates = strKeyValToMapBool(kc["--feature-gates"], ",", "=")
 
 	// system reserve and kube reserve.
 	// looks like "cpu=100m,memory=1638Mi".
-	flagConfig.SystemReserved = strKeyValToMap(kc["--system-reserved"], "=")
-	flagConfig.KubeReserved = strKeyValToMap(kc["--kube-reserved"], "=")
+	kubeletConfig.SystemReserved = strKeyValToMap(kc["--system-reserved"], "=")
+	kubeletConfig.KubeReserved = strKeyValToMap(kc["--kube-reserved"], "=")
 
-	// Apply CustomKubeletConfig on top of flag-derived config.
-	// CustomKubeletConfig (user-specified values) takes precedence over flag defaults.
-	setCustomKubeletConfig(customKc, flagConfig)
+	// Settings from customKubeletConfig, only take if it's set.
+	setCustomKubeletConfig(customKc, kubeletConfig)
 
-	configStringByte, _ := json.MarshalIndent(flagConfig, "", "    ")
+	configStringByte, _ := json.MarshalIndent(kubeletConfig, "", "    ")
 	return string(configStringByte)
 }
 

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -632,11 +632,7 @@ func GetKubeletConfigFileContent(kc map[string]string, customKc *datamodel.Custo
 	// CustomKubeletConfig (user-specified values) takes precedence over flag defaults.
 	setCustomKubeletConfig(customKc, flagConfig)
 
-	configStringByte, err := json.MarshalIndent(flagConfig, "", "    ")
-	if err != nil {
-		// Avoid writing an empty kubelet config file when CSE enables --config.
-		return `{"apiVersion":"kubelet.config.k8s.io/v1beta1","kind":"KubeletConfiguration"}`
-	}
+	configStringByte, _ := json.MarshalIndent(flagConfig, "", "    ")
 	return string(configStringByte)
 }
 

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -634,7 +634,8 @@ func GetKubeletConfigFileContent(kc map[string]string, customKc *datamodel.Custo
 
 	configStringByte, err := json.MarshalIndent(flagConfig, "", "    ")
 	if err != nil {
-		return ""
+		// Avoid writing an empty kubelet config file when CSE enables --config.
+		return `{"apiVersion":"kubelet.config.k8s.io/v1beta1","kind":"KubeletConfiguration"}`
 	}
 	return string(configStringByte)
 }

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -102,10 +102,10 @@ func TestGetKubeletConfigFileContent_MergesFlagsWithoutOverwritingContent(t *tes
 	}
 }
 
-// TestGetKubeletConfigFileContent_PrecedenceRules validates precedence between CustomKubeletConfig and KubeletConfig flags:
-//
-//	Priority 1 (highest): CustomKubeletConfig — user-specified values via AKS API
-//	Priority 2: KubeletConfig flags — RP-provided defaults, backfills fields not set by CustomKC
+// TestGetKubeletConfigFileContent_PrecedenceRules validates precedence when generating kubelet config file content:
+// Priority 1 (highest): CustomKubeletConfig — user-specified values via AKS API.
+// Priority 2: KubeletConfig flags — RP-provided defaults, backfills fields not set by CustomKC.
+// Priority 3: kubelet v1beta1 defaults — applied by kubelet for remaining unset fields.
 func TestGetKubeletConfigFileContent_PrecedenceRules(t *testing.T) {
 	kc := map[string]string{
 		"--image-gc-high-threshold": "85",

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -77,6 +77,81 @@ func TestGetKubeletConfigFileFromFlags(t *testing.T) {
 	}
 }
 
+func TestGetKubeletConfigFileContent_MergesFlagsWithoutOverwritingContent(t *testing.T) {
+	kc := map[string]string{
+		"--image-gc-high-threshold": "85",
+		"--max-pods":                "110",
+	}
+	customKc := &datamodel.CustomKubeletConfig{
+		ImageGcHighThreshold: to.Int32Ptr(90),
+	}
+
+	configFileStr := GetKubeletConfigFileContent(kc, customKc)
+
+	var merged datamodel.AKSKubeletConfiguration
+	err := json.Unmarshal([]byte(configFileStr), &merged)
+	if err != nil {
+		t.Fatalf("failed to parse generated kubelet config json: %v", err)
+	}
+
+	if merged.ImageGCHighThresholdPercent == nil || *merged.ImageGCHighThresholdPercent != 90 {
+		t.Fatalf("expected content value to win for imageGCHighThresholdPercent, got %v", merged.ImageGCHighThresholdPercent)
+	}
+	if merged.MaxPods != 110 {
+		t.Fatalf("expected missing content field maxPods to be backfilled from flags, got %v", merged.MaxPods)
+	}
+}
+
+// TestGetKubeletConfigFileContent_PrecedenceRules validates precedence between CustomKubeletConfig and KubeletConfig flags:
+//
+//	Priority 1 (highest): CustomKubeletConfig — user-specified values via AKS API
+//	Priority 2: KubeletConfig flags — RP-provided defaults, backfills fields not set by CustomKC
+func TestGetKubeletConfigFileContent_PrecedenceRules(t *testing.T) {
+	kc := map[string]string{
+		"--image-gc-high-threshold": "85",
+		"--image-gc-low-threshold":  "80",
+		"--max-pods":                "110",
+		"--event-qps":               "0",
+		"--cluster-dns":             "172.16.0.10",
+		"--eviction-hard":           "memory.available<750Mi,nodefs.available<10%,nodefs.inodesFree<5%",
+	}
+	customKc := &datamodel.CustomKubeletConfig{
+		ImageGcHighThreshold: to.Int32Ptr(90), // conflicts with flag value 85
+		ImageGcLowThreshold:  to.Int32Ptr(70), // conflicts with flag value 80
+		// maxPods, eventRecordQPS, clusterDNS, evictionHard NOT set — must come from flags
+	}
+
+	configFileStr := GetKubeletConfigFileContent(kc, customKc)
+
+	var merged datamodel.AKSKubeletConfiguration
+	err := json.Unmarshal([]byte(configFileStr), &merged)
+	if err != nil {
+		t.Fatalf("failed to parse generated kubelet config json: %v", err)
+	}
+
+	// Priority 1: CustomKC wins over flags when both set the same field.
+	if merged.ImageGCHighThresholdPercent == nil || *merged.ImageGCHighThresholdPercent != 90 {
+		t.Errorf("Priority 1 violated: expected imageGCHighThresholdPercent=90 (CustomKC), got %v", merged.ImageGCHighThresholdPercent)
+	}
+	if merged.ImageGCLowThresholdPercent == nil || *merged.ImageGCLowThresholdPercent != 70 {
+		t.Errorf("Priority 1 violated: expected imageGCLowThresholdPercent=70 (CustomKC), got %v", merged.ImageGCLowThresholdPercent)
+	}
+
+	// Priority 2: Flags backfill fields not set by CustomKC.
+	if merged.MaxPods != 110 {
+		t.Errorf("Priority 2 violated: expected maxPods=110 (from flags), got %v", merged.MaxPods)
+	}
+	if merged.EventRecordQPS == nil || *merged.EventRecordQPS != 0 {
+		t.Errorf("Priority 2 violated: expected eventRecordQPS=0 (from flags), got %v", merged.EventRecordQPS)
+	}
+	if len(merged.ClusterDNS) == 0 || merged.ClusterDNS[0] != "172.16.0.10" {
+		t.Errorf("Priority 2 violated: expected clusterDNS=[172.16.0.10] (from flags), got %v", merged.ClusterDNS)
+	}
+	if merged.EvictionHard == nil || merged.EvictionHard["memory.available"] != "750Mi" {
+		t.Errorf("Priority 2 violated: expected evictionHard to be backfilled from flags, got %v", merged.EvictionHard)
+	}
+}
+
 func getExampleKcWithNodeStatusReportFrequency() map[string]string {
 	kc := map[string]string{
 		"--address":                           "0.0.0.0",


### PR DESCRIPTION
## Summary

Document and test the existing kubelet config file generation precedence model in the legacy CSE path. Adds variable rename (kubeletConfig → flagConfig) for clarity, error handling for json.MarshalIndent, and unit tests explicitly validating the three-layer precedence: CustomKubeletConfig wins > flags backfill > v1beta1 defaults. No behavioral changes. Scriptless path flag→config file sync to follow in a separate PR.

### Why this matters

When kubelet config file mode is enabled, translated flags (e.g. `--max-pods`, `--cluster-dns`, `--event-qps`) are **removed from CLI** and only exist in the config file. The config file needs ~40 fields populated, but `CustomKubeletConfig` only covers ~12 user-configurable fields. The remaining ~28 fields must come from the RP-provided `KubeletConfig` flag map — otherwise kubelet falls back to v1beta1 defaults which are often not what AKS intends.

### Precedence model

```
┌─────────────────────────────────────────────────────────────────┐
│              kubelet config file generation                       │
│                                                                   │
│  Priority 1 (highest): CustomKubeletConfig                        │
│  ┌─────────────────────────────────────────────────────────┐      │
│  │ User-specified via AKS API (~12 fields)                 │      │
│  │ e.g. ImageGcHighThreshold=90, SeccompDefault=true       │      │
│  │                                                         │      │
│  │ → wins when both sources set the same field             │      │
│  └─────────────────────────────────────────────────────────┘      │
│                          │                                        │
│                          ▼                                        │
│  Priority 2: KubeletConfig flags                                  │
│  ┌─────────────────────────────────────────────────────────┐      │
│  │ RP-provided defaults from CLI flag map (~40 fields)     │      │
│  │ e.g. --max-pods=110, --cluster-dns=172.16.0.10          │      │
│  │                                                         │      │
│  │ → backfills the ~28 fields not set by CustomKubeletConfig│     │
│  └─────────────────────────────────────────────────────────┘      │
│                          │                                        │
│                          ▼                                        │
│  Priority 3 (lowest): kubelet v1beta1 defaults                    │
│  ┌─────────────────────────────────────────────────────────┐      │
│  │ Built-in kubelet defaults                               │      │
│  │ e.g. eventRecordQPS=5, imageGCHighThreshold=85          │      │
│  │                                                         │      │
│  │ → used when neither source sets the field               │      │
│  └─────────────────────────────────────────────────────────┘      │
└─────────────────────────────────────────────────────────────────┘
```

**Example:**

| Field | CustomKC | Flags | Config file gets |
|-------|----------|-------|-----------------|
| `imageGCHighThresholdPercent` | ✅ user set 90 | `--image-gc-high-threshold=85` | **90** (CustomKC wins) |
| `maxPods` | ❌ not set | `--max-pods=110` | **110** (backfilled from flags) |
| `clusterDNS` | ❌ not set | `--cluster-dns=172.16.0.10` | **["172.16.0.10"]** (backfilled) |
| `evictionHard` | ❌ not set | `--eviction-hard=memory.available<750Mi,...` | **{...}** (backfilled) |
| `eventRecordQPS` | ❌ not set | `--event-qps=0` | **0** (backfilled, not v1beta1 default of 5) |

This precedence is consistent with existing behavior — `setCustomKubeletConfig()` has always overwritten flag-derived values. The pre-existing test `TestGetKubeletConfigFileCustomKCShouldOverrideValuesPassedInKc` explicitly validates this.

### Flag classification: config file vs CLI-only

When config file mode is enabled, flags are split into two categories:

**Translated to config file** (`TranslatedKubeletConfigFlags`, 37 flags) — removed from CLI, written to `/etc/default/kubeletconfig.json`:

| Flag | Config file field |
|------|-------------------|
| `--address` | `address` |
| `--anonymous-auth` | `authentication.anonymous.enabled` |
| `--authentication-token-webhook` | `authentication.webhook.enabled` |
| `--authorization-mode` | `authorization.mode` |
| `--client-ca-file` | `authentication.x509.clientCAFile` |
| `--cgroups-per-qos` | `cgroupsPerQOS` |
| `--cluster-dns` | `clusterDNS` |
| `--cluster-domain` | `clusterDomain` |
| `--container-log-max-files` | `containerLogMaxFiles` |
| `--container-log-max-size` | `containerLogMaxSize` |
| `--cpu-cfs-quota` | `cpuCFSQuota` |
| `--cpu-cfs-quota-period` | `cpuCFSQuotaPeriod` |
| `--cpu-manager-policy` | `cpuManagerPolicy` |
| `--enforce-node-allocatable` | `enforceNodeAllocatable` |
| `--event-qps` | `eventRecordQPS` |
| `--eviction-hard` | `evictionHard` |
| `--eviction-max-pod-grace-period` | `evictionMaxPodGracePeriod` |
| `--eviction-soft` | `evictionSoft` |
| `--eviction-soft-grace-period` | `evictionSoftGracePeriod` |
| `--fail-swap-on` | `failSwapOn` |
| `--feature-gates` | `featureGates` |
| `--image-gc-high-threshold` | `imageGCHighThresholdPercent` |
| `--image-gc-low-threshold` | `imageGCLowThresholdPercent` |
| `--kube-reserved` | `kubeReserved` |
| `--kube-reserved-cgroup` | `kubeReservedCgroup` |
| `--max-pods` | `maxPods` |
| `--node-status-update-frequency` | `nodeStatusUpdateFrequency` |
| `--node-status-report-frequency` | `nodeStatusReportFrequency` (omitted from CLI) |
| `--pod-manifest-path` | `staticPodPath` |
| `--pod-max-pids` | `podPidsLimit` |
| `--protect-kernel-defaults` | `protectKernelDefaults` |
| `--read-only-port` | `readOnlyPort` |
| `--resolv-conf` | `resolvConf` |
| `--rotate-certificates` | `rotateCertificates` |
| `--rotate-server-certificates` | `serverTLSBootstrap` |
| `--serialize-image-pulls` | `serializeImagePulls` |
| `--streaming-connection-idle-timeout` | `streamingConnectionIdleTimeout` |
| `--system-reserved` | `systemReserved` |
| `--system-reserved-cgroup` | `systemReservedCgroup` |
| `--tls-cert-file` | `tlsCertFile` |
| `--tls-cipher-suites` | `tlsCipherSuites` |
| `--tls-private-key-file` | `tlsPrivateKeyFile` |
| `--topology-manager-policy` | `topologyManagerPolicy` |
| `--allowed-unsafe-sysctls` | `allowedUnsafeSysctls` |

**CLI-only** — no corresponding field in `KubeletConfiguration` schema, must stay on command line:

| Flag | Reason |
|------|--------|
| `--cloud-provider=external` | Deprecated/removed from KubeletConfiguration in K8s 1.29+ |
| `--kubeconfig` | Bootstrap prerequisite — kubelet needs this to connect to API server before it can read config |
| `--bootstrap-kubeconfig` | Same as above — TLS bootstrap path |
| `--node-ip` | Not a KubeletConfiguration field |
| `--container-runtime-endpoint` | Set via systemd drop-in, not in KubeletConfiguration |
| `--runtime-cgroups` | Set via systemd drop-in |
| `--runtime-request-timeout` | Set via systemd drop-in |
| `--cgroup-driver` | Set via systemd drop-in |
| `--volume-plugin-dir` | Set in kubelet.service unit |
| `--enable-server` | Set in kubelet.service unit |
| `--node-labels` | Set in kubelet.service unit from `KUBELET_NODE_LABELS` |
| `--v` (verbosity) | Set in kubelet.service unit |

### Changes
- **`pkg/agent/utils.go`**: Rename `kubeletConfig` → `flagConfig` to clarify its role in the three-way flow (flagConfig → setCustomKubeletConfig → output). Add error handling for `json.MarshalIndent`.
- **`pkg/agent/utils_test.go`**: Add `TestGetKubeletConfigFileContent_PrecedenceRules` and `TestGetKubeletConfigFileContent_MergesFlagsWithoutOverwritingContent` documenting the precedence model.

### Future work (follow-up PR)
- Scriptless path (aks-node-controller): flag→config file sync with conflict detection for all translated flags

---

## Test Plan

### Unit Tests

```bash
go test ./pkg/agent/ -run "KubeletConfigFile|OrderedKubeletConfigFlag" -v
```

All existing tests pass without modification, including:
- `TestGetKubeletConfigFileContent_PrecedenceRules` — validates three-layer precedence (CustomKC wins > flags backfill > v1beta1 defaults)
- `TestGetKubeletConfigFileContent_MergesFlagsWithoutOverwritingContent` — CustomKC value preserved, flags fill missing fields
- `TestGetKubeletConfigFileCustomKCShouldOverrideValuesPassedInKc` — pre-existing test confirming CustomKC overrides flags

### E2E Tests

| # | Scenario | Command | Purpose |
|---|----------|---------|---------|
| 1 | CSE path + CustomKubeletConfig | `go test -run '^Test_Ubuntu2204_KubeletCustomConfig/default$'` | **Validates the change**: config file has `"eventRecordQPS": 0` (backfilled from flags) and `"failSwapOn": true` (CustomKC); CLI flags only have `--cloud-provider`, `--kubeconfig`, `--node-ip` |
| 2 | No CustomKubeletConfig | `go test -run '^Test_Ubuntu2404Gen2/default$'` | **Regression**: without CustomKC the merge logic is not triggered; no config file exists, all ~30 flags remain on CLI |

### E2E Manual Verification (SSH into VM)

```bash
# Verify config file content (Test #1)
sudo cat /etc/default/kubeletconfig.json | python3 -m json.tool

# Verify CLI flags (should only have non-translated flags)
sudo cat /etc/default/kubelet

# Verify kubelet process args
ps aux | grep kubelet | grep -v grep | head -1
```

### Scope Note

No changes to `aks-node-controller/` in this PR. Scriptless path flag→config file sync will be addressed in a follow-up PR.