### PR TITLE
fix: copy aks custom cloud properly on disk for various combinations in anc

### DIFF
--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -64,6 +64,7 @@ cat <<'EOF' | base64 -d | gzip -d >%[3]s
 EOF
 chmod 0600 %[3]s
 %[5]s
+if [ "%[6]s" != "%[7]s" ] && [ -f "%[6]s" ]; then mv -f "%[6]s" "%[7]s"; fi
 logger -t aks-boothook "launching aks-node-controller service $(date -Ins)"
 systemctl start --no-block aks-node-controller.service
 `
@@ -144,11 +145,17 @@ func (t *TemplateGenerator) getScriptlessNBCCustomData(config *datamodel.NodeBoo
 		encodedAKSNodeConfig = getBase64EncodedGzippedCustomScriptFromStr(config.AKSNodeConfigJSON)
 	}
 
+	var aksCustomCloudFilePath string
+	if datamodel.GetCloudTargetEnv(config.ContainerService.Location) == datamodel.USSecCloud || datamodel.GetCloudTargetEnv(config.ContainerService.Location) == datamodel.USNatCloud {
+		aksCustomCloudFilePath = initAKSCustomCloudFilepath
+	} else {
+		aksCustomCloudFilePath = initAKSCustomCloudOperationRequestsFilepath
+	}
 	var customData string
 	if config.IsFlatcar() || config.IsACL() {
 		customData = buildFlatcarScriptlessCustomData(encodedNBCCMD, encodedNodeCustomData, encodedAKSNodeConfig)
 	} else {
-		customData = buildBoothookScriptlessCustomData(encodedNBCCMD, encodedNodeCustomData, encodedAKSNodeConfig)
+		customData = buildBoothookScriptlessCustomData(encodedNBCCMD, encodedNodeCustomData, encodedAKSNodeConfig, aksCustomCloudFilePath)
 	}
 
 	return base64.StdEncoding.EncodeToString([]byte(customData))
@@ -162,11 +169,12 @@ func buildFlatcarScriptlessCustomData(encodedNBCCMD, encodedNodeCustomData, enco
 	return fmt.Sprintf(flatcarTemplate, encodedNBCCMD, encodedNodeCustomData, flatcarAKSNodeConfigBlock)
 }
 
-func buildBoothookScriptlessCustomData(encodedNBCCMD, encodedNodeCustomData, encodedAKSNodeConfig string) string {
+func buildBoothookScriptlessCustomData(encodedNBCCMD, encodedNodeCustomData, encodedAKSNodeConfig, aksCustomCloudFilePath string) string {
 	var aksNodeConfigBlock string
 	if encodedAKSNodeConfig != "" {
 		aksNodeConfigBlock = fmt.Sprintf(aksNodeConfigBlockFmt, aksNodeConfigPath, encodedAKSNodeConfig)
 	}
+
 	return fmt.Sprintf(
 		boothookTemplate,
 		nodeCustomDataPath,
@@ -174,6 +182,8 @@ func buildBoothookScriptlessCustomData(encodedNBCCMD, encodedNodeCustomData, enc
 		nbcCmdFilePath,
 		encodedNBCCMD,
 		aksNodeConfigBlock,
+		aksCustomCloudFilePath,
+		initAKSCustomCloudFilepath,
 	)
 }
 

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -1507,6 +1507,25 @@ var _ = Describe("getLinuxNodeBootstrappingPayload", func() {
 		Expect(string(decodedPayload)).To(ContainSubstring("/opt/azure/containers/provision_preload.sh"))
 	})
 
+	It("should move the operation-requests custom cloud init script to the path used by ANC", func() {
+		templateGenerator := InitializeTemplateGenerator()
+		config := newConfig(false)
+		config.ContainerService.Properties.CustomCloudEnv = &datamodel.CustomCloudEnv{
+			Name: "akscustom",
+		}
+
+		payload := templateGenerator.getLinuxNodeBootstrappingPayload(config)
+		decodedPayload, err := base64.StdEncoding.DecodeString(payload)
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedMoveCommand := fmt.Sprintf(
+			`if [ "%[1]s" != "%[2]s" ] && [ -f "%[1]s" ]; then mv -f "%[1]s" "%[2]s"; fi`,
+			initAKSCustomCloudOperationRequestsFilepath,
+			initAKSCustomCloudFilepath,
+		)
+		Expect(string(decodedPayload)).To(ContainSubstring(expectedMoveCommand))
+	})
+
 	It("should render initAKSCustomCloud file in scriptless custom data for default cloud with Ubuntu", func() {
 		templateGenerator := InitializeTemplateGenerator()
 		config := newConfig(false)

--- a/pkg/agent/const.go
+++ b/pkg/agent/const.go
@@ -110,15 +110,16 @@ const (
 
 // cloud-init destination file references.
 const (
-	cseHelpersScriptFilepath             = "/opt/azure/containers/provision_source.sh"
-	cseHelpersScriptDistroFilepath       = "/opt/azure/containers/provision_source_distro.sh"
-	cseInstallScriptFilepath             = "/opt/azure/containers/provision_installs.sh"
-	cseInstallScriptDistroFilepath       = "/opt/azure/containers/provision_installs_distro.sh"
-	cseConfigScriptFilepath              = "/opt/azure/containers/provision_configs.sh"
-	customSearchDomainsCSEScriptFilepath = "/opt/azure/containers/setup-custom-search-domains.sh"
-	dhcpV6ServiceCSEScriptFilepath       = "/etc/systemd/system/dhcpv6.service"
-	dhcpV6ConfigCSEScriptFilepath        = "/opt/azure/containers/enable-dhcpv6.sh"
-	initAKSCustomCloudFilepath           = "/opt/azure/containers/init-aks-custom-cloud.sh"
+	cseHelpersScriptFilepath                    = "/opt/azure/containers/provision_source.sh"
+	cseHelpersScriptDistroFilepath              = "/opt/azure/containers/provision_source_distro.sh"
+	cseInstallScriptFilepath                    = "/opt/azure/containers/provision_installs.sh"
+	cseInstallScriptDistroFilepath              = "/opt/azure/containers/provision_installs_distro.sh"
+	cseConfigScriptFilepath                     = "/opt/azure/containers/provision_configs.sh"
+	customSearchDomainsCSEScriptFilepath        = "/opt/azure/containers/setup-custom-search-domains.sh"
+	dhcpV6ServiceCSEScriptFilepath              = "/etc/systemd/system/dhcpv6.service"
+	dhcpV6ConfigCSEScriptFilepath               = "/opt/azure/containers/enable-dhcpv6.sh"
+	initAKSCustomCloudFilepath                  = "/opt/azure/containers/init-aks-custom-cloud.sh"
+	initAKSCustomCloudOperationRequestsFilepath = "/opt/azure/containers/init-aks-custom-cloud-operation-requests.sh"
 )
 
 const (

--- a/vhdbuilder/packer/imagecustomizer/azlosguard/azlosguard.yml
+++ b/vhdbuilder/packer/imagecustomizer/azlosguard/azlosguard.yml
@@ -133,6 +133,12 @@ os:
     - source: /AgentBaker/parts/linux/cloud-init/artifacts/cse_send_logs.py
       destination: /opt/azure/containers/provision_send_logs.py
       permissions: 744
+    - source: /AgentBaker/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-mariner.sh
+      destination: /opt/azure/containers/init-aks-custom-cloud.sh
+      permissions: 744
+    - source: /AgentBaker/parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests-mariner.sh
+      destination: /opt/azure/containers/init-aks-custom-cloud-operation-requests.sh
+      permissions: 744
     # private hosts
     - source: /AgentBaker/parts/linux/cloud-init/artifacts/reconcile-private-hosts.service
       destination: /etc/systemd/system/reconcile-private-hosts.service

--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -160,9 +160,13 @@ copyPackerFiles() {
   INIT_CUSTOM_CLOUD_DEST=/opt/azure/containers/init-aks-custom-cloud.sh
   cpAndMode $INIT_CUSTOM_CLOUD_SRC $INIT_CUSTOM_CLOUD_DEST 0744
 
+  INIT_CUSTOM_CLOUD_OP_REQ_SRC=/home/packer/init-aks-custom-cloud-operation-requests.sh
+  INIT_CUSTOM_CLOUD_OP_REQ_DEST=/opt/azure/containers/init-aks-custom-cloud-operation-requests.sh
+  cpAndMode $INIT_CUSTOM_CLOUD_OP_REQ_SRC $INIT_CUSTOM_CLOUD_OP_REQ_DEST 0744
+
   PVT_HOST_SVC_SRC=/home/packer/reconcile-private-hosts.service
   PVT_HOST_SVC_DEST=/etc/systemd/system/reconcile-private-hosts.service
-  cpAndMode $CSE_REDACT_SRC $CSE_REDACT_DEST 600
+  cpAndMode $PVT_HOST_SVC_SRC $PVT_HOST_SVC_DEST 600
 
   if grep -q "kata" <<< "$FEATURE_FLAGS"; then
     # KataCC SPEC file assumes kata config points to the files exactly under this path

--- a/vhdbuilder/packer/vhd-image-builder-acl-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-acl-arm64.json
@@ -234,6 +234,11 @@
     },
     {
       "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests.sh",
+      "destination": "/home/packer/init-aks-custom-cloud-operation-requests.sh"
+    },
+    {
+      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/reconcile-private-hosts.service",
       "destination": "/home/packer/reconcile-private-hosts.service"
     },

--- a/vhdbuilder/packer/vhd-image-builder-acl.json
+++ b/vhdbuilder/packer/vhd-image-builder-acl.json
@@ -234,6 +234,11 @@
     },
     {
       "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests.sh",
+      "destination": "/home/packer/init-aks-custom-cloud-operation-requests.sh"
+    },
+    {
+      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/reconcile-private-hosts.service",
       "destination": "/home/packer/reconcile-private-hosts.service"
     },

--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -244,6 +244,11 @@
     },
     {
       "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests.sh",
+      "destination": "/home/packer/init-aks-custom-cloud-operation-requests.sh"
+    },
+    {
+      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/reconcile-private-hosts.service",
       "destination": "/home/packer/reconcile-private-hosts.service"
     },

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -247,6 +247,11 @@
     },
     {
       "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests.sh",
+      "destination": "/home/packer/init-aks-custom-cloud-operation-requests.sh"
+    },
+    {
+      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/reconcile-private-hosts.service",
       "destination": "/home/packer/reconcile-private-hosts.service"
     },

--- a/vhdbuilder/packer/vhd-image-builder-cvm.json
+++ b/vhdbuilder/packer/vhd-image-builder-cvm.json
@@ -251,6 +251,11 @@
     },
     {
       "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests.sh",
+      "destination": "/home/packer/init-aks-custom-cloud-operation-requests.sh"
+    },
+    {
+      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/reconcile-private-hosts.service",
       "destination": "/home/packer/reconcile-private-hosts.service"
     },

--- a/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
@@ -238,8 +238,13 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud.sh",
+      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud-mariner.sh",
       "destination": "/home/packer/init-aks-custom-cloud.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests-mariner.sh",
+      "destination": "/home/packer/init-aks-custom-cloud-operation-requests.sh"
     },
     {
       "type": "file",

--- a/vhdbuilder/packer/vhd-image-builder-mariner-cvm.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-cvm.json
@@ -244,8 +244,13 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud.sh",
+      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud-mariner.sh",
       "destination": "/home/packer/init-aks-custom-cloud.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests-mariner.sh",
+      "destination": "/home/packer/init-aks-custom-cloud-operation-requests.sh"
     },
     {
       "type": "file",

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -240,8 +240,13 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud.sh",
+      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud-mariner.sh",
       "destination": "/home/packer/init-aks-custom-cloud.sh"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/init-aks-custom-cloud-operation-requests-mariner.sh",
+      "destination": "/home/packer/init-aks-custom-cloud-operation-requests.sh"
     },
     {
       "type": "file",


### PR DESCRIPTION
We are planning to apply node customdata only in hotfix cases where the base version matches. So lets correctly copy and replace the aks custom cloud.