### PR TITLE
fix(gpu): retry the boot-time GPU driver image pull on a VHD cache miss

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1209,7 +1209,10 @@ configAzurePolicyAddon() {
 # Wrapped as functions so logs_to_events can time each step; the install's
 # bash -c command can't be passed to logs_to_events inline (it word-splits args).
 pullGPUDriverImage() {
-    ctr -n k8s.io image pull $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG
+    # Cache-miss path only. Retry to ride out a transient blip, but stay tight: a truly missing image
+    # should fail fast rather than eat the shared CSE window the driver install needs next. retrycmd
+    # also self-caps to the CSE budget, so this can't overrun provisioning.
+    retrycmd_if_failure 3 5 120 ctr -n k8s.io image pull $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG
 }
 
 installGPUDriverImage() {
@@ -1220,11 +1223,11 @@ configGPUDrivers() {
     if [ "$OS" = "$UBUNTU_OS_NAME" ]; then
         waitForContainerdReady || exit $ERR_GPU_DRIVERS_START_FAIL
         mkdir -p /opt/{actions,gpu}
-        # The driver image is normally pre-pulled into the VHD; only hit the registry when it is
-        # actually missing so provisioning doesn't pay a redundant manifest/layer round trip.
-        # Use containerd's native exact-name filter rather than text-matching `images ls` output.
+        # Normally the image is baked into the VHD; only pull on a cache miss (expected under VHD/CSE
+        # version skew). ctr run does not auto-pull, so a failed pull must exit here rather than
+        # resurface as an opaque install error. name== is an exact match, not an `images ls` substring.
         if [ -z "$(ctr -n k8s.io images ls -q "name==${NVIDIA_DRIVER_IMAGE}:${NVIDIA_DRIVER_IMAGE_TAG}")" ]; then
-            logs_to_events "AKS.CSE.configGPUDrivers.pullGPUDriverImage" pullGPUDriverImage
+            logs_to_events "AKS.CSE.configGPUDrivers.pullGPUDriverImage" pullGPUDriverImage || exit $ERR_GPU_DRIVERS_START_FAIL
         fi
         logs_to_events "AKS.CSE.configGPUDrivers.installGPUDriverImage" installGPUDriverImage
         ret=$?

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -2146,6 +2146,25 @@ SETUP_EOF
             The output should include "logs_to_events AKS.CSE.configGPUDrivers.waitForNvidiaSmi"
         End
 
+        It 'exits at the cache-miss pull step and skips install when the pull fails on Ubuntu'
+            OS="UBUNTU"
+            isMarinerOrAzureLinux() { return 1; }
+            isAzureLinuxOSGuard() { return 1; }
+            isACL() { return 1; }
+            # Run the wrapped command so pullGPUDriverImage's failure propagates through the guard;
+            # the default logs_to_events mock only echoes the event name and never runs the command.
+            logs_to_events() { shift; "$@"; }
+            # ctr images ls returns empty -> cache miss -> pull path taken. The pull fails; install
+            # would otherwise succeed, so a missing guard would let INSTALL_RAN leak into the output.
+            pullGPUDriverImage() { return 1; }
+            installGPUDriverImage() { echo "INSTALL_RAN"; return 0; }
+
+            When run configGPUDrivers
+
+            The status should equal 88
+            The output should not include "INSTALL_RAN"
+        End
+
         It 'times the driver download and toolkit install on Mariner/AzureLinux'
             OS="AZURELINUX"
             isMarinerOrAzureLinux() { return 0; }


### PR DESCRIPTION
## What

Hardens the boot-time NVIDIA driver image pull in `configGPUDrivers` (`parts/linux/cloud-init/artifacts/cse_config.sh`). The pull only runs on a **VHD cache miss**; it was a single, unretried `ctr image pull` whose result wasn't checked.

- `pullGPUDriverImage`: wrap the pull in `retrycmd_if_failure 3 5 120`.
- Guard the cache-miss pull with `|| exit $ERR_GPU_DRIVERS_START_FAIL`.
- Add a shellspec case asserting a failed cache-miss pull exits `ERR_GPU_DRIVERS_START_FAIL` and skips install.

## Why

`configGPUDrivers` checks `ctr images ls` for the exact `IMAGE:TAG`; on a miss it pulls, then runs `installGPUDriverImage` (a `ctr run ... /entrypoint.sh install`). A miss happens under **VHD/CSE version skew** — the render layer (agentbakersvc / aks-node-controller) references a different `aks-gpu` image/tag than the one baked into the VHD (e.g. during a driver version or image transition).

Two problems on that path:
1. **The pull had no retry** and its result was unchecked. `ctr run` does **not** auto-pull, so a single transient registry blip left the image absent, then surfaced as an opaque "image not found" install failure five retries later.
2. That produced a confusing failure mode instead of a clear one.

## Retry policy: `3 5 120` (deliberately tight)

`retrycmd_if_failure` / `_retrycmd_internal` already **self-caps to the CSE budget** (`CSE_MAX_DURATION_SECONDS`, ~13 min): it runs `check_cse_timeout` before each attempt and clamps each attempt's `timeout` to the remaining window, so a pull can never overrun provisioning. Given that, the values favor **fail-fast**:

- **404 / unreachable** (the real skew risk): `ctr image pull` returns in ~1-2s, so this fails cleanly in ~15s rather than burning the shared CSE window the expensive driver install needs next.
- **Transient blip**: 3 attempts / 5s apart recover it.
- **Hang**: capped at ~6 min nominal, trimmed further by the CSE self-cap.
- **Normal in-region pull**: completes in one attempt; containerd resumes partial layers across attempts for slower links.

(Intentionally tighter than the canonical `pullContainerImage` `10 1 600`, which is fine for non-critical-path pulls but would let a hang starve the driver install here.)

## Scope / risk

Low. Only the **cache-miss** branch changes — a VHD cache hit is byte-for-byte unaffected. No behavior change for the common (cached) path.

## Testing

- `shellcheck` — clean on changed lines.
- `shellspec` `configGPUDrivers` examples — **4 passed, 0 failed**; the new test is **verified discriminating** (removing the `|| exit` guard makes it fail: install runs / `INSTALL_RAN` leaks).
- `go test ./pkg/agent/` — pass, no golden drift (`cse_config.sh` is consumed via `//go:embed`, no snapshot to regenerate).
