### PR TITLE
test(e2e): verify artifact streaming actually streams an image on pod launch

### DIFF
--- a/e2e/artifact_streaming.go
+++ b/e2e/artifact_streaming.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 
@@ -22,6 +23,16 @@ const artifactStreamingE2ERepoTag = "artifact-streaming-e2e/base-core:2.0"
 // artifactStreamingSourceImage is a small, always-available public image we convert to an
 // overlaybd (artifact streaming) image so the pod pull exercises the streaming path.
 const artifactStreamingSourceImage = "mcr.microsoft.com/cbl-mariner/base/core:2.0"
+
+// overlaybdStreamingArtifactType is the artifactType of the ACR overlaybd streaming referrer that
+// `az acr artifact-streaming create` produces. Verified against a live ACR streaming artifact
+// (annotations include streaming.format=overlaybd). Filtering `list-referrers` by this type avoids
+// matching unrelated referrers such as signatures or SBOMs.
+const overlaybdStreamingArtifactType = "application/vnd.azure.artifact.streaming.v1"
+
+// streamingOperationIDRegex extracts the operation UUID from the async `az acr artifact-streaming
+// create` output, e.g. "... operation show ... --id 1a410a07-d2d5-4f3a-a386-a4a2e75c1e40".
+var streamingOperationIDRegex = regexp.MustCompile(`--id\s+([0-9a-fA-F-]{36})`)
 
 // ValidateArtifactStreamingImagePull verifies that artifact streaming actually streams an image
 // on pod launch, rather than merely bootstrapping the overlaybd/acr-mirror services.
@@ -95,9 +106,15 @@ func ValidateArtifactStreamingImagePull(ctx context.Context, s *Scenario) {
 }
 
 // ensureStreamingArtifactForImage imports the source image into the private ACR and ensures its
-// overlaybd artifact-streaming referrer exists. Success is defined by the end state (a streaming
-// referrer is present), not by the CLI exit code, so it is fully idempotent across cached-ACR
-// re-runs without depending on the exact wording of "already exists" messages.
+// overlaybd artifact-streaming referrer is fully created and ready to pull. It is idempotent across
+// cached-ACR re-runs.
+//
+// IMPORTANT: `az acr artifact-streaming create` is ASYNCHRONOUS — it returns immediately with an
+// operation ID while ACR converts the image to overlaybd format server-side. We MUST wait for that
+// operation to succeed before pulling: if the node pulls before conversion finishes, containerd
+// pulls the plain OCI image, caches it as overlayfs, and no streaming ever happens (and re-pulling
+// on the same node won't fix it, because the image is already cached). This async behaviour is the
+// reason the first version of this test failed.
 //
 // NOTE: this shells out to `az` (as the e2e suite already does in types.go). The E2E runner must be
 // authenticated to the subscription and have the `az acr artifact-streaming`/`az acr manifest`
@@ -120,16 +137,15 @@ func ensureStreamingArtifactForImage(ctx context.Context, s *Scenario, acrName, 
 			artifactStreamingSourceImage, acrName, err, string(out))
 	}
 
