### PR TITLE
test(gpu): switch CUDA GPU e2e SKU from NC6s_v3 (V100) to NC4as_T4_v3 in westus2

### DIFF
--- a/e2e/scenario_gpu_managed_experience_test.go
+++ b/e2e/scenario_gpu_managed_experience_test.go
@@ -462,6 +462,7 @@ func Test_Ubuntu2204_NvidiaDevicePluginRunning(t *testing.T) {
 func Test_AzureLinux3_NvidiaDevicePluginRunning(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that NVIDIA device plugin and DCGM Exporter are running & functional on Azure Linux v3 GPU nodes",
+		Location:    "westus2",
 		Tags: Tags{
 			GPU: true,
 		},
@@ -469,14 +470,14 @@ func Test_AzureLinux3_NvidiaDevicePluginRunning(t *testing.T) {
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2,
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.AgentPoolProfile.VMSize = "Standard_NC6s_v3"
+				nbc.AgentPoolProfile.VMSize = "Standard_NC4as_T4_v3"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = true
 				nbc.EnableNvidia = true
 				nbc.ManagedGPUExperienceAFECEnabled = true
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
-				vmss.SKU.Name = to.Ptr("Standard_NC6s_v3")
+				vmss.SKU.Name = to.Ptr("Standard_NC4as_T4_v3")
 				if vmss.Tags == nil {
 					vmss.Tags = map[string]*string{}
 				}

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -405,7 +405,7 @@ func Test_ACL_DisableSSH(t *testing.T) {
 }
 
 func Test_ACL_GPUNC(t *testing.T) {
-	runScenarioACLGPU(t, "Standard_NC6s_v3", config.Config.DefaultLocation)
+	runScenarioACLGPU(t, "Standard_NC4as_T4_v3", "westus2")
 }
 
 func Test_ACL_GPUA100(t *testing.T) {
@@ -1658,7 +1658,7 @@ func Test_Ubuntu2204_CustomSysctls(t *testing.T) {
 }
 
 func Test_Ubuntu2204_GPUNC(t *testing.T) {
-	runScenarioUbuntu2204GPU(t, "Standard_NC6s_v3", config.Config.DefaultLocation)
+	runScenarioUbuntu2204GPU(t, "Standard_NC4as_T4_v3", "westus2")
 }
 
 func Test_Ubuntu2204_GPUA100(t *testing.T) {
@@ -1795,6 +1795,7 @@ func Test_Ubuntu2204_GPUGridDriver(t *testing.T) {
 func Test_Ubuntu2204_GPUNoDriver(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a GPU-enabled node using the Ubuntu 2204 VHD opting for skipping gpu driver installation can be properly bootstrapped",
+		Location:    "westus2",
 		Tags: Tags{
 			GPU: true,
 		},
@@ -1802,7 +1803,7 @@ func Test_Ubuntu2204_GPUNoDriver(t *testing.T) {
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.AgentPoolProfile.VMSize = "Standard_NC6s_v3"
+				nbc.AgentPoolProfile.VMSize = "Standard_NC4as_T4_v3"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
 				nbc.EnableNvidia = true
@@ -1812,7 +1813,7 @@ func Test_Ubuntu2204_GPUNoDriver(t *testing.T) {
 					// deliberately case mismatched to agentbaker logic to check case insensitivity
 					"SkipGPUDriverInstall": to.Ptr("true"),
 				}
-				vmss.SKU.Name = to.Ptr("Standard_NC6s_v3")
+				vmss.SKU.Name = to.Ptr("Standard_NC4as_T4_v3")
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateNvidiaSMINotInstalled(ctx, s)
@@ -1824,6 +1825,7 @@ func Test_Ubuntu2204_GPUNoDriver(t *testing.T) {
 func Test_Ubuntu2204_GPUNoDriver_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a GPU-enabled node using the Ubuntu 2204 VHD opting for skipping gpu driver installation can be properly bootstrapped",
+		Location:    "westus2",
 		Tags: Tags{
 			GPU: true,
 		},
@@ -1831,13 +1833,13 @@ func Test_Ubuntu2204_GPUNoDriver_Scriptless(t *testing.T) {
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.AgentPoolProfile.VMSize = "Standard_NC6s_v3"
+				nbc.AgentPoolProfile.VMSize = "Standard_NC4as_T4_v3"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
 				nbc.EnableNvidia = true
 			},
 			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
-				config.VmSize = "Standard_NC6s_v3"
+				config.VmSize = "Standard_NC4as_T4_v3"
 				config.GpuConfig.ConfigGpuDriver = true
 				config.GpuConfig.GpuDevicePlugin = false
 				config.GpuConfig.EnableNvidia = to.Ptr(true)
@@ -1848,7 +1850,7 @@ func Test_Ubuntu2204_GPUNoDriver_Scriptless(t *testing.T) {
 					// deliberately case mismatched to agentbaker logic to check case insensitivity
 					"SkipGPUDriverInstall": to.Ptr("true"),
 				}
-				vmss.SKU.Name = to.Ptr("Standard_NC6s_v3")
+				vmss.SKU.Name = to.Ptr("Standard_NC4as_T4_v3")
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateNvidiaSMINotInstalled(ctx, s)
@@ -2244,6 +2246,7 @@ func Test_AzureLinuxV3_KubeletCustomConfig(t *testing.T) {
 func Test_AzureLinuxV3_GPU(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a GPU-enabled node using a AzureLinuxV3 (CgroupV2) VHD can be properly bootstrapped",
+		Location:    "westus2",
 		Tags: Tags{
 			GPU: true,
 		},
@@ -2252,13 +2255,13 @@ func Test_AzureLinuxV3_GPU(t *testing.T) {
 			VHD:               config.VHDAzureLinuxV3Gen2,
 			SkipScriptlessNBC: true,
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.AgentPoolProfile.VMSize = "Standard_NC6s_v3"
+				nbc.AgentPoolProfile.VMSize = "Standard_NC4as_T4_v3"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
 				nbc.EnableNvidia = true
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
-				vmss.SKU.Name = to.Ptr("Standard_NC6s_v3")
+				vmss.SKU.Name = to.Ptr("Standard_NC4as_T4_v3")
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 			},
@@ -2302,6 +2305,7 @@ func Test_AzureLinuxV3_GPUA10(t *testing.T) {
 func Test_AzureLinuxV3_GPUAzureCNI(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "AzureLinux V3 (CgroupV2) gpu scenario on cluster configured with Azure CNI",
+		Location:    "westus2",
 		Tags: Tags{
 			GPU: true,
 		},
@@ -2311,13 +2315,13 @@ func Test_AzureLinuxV3_GPUAzureCNI(t *testing.T) {
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
 				nbc.AgentPoolProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
-				nbc.AgentPoolProfile.VMSize = "Standard_NC6s_v3"
+				nbc.AgentPoolProfile.VMSize = "Standard_NC4as_T4_v3"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
 				nbc.EnableNvidia = true
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
-				vmss.SKU.Name = to.Ptr("Standard_NC6s_v3")
+				vmss.SKU.Name = to.Ptr("Standard_NC4as_T4_v3")
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 			},
@@ -2328,6 +2332,7 @@ func Test_AzureLinuxV3_GPUAzureCNI(t *testing.T) {
 func Test_AzureLinuxV3_GPUAzureCNI_Scriptless(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "AzureLinux V3 (CgroupV2) gpu scenario on cluster configured with Azure CNI",
+		Location:    "westus2",
 		Tags: Tags{
 			GPU: true,
 		},
@@ -2337,20 +2342,20 @@ func Test_AzureLinuxV3_GPUAzureCNI_Scriptless(t *testing.T) {
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				nbc.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
 				nbc.AgentPoolProfile.KubernetesConfig.NetworkPlugin = string(armcontainerservice.NetworkPluginAzure)
-				nbc.AgentPoolProfile.VMSize = "Standard_NC6s_v3"
+				nbc.AgentPoolProfile.VMSize = "Standard_NC4as_T4_v3"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
 				nbc.EnableNvidia = true
 			},
 			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
 				config.NetworkConfig.NetworkPlugin = aksnodeconfigv1.NetworkPlugin_NETWORK_PLUGIN_AZURE
-				config.VmSize = "Standard_NC6s_v3"
+				config.VmSize = "Standard_NC4as_T4_v3"
 				config.GpuConfig.ConfigGpuDriver = true
 				config.GpuConfig.GpuDevicePlugin = false
 				config.GpuConfig.EnableNvidia = to.Ptr(true)
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
-				vmss.SKU.Name = to.Ptr("Standard_NC6s_v3")
+				vmss.SKU.Name = to.Ptr("Standard_NC4as_T4_v3")
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 			},
@@ -2514,6 +2519,7 @@ func Test_Ubuntu2404_SecureTLSBootstrapping_BootstrapToken_Fallback(t *testing.T
 func Test_Ubuntu2404Gen2_GPUNoDriver(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a GPU-enabled node using the Ubuntu 2404 VHD opting for skipping gpu driver installation can be properly bootstrapped",
+		Location:    "westus2",
 		Tags: Tags{
 			GPU: true,
 		},
@@ -2521,7 +2527,7 @@ func Test_Ubuntu2404Gen2_GPUNoDriver(t *testing.T) {
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2404Gen2Containerd,
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.AgentPoolProfile.VMSize = "Standard_NC6s_v3"
+				nbc.AgentPoolProfile.VMSize = "Standard_NC4as_T4_v3"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
 				nbc.EnableNvidia = true
@@ -2531,7 +2537,7 @@ func Test_Ubuntu2404Gen2_GPUNoDriver(t *testing.T) {
 					// deliberately case mismatched to agentbaker logic to check case insensitivity
 					"SkipGPUDriverInstall": to.Ptr("true"),
 				}
-				vmss.SKU.Name = to.Ptr("Standard_NC6s_v3")
+				vmss.SKU.Name = to.Ptr("Standard_NC4as_T4_v3")
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				containerdVersions := components.GetExpectedPackageVersions("containerd", "ubuntu", "r2404")


### PR DESCRIPTION
## What

Switches the CUDA GPU e2e scenarios from `Standard_NC6s_v3` (V100) to **`Standard_NC4as_T4_v3`** (T4), pinned to **`westus2`**.

Affected scenarios (all previously failing at VMSS creation): `Test_ACL_GPUNC`, `Test_Ubuntu2204_GPUNC`, `Test_Ubuntu2204_GPUNoDriver`(+`_Scriptless`), `Test_AzureLinuxV3_GPU`, `Test_AzureLinuxV3_GPUAzureCNI`(+`_Scriptless`), `Test_Ubuntu2404Gen2_GPUNoDriver`, `Test_AzureLinux3_NvidiaDevicePluginRunning`.

## Why

`Standard_NC6s_v3` (V100 / NCSv3) is **not offered** in the default e2e region (`westus3`) — V100 hardware is retired from newer regions. Every CUDA GPU scenario using it fails at VMSS creation with:

```
InvalidParameter: The requested VM size Standard_NC6s_v3 is not available in the current region.
```

This was the dominant failure bucket (~13 of the GPU E2E failures) and it reproduces on `main`, not just in one PR.

## Why T4 / westus2

Verified against the e2e subscription (`az vm list-skus` / `list-usage`):

| SKU | westus3 (default) | westus2 (chosen) | eastus |
|-----|-------------------|------------------|--------|
| T4 `NC4as_T4_v3`  | ❌ NotAvailableForSubscription | ✅ offered, quota 300 / 0 used | ❌ restricted |
| V100 `NC6s_v3`    | ❌ not offered | ❌ not offered | ❌ restricted |

- **westus2** already hosts the A100 GPU tests, and T4 is a **separate quota family** (no contention with A100).
- T4 keeps the **identical driver path** as V100: both are legacy GPUs that take the proprietary-CUDA branch in `should_use_nvidia_open_drivers()` and resolve to the `cuda-lts` (R580 LTS) image — so GPU driver + device-plugin coverage is unchanged, only the region-capacity flake is removed.

## Testing

- `go build ./...` and `go vet` pass for the `e2e` module.
- Change is e2e-only (test SKU + `Location`); no provisioning/runtime code touched.