### PR TITLE
fix: harden Linux E2E scriptless hack and skip it in VHD-build pipelines

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -991,6 +991,8 @@ stages:
     variables:
       VHD_BUILD_ID: $(Build.BuildId)
       TAGS_TO_SKIP: "os=windows"
+      # VHD already contains the binary under test; skip the compile+download hack.
+      DISABLE_SCRIPTLESS_COMPILATION: true
     jobs:
       - template: ./templates/e2e-template.yaml
         parameters:

--- a/e2e/config/azure.go
+++ b/e2e/config/azure.go
@@ -372,8 +372,10 @@ func (a *AzureClient) UploadAndGetSignedLink(ctx context.Context, blobName strin
 		return "", fmt.Errorf("upload blob: %w", err)
 	}
 
+	// Link is cached and reused across the whole suite; 1h expired mid-run.
+	expiry := time.Now().Add(6 * time.Hour).UTC()
 	udc, err := a.Blob.ServiceClient().GetUserDelegationCredential(ctx, service.KeyInfo{
-		Expiry: to.Ptr(time.Now().Add(time.Hour).UTC().Format(sas.TimeFormat)),
+		Expiry: to.Ptr(expiry.Format(sas.TimeFormat)),
 		Start:  to.Ptr(time.Now().UTC().Format(sas.TimeFormat)),
 	}, nil)
 	if err != nil {
@@ -382,7 +384,7 @@ func (a *AzureClient) UploadAndGetSignedLink(ctx context.Context, blobName strin
 
 	sig, err := sas.BlobSignatureValues{
 		Protocol:      sas.ProtocolHTTPS,
-		ExpiryTime:    time.Now().Add(time.Hour).UTC(),
+		ExpiryTime:    expiry,
 		Permissions:   to.Ptr(sas.BlobPermissions{Read: true}).String(),
 		ContainerName: Config.BlobContainer,
 		BlobName:      blobName,

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -108,7 +108,7 @@ cat <<'SCRIPT' > /opt/azure/bin/run-aks-node-controller-hack.sh
 #!/bin/bash
 set -euo pipefail
 mkdir -p /opt/azure/bin
-curl -fSL --retry 10 --retry-delay 2 "%[3]s" -o /opt/azure/bin/aks-node-controller-hack
+curl -fSL --retry 10 --retry-delay 2 --retry-connrefused "%[3]s" -o /opt/azure/bin/aks-node-controller-hack
 chmod +x /opt/azure/bin/aks-node-controller-hack
 
 /opt/azure/bin/aks-node-controller-hack provision --provision-config=%[1]s
@@ -151,7 +151,7 @@ write_files:
     #!/bin/bash
     set -euo pipefail
     mkdir -p /opt/azure/bin
-    curl -fSL --retry 10 --retry-delay 2 "%[3]s" -o /opt/azure/bin/aks-node-controller-hack
+    curl -fSL --retry 10 --retry-delay 2 --retry-connrefused "%[3]s" -o /opt/azure/bin/aks-node-controller-hack
     chmod +x /opt/azure/bin/aks-node-controller-hack
     /opt/azure/bin/aks-node-controller-hack provision --provision-config=%[1]s
 # Flatcar specific configuration. It supports only a subset of cloud-init features https://github.com/flatcar/coreos-cloudinit/blob/main/Documentation/cloud-config.md#coreos-parameters
@@ -282,7 +282,7 @@ write_files:
     #!/bin/bash
     set -euo pipefail
     mkdir -p /opt/azure/bin
-    curl -fSL --retry 10 --retry-delay 2 "%[2]s" -o /opt/azure/bin/aks-node-controller-hack
+    curl -fSL --retry 10 --retry-delay 2 --retry-connrefused "%[2]s" -o /opt/azure/bin/aks-node-controller-hack
     chmod +x /opt/azure/bin/aks-node-controller-hack
     /opt/azure/bin/aks-node-controller-hack provision %[3]s
 coreos:
@@ -325,7 +325,7 @@ cat <<'SCRIPT' > /opt/azure/bin/run-aks-node-controller-hack.sh
 #!/bin/bash
 set -euo pipefail
 mkdir -p /opt/azure/bin
-curl -fSL --retry 10 --retry-delay 2 "%s" -o /opt/azure/bin/aks-node-controller-hack
+curl -fSL --retry 10 --retry-delay 2 --retry-connrefused "%s" -o /opt/azure/bin/aks-node-controller-hack
 chmod +x /opt/azure/bin/aks-node-controller-hack
 
 /opt/azure/bin/aks-node-controller-hack provision %s


### PR DESCRIPTION
**What this PR does / why we need it**:

The scriptless E2E "hack" compiles `aks-node-controller`, uploads it to blob storage, and `curl`s it onto the test node at provision time. It was failing in pipelines. Three fixes:

1. **Don't run the hack in pipelines that build the VHD.** The Linux PR/release and Windows VHD-build pipelines just built a VHD that already contains the exact binary under test — re-downloading a freshly-compiled copy over the node's outbound path was an unnecessary failure point. The Linux PR builder and Windows template already set `DISABLE_SCRIPTLESS_COMPILATION: true`; this adds it to the **release** Linux builder, which was the remaining gap. Standalone E2E pipelines (`e2e.yaml`, `e2e-gpu.yaml`, etc.) test *published* VHDs and intentionally keep the hack to exercise the PR's source.

2. **Bump the SAS link expiry 1h → 6h.** The signed download link is cached and reused across the whole suite; a 1-hour expiry lapsed mid-run on longer suites.

3. **Harden the curl download** with `--retry-connrefused`. Note: deliberately *not* using `--retry-all-errors` — it requires curl ≥7.71.0, but the Ubuntu 20.04 FIPS VHDs ship curl 7.68.0 (and run `scriptless_nbc` subtests via the hack), so that flag would hard-fail provisioning with "unknown option". `--retry-connrefused` (curl 7.52.0+) is safe on every target VHD.

All changes are confined to `e2e/` and pipeline YAML — no product provisioning scripts touched.

**Which issue(s) this PR fixes**:

Fixes #