### PR TITLE
fix: bump cisassessor package version

### DIFF
--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -21,7 +21,7 @@ steps:
       command: download
       vstsFeed: AzCoreLinux-Compliance
       vstsFeedPackage: cisassessor
-      vstsPackageVersion: '0.0.229'
+      vstsPackageVersion: '0.0.230'
       downloadDirectory: vhdbuilder/
 
   - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
The CIS license has expired and a new package has been built. This PR updates the package version to the newest.

