### PR TITLE
feat(gpu): bump aks-gpu-cuda to 595.71.05 (build-only-capable; prereq for CUDA prebake)

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -739,7 +739,7 @@
       "downloadURL": "mcr.microsoft.com/aks/aks-gpu-cuda:*",
       "gpuVersion": {
         "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-cuda",
-        "latestVersion": "580.126.09-20260126030251"
+        "latestVersion": "595.71.05-20260623180420"
       }
     },
     {


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the cached CUDA driver image **`aks-gpu-cuda`** in `parts/common/components.json`:

```
580.126.09-20260126030251  (Jan 2026)  →  595.71.05-20260623180420  (Jun 2026)
```

This is the **prerequisite** that unblocks the CUDA driver **prebake** (bake merged in #8786, flag enabled in #8803). The prebake runs the aks-gpu container with `/entrypoint.sh build-only`, an action added in **aks-gpu #162 (merged June 2026)**. I verified against MCR that **no `580.126.09` image supports `build-only`** (newest 580 build is `2026-04-30`, pre-#162) — only the `595.71.05` family (May–June builds) does. Without this bump the prebake fails at VHD build:

```
/opt/actions/install.sh: line 4: /opt/gpu/config.sh: No such file or directory  → exit 1
```
(observed in PR-gate build `170469320` for #8803). `595.71.05-20260623180420` is the exact image validated green in the prebake GPU e2e.

Only `aks-gpu-cuda` is bumped; `aks-gpu-grid` / `aks-gpu-grid-v20` are not baked by the enablement (#8803) and are left unchanged.

---

## 🔴 BLOCKER — this drops V100 / Volta support (why it's a draft)

**Version change**: `aks-gpu-cuda` 580.126.09 → 595.71.05 (major driver-branch bump)
**OS variants affected**: Ubuntu 22.04 / 24.04 gen2 x86 (shared image used by all CUDA GPU SKUs)

| Change | Description | Risk |
|--------|-------------|------|
| Breaking | NVIDIA **R590/R595 branches no longer load on Tesla V100 (Volta/GV100)**; R580 is the last branch supporting it ([NVIDIA fora](https://forums.developer.nvidia.com/t/latest-v100-driver/357228), [590 deprecation](https://windowsforum.com/threads/nvidia-ends-feature-support-for-maxwell-pascal-and-volta-gpus-with-590-driver.395102/)) | 🔴 High |
| Feature | Adds `build-only` entrypoint (aks-gpu #162) → enables VHD-time DKMS prebake | 🟢 Low |
| Feature | Newer CUDA driver for Ampere/Hopper/Ada/Blackwell | 🟡 Medium |

**AgentBaker e2e still actively tests V100** via `Standard_NC6s_v3`:
`Test_Ubuntu2204_GPUNC`, `Test_ACL_GPUNC`, `Test_Ubuntu2204_GPUNoDriver(_Scriptless)`, `Test_AzureLinuxV3_GPU`. This bump will **break those scenarios** and any **NC-v3 / V100 customer nodes** on the shared image.

This is almost certainly *why* `components.json` has been held at 580.126.09 despite 595.71.05 being available since May.

### Do NOT merge until one of these is resolved
1. **V100 / NC-v3 EOL sign-off** — confirm Volta is out of support on the affected node images (then drop/skip the GPUNC e2e), **or**
2. **aks-gpu backports `build-only` to a V100-capable `580.x` image** — keeps V100 and enables prebake (no driver-branch jump), **or**
3. **Split the CUDA driver** — V100 stays on 580.x (fallback compile, no prebake) while newer GPUs get 595.71.05 prebaked (needs driver-selection logic; larger change).

### Overall Risk: 🔴 High
**Justification**: Major GPU driver-branch bump on the shared image that removes support for a still-tested, still-shipping GPU architecture (V100/NC-v3).
**Recommendation**: Hold as draft pending the V100 disposition above. Sequenced before #8803.

**Which issue(s) this PR fixes**: Fixes #

**Requirements**
- [x] Conventional-commit title · DCO signed-off · GPG-verified · branch on `Azure/AgentBaker`
- [x] `make generate-testdata` clean (GPU image version isn't snapshotted); `make validate-components` passes
