### PR TITLE
feat(gpu): enable CUDA driver prebake on shared Ubuntu gen2 VHD builds

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -612,7 +612,8 @@ stages:
               echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
               echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ds_v5'
               # NVIDIA_CUDA_PREBAKE bakes the CUDA driver kernel module into this shared x86 gen2 image so GPU
-              # nodes skip the ~80-150s DKMS compile at boot; non-GPU nodes tear it down during provisioning.
+              # nodes can later skip the ~80-150s in-CSE DKMS compile via the configGPUDrivers skip-build path
+              # (PR #8787); non-GPU and --gpu-driver None nodes tear the module down during provisioning.
               echo '##vso[task.setvariable variable=FEATURE_FLAGS]NVIDIA_CUDA_PREBAKE'
               echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
               echo '##vso[task.setvariable variable=ENABLE_FIPS]False'
@@ -686,7 +687,8 @@ stages:
               echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
               echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ds_v5'
               # NVIDIA_CUDA_PREBAKE bakes the CUDA driver kernel module into this shared x86 gen2 image so GPU
-              # nodes skip the ~80-150s DKMS compile at boot; non-GPU nodes tear it down during provisioning.
+              # nodes can later skip the ~80-150s in-CSE DKMS compile via the configGPUDrivers skip-build path
+              # (PR #8787); non-GPU and --gpu-driver None nodes tear the module down during provisioning.
               echo '##vso[task.setvariable variable=FEATURE_FLAGS]NVIDIA_CUDA_PREBAKE'
               echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
               echo '##vso[task.setvariable variable=ENABLE_FIPS]False'

--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -611,7 +611,9 @@ stages:
               echo '##vso[task.setvariable variable=IMG_VERSION]latest'
               echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
               echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ds_v5'
-              echo '##vso[task.setvariable variable=FEATURE_FLAGS]None'
+              # NVIDIA_CUDA_PREBAKE bakes the CUDA driver kernel module into this shared x86 gen2 image so GPU
+              # nodes skip the ~80-150s DKMS compile at boot; non-GPU nodes tear it down during provisioning.
+              echo '##vso[task.setvariable variable=FEATURE_FLAGS]NVIDIA_CUDA_PREBAKE'
               echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
               echo '##vso[task.setvariable variable=ENABLE_FIPS]False'
               echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]False'
@@ -683,7 +685,9 @@ stages:
               echo '##vso[task.setvariable variable=IMG_VERSION]latest'
               echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
               echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ds_v5'
-              echo '##vso[task.setvariable variable=FEATURE_FLAGS]None'
+              # NVIDIA_CUDA_PREBAKE bakes the CUDA driver kernel module into this shared x86 gen2 image so GPU
+              # nodes skip the ~80-150s DKMS compile at boot; non-GPU nodes tear it down during provisioning.
+              echo '##vso[task.setvariable variable=FEATURE_FLAGS]NVIDIA_CUDA_PREBAKE'
               echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
               echo '##vso[task.setvariable variable=ENABLE_FIPS]False'
               echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]False'

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -84,7 +84,8 @@ stages:
             echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
             echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ds_v5'
             # NVIDIA_CUDA_PREBAKE bakes the CUDA driver kernel module into this shared x86 gen2 image so GPU
-            # nodes skip the ~80-150s DKMS compile at boot; non-GPU nodes tear it down during provisioning.
+            # nodes can later skip the ~80-150s in-CSE DKMS compile via the configGPUDrivers skip-build path
+            # (PR #8787); non-GPU and --gpu-driver None nodes tear the module down during provisioning.
             echo '##vso[task.setvariable variable=FEATURE_FLAGS]NVIDIA_CUDA_PREBAKE'
             echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
             echo '##vso[task.setvariable variable=ENABLE_FIPS]False'
@@ -107,7 +108,8 @@ stages:
             echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
             echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ds_v5'
             # NVIDIA_CUDA_PREBAKE bakes the CUDA driver kernel module into this shared x86 gen2 image so GPU
-            # nodes skip the ~80-150s DKMS compile at boot; non-GPU nodes tear it down during provisioning.
+            # nodes can later skip the ~80-150s in-CSE DKMS compile via the configGPUDrivers skip-build path
+            # (PR #8787); non-GPU and --gpu-driver None nodes tear the module down during provisioning.
             echo '##vso[task.setvariable variable=FEATURE_FLAGS]NVIDIA_CUDA_PREBAKE'
             echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
             echo '##vso[task.setvariable variable=ENABLE_FIPS]false'

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -83,7 +83,9 @@ stages:
             echo '##vso[task.setvariable variable=IMG_VERSION]latest'
             echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
             echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ds_v5'
