### PR TITLE
feat(vhd): add FIPS-compliant AzureLinux v3 gen2 Kata host VHD

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -33,6 +33,10 @@ parameters:
     displayName: Build AzureLinuxV3 Gen2 Kata
     type: boolean
     default: true
+  - name: buildAzureLinuxV3gen2katafips
+    displayName: Build AzureLinuxV3 Gen2 Kata FIPS
+    type: boolean
+    default: true
   - name: buildAzureLinuxV3ARM64
     displayName: Build AzureLinuxV3 Gen2 - ARM64
     type: boolean
@@ -324,6 +328,31 @@ stages:
               useOverrides: ${{ parameters.useOverrides }}
               overrideBranch: ${{ parameters.overrideBranch }}
               artifactName: azurelinuxv3-gen2-kata
+      - job: buildAzureLinuxV3gen2katafips
+        condition: eq('${{ parameters.buildAzureLinuxV3gen2katafips }}', true)
+        dependsOn: [ ]
+        timeoutInMinutes: 360
+        steps:
+          - bash: |
+              echo '##vso[task.setvariable variable=OS_SKU]AzureLinux'
+              echo '##vso[task.setvariable variable=OS_VERSION]V3kata'
+              echo '##vso[task.setvariable variable=IMG_PUBLISHER]MicrosoftCBLMariner'
+              echo '##vso[task.setvariable variable=IMG_OFFER]azure-linux-3'
+              echo '##vso[task.setvariable variable=IMG_SKU]azure-linux-3-gen2'
+              echo '##vso[task.setvariable variable=IMG_VERSION]latest'
+              echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
+              echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ads_v5'
+              echo '##vso[task.setvariable variable=FEATURE_FLAGS]kata'
+              echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
+              echo '##vso[task.setvariable variable=ENABLE_FIPS]True'
+              echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]False'
+              echo '##vso[task.setvariable variable=ENABLE_CGROUPV2]True'
+            displayName: Setup Build Variables
+          - template: ./templates/.builder-release-template.yaml
+            parameters:
+              useOverrides: ${{ parameters.useOverrides }}
+              overrideBranch: ${{ parameters.overrideBranch }}
+              artifactName: azurelinuxv3-gen2-kata-fips
       - job: buildAzureLinuxV3gen2TrustedLaunch
         condition: eq('${{ parameters.buildAzureLinuxV3gen2TrustedLaunch }}', true)
         dependsOn: [ ]

