### PR TITLE
test(e2e): poll ARM every 15s (not 1s) to stop VMSS-list throttling

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -29,8 +29,13 @@ var (
 	Azure          = mustNewAzureClient()
 	VMIdentityName = "abe2e-vm-identity"
 
+	// Poll long-running ARM operations every 15s rather than every 1s. The E2E suite runs
+	// with -parallel 60, so a 1s cadence across dozens of concurrent VMSS create/delete
+	// operations floods ARM and triggers ResourceCollectionRequestsThrottled (429), which
+	// stalls provisioning past TestTimeoutVMSS and surfaces as "context deadline exceeded".
+	// These operations take minutes, so 15s polling is ample and cuts ARM request volume ~15x.
 	DefaultPollUntilDoneOptions = &runtime.PollUntilDoneOptions{
-		Frequency: time.Second,
+		Frequency: 15 * time.Second,
 	}
 	VMSSHPublicKey, VMSSHPrivateKey, SysSSHPublicKey, SysSSHPrivateKey []byte
 	VMSSHPrivateKeyFileName, SysSSHPrivateKeyFileName                  string
@@ -57,7 +62,7 @@ type Configuration struct {
 	BlobStorageAccountPrefix               string        `env:"BLOB_STORAGE_ACCOUNT_PREFIX" envDefault:"abe2e"`
 	BuildID                                string        `env:"BUILD_ID" envDefault:"local"`
 	DefaultLocation                        string        `env:"E2E_LOCATION" envDefault:"westus3"`
-	DefaultPollInterval                    time.Duration `env:"DEFAULT_POLL_INTERVAL" envDefault:"1s"`
+	DefaultPollInterval                    time.Duration `env:"DEFAULT_POLL_INTERVAL" envDefault:"15s"`
 	DefaultSubnetName                      string        `env:"DEFAULT_SUBNET_NAME" envDefault:"aks-subnet"`
 	DefaultVMSKU                           string        `env:"DEFAULT_VM_SKU" envDefault:"Standard_D2ds_v5"`
 	DisableScriptless                      bool          `env:"DISABLE_SCRIPTLESS"`


### PR DESCRIPTION
## Problem

The GPU E2E pipeline has been failing on **`context deadline exceeded`** across all branches (latest `main` run: 45 failures), hitting A100 / H100 / A10 / MIG / T4 tests alike. Every VMSS creation took 200–1020s (0 under 200s), bumping the 17-min `TestTimeoutVMSS`.

## Root cause

The suite runs with **`-parallel 60`** (`.pipelines/scripts/e2e_run.sh`). Each concurrent test:

- `waitForVMSSVM` polls via an ARM **LIST (collection)** call every **1s** (`DefaultPollInterval`)
- VMSS create/delete LROs poll every **1s** (`DefaultPollUntilDoneOptions.Frequency`)

→ up to **~60 collection requests/second**, which overruns ARM's collection bucket → **`ResourceCollectionRequestsThrottled`** (429, "retry after 120s"). The retry policy then backs off 10–180s per call, so provisioning drags past the 17-min VMSS timeout and surfaces as `context deadline exceeded`.

## Fix

Raise both poll cadences from **1s → 15s**. These operations take minutes, so 15s polling is ample and cuts ARM request volume **~15×** (60/s → ~4/s), comfortably under the throttle threshold, with negligible latency cost. `DefaultPollInterval` stays overridable via `DEFAULT_POLL_INTERVAL`.

## Scope / testing

- e2e-only change (`e2e/config/config.go`); no provisioning/runtime code touched.
- `go build ./...` + `go vet` pass.
- Reducing `-parallel 60` is a complementary lever, deferred to a separate PR.
