### PR TITLE
feat(gpu): recognize aks-gpu-cuda in LoadConfig alongside aks-gpu-cuda-lts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -582,6 +582,17 @@
     },
     {
       "matchPackageNames": [
+        "aks/aks-gpu-cuda"
+      ],
+      "groupName": "nvidia-gpu-cuda-legacy",
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<prerelease>\\d{14})$",
+      "allowedVersions": "/^580\\./",
+      "automerge": false,
+      "enabled": true,
+      "ignoreUnstable": false
+    },
+    {
+      "matchPackageNames": [
         "aks/aks-gpu-grid"
       ],
       "groupName": "nvidia-gpu-grid",

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -743,6 +743,13 @@
       }
     },
     {
+      "downloadURL": "mcr.microsoft.com/aks/aks-gpu-cuda:*",
+      "gpuVersion": {
+        "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-cuda",
+        "latestVersion": "580.126.09-20260430040408"
+      }
+    },
+    {
       "downloadURL": "mcr.microsoft.com/aks/aks-gpu-grid:*",
       "gpuVersion": {
         "renovateTag": "registry=https://mcr.microsoft.com, name=aks/aks-gpu-grid",

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -1497,7 +1497,7 @@ func GetGPUDriverVersion(size string) string {
 	if isStandardNCv1(size) {
 		return datamodel.Nvidia470CudaDriverVersion
 	}
-	return datamodel.NvidiaCudaDriverVersion
+	return datamodel.NvidiaCudaLTSDriverVersion
 }
 
 func isStandardNCv1(size string) bool {
@@ -1522,7 +1522,7 @@ func GetAKSGPUImageSHA(size string) string {
 	if useGridDrivers(size) {
 		return datamodel.AKSGPUGridVersionSuffix
 	}
-	return datamodel.AKSGPUCudaVersionSuffix
+	return datamodel.AKSGPUCudaLTSVersionSuffix
 }
 
 // GetGPUDriverType maps a GPU VM size to the aks-gpu image variant used to install its driver.

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -943,7 +943,7 @@ var _ = Describe("GetGPUDriverVersion", func() {
 		Expect(GetGPUDriverVersion("standard_nc6")).To(Equal(datamodel.Nvidia470CudaDriverVersion))
 	})
 	It("should use cuda with nc v3", func() {
-		Expect(GetGPUDriverVersion("standard_nc6_v3")).To(Equal(datamodel.NvidiaCudaDriverVersion))
+		Expect(GetGPUDriverVersion("standard_nc6_v3")).To(Equal(datamodel.NvidiaCudaLTSDriverVersion))
 	})
 	It("should use grid with nv v5", func() {
 		Expect(GetGPUDriverVersion("standard_nv6ads_a10_v5")).To(Equal(datamodel.NvidiaGridDriverVersion))
@@ -958,7 +958,7 @@ var _ = Describe("GetGPUDriverVersion", func() {
 	})
 	// NV V1 SKUs were retired in September 2023, leaving this test just for safety
 	It("should use cuda with nv v1", func() {
-		Expect(GetGPUDriverVersion("standard_nv6")).To(Equal(datamodel.NvidiaCudaDriverVersion))
+		Expect(GetGPUDriverVersion("standard_nv6")).To(Equal(datamodel.NvidiaCudaLTSDriverVersion))
 	})
 })
 
@@ -995,8 +995,8 @@ var _ = Describe("GetAKSGPUImageSHA", func() {
 		Expect(GetAKSGPUImageSHA("standard_nc128ds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.AKSGPUGridV20VersionSuffix))
 		Expect(GetAKSGPUImageSHA("standard_nc128lds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.AKSGPUGridV20VersionSuffix))
 	})
-	It("should use newest AKSGPUCudaVersionSuffix with non grid SKU", func() {
-		Expect(GetAKSGPUImageSHA("standard_nc6_v3")).To(Equal(datamodel.AKSGPUCudaVersionSuffix))
+	It("should use newest AKSGPUCudaLTSVersionSuffix with non grid SKU", func() {
+		Expect(GetAKSGPUImageSHA("standard_nc6_v3")).To(Equal(datamodel.AKSGPUCudaLTSVersionSuffix))
 	})
 })
 

--- a/pkg/agent/datamodel/gpu_components.go
+++ b/pkg/agent/datamodel/gpu_components.go
@@ -13,9 +13,11 @@ const Nvidia470CudaDriverVersion = "cuda-470.82.01"
 //nolint:gochecknoglobals
 var (
 	NvidiaCudaDriverVersion    string
+	NvidiaCudaLTSDriverVersion string
 	NvidiaGridDriverVersion    string
 	NvidiaGridV20DriverVersion string
 	AKSGPUCudaVersionSuffix    string
+	AKSGPUCudaLTSVersionSuffix string
 	AKSGPUGridVersionSuffix    string
 	AKSGPUGridV20VersionSuffix string
 )
@@ -63,6 +65,12 @@ func LoadConfig() error {
 		// confused by substring matching.
 		switch gpuImageRepo(image.DownloadURL) {
 		case "aks-gpu-cuda-lts":
+			NvidiaCudaLTSDriverVersion = version
+			AKSGPUCudaLTSVersionSuffix = suffix
+		case "aks-gpu-cuda":
+			// Pre-LTS CUDA image, pinned to the R580 line (V100-capable). Loaded so its version is
+			// available if a SKU is ever routed to the "cuda" image in CSE; the default managed CUDA
+			// image is aks-gpu-cuda-lts (see GetGPUDriverType / GetGPUDriverVersion in baker.go).
 			NvidiaCudaDriverVersion = version
 			AKSGPUCudaVersionSuffix = suffix
 		case "aks-gpu-grid":

--- a/pkg/agent/datamodel/gpu_components_test.go
+++ b/pkg/agent/datamodel/gpu_components_test.go
@@ -63,6 +63,16 @@ func TestLoadConfig(t *testing.T) {
 	if !suffixPattern.MatchString(AKSGPUGridV20VersionSuffix) {
 		t.Errorf("AKSGPUGridV20VersionSuffix '%s' does not match expected format", AKSGPUGridV20VersionSuffix)
 	}
+
+	// aks-gpu-cuda-lts drives the render, so its version/suffix must be loaded. aks-gpu-cuda
+	// (NvidiaCudaDriverVersion / AKSGPUCudaVersionSuffix, checked above) is the recognized pre-LTS
+	// image, available if a SKU is routed to the "cuda" image in CSE later.
+	if !versionPattern.MatchString(NvidiaCudaLTSDriverVersion) {
+		t.Errorf("NvidiaCudaLTSDriverVersion '%s' does not match expected format", NvidiaCudaLTSDriverVersion)
+	}
+	if !suffixPattern.MatchString(AKSGPUCudaLTSVersionSuffix) {
+		t.Errorf("AKSGPUCudaLTSVersionSuffix '%s' does not match expected format", AKSGPUCudaLTSVersionSuffix)
+	}
 }
 
 // TestGPUImageRepo verifies that the bare repo name is extracted via exact final


### PR DESCRIPTION
## What

Restores a first-class **`case "aks-gpu-cuda"`** in `LoadConfig` (removed in effect by #8811, which repurposed the shared CUDA globals for `aks-gpu-cuda-lts`). Now the pre-LTS `aks-gpu-cuda` version is loaded and available **if a SKU is ever routed to the `"cuda"` image in CSE again** — without changing today's render.

- `components.json`: add an `aks-gpu-cuda` entry **pinned to the R580 line** (`580.126.09`), not the R595 line that drops Volta/V100.
- `gpu_components.go`: **`aks-gpu-cuda` reclaims `NvidiaCudaDriverVersion` / `AKSGPUCudaVersionSuffix`** (its pre-#8811 names); **`aks-gpu-cuda-lts` moves to `NvidiaCudaLTSDriverVersion` / `AKSGPUCudaLTSVersionSuffix`**. This mirrors the existing base-vs-variant naming (`NvidiaGridDriverVersion` vs `NvidiaGridV20DriverVersion`) and avoids clobbering a shared global.
- `baker.go`: `GetGPUDriverVersion` / `GetAKSGPUImageSHA` render the **LTS** globals for modern CUDA SKUs.
- `renovate.json`: constrain `aks-gpu-cuda` to `/^580\./` so it never bumps to the V100-dropping R595 line.
- Tests updated for the new names + LTS-global coverage.

## Why the rename (and why it's safe)

You can't have both cases write the *same* globals — the `LoadConfig` loop would clobber them (last-one-wins), making modern SKUs render a non-existent `aks-gpu-cuda-lts:580.126.09-…` tag → 404. So `aks-gpu-cuda` takes back the base `NvidiaCuda*` names (as before #8811) and the LTS image gets an explicit `…LTS…` name; the render is repointed to the LTS globals.

**Render output is byte-identical** — verified: `GENERATE_TEST_DATA=true go test ./pkg/agent/...` produces **zero golden drift**. Modern CUDA SKUs still resolve `aks-gpu-cuda-lts:580.159.04-…` exactly as before. The globals are internal; nothing outside `baker.go`/`gpu_components.go` references them.

## What it deliberately does NOT do

- **Not VHD-cached** — `install-dependencies.sh` unchanged (only pre-pulls `aks-gpu-cuda-lts`), zero size cost.
- **Not the default render target** — `GetGPUDriverType` still returns `"cuda-lts"`; `aks-gpu-cuda`'s version is loaded but currently unrendered (forward-plumbing).

Old-VHD / version-skewed nodes that target `aks-gpu-cuda` already resolve it at boot via the hardened registry pull (#8821), served by required-MCR egress or the wildcard network-isolated ACR cache.

## Testing

- `go build ./pkg/agent/...` + `aks-node-controller`, `go vet`, `go test ./pkg/agent/...` — pass.
- `GENERATE_TEST_DATA=true go test ./pkg/agent/...` — **zero golden drift** (render unchanged).
- `make validate-components` (cue) — pass.