-	// 2. If the overlaybd streaming referrer already exists (e.g. cached ACR from a previous run),
-	//    there's nothing to do.
-	if streamingReferrerExists(ctx, s, acrName, repoTag) {
+	// 2. If the overlaybd streaming referrer is already present (cached ACR from a previous run),
+	//    conversion is done — nothing to do. ACR publishes the streaming referrer only once the
+	//    overlaybd blobs exist, so this is a reliable "ready" signal.
+	if streamingReferrerReady(ctx, s, acrName, repoTag) {
 		s.T.Logf("overlaybd streaming referrer already exists for %q in ACR %q, skipping create", repoTag, acrName)
 		return
 	}
 
-	// 3. Create the overlaybd streaming referrer. This is synchronous (`--no-wait` defaults to
-	//    false), so the conversion completes before we pull. Define success by re-checking that the
-	//    referrer now exists rather than trusting the CLI exit code.
+	// 3. Kick off conversion. The command is async and prints the operation ID to poll.
 	streamCmd := exec.CommandContext(ctx, "az", "acr", "artifact-streaming", "create",
 		"--name", acrName,
 		"--image", repoTag,
@@ -137,30 +153,105 @@ func ensureStreamingArtifactForImage(ctx context.Context, s *Scenario, acrName, 
 	)
 	out, err := streamCmd.CombinedOutput()
 	s.T.Logf("az acr artifact-streaming create output:\n%s", string(out))
-	if err != nil && !streamingReferrerExists(ctx, s, acrName, repoTag) {
+
+	// 4. Wait for the async conversion to finish. Prefer polling the returned operation; fall back
+	//    to polling for the referrer if no operation ID was printed (e.g. CLI-version differences).
+	if opID := parseStreamingOperationID(string(out)); opID != "" {
+		waitForStreamingOperationSucceeded(ctx, s, acrName, repoNameWithoutTag(repoTag), opID)
+	}
+	waitForStreamingReferrerReady(ctx, s, acrName, repoTag)
+
+	if err != nil && !streamingReferrerReady(ctx, s, acrName, repoTag) {
 		s.T.Fatalf("failed to create overlaybd streaming artifact for %q in ACR %q: %v", repoTag, acrName, err)
 	}
 }
 
-// streamingReferrerExists reports whether the given image already has an overlaybd artifact-
-// streaming referrer in the ACR. Best-effort: on any CLI error it returns false so the caller
-// falls through to (re-)creating the referrer.
-func streamingReferrerExists(ctx context.Context, s *Scenario, acrName, repoTag string) bool {
+// waitForStreamingOperationSucceeded polls `az acr artifact-streaming operation show` until the
+// conversion operation reports Succeeded, failing the test on a Failed status or timeout.
+func waitForStreamingOperationSucceeded(ctx context.Context, s *Scenario, acrName, repository, operationID string) {
+	s.T.Helper()
+	const timeout = 8 * time.Minute
+	deadline := time.Now().Add(timeout)
+	for {
+		cmd := exec.CommandContext(ctx, "az", "acr", "artifact-streaming", "operation", "show",
+			"--name", acrName,
+			"--repository", repository,
+			"--id", operationID,
+			"--subscription", config.Config.SubscriptionID,
+			"-o", "json",
+		)
+		out, err := cmd.CombinedOutput()
+		status := strings.ToLower(string(out))
+		switch {
+		case err == nil && strings.Contains(status, "succeeded"):
+			s.T.Logf("overlaybd streaming conversion operation %s for %q succeeded", operationID, repository)
+			return
+		case err == nil && strings.Contains(status, "failed"):
+			s.T.Fatalf("overlaybd streaming conversion operation %s for %q failed:\n%s", operationID, repository, string(out))
+		}
+		if time.Now().After(deadline) {
+			s.T.Fatalf("timed out after %s waiting for overlaybd streaming conversion operation %s (repo %q); last status:\n%s",
+				timeout, operationID, repository, string(out))
+		}
+		time.Sleep(10 * time.Second)
+	}
+}
+
+// waitForStreamingReferrerReady polls until the overlaybd streaming referrer is queryable, as a
+// backstop for the operation poll (covers CLI versions that don't print an operation ID and any lag
+// between the operation completing and the referrer being listable).
+func waitForStreamingReferrerReady(ctx context.Context, s *Scenario, acrName, repoTag string) {
+	s.T.Helper()
+	const timeout = 3 * time.Minute
+	deadline := time.Now().Add(timeout)
+	for {
+		if streamingReferrerReady(ctx, s, acrName, repoTag) {
+			return
+		}
+		if time.Now().After(deadline) {
+			s.T.Fatalf("timed out after %s waiting for the overlaybd streaming referrer of %q in ACR %q", timeout, repoTag, acrName)
+		}
+		time.Sleep(10 * time.Second)
+	}
+}
+
+// streamingReferrerReady reports whether the given image has a ready overlaybd artifact-streaming
+// referrer in the ACR. It filters `list-referrers` by the overlaybd streaming artifactType so it
+// does not match unrelated referrers (signatures, SBOMs). Best-effort: any CLI error returns false.
+func streamingReferrerReady(ctx context.Context, s *Scenario, acrName, repoTag string) bool {
 	s.T.Helper()
 	cmd := exec.CommandContext(ctx, "az", "acr", "manifest", "list-referrers",
 		"--name", repoTag,
 		"--registry", acrName,
+		"--artifact-type", overlaybdStreamingArtifactType,
 		"--subscription", config.Config.SubscriptionID,
 		"-o", "json",
 	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		s.T.Logf("could not list referrers for %q in ACR %q (will attempt create): %v\n%s", repoTag, acrName, err, string(out))
+		s.T.Logf("could not list overlaybd streaming referrers for %q in ACR %q: %v\n%s", repoTag, acrName, err, string(out))
 		return false
 	}
-	// A streaming (overlaybd) referrer appears as an entry with an artifactType in the referrers
-	// list. An empty referrers list has no such field.
-	return strings.Contains(string(out), "artifactType")
+	// A matching referrer is present iff the (type-filtered) manifest list has at least one digest.
+	return strings.Contains(string(out), `"digest"`)
+}
+
+// parseStreamingOperationID extracts the conversion operation UUID from the async create output.
+func parseStreamingOperationID(createOutput string) string {
+	m := streamingOperationIDRegex.FindStringSubmatch(createOutput)
+	if len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// repoNameWithoutTag strips a ":tag" suffix, since `operation show --repository` wants the bare
+// repository name (e.g. "artifact-streaming-e2e/base-core", not "...:2.0").
+func repoNameWithoutTag(repoTag string) string {
+	if i := strings.LastIndex(repoTag, ":"); i != -1 {
+		return repoTag[:i]
+	}
+	return repoTag
 }
 
 // logArtifactStreamingDiagnostics dumps overlaybd's on-node log tail and exporter metrics to help
@@ -174,6 +265,22 @@ func logArtifactStreamingDiagnostics(ctx context.Context, s *Scenario) {
 	metrics := execScriptOnVMForScenario(ctx, s,
 		"sudo curl -s --max-time 5 http://localhost:9863/metrics 2>/dev/null | grep -iE 'overlaybd|obd' | head -n 30 || true")
 	s.T.Logf("overlaybd exporter (:9863) metrics sample:\n%s", metrics.stdout)
+
+	// acr-mirror is what discovers the ACR streaming referrer and redirects the pull to the
+	// overlaybd manifest; if it can't (auth/config), the pull silently falls back to overlayfs.
+	mirror := execScriptOnVMForScenario(ctx, s,
+		"sudo journalctl -u acr-mirror --no-pager 2>/dev/null | tail -n 40 || true")
+	s.T.Logf("acr-mirror journal tail:\n%s", mirror.stdout)
+
+	snapshotter := execScriptOnVMForScenario(ctx, s,
+		"sudo journalctl -u overlaybd-snapshotter --no-pager 2>/dev/null | tail -n 40 || true")
+	s.T.Logf("overlaybd-snapshotter journal tail:\n%s", snapshotter.stdout)
+
+	// Which snapshotter backs the pulled image, and the containerd hosts.toml that routes
+	// azurecr.io pulls through acr-mirror.
+	images := execScriptOnVMForScenario(ctx, s,
+		"sudo ctr -n k8s.io images ls 2>/dev/null | grep -iE 'base-core|REF' || true; echo '--- certs.d ---'; sudo cat /etc/containerd/certs.d/*azurecr.io*/hosts.toml 2>/dev/null || true")
+	s.T.Logf("containerd images + azurecr.io hosts.toml:\n%s", images.stdout)
 }
 
 // podStreamingImageLinux builds a pod pinned to the scenario's node that pulls the given ACR

--- a/e2e/artifact_streaming.go
+++ b/e2e/artifact_streaming.go
@@ -45,13 +45,17 @@ var streamingOperationIDRegex = regexp.MustCompile(`--id\s+([0-9a-fA-F-]{36})`)
 //     signal that the image was *streamed* on demand rather than downloaded and unpacked into
 //     overlayfs (the fallback path taken for plain OCI images like busybox).
 //
-// Requires a cluster with a private ACR attached and the ACR pull secret created in the cluster
-// (Tags.NonAnonymousACR = true, e.g. Cluster: ClusterAzureBootstrapProfileCache).
+// Uses the cluster's ANONYMOUS-pull private ACR (Cluster: ClusterAzureBootstrapProfileCache, which
+// attaches one). Anonymous pull is required because on the standalone e2e VMSS node the acr-mirror
+// service has no managed identity to obtain an AAD token, so it cannot authenticate to a
+// non-anonymous ACR to serve the overlaybd streaming manifest — the pull then silently falls back
+// to overlayfs. Against an anonymous-pull ACR, acr-mirror's anonymous path succeeds and streaming
+// works. (Observed acr-mirror error on a non-anon ACR: "Error with azure sdk, request token error"
+// -> "falling back to anonymous auth" -> 503.)
 func ValidateArtifactStreamingImagePull(ctx context.Context, s *Scenario) {
-	require.True(s.T, s.Tags.NonAnonymousACR,
-		"ValidateArtifactStreamingImagePull requires a private ACR with pull secret (set Tags.NonAnonymousACR = true)")
-
-	acrName := config.GetPrivateACRName(s.Tags.NonAnonymousACR, s.Location)
+	// Deliberately use the anonymous ACR (NonAnonymousACR = false) regardless of the scenario tag,
+	// so acr-mirror can serve the streaming manifest without a node identity.
+	acrName := config.GetPrivateACRName(false, s.Location)
 	image := fmt.Sprintf("%s.azurecr.io/%s", acrName, artifactStreamingE2ERepoTag)
 
 	// Prepare the overlaybd streaming artifact in the ACR. This is idempotent across runs, so a
@@ -284,8 +288,9 @@ func logArtifactStreamingDiagnostics(ctx context.Context, s *Scenario) {
 }
 
 // podStreamingImageLinux builds a pod pinned to the scenario's node that pulls the given ACR
-// artifact-streaming image using the ACR pull secret. It mirrors the taint tolerations and node
-// selector used by podHTTPServerLinux so it schedules onto the freshly-provisioned node.
+// artifact-streaming image. The image is served from the anonymous-pull private ACR (see
+// ValidateArtifactStreamingImagePull), so no image pull secret is needed. It mirrors the taint
+// tolerations and node selector used by podHTTPServerLinux so it schedules onto the node.
 func podStreamingImageLinux(s *Scenario, image string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -293,9 +298,6 @@ func podStreamingImageLinux(s *Scenario, image string) *corev1.Pod {
 			Namespace: "default",
 		},
 		Spec: corev1.PodSpec{
-			ImagePullSecrets: []corev1.LocalObjectReference{
-				{Name: config.Config.ACRSecretName},
-			},
 			Containers: []corev1.Container{
 				{
 					Name:    "streaming",

--- a/e2e/artifact_streaming.go
+++ b/e2e/artifact_streaming.go
@@ -1,0 +1,219 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/Azure/agentbaker/e2e/config"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// artifactStreamingE2ERepoTag is the repository:tag used for the artifact-streaming e2e image
+// in the private ACR. It is a dedicated path (not under the aks-managed-repository/* cache-rule
+// prefix) so the manually-imported manifest and its overlaybd streaming referrer don't interact
+// with the MCR pull-through cache rule.
+const artifactStreamingE2ERepoTag = "artifact-streaming-e2e/base-core:2.0"
+
+// artifactStreamingSourceImage is a small, always-available public image we convert to an
+// overlaybd (artifact streaming) image so the pod pull exercises the streaming path.
+const artifactStreamingSourceImage = "mcr.microsoft.com/cbl-mariner/base/core:2.0"
+
+// ValidateArtifactStreamingImagePull verifies that artifact streaming actually streams an image
+// on pod launch, rather than merely bootstrapping the overlaybd/acr-mirror services.
+//
+// Unlike the existing artifact-streaming scenarios (which only assert that overlaybd-snapshotter,
+// overlaybd-tcmu and acr-mirror are running and that /etc/overlaybd exists), this validator:
+//  1. ensures an overlaybd-converted (artifact-streaming) image exists in the e2e private ACR,
+//  2. launches a pod from that image and waits for it to run (proving the image was pullable), and
+//  3. asserts on the node that overlaybd opened a TCMU-backed block device for it — the definitive
+//     signal that the image was *streamed* on demand rather than downloaded and unpacked into
+//     overlayfs (the fallback path taken for plain OCI images like busybox).
+//
+// Requires a cluster with a private ACR attached and the ACR pull secret created in the cluster
+// (Tags.NonAnonymousACR = true, e.g. Cluster: ClusterAzureBootstrapProfileCache).
+func ValidateArtifactStreamingImagePull(ctx context.Context, s *Scenario) {
+	require.True(s.T, s.Tags.NonAnonymousACR,
+		"ValidateArtifactStreamingImagePull requires a private ACR with pull secret (set Tags.NonAnonymousACR = true)")
+
+	acrName := config.GetPrivateACRName(s.Tags.NonAnonymousACR, s.Location)
+	image := fmt.Sprintf("%s.azurecr.io/%s", acrName, artifactStreamingE2ERepoTag)
+
+	// Prepare the overlaybd streaming artifact in the ACR. This is idempotent across runs, so a
+	// cached ACR that already has the streaming referrer is a no-op.
+	ensureStreamingArtifactForImage(ctx, s, acrName, artifactStreamingE2ERepoTag)
+
+	// Launch the pod ourselves and keep it running across the node-side check. We deliberately do
+	// NOT use ValidatePodRunning*/ValidatePodRunningWithRetry here: those delete the pod with a 0s
+	// grace period as soon as it reaches Running (see validatePodRunning in validation.go). That
+	// would tear down the container, causing the overlaybd snapshotter to unmount the image and
+	// overlaybd-tcmu to remove the TCMU backstore — before we could observe it — turning the
+	// streaming proof into a flaky false negative. The backstore only exists while the container
+	// rootfs is mounted, so the assertion must run with the pod still alive.
+	kube := s.Runtime.Kube
+	pod := podStreamingImageLinux(s, image)
+	truncatePodName(s.T, pod)
+
+	s.T.Logf("launching pod %q from artifact-streaming image %q", pod.Name, image)
+	_, err := kube.Typed.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+	require.NoErrorf(s.T, err, "failed to create artifact-streaming pod %q", pod.Name)
+	defer func() {
+		delCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		grace := int64(0)
+		if err := kube.Typed.CoreV1().Pods(pod.Namespace).Delete(delCtx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &grace}); err != nil {
+			s.T.Logf("could not delete artifact-streaming pod %q: %v", pod.Name, err)
+		}
+	}()
+
+	// A successful pull through the overlaybd snapshotter means the streamed layers were mounted for
+	// the container rootfs; reaching Running proves the image was pullable via streaming.
+	_, err = kube.WaitUntilPodRunning(ctx, pod.Namespace, "", "metadata.name="+pod.Name)
+	require.NoErrorf(s.T, err, "artifact-streaming pod %q never reached Running — overlaybd streaming pull likely failed for %q", pod.Name, image)
+
+	// Definitive node-side proof, checked WHILE the pod is still running: overlaybd exposes each
+	// streamed image layer as a TCMU-backed block device (target_core_user). Each opened device is
+	// a backstore directory under an HBA, i.e. /sys/kernel/config/target/core/user_<hba>/<device>/.
+	// We count the device directories (not the HBA itself, which overlaybd-tcmu may pre-create
+	// empty) so the signal is specifically "an overlaybd layer is currently mounted as a block
+	// device". A plain OCI image falls back to overlayfs and produces zero such backstores, so a
+	// non-zero count proves the image we just pulled was streamed on demand.
+	tcmuBackstoreCount := execScriptOnVMForScenarioValidateExitCode(
+		ctx, s,
+		`sudo bash -c 'ls -d /sys/kernel/config/target/core/user_*/*/ 2>/dev/null | wc -l'`,
+		0,
+		"failed to enumerate overlaybd TCMU backstores",
+	).stdout
+	logArtifactStreamingDiagnostics(ctx, s)
+	require.NotEqual(s.T, "0", strings.TrimSpace(tcmuBackstoreCount),
+		"expected at least one overlaybd TCMU backstore device under /sys/kernel/config/target/core "+
+			"while the streaming pod is running, but found none — image %q was not streamed (overlayfs fallback)", image)
+}
+
+// ensureStreamingArtifactForImage imports the source image into the private ACR and ensures its
+// overlaybd artifact-streaming referrer exists. Success is defined by the end state (a streaming
+// referrer is present), not by the CLI exit code, so it is fully idempotent across cached-ACR
+// re-runs without depending on the exact wording of "already exists" messages.
+//
+// NOTE: this shells out to `az` (as the e2e suite already does in types.go). The E2E runner must be
+// authenticated to the subscription and have the `az acr artifact-streaming`/`az acr manifest`
+// commands available. There is currently no armcontainerregistry SDK surface for creating a
+// streaming artifact; swap this for an SDK call if/when one is published.
+func ensureStreamingArtifactForImage(ctx context.Context, s *Scenario, acrName, repoTag string) {
+	s.T.Helper()
+
+	// 1. Import a concrete manifest into the ACR (cache rules are lazy/pull-through; import gives us
+	//    a real artifact we can attach a streaming referrer to). --force makes re-runs idempotent.
+	importCmd := exec.CommandContext(ctx, "az", "acr", "import",
+		"--name", acrName,
+		"--source", artifactStreamingSourceImage,
+		"--image", repoTag,
+		"--force",
+		"--subscription", config.Config.SubscriptionID,
+	)
+	if out, err := importCmd.CombinedOutput(); err != nil && !strings.Contains(strings.ToLower(string(out)), "already") {
+		s.T.Fatalf("failed to import %q into ACR %q for artifact streaming: %v\noutput: %s",
+			artifactStreamingSourceImage, acrName, err, string(out))
+	}
+
+	// 2. If the overlaybd streaming referrer already exists (e.g. cached ACR from a previous run),
+	//    there's nothing to do.
+	if streamingReferrerExists(ctx, s, acrName, repoTag) {
+		s.T.Logf("overlaybd streaming referrer already exists for %q in ACR %q, skipping create", repoTag, acrName)
+		return
+	}
+
+	// 3. Create the overlaybd streaming referrer. This is synchronous (`--no-wait` defaults to
+	//    false), so the conversion completes before we pull. Define success by re-checking that the
+	//    referrer now exists rather than trusting the CLI exit code.
+	streamCmd := exec.CommandContext(ctx, "az", "acr", "artifact-streaming", "create",
+		"--name", acrName,
+		"--image", repoTag,
+		"--subscription", config.Config.SubscriptionID,
+	)
+	out, err := streamCmd.CombinedOutput()
+	s.T.Logf("az acr artifact-streaming create output:\n%s", string(out))
+	if err != nil && !streamingReferrerExists(ctx, s, acrName, repoTag) {
+		s.T.Fatalf("failed to create overlaybd streaming artifact for %q in ACR %q: %v", repoTag, acrName, err)
+	}
+}
+
+// streamingReferrerExists reports whether the given image already has an overlaybd artifact-
+// streaming referrer in the ACR. Best-effort: on any CLI error it returns false so the caller
+// falls through to (re-)creating the referrer.
+func streamingReferrerExists(ctx context.Context, s *Scenario, acrName, repoTag string) bool {
+	s.T.Helper()
+	cmd := exec.CommandContext(ctx, "az", "acr", "manifest", "list-referrers",
+		"--name", repoTag,
+		"--registry", acrName,
+		"--subscription", config.Config.SubscriptionID,
+		"-o", "json",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		s.T.Logf("could not list referrers for %q in ACR %q (will attempt create): %v\n%s", repoTag, acrName, err, string(out))
+		return false
+	}
+	// A streaming (overlaybd) referrer appears as an entry with an artifactType in the referrers
+	// list. An empty referrers list has no such field.
+	return strings.Contains(string(out), "artifactType")
+}
+
+// logArtifactStreamingDiagnostics dumps overlaybd's on-node log tail and exporter metrics to help
+// triage streaming failures. Best-effort only — never fails the test.
+func logArtifactStreamingDiagnostics(ctx context.Context, s *Scenario) {
+	s.T.Helper()
+	obdLog := execScriptOnVMForScenario(ctx, s,
+		"sudo tail -n 50 /var/log/overlaybd.log 2>/dev/null || sudo journalctl -u overlaybd-tcmu --no-pager 2>/dev/null | tail -n 50 || true")
+	s.T.Logf("overlaybd log tail:\n%s", obdLog.stdout)
+
+	metrics := execScriptOnVMForScenario(ctx, s,
+		"sudo curl -s --max-time 5 http://localhost:9863/metrics 2>/dev/null | grep -iE 'overlaybd|obd' | head -n 30 || true")
+	s.T.Logf("overlaybd exporter (:9863) metrics sample:\n%s", metrics.stdout)
+}
+
+// podStreamingImageLinux builds a pod pinned to the scenario's node that pulls the given ACR
+// artifact-streaming image using the ACR pull secret. It mirrors the taint tolerations and node
+// selector used by podHTTPServerLinux so it schedules onto the freshly-provisioned node.
+func podStreamingImageLinux(s *Scenario, image string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-streaming-pod", s.Runtime.VM.KubeName),
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{Name: config.Config.ACRSecretName},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:    "streaming",
+					Image:   image,
+					Command: []string{"sleep", "infinity"},
+				},
+			},
+			// Tolerate the standard e2e node taints so the pod can schedule on the test node.
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      "testkey1",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "testkey2",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			NodeSelector: map[string]string{
+				"kubernetes.io/hostname": s.Runtime.VM.KubeName,
+			},
+		},
+	}
+}

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1412,14 +1412,12 @@ func Test_Ubuntu2204_ArtifactStreaming_NetworkIsolatedCluster(t *testing.T) {
 // image was streamed on demand (TCMU-backed block device) rather than downloaded into overlayfs.
 //
 // It uses ClusterAzureBootstrapProfileCache because that cluster attaches a Premium private ACR
-// (required for `az acr artifact-streaming`) and creates the ACR pull secret, without the added
-// complexity of full network isolation.
+// (required for `az acr artifact-streaming`), including an anonymous-pull ACR that the validator
+// uses so acr-mirror can serve the streaming manifest without a node managed identity — without the
+// added complexity of full network isolation.
 func Test_Ubuntu2204_ArtifactStreaming_ImagePull(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that an artifact streaming node actually streams an overlaybd image on pod launch (TCMU-backed), not just that the streaming services are running",
-		Tags: Tags{
-			NonAnonymousACR: true,
-		},
 		Config: Config{
 			Cluster: ClusterAzureBootstrapProfileCache,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1406,6 +1406,41 @@ func Test_Ubuntu2204_ArtifactStreaming_NetworkIsolatedCluster(t *testing.T) {
 	})
 }
 
+// Test_Ubuntu2204_ArtifactStreaming_ImagePull goes beyond the other artifact-streaming scenarios
+// (which only assert the overlaybd/acr-mirror services are running on a freshly bootstrapped node)
+// by actually launching a pod from an overlaybd-converted image and proving on the node that the
+// image was streamed on demand (TCMU-backed block device) rather than downloaded into overlayfs.
+//
+// It uses ClusterAzureBootstrapProfileCache because that cluster attaches a Premium private ACR
+// (required for `az acr artifact-streaming`) and creates the ACR pull secret, without the added
+// complexity of full network isolation.
+func Test_Ubuntu2204_ArtifactStreaming_ImagePull(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "tests that an artifact streaming node actually streams an overlaybd image on pod launch (TCMU-backed), not just that the streaming services are running",
+		Tags: Tags{
+			NonAnonymousACR: true,
+		},
+		Config: Config{
+			Cluster: ClusterAzureBootstrapProfileCache,
+			VHD:     config.VHDUbuntu2204Gen2Containerd,
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.EnableArtifactStreaming = true
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				// Node bootstrap sanity (same checks as the other streaming scenarios).
+				ValidateNonEmptyDirectory(ctx, s, "/etc/overlaybd")
+				ValidateSystemdUnitIsRunning(ctx, s, "overlaybd-snapshotter.service")
+				ValidateSystemdUnitIsRunning(ctx, s, "overlaybd-tcmu.service")
+				ValidateSystemdUnitIsRunning(ctx, s, "acr-mirror.service")
+				ValidateSystemdUnitIsRunning(ctx, s, "containerd.service")
+
+				// The actual streaming validation: pull an overlaybd image in a pod and confirm it streamed.
+				ValidateArtifactStreamingImagePull(ctx, s)
+			},
+		},
+	})
+}
+
 func Test_Ubuntu2204_ChronyRestarts_Taints_And_Tolerations(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that the chrony service restarts if it is killed. Also tests taints and tolerations",


### PR DESCRIPTION
## What

Adds `Test_Ubuntu2204_ArtifactStreaming_ImagePull`, an e2e that verifies artifact streaming **actually streams an image on pod launch**, not just that the streaming services come up.

## Why

Every existing `*_ArtifactStreaming*` scenario only asserts node bootstrap: that `overlaybd-snapshotter`, `overlaybd-tcmu`, and `acr-mirror` are running and `/etc/overlaybd` is non-empty. The per-scenario pod (`podHTTPServerLinux`) pulls a plain OCI image (`cbl-mariner/busybox:2.0`). With streaming enabled the CRI snapshotter is `overlaybd`, but overlaybd only *streams* overlaybd-format images — a plain OCI image falls back to overlayfs. So **the on-demand (TCMU) streaming path is never exercised** by the current tests.

## How

The new test:
1. Ensures an overlaybd **artifact-streaming referrer** exists for an image in the e2e private ACR — `az acr import` + `az acr artifact-streaming create`, made idempotent by checking the referrer end-state via `az acr manifest list-referrers` (so cached-ACR re-runs are a no-op and it does not depend on CLI "already exists" wording).
2. Launches a pod from that ACR image and waits for `Running` (a successful pull through the overlaybd snapshotter).
3. **While the pod is still running**, asserts overlaybd opened a TCMU-backed block device for it — a backstore device under `/sys/kernel/config/target/core/user_*/*/`. Plain OCI images (overlayfs fallback) create none, so a non-zero count is the definitive proof the image was streamed on demand.

Uses `ClusterAzureBootstrapProfileCache` (Premium private ACR attached, **not** network isolated) with `NonAnonymousACR` so the ACR pull secret is present.

### Notes / review focus
- **Node-side proof timing:** the TCMU check runs before pod teardown on purpose. The backstore only exists while the container rootfs is mounted, so the test does not use `ValidatePodRunning*` (which force-deletes the pod on return).
- **False-positive hardening:** counts backstore **devices** under `user_*/*/`, not the HBA directory (which `overlaybd-tcmu` may pre-create empty).
- **`az` dependency:** the setup shells out to `az` (as the suite already does in `types.go`). The runner must be subscription-authenticated with `az acr artifact-streaming`/`az acr manifest` available. There is no armcontainerregistry SDK surface for creating a streaming artifact today; swap for an SDK call once one exists.

## Test
- `go build ./...`, `go vet .` clean; test compiles and is registered.
- Full run requires Azure infra (Premium ACR + streaming-enabled node) — not run in this change.

Draft: seeking feedback on the streaming-artifact prep approach and the TCMU signal before a full pipeline run.
