### PR TITLE
feat(gpu): remove dead NCv1/K80 R470 driver support

### DIFF
--- a/parts/linux/cloud-init/artifacts/acl/cse_install_acl.sh
+++ b/parts/linux/cloud-init/artifacts/acl/cse_install_acl.sh
@@ -175,8 +175,9 @@ installGPUDriverSysext() {
     #
     # NVIDIA_GPU_DRIVER_TYPE is set by AgentBaker based on the GPU SKU maps in
     # gpu_components.go. Converged sizes get "grid"; RTX PRO 6000 BSE v6 gets
-    # "grid-v20" (Ubuntu-only, rejected below); modern CUDA SKUs get "cuda-lts" and legacy
-    # NCv1 gets "cuda". Only grid vs non-grid matters here, so both take the CUDA path below.
+    # "grid-v20" (Ubuntu-only, rejected below); all other CUDA SKUs (including legacy
+    # NCv1/K80) get "cuda-lts". Only grid vs non-grid matters here, so the CUDA path
+    # below handles every non-grid SKU.
     # Legacy GPUs (T4, V100) require proprietary CUDA drivers; A100+ use NVIDIA open drivers.
     local vm_sku
     vm_sku=$(get_compute_sku)

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -115,8 +115,9 @@ downloadGPUDrivers() {
     #
     # NVIDIA_GPU_DRIVER_TYPE is set by AgentBaker based on the GPU SKU maps in
     # gpu_components.go. Converged sizes get "grid"; RTX PRO 6000 BSE v6 gets
-    # "grid-v20" (Ubuntu-only, rejected below); modern CUDA SKUs get "cuda-lts" and legacy
-    # NCv1 gets "cuda". Only grid vs non-grid matters here, so both take the CUDA path below.
+    # "grid-v20" (Ubuntu-only, rejected below); all other CUDA SKUs (including legacy
+    # NCv1/K80) get "cuda-lts". Only grid vs non-grid matters here, so the CUDA path
+    # below handles every non-grid SKU.
     # Legacy GPUs (T4, V100) require proprietary CUDA drivers; A100+ use NVIDIA open drivers.
     KERNEL_VERSION=$(uname -r | sed 's/-/./g')
     VM_SKU=$(get_compute_sku)

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -1494,15 +1494,7 @@ func GetGPUDriverVersion(size string) string {
 	if useGridDrivers(size) {
 		return datamodel.NvidiaGridDriverVersion
 	}
-	if isStandardNCv1(size) {
-		return datamodel.Nvidia470CudaDriverVersion
-	}
 	return datamodel.NvidiaCudaDriverVersion
-}
-
-func isStandardNCv1(size string) bool {
-	tmp := strings.ToLower(size)
-	return strings.HasPrefix(tmp, "standard_nc") && !strings.Contains(tmp, "_v")
 }
 
 func useGridDrivers(size string) bool {
@@ -1527,19 +1519,21 @@ func GetAKSGPUImageSHA(size string) string {
 
 // GetGPUDriverType maps a GPU VM size to the aks-gpu image variant used to install its driver.
 // The value becomes NVIDIA_GPU_DRIVER_TYPE at provision time, which selects the container image
-// mcr.microsoft.com/aks/aks-gpu-<type>. Modern CUDA compute SKUs (T4, V100, A100, H100, H200, ...)
+// mcr.microsoft.com/aks/aks-gpu-<type>. All CUDA compute SKUs (T4, V100, A100, H100, H200, ...)
 // use the R580 LTS image (aks-gpu-cuda-lts): it retains Volta/V100 support that the newer aks-gpu-cuda
 // R595 line drops, is supported through Aug 2028, and is the branch the VHD driver prebake is built
-// against. Legacy NCv1 (K80) keeps the separate "cuda" path with its pinned R470 driver.
+// against.
+//
+// Legacy NCv1 (K80, Kepler) is intentionally NOT special-cased. NVIDIA R470 was the last branch to
+// support Kepler data-center GPUs, and AKS never published an aks-gpu-cuda R470 image (that tag always
+// 404'd), so no managed driver can actually run a K80. NCv1 therefore falls through to the default
+// cuda-lts path like any other compute SKU. The hardware is EOL and effectively unused on AKS.
 func GetGPUDriverType(size string) string {
 	if useGridV20Drivers(size) {
 		return "grid-v20"
 	}
 	if useGridDrivers(size) {
 		return "grid"
-	}
-	if isStandardNCv1(size) {
-		return "cuda"
 	}
 	return "cuda-lts"
 }

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -939,8 +939,11 @@ var _ = Describe("Test normalizeResourceGroupNameForLabel", func() {
 })
 
 var _ = Describe("GetGPUDriverVersion", func() {
-	It("should use 470 with nc v1", func() {
-		Expect(GetGPUDriverVersion("standard_nc6")).To(Equal(datamodel.Nvidia470CudaDriverVersion))
+	// NCv1 (K80, Kepler) is EOL: R470 was the last branch to support it and AKS never published an
+	// R470 image, so it is no longer special-cased and falls through to the default CUDA (cuda-lts)
+	// version like any other compute SKU.
+	It("should fall through to cuda-lts version for legacy nc v1 (K80)", func() {
+		Expect(GetGPUDriverVersion("standard_nc6")).To(Equal(datamodel.NvidiaCudaDriverVersion))
 	})
 	It("should use cuda with nc v3", func() {
 		Expect(GetGPUDriverVersion("standard_nc6_v3")).To(Equal(datamodel.NvidiaCudaDriverVersion))
@@ -967,8 +970,9 @@ var _ = Describe("GetGPUDriverType", func() {
 	It("should use cuda-lts with nc v3", func() {
 		Expect(GetGPUDriverType("standard_nc6_v3")).To(Equal("cuda-lts"))
 	})
-	It("should keep cuda (legacy R470) with nc v1 (K80)", func() {
-		Expect(GetGPUDriverType("standard_nc6")).To(Equal("cuda"))
+	// NCv1 (K80, Kepler) is EOL and no longer special-cased; it falls through to cuda-lts.
+	It("should fall through to cuda-lts for legacy nc v1 (K80)", func() {
+		Expect(GetGPUDriverType("standard_nc6")).To(Equal("cuda-lts"))
 	})
 	It("should use grid with nv v5", func() {
 		Expect(GetGPUDriverType("standard_nv6ads_a10_v5")).To(Equal("grid"))

--- a/pkg/agent/datamodel/gpu_components.go
+++ b/pkg/agent/datamodel/gpu_components.go
@@ -8,8 +8,6 @@ import (
 	"github.com/Azure/agentbaker/parts"
 )
 
-const Nvidia470CudaDriverVersion = "cuda-470.82.01"
-
 //nolint:gochecknoglobals
 var (
 	NvidiaCudaDriverVersion    string


### PR DESCRIPTION
## What

Removes the special-casing that mapped legacy **NCv1 (K80, Kepler)** SKUs to the `aks-gpu-cuda` **R470** driver (`cuda-470.82.01`). NCv1 now falls through to the default **`cuda-lts`** (R580 LTS) path like every other compute GPU SKU.

- Drop the `Nvidia470CudaDriverVersion` constant (`pkg/agent/datamodel/gpu_components.go`)
- Drop the `isStandardNCv1` helper and its branches in `GetGPUDriverType` / `GetGPUDriverVersion` (`pkg/agent/baker.go`)
- Refresh the `GetGPUDriverType` doc comment and the ACL / Mariner `cse_install` comments to match
- Update the `GetGPUDriverType` / `GetGPUDriverVersion` tests to assert the `cuda-lts` fall-through

## Why

The NCv1 → R470 path has never worked and cannot be made to work:

1. **No image exists.** AKS has never published an `aks-gpu-cuda` R470 image. `mcr.microsoft.com/aks/aks-gpu-cuda:cuda-470.82.01-<suffix>` **404s for every suffix** (verified for the pre-existing suffix, the current suffix, the bare `cuda-470.82.01`, and `470.82.01`). The repo only carries 550.x-595.x tags (0 of 74 contain `470`). So the managed driver install for K80 has always failed on this path.
2. **No forward-compatible driver.** Per NVIDIA, **R470 is the last branch to support Kepler data-center GPUs**; R525+ (including R580) dropped Kepler. There is no newer managed driver that can drive a K80.
3. **EOL & effectively unused.** Only a handful of legacy NCv1 nodes remain, all on very old Kubernetes versions and predating the current container-driver scheme; no new NCv1 node provisions a managed driver successfully today.

The constant, helper, and comments describing a "pinned R470 driver" were therefore dead code / misleading documentation.

## Behavior change (intentional)

| | Before | After |
|---|---|---|
| NCv1 (`standard_nc6/nc12/nc24[r]` + `_promo`) | `aks-gpu-cuda:cuda-470.82.01-*` -> **404**, CSE fails | falls through to `aks-gpu-cuda-lts:580.159.04-*` -> pulls & installs **R580** |

R580 cannot drive a K80 either, so **neither state yields a working K80** - this is not a regression in capability. It trades a hard 404 for the same default path all other CUDA SKUs take, and removes the fiction that AKS ships an R470 driver. All working SKUs (T4, V100, A100, H100, H200, GRID, GRID-v20) are **unaffected**.

## Testing

- `go build ./pkg/agent/...` + `aks-node-controller` (reuses `agent.GetGPUDriverType/Version` via `replace => ../`) - OK
- `go vet ./pkg/agent/` - OK
- `GENERATE_TEST_DATA=true go test ./pkg/agent/...` - **pass, zero golden drift** (no testdata renders an NCv1 SKU)
- Focused `GetGPUDriver*` Ginkgo specs - pass
- `shellcheck` on the two edited shell files - clean on changed lines (only pre-existing warnings elsewhere)
- No remaining `Nvidia470CudaDriverVersion` / `isStandardNCv1` references in the tree

## Risk

Low. Contained to AgentBaker (no RP consumers of these functions). Only NCv1/K80 behavior changes, and that SKU has no working managed driver in either state.