### PR TITLE
fix(windows): write TLS bootstrap-config in NodePrep, not BasePrep

### DIFF
--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -390,7 +390,19 @@ func Test_Windows2025Gen2_VHDCaching(t *testing.T) {
 // to use the legacy bootstrap-token path. Catches regressions in the two-stage
 // CSE flow that only surface when no secure-tls-bootstrap client is around to
 // overwrite the temporary kubeconfig.
+//
+// It also positively guards the BasePrep->NodePrep kubeconfig fix: a stale
+// sentinel bootstrap token is baked during the pre-provision (BasePrep) stage,
+// while the real cluster token is used at provision time. If bootstrap-config
+// were written in BasePrep (the buggy behaviour), the cached VHD would carry the
+// stale token and the node would fail to register; because it is written in
+// NodePrep, the live token wins and the sentinel must never reach the node.
 func Test_Windows2022_VHDCaching_LegacyTLSBootstrap(t *testing.T) {
+	// Deliberately bogus but correctly-formatted ([a-z0-9]{6}.[a-z0-9]{16}) token.
+	// Baked into the VHD at BasePrep time only; must be overwritten by the live
+	// token in NodePrep. The bake stage is PreProvisionOnly (no kubelet start), so
+	// this bogus value never breaks stage 1.
+	const staleBakeTimeToken = "baketk.000000000000bake"
 	RunScenario(t, &Scenario{
 		Description: "VHD Caching with secure TLS bootstrap disabled",
 		Config: Config{
@@ -405,6 +417,17 @@ func Test_Windows2022_VHDCaching_LegacyTLSBootstrap(t *testing.T) {
 					nbc.SecureTLSBootstrappingConfig = &datamodel.SecureTLSBootstrappingConfig{}
 				}
 				nbc.SecureTLSBootstrappingConfig.Enabled = false
+			},
+			// Bake stage only: inject the stale sentinel token so the provision-stage
+			// validator can prove bootstrap-config is (re)written from the live token.
+			PreProvisionBootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.KubeletClientTLSBootstrapToken = to.Ptr(staleBakeTimeToken)
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				// The provisioned node must use the live token written in NodePrep,
+				// never the stale token baked during VHD creation.
+				ValidateFileHasContent(ctx, s, "C:\\k\\bootstrap-config", s.GetTLSBootstrapToken())
+				ValidateFileExcludesContent(ctx, s, "C:\\k\\bootstrap-config", staleBakeTimeToken)
 			},
 		},
 	})

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -147,11 +147,18 @@ func runScenarioWithPreProvision(t *testing.T, original *Scenario) {
 			vmss.Properties.VirtualMachineProfile.StorageProfile.OSDisk.DiffDiskSettings = nil
 		}
 	}
