### PR TITLE
fix: fail vhd build due to platform mismatch during container caching

### DIFF
--- a/image-fetcher/main.go
+++ b/image-fetcher/main.go
@@ -9,6 +9,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/platforms"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 const (
@@ -86,12 +87,15 @@ func fetchImage(ctx context.Context, client *containerd.Client, ref string) erro
 		return fmt.Errorf("fetch failed: %w", err)
 	}
 
+	image := containerd.NewImageWithPlatform(client, imageMeta, platformMatcher)
+	if err := validateImagePlatform(ctx, image, p); err != nil {
+		return err
+	}
+
 	if fetchOnly {
 		fmt.Printf("OK    %s -> %s (fetched)\n", imageMeta.Name, imageMeta.Target.Digest)
 		return nil
 	}
-
-	image := containerd.NewImage(client, imageMeta)
 
 	size, err := image.Size(ctx)
 	if err != nil {
@@ -112,6 +116,20 @@ func fetchImage(ctx context.Context, client *containerd.Client, ref string) erro
 		fmt.Printf("OK    %s -> %s (pulled, %s)\n", imageMeta.Name, imageMeta.Target.Digest, formatSize(size))
 	} else {
 		fmt.Printf("OK    %s -> %s (fetched, %s)\n", imageMeta.Name, imageMeta.Target.Digest, formatSize(size))
+	}
+
+	return nil
+}
+
+func validateImagePlatform(ctx context.Context, image containerd.Image, expected ocispec.Platform) error {
+	spec, err := image.Spec(ctx)
+	if err != nil {
+		return fmt.Errorf("read image config: %w", err)
+	}
+
+	actual := spec.Platform
+	if !platforms.OnlyStrict(expected).Match(actual) {
+		return fmt.Errorf("image platform mismatch: selected manifest for %s, but image config is %s", platforms.Format(expected), platforms.Format(actual))
 	}
 
 	return nil

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -880,7 +880,16 @@ while IFS= read -r imageToBePulled; do
   done
 done <<< "$ContainerImages"
 echo "Waiting for container image pulls to finish. PID: ${image_pids[@]}"
-wait ${image_pids[@]}
+while [ "$(jobs -p | wc -l)" -gt 0 ]; do
+  wait -n || {
+    ret=$?
+    echo "A background job pullContainerImage failed: ${ret}. Exiting..." >&2
+    for pid in "${image_pids[@]}"; do
+      kill -9 "$pid" 2>/dev/null || echo "Failed to kill process $pid"
+    done
+    exit "${ret}"
+  }
+done
 capture_benchmark "${SCRIPT_NAME}_caching_container_images"
 
 retagAKSNodeCAWatcher() {


### PR DESCRIPTION
fail vhd build if there is a platform mismatch.

Found the likely difference: the 1.17 arm64 manifest points to an image config that says  linux/amd64 .

For failing  cilium:v1.17.10-260319 :

index manifest: sha256:bcd0... platform linux/arm64
config:         sha256:a9d7... platform linux/amd64
layers:         9

For working  cilium-distroless:v1.18.9-260508 :

index manifest: sha256:05a3... platform linux/arm64
config:         sha256:e4fc... platform linux/arm64
layers:         27

This explains the containerd-version behavior:

• containerd 2.1 CRI fallback uses  i.Unpack(ctx, snapshotter) , which selects the arm64 manifest from the index and unpacks it even if the config platform says amd64.
• containerd 2.2 CRI fallback changed to the new  core/unpack  path. That path reads the image config platform and only unpacks if config platform matches host. For this 1.17 image on arm64, config says  amd64 , so it skips actual unpack/falls into fetch-only behavior, returns no error, then retry hits missing parent snapshot again.

That also matches our logs:  error_unpacking_count=0 ,  image_unpacked_count=0 ,  prepare_extraction_count=0 ; containerd never actually attempted layer extraction for 1.17 on arm64.

The image config is a JSON blob inside an OCI/Docker image manifest. It describes the image’s runtime metadata and root filesystem metadata:  os ,  architecture , env vars, entrypoint/cmd, user, history, and the uncompressed layer diff IDs.

For a multi-arch image:

1. The index/manifest list says: “for  linux/arm64 , use manifest digest X.”
2. That platform manifest points to:
• one config blob
• N compressed layer blobs
3. The config blob should also say the same platform, e.g.  os=linux ,  architecture=arm64 .

In this bad image, the outer index correctly says the selected manifest is  linux/arm64 , but the config inside that arm64 manifest says  architecture=amd64 . Containerd 2.2’s new unpack path appears to trust/check the config platform, decides it doesn’t match the arm64 node, and doesn’t unpack the layers. Then CreateContainer still tries to use the expected arm64 snapshot chain and fails because it was never created.