-            echo '##vso[task.setvariable variable=FEATURE_FLAGS]None'
+            # NVIDIA_CUDA_PREBAKE bakes the CUDA driver kernel module into this shared x86 gen2 image so GPU
+            # nodes skip the ~80-150s DKMS compile at boot; non-GPU nodes tear it down during provisioning.
+            echo '##vso[task.setvariable variable=FEATURE_FLAGS]NVIDIA_CUDA_PREBAKE'
             echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
             echo '##vso[task.setvariable variable=ENABLE_FIPS]False'
             echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]False'
@@ -104,7 +106,9 @@ stages:
             echo '##vso[task.setvariable variable=IMG_VERSION]latest'
             echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
             echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ds_v5'
-            echo '##vso[task.setvariable variable=FEATURE_FLAGS]None'
+            # NVIDIA_CUDA_PREBAKE bakes the CUDA driver kernel module into this shared x86 gen2 image so GPU
+            # nodes skip the ~80-150s DKMS compile at boot; non-GPU nodes tear it down during provisioning.
+            echo '##vso[task.setvariable variable=FEATURE_FLAGS]NVIDIA_CUDA_PREBAKE'
             echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
             echo '##vso[task.setvariable variable=ENABLE_FIPS]false'
             echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]False'

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -353,7 +353,7 @@ steps:
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
   - task: CopyFiles@2
-    condition: and(eq(variables.OS_SKU, 'Ubuntu'), in(variables.OS_VERSION, '22.04', '24.04'), in(variables.FEATURE_FLAGS, 'None', 'cvm', 'NVIDIA_GB'))
+    condition: and(eq(variables.OS_SKU, 'Ubuntu'), in(variables.OS_VERSION, '22.04', '24.04'), in(variables.FEATURE_FLAGS, 'None', 'cvm', 'NVIDIA_GB', 'NVIDIA_CUDA_PREBAKE'))
     displayName: Copy CIS Reports
     inputs:
       SourceFolder: '$(System.DefaultWorkingDirectory)'


### PR DESCRIPTION
**What this PR does / why we need it**:

Activates the NVIDIA CUDA driver **prebake** that was merged _dark_ in #8786. It flips `FEATURE_FLAGS` from `None` to `NVIDIA_CUDA_PREBAKE` on the two shared x86 **gen2** Ubuntu images that GPU CUDA nodes boot, in **both** VHD pipelines:

| Job | Release pipeline | PR/test pipeline |
|---|:---:|:---:|
| `build2204gen2containerd` | ✅ | ✅ |
| `build2404gen2containerd` | ✅ | ✅ |

With the flag set, `install-dependencies.sh` pre-builds the NVIDIA CUDA kernel module into the VHD at build time, so GPU nodes can skip the ~80–150s DKMS compile at boot.

**Why only these images**

The supported CUDA GPU SKUs (A10/A100/H100) boot the gen2 22.04/24.04 Ubuntu images — confirmed by the e2e GPU scenarios, which pin `VHDUbuntu2204Gen2Containerd` / `VHDUbuntu2404Gen2Containerd`. AzureLinux GPU is out of scope (the bake lives in the Ubuntu path); gen1 / FIPS / TL / arm64 are not used by these SKUs, so enabling there would only add build time + teardown surface for no GPU benefit.

**Safety**

- **Coupled teardown ships it safe.** The bake lands on a _shared_ image, but non-GPU and `--gpu-driver None` nodes remove the module during provisioning via `cleanUpPrebakedGPUDriver` (merged in #8786, runs unconditionally). No extra attack surface on those nodes.
- **No flag collisions.** Every other `FEATURE_FLAGS` consumer is an additive substring `grep` (`cvm`/`NVIDIA_GB`/`kata`) that `NVIDIA_CUDA_PREBAKE` doesn't match; there's no `case`/allowlist that rejects unknown values; `SKU_NAME` is unaffected so the published image keeps its name.
- **CIS reports preserved.** The one exact-match gate (`Copy CIS Reports`, `in(FEATURE_FLAGS, …)`) is extended to include `NVIDIA_CUDA_PREBAKE`.

**Rollout / sequencing**

- Depends on #8786 (merged ✅).
- The **consume** half (#8787, boot-time skip-build) is still open. Until it lands, GPU nodes carry the prebaked module but still recompile at boot (marker ignored) — i.e. this PR is **inert-but-safe**: teardown is active now, and the `AKS_GPU_PREBAKE event=managed_gpu marker_present=…` readiness logs let us confirm Stage-2 readiness before enabling consume.
- This is a node-image change; it activates on the next VHD build and rolls via node-image SDP. Revert = flip the flag back to `None`.

**Validation**

- All three pipeline YAMLs parse clean; only the 4 intended jobs (2 per pipeline) carry the new flag.
- The bake itself was already proven end-to-end on a `2404gen2containerd` build (production base image), which produced `/opt/azure/aks-gpu/dkms-marker`. The PR/test pipeline here will exercise it again through the GPU e2e scenarios.

**Which issue(s) this PR fixes**:

Fixes #

**Requirements**

- [x] PR title follows conventional commits
- [x] Commit is DCO signed-off and GPG-verified
- [x] Branch lives in `Azure/AgentBaker` (not a fork)
