### PR TITLE
docs: add PIS basePrep/nodePrep review guidance to Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,8 @@ Windows VHD is configured through [VHD](./vhdbuilder/packer/windows/windows-vhd-
 
 windows generates its CSE package using [script](./parts/windows/kuberneteswindowssetup.ps1).
 
+Both CSE scripts run in two phases — Windows `BasePrep`/`NodePrep` (`kuberneteswindowssetup.ps1`) and Linux `basePrep`/`nodePrep` (`cse_main.sh`). `basePrep` is gated only by the `base_prep.complete` marker, so it is **skipped on a PIS-cached VHD** (the marker is baked in); `nodePrep` runs whenever `PreProvisionOnly` is false — every real node. So node-specific, secret, or expiring data (e.g. the TLS bootstrap token / kubeconfig) must be written in `nodePrep`, not `basePrep`, or the baked copy goes stale. On PIS the phases are separate VM runs — variables re-initialize from the real node's live CustomData, so `nodePrep` can't rely on `basePrep` state. (Non-PIS: both run sequentially in one execution, no reboot between phases.)
+
 The webserver is also used to determine the latest version of Linux VHDs available for provisioning within AKS clusters.
 
 ## Code Structure
@@ -142,7 +144,21 @@ Analyze PRs for these compatibility scenarios:
   - Missing feature detection to determine which mode is running
   - Hardcoded paths that differ between deployment modes
 
-**4. Cross-OS Compatibility**
+**4. PIS / VHD Caching — basePrep vs nodePrep split (Windows + Linux)**
+- **Context**: PIS bakes a VHD from a temporary VM, then boots many real nodes from it. Same model in Windows `parts/windows/kuberneteswindowssetup.ps1` (`BasePrep`/`NodePrep`) and Linux `parts/linux/cloud-init/artifacts/cse_main.sh` (`basePrep`/`nodePrep`):
+  - `basePrep` — gated only by the `base_prep.complete` marker (`C:\AzureData\` Windows, `/opt/azure/containers/` Linux). **Skipped on PIS real nodes** because the marker is baked into the VHD.
+  - `nodePrep` — runs whenever `PreProvisionOnly` is false (every real node); skipped only on the bake VM.
+  - The bake run sets `PreProvisionOnly=true` (`{{GetPreProvisionOnly}}`) and writes the marker after `basePrep` succeeds (Windows `finally`; Linux `cse_start.sh`).
+  - On PIS, basePrep and nodePrep are separate VM runs: variables re-initialize from the real node's live CustomData, so `basePrep` in-memory state is gone. (Non-PIS: both run in one execution, no reboot between phases, so state carries — but don't rely on it.)
+- **Breaking signals**:
+  - Perishable data written in `basePrep`: TLS bootstrap tokens, any kubeconfig embedding a token (e.g. Windows `Write-BootstrapKubeConfig` → `c:\k\bootstrap-config`), secrets, expiring SAS URLs/creds, per-node identity/name/certs. Baked into the VHD and never refreshed (real nodes skip `basePrep`) → stale. Write it in `nodePrep`.
+  - `nodePrep` reading a variable that only `basePrep` set (not re-derived from CustomData) — empty on PIS nodes.
+  - A service/scheduled task enabled in `basePrep` that auto-starts on the real node before `nodePrep` refreshes its config — it runs against the stale baked config (e.g. a kubelet unit starting from the bake-time `bootstrap-config` before `nodePrep` rewrites the token).
+  - Heavy node-agnostic work (package/binary downloads, image pulls) moved into `nodePrep` — defeats caching, slows provisioning. Keep it in `basePrep`.
+- **Rule**: `basePrep` = static, non-secret, valid for every node booting weeks later. `nodePrep` = node-specific, secret, expiring, or CustomData-derived.
+- **Don't flag**: plain variable reads (live on the real node from CustomData); cached binaries/packages/images; the `base_prep.complete` marker; cluster-wide non-secrets (CA cert, apiserver FQDN, service CIDR); pre-existing `basePrep` writes unless the PR newly depends on them.
+
+**5. Cross-OS Compatibility**
 - **What to check**: Changes work on Ubuntu, Azure Linux/Mariner, and Windows
 - **Breaking signals**:
   - Linux commands that don't work on both Ubuntu and Azure Linux/Mariner
@@ -150,7 +166,7 @@ Analyze PRs for these compatibility scenarios:
   - Package manager assumptions (apt vs dnf/tdnf)
   - Systemd differences between distributions
 
-**5. Package/Dependency Update PRs (Renovate)**
+**6. Package/Dependency Update PRs (Renovate)**
 - **Context**: Renovate bot automatically creates PRs to update component versions in `parts/common/components.json`. These components are cached on VHDs during build and directly affect node stability, GPU workloads, networking, and security. Updated packages are downloaded from `packages.aks.azure.com` or upstream registries during VHD build.
 - **What to check**: Every version bump—even patch versions—can introduce regressions that affect production nodes.
 - **`renovate.json` syntax guardrails**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ Windows VHD is configured through [VHD](./vhdbuilder/packer/windows/windows-vhd-
 
 windows generates its CSE package using [script](./parts/windows/kuberneteswindowssetup.ps1).
 
+Both CSE scripts run in two phases — Windows `BasePrep`/`NodePrep` (`kuberneteswindowssetup.ps1`) and Linux `basePrep`/`nodePrep` (`cse_main.sh`). `basePrep` is gated only by the `base_prep.complete` marker, so it is **skipped on a PIS-cached VHD** (the marker is baked in); `nodePrep` runs whenever `PreProvisionOnly` is false — every real node. So node-specific, secret, or expiring data (e.g. the TLS bootstrap token / kubeconfig) must be written in `nodePrep`, not `basePrep`, or the baked copy goes stale. On PIS the phases are separate VM runs — variables re-initialize from the real node's live CustomData, so `nodePrep` can't rely on `basePrep` state. (Non-PIS: both run sequentially in one execution, no reboot between phases.)
+
 The webserver is also used to determine the latest version of Linux VHDs available for provisioning within AKS clusters.
 
 ## Code Structure
@@ -133,7 +135,21 @@ Analyze PRs for these compatibility scenarios:
   - Missing feature detection to determine which mode is running
   - Hardcoded paths that differ between deployment modes
 
-**4. Cross-OS Compatibility**
+**4. PIS / VHD Caching — basePrep vs nodePrep split (Windows + Linux)**
+- **Context**: PIS bakes a VHD from a temporary VM, then boots many real nodes from it. Same model in Windows `parts/windows/kuberneteswindowssetup.ps1` (`BasePrep`/`NodePrep`) and Linux `parts/linux/cloud-init/artifacts/cse_main.sh` (`basePrep`/`nodePrep`):
+  - `basePrep` — gated only by the `base_prep.complete` marker (`C:\AzureData\` Windows, `/opt/azure/containers/` Linux). **Skipped on PIS real nodes** because the marker is baked into the VHD.
+  - `nodePrep` — runs whenever `PreProvisionOnly` is false (every real node); skipped only on the bake VM.
+  - The bake run sets `PreProvisionOnly=true` (`{{GetPreProvisionOnly}}`) and writes the marker after `basePrep` succeeds (Windows `finally`; Linux `cse_start.sh`).
+  - On PIS, basePrep and nodePrep are separate VM runs: variables re-initialize from the real node's live CustomData, so `basePrep` in-memory state is gone. (Non-PIS: both run in one execution, no reboot between phases, so state carries — but don't rely on it.)
+- **Breaking signals**:
+  - Perishable data written in `basePrep`: TLS bootstrap tokens, any kubeconfig embedding a token (e.g. Windows `Write-BootstrapKubeConfig` → `c:\k\bootstrap-config`), secrets, expiring SAS URLs/creds, per-node identity/name/certs. Baked into the VHD and never refreshed (real nodes skip `basePrep`) → stale. Write it in `nodePrep`.
+  - `nodePrep` reading a variable that only `basePrep` set (not re-derived from CustomData) — empty on PIS nodes.
+  - A service/scheduled task enabled in `basePrep` that auto-starts on the real node before `nodePrep` refreshes its config — it runs against the stale baked config (e.g. a kubelet unit starting from the bake-time `bootstrap-config` before `nodePrep` rewrites the token).
+  - Heavy node-agnostic work (package/binary downloads, image pulls) moved into `nodePrep` — defeats caching, slows provisioning. Keep it in `basePrep`.
+- **Rule**: `basePrep` = static, non-secret, valid for every node booting weeks later. `nodePrep` = node-specific, secret, expiring, or CustomData-derived.
+- **Don't flag**: plain variable reads (live on the real node from CustomData); cached binaries/packages/images; the `base_prep.complete` marker; cluster-wide non-secrets (CA cert, apiserver FQDN, service CIDR); pre-existing `basePrep` writes unless the PR newly depends on them.
+
+**5. Cross-OS Compatibility**
 - **What to check**: Changes work on Ubuntu, Azure Linux/Mariner, and Windows
 - **Breaking signals**:
   - Linux commands that don't work on both Ubuntu and Azure Linux/Mariner
@@ -141,7 +157,7 @@ Analyze PRs for these compatibility scenarios:
   - Package manager assumptions (apt vs dnf/tdnf)
   - Systemd differences between distributions
 
-**5. Package/Dependency Update PRs (Renovate)**
+**6. Package/Dependency Update PRs (Renovate)**
 - **Context**: Renovate bot automatically creates PRs to update component versions in `parts/common/components.json`. These components are cached on VHDs during build and directly affect node stability, GPU workloads, networking, and security. Updated packages are downloaded from `packages.aks.azure.com` or upstream registries during VHD build.
 - **What to check**: Every version bump—even patch versions—can introduce regressions that affect production nodes.
 - **Analysis steps for every package update PR**:


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Copilot review guidance so the PIS basePrep/nodePrep class of bug is caught at review time (and known as general context), instead of reaching production.

Background: PIS ("VHD caching") bakes a VHD from a temporary VM that runs `basePrep` only, then boots many real nodes that run `nodePrep` only — `basePrep` is skipped on real nodes because the `base_prep.complete` marker is baked into the VHD. Anything node-specific, secret, or expiring written in `basePrep` therefore goes **stale**. This is the failure mode behind the Cosmic Windows nodes that could not register (`Unauthorized`): `c:\k\bootstrap-config` kept the bake-time TLS bootstrap token because `Write-BootstrapKubeConfig` runs in `BasePrep`, which the real node skips.

Changes (docs only, mirrored across both files):
- **Architecture note** in the AgentBaker Service section — general context on the two-phase Windows `BasePrep`/`NodePrep` + Linux `basePrep`/`nodePrep` split and the PIS staleness trap.
- **New breaking-change review scenario #4** — "PIS / VHD Caching — basePrep vs nodePrep split (Windows + Linux)" with concrete breaking signals, a rule of thumb, and explicit "don't flag" false-positive guards. Renumbered the following scenarios (Cross-OS → 5, Renovate → 6).

Scope notes:
- **No code / bug-fix changes.** This PR only updates `AGENTS.md` and `.github/copilot-instructions.md` (identical inserted content). The actual `parts/windows/kuberneteswindowssetup.ps1` fix is tracked separately (ADO 38630884).
- All factual claims were verified against the Windows and Linux CSE scripts (function gating, marker write location, `{{GetPreProvisionOnly}}` → `config.PreProvisionOnly`).

**Which issue(s) this PR fixes**:

Related: ADO 38630884 (fix tracked separately). No GitHub issue.