--- a/pkg/agent/bakerapi_test.go
+++ b/pkg/agent/bakerapi_test.go
@@ -350,6 +350,7 @@ var _ = Describe("AgentBaker API implementation tests", func() {
 				datamodel.AKSAzureLinuxV3Gen2FIPS,
 				datamodel.AKSAzureLinuxV2Gen2Kata,
 				datamodel.AKSAzureLinuxV3Gen2Kata,
+				datamodel.AKSAzureLinuxV3Gen2KataFIPS,
 				datamodel.AKSAzureLinuxV2Arm64Gen2,
 				datamodel.AKSAzureLinuxV3Arm64Gen2,
 				datamodel.AKSAzureLinuxV2Gen2TL,

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -141,6 +141,7 @@ var AvailableContainerdDistros = []Distro{
 	AKSCBLMarinerV2Gen2Kata,
 	AKSAzureLinuxV2Gen2Kata,
 	AKSAzureLinuxV3Gen2Kata,
+	AKSAzureLinuxV3Gen2KataFIPS,
 	AKSCBLMarinerV2Gen2TL,
 	AKSAzureLinuxV2Gen2TL,
 	AKSAzureLinuxV3Gen2TL,
@@ -200,6 +201,7 @@ var AvailableGen2Distros = []Distro{
 	AKSCBLMarinerV2Gen2Kata,
 	AKSAzureLinuxV2Gen2Kata,
 	AKSAzureLinuxV3Gen2Kata,
+	AKSAzureLinuxV3Gen2KataFIPS,
 	AKSCBLMarinerV2Gen2TL,
 	AKSAzureLinuxV2Gen2TL,
 	AKSAzureLinuxV3Gen2TL,
@@ -230,6 +232,7 @@ var AvailableAzureLinuxDistros = []Distro{
 	AKSCBLMarinerV2Gen2Kata,
 	AKSAzureLinuxV2Gen2Kata,
 	AKSAzureLinuxV3Gen2Kata,
+	AKSAzureLinuxV3Gen2KataFIPS,
 	AKSCBLMarinerV2Arm64Gen2,
 	AKSAzureLinuxV2Arm64Gen2,
 	AKSAzureLinuxV3Arm64Gen2,
@@ -255,6 +258,7 @@ var AvailableAzureLinuxCgroupV2Distros = []Distro{
 	AKSCBLMarinerV2Gen2Kata, // Per mheberling, AKSCBLMarinerV2Gen2Kata is equal to AKSAzureLinuxV2Gen2Kata. AKSCBLMarinerV2Gen2Kata is added for now to unblock scenario_kata.
 	AKSAzureLinuxV2Gen2Kata,
 	AKSAzureLinuxV3Gen2Kata,
+	AKSAzureLinuxV3Gen2KataFIPS,
 	AKSAzureLinuxV2Arm64Gen2,
 	AKSAzureLinuxV3Arm64Gen2,
 	AKSAzureLinuxV3Arm64Gen2FIPS,
@@ -692,6 +696,13 @@ var (
 		Version:       LinuxSIGImageVersion,
 	}
 
+	SIGAzureLinuxV3KataFIPSImageConfigTemplate = SigImageConfigTemplate{
+		ResourceGroup: AKSAzureLinuxResourceGroup,
+		Gallery:       AKSAzureLinuxGalleryName,
+		Definition:    "V3katagen2fips",
+		Version:       LinuxSIGImageVersion,
+	}
+
 	SIGCBLMarinerV2Arm64ImageConfigTemplate = SigImageConfigTemplate{
 		ResourceGroup: AKSCBLMarinerResourceGroup,
 		Gallery:       AKSCBLMarinerGalleryName,
@@ -942,6 +953,7 @@ func getSigAzureLinuxImageConfigMapWithOpts(opts ...SigImageConfigOpt) map[Distr
 		AKSAzureLinuxV3Gen2FIPS:          SIGAzureLinuxV3Gen2FIPSImageConfigTemplate.WithOptions(opts...),
 		AKSAzureLinuxV2Gen2Kata:          SIGAzureLinuxV2KataImageConfigTemplate.WithOptions(opts...),
 		AKSAzureLinuxV3Gen2Kata:          SIGAzureLinuxV3KataImageConfigTemplate.WithOptions(opts...),
+		AKSAzureLinuxV3Gen2KataFIPS:      SIGAzureLinuxV3KataFIPSImageConfigTemplate.WithOptions(opts...),
 		AKSAzureLinuxV2Arm64Gen2:         SIGAzureLinuxV2Arm64ImageConfigTemplate.WithOptions(opts...),
 		AKSAzureLinuxV3Arm64Gen2:         SIGAzureLinuxV3Arm64ImageConfigTemplate.WithOptions(opts...),
 		AKSAzureLinuxV3Arm64Gen2FIPS:     SIGAzureLinuxV3Arm64Gen2FIPSImageConfigTemplate.WithOptions(opts...),

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -31,6 +31,7 @@ var _ = Describe("GetMaintainedLinuxSIGImageConfigMap", func() {
 			AKSAzureLinuxV3FIPS:                     SIGAzureLinuxV3Gen1FIPSImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV3Gen2FIPS:                 SIGAzureLinuxV3Gen2FIPSImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV3Gen2Kata:                 SIGAzureLinuxV3KataImageConfigTemplate.WithOptions(),
+			AKSAzureLinuxV3Gen2KataFIPS:             SIGAzureLinuxV3KataFIPSImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV3Arm64Gen2:                SIGAzureLinuxV3Arm64ImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV3Arm64Gen2FIPS:            SIGAzureLinuxV3Arm64Gen2FIPSImageConfigTemplate.WithOptions(),
 			AKSAzureLinuxV3Gen2TL:                   SIGAzureLinuxV3TLImageConfigTemplate.WithOptions(),
@@ -109,7 +110,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(mariner.Definition).To(Equal("V1"))
 		Expect(mariner.Version).To(Equal(FrozenCBLMarinerV1SIGImageVersionForDeprecation))
 
-		Expect(len(sigConfig.SigAzureLinuxImageConfig)).To(Equal(21))
+		Expect(len(sigConfig.SigAzureLinuxImageConfig)).To(Equal(22))
 
 		azurelinuxV2 := sigConfig.SigAzureLinuxImageConfig[AKSAzureLinuxV2]
 		Expect(azurelinuxV2.ResourceGroup).To(Equal("resourcegroup"))
@@ -336,6 +337,12 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(azurelinuxV3Gen2Kata.Gallery).To(Equal("aksazurelinux"))
 		Expect(azurelinuxV3Gen2Kata.Definition).To(Equal("V3katagen2"))
 		Expect(azurelinuxV3Gen2Kata.Version).To(Equal(LinuxSIGImageVersion))
+
+		azurelinuxV3Gen2KataFIPS := sigConfig.SigAzureLinuxImageConfig[AKSAzureLinuxV3Gen2KataFIPS]
+		Expect(azurelinuxV3Gen2KataFIPS.ResourceGroup).To(Equal("resourcegroup"))
+		Expect(azurelinuxV3Gen2KataFIPS.Gallery).To(Equal("aksazurelinux"))
+		Expect(azurelinuxV3Gen2KataFIPS.Definition).To(Equal("V3katagen2fips"))
+		Expect(azurelinuxV3Gen2KataFIPS.Version).To(Equal(LinuxSIGImageVersion))
 
 		aksUbuntuEgressContainerd2204Gen2 := sigConfig.SigUbuntuImageConfig[AKSUbuntuEgressContainerd2204Gen2]
 		Expect(aksUbuntuEgressContainerd2204Gen2.ResourceGroup).To(Equal("resourcegroup"))

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -160,6 +160,7 @@ const (
 	AKSCBLMarinerV2Gen2Kata                 Distro = "aks-cblmariner-v2-gen2-kata"
 	AKSAzureLinuxV2Gen2Kata                 Distro = "aks-azurelinux-v2-gen2-kata"
 	AKSAzureLinuxV3Gen2Kata                 Distro = "aks-azurelinux-v3-gen2-kata"
+	AKSAzureLinuxV3Gen2KataFIPS             Distro = "aks-azurelinux-v3-gen2-kata-fips"
 	AKSCBLMarinerV2Gen2TL                   Distro = "aks-cblmariner-v2-gen2-tl"
 	AKSAzureLinuxV2Gen2TL                   Distro = "aks-azurelinux-v2-gen2-tl"
 	AKSAzureLinuxV3Gen2TL                   Distro = "aks-azurelinux-v3-gen2-tl"
@@ -315,7 +316,7 @@ func (d Distro) IsAzureLinuxCgroupV2VHDDistro() bool {
 }
 
 func (d Distro) IsKataDistro() bool {
-	return d == AKSCBLMarinerV2Gen2Kata || d == AKSAzureLinuxV3Gen2Kata || d == AKSAzureLinuxV2Gen2Kata || d == AKSCBLMarinerV2KataGen2TL || d == CustomizedImageKata
+	return d == AKSCBLMarinerV2Gen2Kata || d == AKSAzureLinuxV3Gen2Kata || d == AKSAzureLinuxV3Gen2KataFIPS || d == AKSAzureLinuxV2Gen2Kata || d == AKSCBLMarinerV2KataGen2TL || d == CustomizedImageKata
 }
 
 func (d Distro) IsFlatcarDistro() bool {

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -1179,6 +1179,13 @@ func TestAgentPoolProfileIsAzureLinuxCgroupV2VHDDistro(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "Azure Linux V3 Gen2 Kata FIPS VHD distro",
+			ap: AgentPoolProfile{
+				Distro: AKSAzureLinuxV3Gen2KataFIPS,
+			},
+			expected: true,
+		},
+		{
 			name: "CBLMariner V2 Gen2 VHD distro",
 			ap: AgentPoolProfile{
 				Distro: AKSCBLMarinerV2Gen2,


### PR DESCRIPTION
## Summary
- Adds a new `aks-azurelinux-v3-gen2-kata-fips` distro that builds the AzureLinux 3 gen2 Kata **host** VHD with host-side FIPS enabled (`ENABLE_FIPS=True`, `ENABLE_CGROUPV2=True`).
- Wires the new distro end-to-end: release pipeline build job, distro const + Kata/cgroupv2 classification, SIG image config template + mapping, and unit test coverage.

## Changes
- **`.pipelines/.vsts-vhd-builder-release.yaml`** — new param `buildAzureLinuxV3gen2katafips` and build job (`OS_VERSION=V3kata`, SKU `azure-linux-3-gen2`, `FEATURE_FLAGS=kata`, `ENABLE_FIPS=True`, `ENABLE_CGROUPV2=True`, VM size `Standard_D16ads_v5`, artifact `azurelinuxv3-gen2-kata-fips`).
- **`pkg/agent/datamodel/types.go`** — const `AKSAzureLinuxV3Gen2KataFIPS`; added to `IsKataDistro()`.
- **`pkg/agent/datamodel/sig_config.go`** — `SIGAzureLinuxV3KataFIPSImageConfigTemplate`; added to the Kata / cgroupv2 / AzureLinux classification lists; wired distro → template in the AzureLinux image map.
- **Tests** — `sig_config_test.go`, `types_test.go`, `bakerapi_test.go` updated for the new distro.

## Scope / Notes
- **Host FIPS only.** `installFIPS()` installs `dracut-fips` and sets `fips=1` on the host kernel cmdline. This does **not** propagate into the Kata guest microVM.
- True guest-UVM FIPS (guest kernel `fips=1`, OpenSSL FIPS provider, FIPS Go binaries) lives in the `kernel-uvm` / CloudNativeCompute pipeline (417429), **not** AgentBaker, and is tracked separately.

## Validation
- `make generate` — passes, no testdata drift.
- `go test ./pkg/agent/...` — passes (agent, datamodel, toggles).

> Draft: opening for early review / pipeline validation.