### PR TITLE
fix: configure renovate for ig-gadgets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -392,7 +392,8 @@
     },
     {
       "matchPackageNames": [
-        "ig"
+        "ig",
+        "ig-gadgets"
       ],
       "matchUpdateTypes": [
         "patch"
@@ -409,7 +410,8 @@
     },
     {
       "matchPackageNames": [
-        "ig"
+        "ig",
+        "ig-gadgets"
       ],
       "matchUpdateTypes": [
         "minor"
@@ -793,6 +795,17 @@
       "matchStringsStrategy": "any",
       "matchStrings": [
         "#\\s*renovate:\\s*(datasource=(?<datasource>.*?) )?depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s*.*?version.*\\\"(?<currentValue>.*)\\\""
+      ]
+    },
+    {
+      "customType": "regex",
+      "description": "auto update ig-gadgets versions in install-ig.sh from PMC",
+      "managerFilePatterns": [
+        "/install-ig\\.sh/"
+      ],
+      "matchStringsStrategy": "any",
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s*\\n[^\\n]*IG_GADGETS_[A-Z_]+_VERSION=\\\"(?<currentValue>[^\\\"]+)\\\""
       ]
     },
     {

--- a/spec/vhdbuilder/packer/install_ig_spec.sh
+++ b/spec/vhdbuilder/packer/install_ig_spec.sh
@@ -17,3 +17,56 @@ Describe 'ig_extract_upstream_version function'
     The stderr should include "[ig] Could not parse upstream version from 'not-a-version'"
   End
 End
+
+Describe 'ig-gadgets pinned versions'
+  Include './vhdbuilder/packer/install-ig.sh'
+
+  ig_component_upstream_versions() {
+    local current_version ig_versions
+
+    ig_versions="$(jq -r '
+      .Packages[]
+      | select(.name == "inspektor-gadget")
+      | .downloadURIs
+      | ..
+      | objects
+      | select((.renovateTag? // "") | test("(^|, )name=ig,"))
+      | .latestVersion
+    ' parts/common/components.json)" || return 1
+
+    while IFS= read -r current_version; do
+      ig_extract_upstream_version "${current_version}" || return 1
+    done <<EOF | sort -u
+${ig_versions}
+EOF
+  }
+
+  ig_assert_gadget_versions_match_components() {
+    local ig_upstream_versions gadget_upstream_versions all_upstream_versions version_count deb_upstream rpm_upstream
+
+    ig_upstream_versions="$(ig_component_upstream_versions)" || return 1
+    if [ -z "${ig_upstream_versions}" ]; then
+      echo "No inspektor-gadget component versions found" >&2
+      return 1
+    fi
+
+    deb_upstream="$(ig_extract_upstream_version "${IG_GADGETS_DEB_VERSION}")" || return 1
+    rpm_upstream="$(ig_extract_upstream_version "${IG_GADGETS_RPM_VERSION}")" || return 1
+    gadget_upstream_versions="$(printf '%s\n%s\n' "${deb_upstream}" "${rpm_upstream}" | sort -u)"
+
+    all_upstream_versions="$(printf '%s\n%s\n' "${ig_upstream_versions}" "${gadget_upstream_versions}" | sort -u)"
+    version_count="$(printf '%s\n' "${all_upstream_versions}" | wc -l | tr -d ' ')"
+    if [ "${version_count}" != "1" ]; then
+      echo "Expected ig and ig-gadgets to share one upstream version, found:" >&2
+      printf '%s\n' "${all_upstream_versions}" >&2
+      return 1
+    fi
+  }
+
+  It 'matches every ig upstream version in components.json'
+    When call ig_assert_gadget_versions_match_components
+    The status should be success
+    The output should eq ""
+    The stderr should eq ""
+  End
+End

--- a/vhdbuilder/packer/install-ig.sh
+++ b/vhdbuilder/packer/install-ig.sh
@@ -16,10 +16,11 @@ IG_SKIP_FILE="/etc/ig.d/skip_vhd_ig"
 # distro/package revisions can differ. The PMC feeds typically publish multiple
 # ig revisions per OS while ig-gadgets is published once per upstream release.
 # Example: ig 0.51.0-4.azl3 is compatible with ig-gadgets 0.51.0-1.azl3.
-# Since ig-gadgets is NOT in components.json (no Renovate coverage), its version
-# must still be updated manually here whenever ig moves to a new upstream
-# release. testInspektorGadgetAssets should catch any mismatch.
+# Since ig-gadgets has a different publishing pattern, keep it out of
+# components.json and let Renovate manage the pinned package versions here.
+# renovate: datasource=custom.deb2004 depName=ig-gadgets versioning=deb
 IG_GADGETS_DEB_VERSION="0.53.2-ubuntu20.04u1"
+# renovate: datasource=rpm depName=ig-gadgets registryUrl=https://packages.microsoft.com/azurelinux/3.0/prod/cloud-native/x86_64/repodata
 IG_GADGETS_RPM_VERSION="0.53.2-1.azl3"
 
 ig_detect_arch() {


### PR DESCRIPTION
**What this PR does / why we need it**:

ig and gadgets are two different things in pmc. originally we just had manual update for gadgets and renovate for ig. but the automated prs weren't following the ig / gadgets constraints. so we met sadness.

this attempts to align ig and gadgets in the automated prs

**Which issue(s) this PR fixes**:
Fixes #
