### PR TITLE
test(e2e): serialize gallery image-version replication to fix GalleryImageNotFound

### DIFF
--- a/e2e/config/azure.go
+++ b/e2e/config/azure.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Azure/agentbaker/e2e/toolkit"
@@ -565,7 +566,49 @@ func (a *AzureClient) LatestSIGImageVersionByTag(ctx context.Context, image *Ima
 	return VHDResourceID(*latestVersion.ID), nil
 }
 
+// versionReplicationLocks serializes concurrent replications of the same gallery image version
+// (keyed by version resource ID). Adding a target region is a read-modify-write of the version's
+// TargetRegions, so concurrent updates from scenarios in different regions would otherwise clobber
+// each other and leave the image unavailable in a dropped region (GalleryImageNotFound).
+var versionReplicationLocks sync.Map
+
+func versionReplicationLock(versionID string) *sync.Mutex {
+	mu, _ := versionReplicationLocks.LoadOrStore(versionID, &sync.Mutex{})
+	return mu.(*sync.Mutex)
+}
+
+// refreshImageVersion re-reads the live gallery image version and updates version in place, so
+// callers act on the current TargetRegions/ProvisioningState rather than a stale snapshot.
+func (a *AzureClient) refreshImageVersion(ctx context.Context, image *Image, version *armcompute.GalleryImageVersion) error {
+	client, err := armcompute.NewGalleryImageVersionsClient(image.Gallery.SubscriptionID, a.Credential, a.ArmOptions)
+	if err != nil {
+		return fmt.Errorf("create image version client: %w", err)
+	}
+	resp, err := client.Get(ctx, image.Gallery.ResourceGroupName, image.Gallery.Name, image.Name, *version.Name, nil)
+	if err != nil {
+		return fmt.Errorf("get image version: %w", err)
+	}
+	*version = resp.GalleryImageVersion
+	return nil
+}
+
 func (a *AzureClient) ensureReplication(ctx context.Context, image *Image, version *armcompute.GalleryImageVersion, location string) error {
+	// Serialize replication of a given image version across concurrently-running scenarios.
+	// Adding a region is a read-modify-write PUT of the version's TargetRegions; scenarios in
+	// different regions resolve the same freshly-built version in parallel, so without
+	// serialization a stale PUT drops a region another goroutine just added and the image
+	// becomes unavailable there (GalleryImageNotFound). Lock per version ID and re-read the live
+	// TargetRegions inside the lock so every update builds on the current region set.
+	mu := versionReplicationLock(*version.ID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Re-read the live version under the lock: the snapshot passed in was captured (by List/Get)
+	// before the lock was acquired and may be missing regions added by another goroutine.
+	if err := a.refreshImageVersion(ctx, image, version); err != nil {
+		return fmt.Errorf("refreshing image version before replication: %w", err)
+	}
+
 	// Wait for any ongoing update operations to complete first
 	if err := a.waitForVersionOperationCompletion(ctx, image, version); err != nil {
 		return fmt.Errorf("waiting for version operation completion: %w", err)


### PR DESCRIPTION
## Problem

The GPU E2E suite has been failing with **`GalleryImageNotFound`** (20 failures in the latest `main` run) — e.g.:

```
The gallery image .../images/2404gen2containerd/versions/1.1783016979.17372
is not available in southeastasia region. Please contact image owner to
replicate to this region, or change your requested region.
```

All 20 were the **same version** in the **same region** (southeastasia).

## Root cause — a concurrent lost-update race on `TargetRegions`

`CachedPrepareVHD` memoizes VHD resolution per **(image, region)**, so different regions resolve the *same* freshly-built SIG image version **in parallel**. Adding a region is a **read-modify-write PUT** of the version's `TargetRegions` (`replicateImageVersionToCurrentRegion`), and there was **no locking**:

1. southeastasia reads the version (regions `[eastus]`), appends → PUT `[eastus, southeastasia]`.
2. uaenorth reads the version (also `[eastus]`, before step 1 lands), appends → PUT `[eastus, uaenorth]`.
3. uaenorth's stale PUT **drops southeastasia** → the image is no longer replicated there → every cached southeastasia scenario fails with `GalleryImageNotFound`.

The run log confirms it: southeastasia **and** uaenorth replicated version `1.1783016979.17372` concurrently.

## Fix

Serialize replication **per image-version ID** with an in-process mutex, and **re-read the live `TargetRegions` inside the lock** before each update, so every PUT builds on the current region set instead of clobbering a concurrent addition. Distinct versions still replicate in parallel — only same-version region additions serialize (which Azure requires anyway, since a version resource only accepts one update at a time).

## Scope / testing

- e2e-only change (`e2e/config/azure.go`); no provisioning/runtime code touched.
- `go build ./config/` + `go vet ./config/` pass.
- Trade-off: same-version replications now run sequentially (only on the first run after a new VHD build, for the ~2–3 regions a version is used in) — correctness over a small first-run latency; the tests already block on replication today.