-	if original.BootstrapConfigMutator != nil {
+	if original.BootstrapConfigMutator != nil || original.PreProvisionBootstrapConfigMutator != nil {
 		firstStage.BootstrapConfigMutator = func(cluster *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-			original.BootstrapConfigMutator(cluster, nbc)
+			if original.BootstrapConfigMutator != nil {
+				original.BootstrapConfigMutator(cluster, nbc)
+			}
 			nbc.PreProvisionOnly = true
 			nbc.EnableScriptlessNBCCSECmd = false
+			// Bake-stage-only mutation: lets a scenario deliberately diverge bake-time
+			// state from provision-time state (e.g. a stale sentinel bootstrap token).
+			if original.PreProvisionBootstrapConfigMutator != nil {
+				original.PreProvisionBootstrapConfigMutator(cluster, nbc)
+			}
 		}
 	}
 	if original.AKSNodeConfigMutator != nil {

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -190,6 +190,13 @@ type Config struct {
 	// BootstrapConfigMutator is a function which mutates the base NodeBootstrappingConfig according to the scenario's requirements
 	BootstrapConfigMutator func(*Cluster, *datamodel.NodeBootstrappingConfiguration)
 
+	// PreProvisionBootstrapConfigMutator, when set, mutates the NodeBootstrappingConfig for the
+	// BAKE (pre-provision) stage ONLY of a VHDCaching/TestPreProvision two-stage run. It runs after
+	// BootstrapConfigMutator (and after PreProvisionOnly is set). Use it to deliberately make
+	// bake-time state differ from provision-time state - e.g. inject a sentinel TLS bootstrap token -
+	// so that staleness regressions in the BasePrep->NodePrep split are caught positively.
+	PreProvisionBootstrapConfigMutator func(*Cluster, *datamodel.NodeBootstrappingConfiguration)
+
 	// AKSNodeConfigMutator if defined then aks-node-controller will be used to provision nodes
 	AKSNodeConfigMutator func(*Cluster, *aksnodeconfigv1.Configuration)
 

--- a/parts/windows/kuberneteswindowssetup.ps1
+++ b/parts/windows/kuberneteswindowssetup.ps1
@@ -453,13 +453,6 @@ function BasePrep {
         New-CsiProxyService -CsiProxyPackageUrl $global:CsiProxyUrl -KubeDir $global:KubeDir
     }
 
-    if ($global:TLSBootstrapToken) {
-        Write-BootstrapKubeConfig -CACertificate $global:CACertificate `
-            -KubeDir $global:KubeDir `
-            -MasterFQDNPrefix $MasterFQDNPrefix `
-            -MasterIP $MasterIP `
-            -TLSBootstrapToken $global:TLSBootstrapToken
-    }
     if ($global:TLSBootstrapToken -or $global:EnableSecureTLSBootstrapping) {
         # NOTE: we need kubeconfig to setup calico even if vanilla/secure TLS bootstrapping is enabled
         # This kubeconfig will deleted after calico installation.
@@ -514,6 +507,20 @@ function BasePrep {
 # ====== NODE PREP: CLUSTER INTEGRATION ======
 # All operations that should only run when connecting to the actual cluster
 function NodePrep {
+    # Write the TLS bootstrap kubeconfig here (NodePrep), not in BasePrep. BasePrep
+    # is skipped on PIS/VHD-cached nodes (base_prep.complete marker), so writing
+    # bootstrap-config there would leave the stale bake-time token baked into the
+    # VHD. kubelet (installed/started by Install-KubernetesServices below) is the
+    # only consumer of bootstrap-config, so it must be written from the live
+    # $global:TLSBootstrapToken on every real provision, before kubelet starts.
+    if ($global:TLSBootstrapToken) {
+        Write-BootstrapKubeConfig -CACertificate $global:CACertificate `
+            -KubeDir $global:KubeDir `
+            -MasterFQDNPrefix $MasterFQDNPrefix `
+            -MasterIP $MasterIP `
+            -TLSBootstrapToken $global:TLSBootstrapToken
+    }
+
     Install-KubernetesServices -KubeDir $global:KubeDir
     Update-ServiceFailureActions
 

--- a/parts/windows/kuberneteswindowssetup.ps1
+++ b/parts/windows/kuberneteswindowssetup.ps1
@@ -492,19 +492,10 @@ function BasePrep {
 # ====== NODE PREP: CLUSTER INTEGRATION ======
 # All operations that should only run when connecting to the actual cluster
 function NodePrep {
-    # Write the cluster-specific kubeconfigs here (NodePrep), not in BasePrep.
-    # BasePrep is skipped on PIS/VHD-cached nodes (base_prep.complete marker), so
-    # anything cluster-specific written there is baked into the VHD with bake-time
-    # values and never refreshed on the real node. Both kubeconfigs are only ever
-    # consumed in NodePrep, so they must be (re)written here from the live values
-    # on every real provision, before their consumers run:
-    #   - bootstrap-config (token, $global:TLSBootstrapToken): consumed by kubelet,
-    #     installed/started by Install-KubernetesServices below. A stale baked token
-    #     makes the apiserver reject the kubelet CSR as Unauthorized.
-    #   - config (cert-based, from Write-KubeConfig): consumed by Calico's
-    #     GetCalicoKubeConfig (Start-InstallCalico) to reach the API server, and in
-    #     the legacy cert-auth mode it is kubelet's own kubeconfig. In either
-    #     bootstrapping mode it is temporary and removed after Calico installs.
+    # Write the kubeconfigs here, not in BasePrep: BasePrep is skipped on
+    # PIS/VHD-cached nodes, so anything written there is baked with stale
+    # bake-time values. Both are only consumed in NodePrep, so write them from
+    # live values on every provision before their consumers run below.
     if ($global:TLSBootstrapToken) {
         Write-BootstrapKubeConfig -CACertificate $global:CACertificate `
             -KubeDir $global:KubeDir `

--- a/parts/windows/kuberneteswindowssetup.ps1
+++ b/parts/windows/kuberneteswindowssetup.ps1
@@ -453,21 +453,6 @@ function BasePrep {
         New-CsiProxyService -CsiProxyPackageUrl $global:CsiProxyUrl -KubeDir $global:KubeDir
     }
 
-    if ($global:TLSBootstrapToken -or $global:EnableSecureTLSBootstrapping) {
-        # NOTE: we need kubeconfig to setup calico even if vanilla/secure TLS bootstrapping is enabled
-        # This kubeconfig will deleted after calico installation.
-        Write-Log "Write temporary kube config"
-    } else {
-        Write-Log "Write kube config"
-    }
-
-    Write-KubeConfig -CACertificate $global:CACertificate `
-        -KubeDir $global:KubeDir `
-        -MasterFQDNPrefix $MasterFQDNPrefix `
-        -MasterIP $MasterIP `
-        -AgentKey $AgentKey `
-        -AgentCertificate $global:AgentCertificate
-
     if ($global:EnableHostsConfigAgent) {
         New-HostsConfigService
     }
@@ -507,12 +492,19 @@ function BasePrep {
 # ====== NODE PREP: CLUSTER INTEGRATION ======
 # All operations that should only run when connecting to the actual cluster
 function NodePrep {
-    # Write the TLS bootstrap kubeconfig here (NodePrep), not in BasePrep. BasePrep
-    # is skipped on PIS/VHD-cached nodes (base_prep.complete marker), so writing
-    # bootstrap-config there would leave the stale bake-time token baked into the
-    # VHD. kubelet (installed/started by Install-KubernetesServices below) is the
-    # only consumer of bootstrap-config, so it must be written from the live
-    # $global:TLSBootstrapToken on every real provision, before kubelet starts.
+    # Write the cluster-specific kubeconfigs here (NodePrep), not in BasePrep.
+    # BasePrep is skipped on PIS/VHD-cached nodes (base_prep.complete marker), so
+    # anything cluster-specific written there is baked into the VHD with bake-time
+    # values and never refreshed on the real node. Both kubeconfigs are only ever
+    # consumed in NodePrep, so they must be (re)written here from the live values
+    # on every real provision, before their consumers run:
+    #   - bootstrap-config (token, $global:TLSBootstrapToken): consumed by kubelet,
+    #     installed/started by Install-KubernetesServices below. A stale baked token
+    #     makes the apiserver reject the kubelet CSR as Unauthorized.
+    #   - config (cert-based, from Write-KubeConfig): consumed by Calico's
+    #     GetCalicoKubeConfig (Start-InstallCalico) to reach the API server, and in
+    #     the legacy cert-auth mode it is kubelet's own kubeconfig. In either
+    #     bootstrapping mode it is temporary and removed after Calico installs.
     if ($global:TLSBootstrapToken) {
         Write-BootstrapKubeConfig -CACertificate $global:CACertificate `
             -KubeDir $global:KubeDir `
@@ -520,6 +512,21 @@ function NodePrep {
             -MasterIP $MasterIP `
             -TLSBootstrapToken $global:TLSBootstrapToken
     }
+
+    if ($global:TLSBootstrapToken -or $global:EnableSecureTLSBootstrapping) {
+        # NOTE: we need kubeconfig to setup calico even if vanilla/secure TLS bootstrapping is enabled
+        # This kubeconfig will deleted after calico installation.
+        Write-Log "Write temporary kube config"
+    } else {
+        Write-Log "Write kube config"
+    }
+
+    Write-KubeConfig -CACertificate $global:CACertificate `
+        -KubeDir $global:KubeDir `
+        -MasterFQDNPrefix $MasterFQDNPrefix `
+        -MasterIP $MasterIP `
+        -AgentKey $AgentKey `
+        -AgentCertificate $global:AgentCertificate
 
     Install-KubernetesServices -KubeDir $global:KubeDir
     Update-ServiceFailureActions

--- a/parts/windows/kuberneteswindowssetup.ps1
+++ b/parts/windows/kuberneteswindowssetup.ps1
@@ -373,12 +373,6 @@ function BasePrep {
     Get-ProvisioningScripts
     Get-LogCollectionScripts
 
-    # NOTE: this function MUST be called before Write-KubeClusterConfig since it has the potential
-    # to mutate both kubelet config args and kubelet node labels.
-    Configure-KubeletServingCertificateRotation
-
-    Write-KubeClusterConfig -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp
-
     # oras initialization, including install and login, must be in front of Install-CredentialProvider, Get-KubePackage and Install-Containerd-Based-On-Kubernetes-Version
     if ((Test-Path variable:global:BootstrapProfileContainerRegistryServer) -and
     -not [string]::IsNullOrWhiteSpace($global:BootstrapProfileContainerRegistryServer)) {
@@ -412,42 +406,6 @@ function BasePrep {
     Install-Containerd-Based-On-Kubernetes-Version -ContainerdUrl $global:ContainerdUrl -CNIBinDir $cniBinPath -CNIConfDir $cniConfigPath -KubeDir $global:KubeDir -KubernetesVersion $global:KubeBinariesVersion
 
     Retag-ImagesForAzureChinaCloud -TargetEnvironment $TargetEnvironment
-
-    # For AKSClustomCloud, TargetEnvironment must be set to AzureStackCloud
-    Write-AzureConfig `
-        -KubeDir $global:KubeDir `
-        -AADClientId $AADClientId `
-        -AADClientSecret $([System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($AADClientSecret))) `
-        -TenantId $global:TenantId `
-        -SubscriptionId $global:SubscriptionId `
-        -ResourceGroup $global:ResourceGroup `
-        -Location $Location `
-        -VmType $global:VmType `
-        -SubnetName $global:SubnetName `
-        -SecurityGroupName $global:SecurityGroupName `
-        -VNetName $global:VNetName `
-        -RouteTableName $global:RouteTableName `
-        -PrimaryAvailabilitySetName $global:PrimaryAvailabilitySetName `
-        -PrimaryScaleSetName $global:PrimaryScaleSetName `
-        -UseManagedIdentityExtension $global:UseManagedIdentityExtension `
-        -UserAssignedClientID $UserAssignedClientID `
-        -UseInstanceMetadata $global:UseInstanceMetadata `
-        -LoadBalancerSku $global:LoadBalancerSku `
-        -ExcludeMasterFromStandardLB $global:ExcludeMasterFromStandardLB `
-        -TargetEnvironment {{if IsAKSCustomCloud}}"AzureStackCloud"{{else}}$TargetEnvironment{{end}}
-
-    # we borrow the logic of AzureStackCloud to achieve AKSCustomCloud.
-    # In case of AKSCustomCloud, customer cloud env will be loaded from azurestackcloud.json
-    {{if IsAKSCustomCloud}}
-    $azureStackConfigFile = [io.path]::Combine($global:KubeDir, "azurestackcloud.json")
-    $envJSON = "{{ GetBase64EncodedEnvironmentJSON }}"
-    [io.file]::WriteAllBytes($azureStackConfigFile, [System.Convert]::FromBase64String($envJSON))
-
-    Get-CACertificates
-    {{end}}
-
-    Write-CACert -CACertificate $global:CACertificate `
-        -KubeDir $global:KubeDir
 
     if ($global:EnableCsiProxy) {
         New-CsiProxyService -CsiProxyPackageUrl $global:CsiProxyUrl -KubeDir $global:KubeDir
@@ -518,6 +476,48 @@ function NodePrep {
         -MasterIP $MasterIP `
         -AgentKey $AgentKey `
         -AgentCertificate $global:AgentCertificate
+
+    # Write cluster-specific configuration files from live CustomData.
+    # PIS images are reusable across clusters, so these files must not be baked
+    # into the VHD during BasePrep.
+    #
+    # NOTE: Configure-KubeletServingCertificateRotation MUST run before
+    # Write-KubeClusterConfig (it mutates kubelet config args and node labels).
+    Configure-KubeletServingCertificateRotation
+    Write-KubeClusterConfig -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp
+
+    Write-AzureConfig `
+        -KubeDir $global:KubeDir `
+        -AADClientId $AADClientId `
+        -AADClientSecret $([System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($AADClientSecret))) `
+        -TenantId $global:TenantId `
+        -SubscriptionId $global:SubscriptionId `
+        -ResourceGroup $global:ResourceGroup `
+        -Location $Location `
+        -VmType $global:VmType `
+        -SubnetName $global:SubnetName `
+        -SecurityGroupName $global:SecurityGroupName `
+        -VNetName $global:VNetName `
+        -RouteTableName $global:RouteTableName `
+        -PrimaryAvailabilitySetName $global:PrimaryAvailabilitySetName `
+        -PrimaryScaleSetName $global:PrimaryScaleSetName `
+        -UseManagedIdentityExtension $global:UseManagedIdentityExtension `
+        -UserAssignedClientID $UserAssignedClientID `
+        -UseInstanceMetadata $global:UseInstanceMetadata `
+        -LoadBalancerSku $global:LoadBalancerSku `
+        -ExcludeMasterFromStandardLB $global:ExcludeMasterFromStandardLB `
+        -TargetEnvironment {{if IsAKSCustomCloud}}"AzureStackCloud"{{else}}$TargetEnvironment{{end}}
+
+    {{if IsAKSCustomCloud}}
+    $azureStackConfigFile = [io.path]::Combine($global:KubeDir, "azurestackcloud.json")
+    $envJSON = "{{ GetBase64EncodedEnvironmentJSON }}"
+    [io.file]::WriteAllBytes($azureStackConfigFile, [System.Convert]::FromBase64String($envJSON))
+
+    Get-CACertificates
+    {{end}}
+
+    Write-CACert -CACertificate $global:CACertificate `
+        -KubeDir $global:KubeDir
 
     Install-KubernetesServices -KubeDir $global:KubeDir
     Update-ServiceFailureActions

--- a/parts/windows/kuberneteswindowssetup.ps1
+++ b/parts/windows/kuberneteswindowssetup.ps1
@@ -506,7 +506,7 @@ function NodePrep {
 
     if ($global:TLSBootstrapToken -or $global:EnableSecureTLSBootstrapping) {
         # NOTE: we need kubeconfig to setup calico even if vanilla/secure TLS bootstrapping is enabled
-        # This kubeconfig will deleted after calico installation.
+        # This kubeconfig will be deleted after calico installation.
         Write-Log "Write temporary kube config"
     } else {
         Write-Log "Write kube config"

--- a/parts/windows/kuberneteswindowssetup.ps1
+++ b/parts/windows/kuberneteswindowssetup.ps1
@@ -373,6 +373,14 @@ function BasePrep {
     Get-ProvisioningScripts
     Get-LogCollectionScripts
 
+    # kubeclusterconfig.json must exist before Install-Containerd-Based-On-Kubernetes-Version
+    # runs below: the CSE scripts package cached on the VHD (e.g. v0.0.52) reads the pause image
+    # from this file while configuring containerd during BasePrep. The cluster-specific values
+    # written here are only placeholders for the bake/non-cached containerd read - NodePrep
+    # rewrites this file from live CustomData on every provision (including PIS/VHD-cached nodes
+    # where BasePrep is skipped), so the runtime always sees fresh values.
+    Write-KubeClusterConfig -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp
+
     # oras initialization, including install and login, must be in front of Install-CredentialProvider, Get-KubePackage and Install-Containerd-Based-On-Kubernetes-Version
     if ((Test-Path variable:global:BootstrapProfileContainerRegistryServer) -and
     -not [string]::IsNullOrWhiteSpace($global:BootstrapProfileContainerRegistryServer)) {
@@ -483,6 +491,10 @@ function NodePrep {
     #
     # NOTE: Configure-KubeletServingCertificateRotation MUST run before
     # Write-KubeClusterConfig (it mutates kubelet config args and node labels).
+    # Write-KubeClusterConfig also runs in BasePrep (the cached CSE scripts read
+    # the pause image from it while configuring containerd); we rewrite it here so
+    # cluster-specific values are refreshed on every provision, including
+    # PIS/VHD-cached nodes where BasePrep is skipped.
     Configure-KubeletServingCertificateRotation
     Write-KubeClusterConfig -MasterIP $MasterIP -KubeDnsServiceIp $KubeDnsServiceIp
 


### PR DESCRIPTION
Work item: AB#38630884

## Summary

Fixes [AB#38630884](https://dev.azure.com/msazure/CloudNativeCompute/_workitems/edit/38630884): PIS / VHD-caching Windows nodes fail to register with `cannot create certificate signing request: Unauthorized`.

## Root cause

On PIS/VHD-cached clusters the Windows VHD is baked from a temporary VMSS with TLS bootstrapping enabled. During the bake, `BasePrep` writes `c:\k\bootstrap-config` with the **bake-time** TLS bootstrap token and drops a `C:\AzureData\base_prep.complete` marker — both captured into the cached VHD.

On the real node the CSE **skips `BasePrep`** because that marker exists, so `bootstrap-config` keeps the stale baked token instead of the fresh `$global:TLSBootstrapToken` delivered via CustomData. The apiserver then rejects the kubelet's first CSR as `Unauthorized`.

The bootstrap-config write was simply left in `BasePrep` when the script was split into `BasePrep`/`NodePrep` (commit `63b9d9b9`, #6601).

## Fix

Move `Write-BootstrapKubeConfig` from `BasePrep` into `NodePrep`, before `Install-KubernetesServices`. kubelet (installed/started by `Install-KubernetesServices`) is the only consumer of `bootstrap-config`, so writing it in `NodePrep` guarantees the **live** token is used on every real provision.

- **No VHD rebake required** — the Windows CSE script is rendered fresh into CustomData by the RP on every provision; only the on-disk `bootstrap-config` file is baked. The corrected `NodePrep` write takes effect on new nodes from existing cached VHDs.
- **A move (not keep-and-refresh) is correct** — `BasePrep` never starts kubelet nor connects to the API server, so nothing there consumes the token-based `bootstrap-config`. Calico in `BasePrep` uses the separate **cert-based** `config` from `Write-KubeConfig`, which is unchanged.

## Validation

- `go test ./pkg/agent/...` passes; `make generate-testdata` produced no snapshot drift.
- Suggested manual validation (from the work item):
  - Provision a Windows node from a PIS cached VHD; confirm `c:\k\bootstrap-config` token == `$global:TLSBootstrapToken` and the node reaches Ready.
  - Rotate the agent pool TLS bootstrap token, provision again from the same cached VHD, and confirm the node still joins.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>

