### PR TITLE
chore(gpu): rename RTX PRO 6000 BSE v6 SKUs from preview to GA names

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -2459,13 +2459,13 @@ func Test_Ubuntu2404_GPU_RTXPro6000_GridV20(t *testing.T) {
 			// ephemeral OS disk placement (SupportedEphemeralOSDiskPlacements=NvmeDisk).
 			UseNVMe: true,
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.AgentPoolProfile.VMSize = "Standard_NC128ds_xl_RTXPRO6000BSE_v6"
+				nbc.AgentPoolProfile.VMSize = "Standard_NC144ds_xl_RTXPRO6000BSE_v6"
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = false
 				nbc.EnableNvidia = true
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
-				vmss.SKU.Name = to.Ptr("Standard_NC128ds_xl_RTXPRO6000BSE_v6")
+				vmss.SKU.Name = to.Ptr("Standard_NC144ds_xl_RTXPRO6000BSE_v6")
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateNvidiaModProbeInstalled(ctx, s)

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -981,6 +981,9 @@ var _ = Describe("GetGPUDriverType", func() {
 		// lds (lower-memory) variants share the same GPU/driver
 		Expect(GetGPUDriverType("standard_nc144lds_xl_rtxpro6000bse_v6")).To(Equal("grid-v20"))
 		Expect(GetGPUDriverType("Standard_NC288lds_xl_RTXPRO6000BSE_v6")).To(Equal("grid-v20"))
+		// preview SKU names are retained as backward-compat aliases
+		Expect(GetGPUDriverType("standard_nc128ds_xl_rtxpro6000bse_v6")).To(Equal("grid-v20"))
+		Expect(GetGPUDriverType("standard_nc320lds_xl_rtxpro6000bse_v6")).To(Equal("grid-v20"))
 	})
 	// NV V1 SKUs were retired in September 2023, leaving this test just for safety
 	It("should use cuda-lts with nv v1", func() {
@@ -995,6 +998,8 @@ var _ = Describe("GetAKSGPUImageSHA", func() {
 	It("should use newest AKSGPUGridV20VersionSuffix with rtx pro 6000 bse v6", func() {
 		Expect(GetAKSGPUImageSHA("standard_nc144ds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.AKSGPUGridV20VersionSuffix))
 		Expect(GetAKSGPUImageSHA("standard_nc144lds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.AKSGPUGridV20VersionSuffix))
+		Expect(GetAKSGPUImageSHA("standard_nc288ds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.AKSGPUGridV20VersionSuffix))
+		Expect(GetAKSGPUImageSHA("standard_nc288lds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.AKSGPUGridV20VersionSuffix))
 	})
 	It("should use newest AKSGPUCudaLTSVersionSuffix with non grid SKU", func() {
 		Expect(GetAKSGPUImageSHA("standard_nc6_v3")).To(Equal(datamodel.AKSGPUCudaLTSVersionSuffix))

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -951,11 +951,11 @@ var _ = Describe("GetGPUDriverVersion", func() {
 		Expect(GetGPUDriverVersion("Standard_nv36adms_A10_V5")).To(Equal(datamodel.NvidiaGridDriverVersion))
 	})
 	It("should use grid v20 with rtx pro 6000 bse v6", func() {
-		Expect(GetGPUDriverVersion("standard_nc128ds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.NvidiaGridV20DriverVersion))
-		Expect(GetGPUDriverVersion("Standard_NC320ds_xl_RTXPRO6000BSE_v6")).To(Equal(datamodel.NvidiaGridV20DriverVersion))
+		Expect(GetGPUDriverVersion("standard_nc144ds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.NvidiaGridV20DriverVersion))
+		Expect(GetGPUDriverVersion("Standard_NC288ds_xl_RTXPRO6000BSE_v6")).To(Equal(datamodel.NvidiaGridV20DriverVersion))
 		// lds (lower-memory) variants share the same GPU/driver
-		Expect(GetGPUDriverVersion("standard_nc128lds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.NvidiaGridV20DriverVersion))
-		Expect(GetGPUDriverVersion("Standard_NC320lds_xl_RTXPRO6000BSE_v6")).To(Equal(datamodel.NvidiaGridV20DriverVersion))
+		Expect(GetGPUDriverVersion("standard_nc144lds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.NvidiaGridV20DriverVersion))
+		Expect(GetGPUDriverVersion("Standard_NC288lds_xl_RTXPRO6000BSE_v6")).To(Equal(datamodel.NvidiaGridV20DriverVersion))
 	})
 	// NV V1 SKUs were retired in September 2023, leaving this test just for safety
 	It("should use cuda with nv v1", func() {
@@ -976,11 +976,11 @@ var _ = Describe("GetGPUDriverType", func() {
 		Expect(GetGPUDriverType("Standard_nv36adms_A10_V5")).To(Equal("grid"))
 	})
 	It("should use grid-v20 with rtx pro 6000 bse v6", func() {
-		Expect(GetGPUDriverType("standard_nc128ds_xl_rtxpro6000bse_v6")).To(Equal("grid-v20"))
-		Expect(GetGPUDriverType("Standard_NC320ds_xl_RTXPRO6000BSE_v6")).To(Equal("grid-v20"))
+		Expect(GetGPUDriverType("standard_nc144ds_xl_rtxpro6000bse_v6")).To(Equal("grid-v20"))
+		Expect(GetGPUDriverType("Standard_NC288ds_xl_RTXPRO6000BSE_v6")).To(Equal("grid-v20"))
 		// lds (lower-memory) variants share the same GPU/driver
-		Expect(GetGPUDriverType("standard_nc128lds_xl_rtxpro6000bse_v6")).To(Equal("grid-v20"))
-		Expect(GetGPUDriverType("Standard_NC320lds_xl_RTXPRO6000BSE_v6")).To(Equal("grid-v20"))
+		Expect(GetGPUDriverType("standard_nc144lds_xl_rtxpro6000bse_v6")).To(Equal("grid-v20"))
+		Expect(GetGPUDriverType("Standard_NC288lds_xl_RTXPRO6000BSE_v6")).To(Equal("grid-v20"))
 	})
 	// NV V1 SKUs were retired in September 2023, leaving this test just for safety
 	It("should use cuda-lts with nv v1", func() {
@@ -993,8 +993,8 @@ var _ = Describe("GetAKSGPUImageSHA", func() {
 		Expect(GetAKSGPUImageSHA("standard_nv6ads_a10_v5")).To(Equal(datamodel.AKSGPUGridVersionSuffix))
 	})
 	It("should use newest AKSGPUGridV20VersionSuffix with rtx pro 6000 bse v6", func() {
-		Expect(GetAKSGPUImageSHA("standard_nc128ds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.AKSGPUGridV20VersionSuffix))
-		Expect(GetAKSGPUImageSHA("standard_nc128lds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.AKSGPUGridV20VersionSuffix))
+		Expect(GetAKSGPUImageSHA("standard_nc144ds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.AKSGPUGridV20VersionSuffix))
+		Expect(GetAKSGPUImageSHA("standard_nc144lds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.AKSGPUGridV20VersionSuffix))
 	})
 	It("should use newest AKSGPUCudaLTSVersionSuffix with non grid SKU", func() {
 		Expect(GetAKSGPUImageSHA("standard_nc6_v3")).To(Equal(datamodel.AKSGPUCudaLTSVersionSuffix))

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -956,6 +956,9 @@ var _ = Describe("GetGPUDriverVersion", func() {
 		// lds (lower-memory) variants share the same GPU/driver
 		Expect(GetGPUDriverVersion("standard_nc144lds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.NvidiaGridV20DriverVersion))
 		Expect(GetGPUDriverVersion("Standard_NC288lds_xl_RTXPRO6000BSE_v6")).To(Equal(datamodel.NvidiaGridV20DriverVersion))
+		// smaller GA fractional-GPU sizes also use grid-v20
+		Expect(GetGPUDriverVersion("standard_nc36ds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.NvidiaGridV20DriverVersion))
+		Expect(GetGPUDriverVersion("standard_nc24lds_xl_rtxpro6000bse_v6")).To(Equal(datamodel.NvidiaGridV20DriverVersion))
 	})
 	// NV V1 SKUs were retired in September 2023, leaving this test just for safety
 	It("should use cuda with nv v1", func() {

--- a/pkg/agent/datamodel/gpu_components.go
+++ b/pkg/agent/datamodel/gpu_components.go
@@ -132,12 +132,10 @@ the same GPU and therefore the same driver, so both are listed here.
 */
 //nolint:gochecknoglobals
 var RTXPro6000GPUDriverSizes = map[string]bool{
-	"standard_nc128ds_xl_rtxpro6000bse_v6":  true,
-	"standard_nc128lds_xl_rtxpro6000bse_v6": true,
-	"standard_nc256ds_xl_rtxpro6000bse_v6":  true,
-	"standard_nc256lds_xl_rtxpro6000bse_v6": true,
-	"standard_nc320ds_xl_rtxpro6000bse_v6":  true,
-	"standard_nc320lds_xl_rtxpro6000bse_v6": true,
+	"standard_nc144ds_xl_rtxpro6000bse_v6":  true,
+	"standard_nc144lds_xl_rtxpro6000bse_v6": true,
+	"standard_nc288ds_xl_rtxpro6000bse_v6":  true,
+	"standard_nc288lds_xl_rtxpro6000bse_v6": true,
 }
 
 //nolint:gochecknoglobals

--- a/pkg/agent/datamodel/gpu_components.go
+++ b/pkg/agent/datamodel/gpu_components.go
@@ -127,18 +127,25 @@ var ConvergedGPUDriverSizes = map[string]bool{
 /* RTXPro6000GPUDriverSizes : NC_RTXPRO6000BSE_v6 (RTX PRO 6000 Blackwell Server
 Edition) SKUs require the GRID v20 (595.x) driver, published as the
 aks-gpu-grid-v20 image. All other GRID SKUs continue to use aks-gpu-grid.
-Each size ships as a ds (higher-memory) and lds (lower-memory) pair; both use
-the same GPU and therefore the same driver, so both are listed here.
+The family ships General Purpose (ds) and Compute Optimized (lds) sizes across
+fractional and whole GPU allocations (1/4, 1/2, 1, 2 GPUs); all use the same
+RTX PRO 6000 Blackwell GPU and therefore the same driver, so every size is
+listed here.
 
-Post-GA the sizes were renamed (128->144, 256/320->288 vCPU). The GA names are
-the primary entries; the original preview names are retained as backward-compat
-aliases so driver selection stays correct if an older node pool or template
-still reports them (same physical GPU, same grid-v20 driver). Azure no longer
-deploys the preview sizes.
+Post-GA the sizes were renamed (128->144, 256/320->288 vCPU) and smaller sizes
+were added. The GA names are the primary entries; the original preview names
+are retained as backward-compat aliases so driver selection stays correct if an
+older node pool or template still reports them (same physical GPU, same grid-v20
+driver). Azure no longer deploys the preview sizes.
 */
 //nolint:gochecknoglobals
 var RTXPro6000GPUDriverSizes = map[string]bool{
-	// GA sizes.
+	// GA sizes (General Purpose "ds" + Compute Optimized "lds").
+	"standard_nc24lds_xl_rtxpro6000bse_v6":  true,
+	"standard_nc36ds_xl_rtxpro6000bse_v6":   true,
+	"standard_nc36lds_xl_rtxpro6000bse_v6":  true,
+	"standard_nc72ds_xl_rtxpro6000bse_v6":   true,
+	"standard_nc72lds_xl_rtxpro6000bse_v6":  true,
 	"standard_nc144ds_xl_rtxpro6000bse_v6":  true,
 	"standard_nc144lds_xl_rtxpro6000bse_v6": true,
 	"standard_nc288ds_xl_rtxpro6000bse_v6":  true,

--- a/pkg/agent/datamodel/gpu_components.go
+++ b/pkg/agent/datamodel/gpu_components.go
@@ -129,13 +129,27 @@ Edition) SKUs require the GRID v20 (595.x) driver, published as the
 aks-gpu-grid-v20 image. All other GRID SKUs continue to use aks-gpu-grid.
 Each size ships as a ds (higher-memory) and lds (lower-memory) pair; both use
 the same GPU and therefore the same driver, so both are listed here.
+
+Post-GA the sizes were renamed (128->144, 256/320->288 vCPU). The GA names are
+the primary entries; the original preview names are retained as backward-compat
+aliases so driver selection stays correct if an older node pool or template
+still reports them (same physical GPU, same grid-v20 driver). Azure no longer
+deploys the preview sizes.
 */
 //nolint:gochecknoglobals
 var RTXPro6000GPUDriverSizes = map[string]bool{
+	// GA sizes.
 	"standard_nc144ds_xl_rtxpro6000bse_v6":  true,
 	"standard_nc144lds_xl_rtxpro6000bse_v6": true,
 	"standard_nc288ds_xl_rtxpro6000bse_v6":  true,
 	"standard_nc288lds_xl_rtxpro6000bse_v6": true,
+	// Preview sizes, retained as backward-compat aliases (see doc comment above).
+	"standard_nc128ds_xl_rtxpro6000bse_v6":  true,
+	"standard_nc128lds_xl_rtxpro6000bse_v6": true,
+	"standard_nc256ds_xl_rtxpro6000bse_v6":  true,
+	"standard_nc256lds_xl_rtxpro6000bse_v6": true,
+	"standard_nc320ds_xl_rtxpro6000bse_v6":  true,
+	"standard_nc320lds_xl_rtxpro6000bse_v6": true,
 }
 
 //nolint:gochecknoglobals

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_acl_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_acl_spec.sh
@@ -131,7 +131,7 @@ Describe 'cse_install_acl.sh'
             # through to the cuda sysext on a vGPU node. Use 'run' so the guard's
             # exit is captured as a status instead of aborting the example.
             NVIDIA_GPU_DRIVER_TYPE="grid-v20"
-            MOCK_VM_SKU="Standard_NC128ds_xl_RTXPRO6000BSE_v6"
+            MOCK_VM_SKU="Standard_NC144ds_xl_RTXPRO6000BSE_v6"
             When run installGPUDriverSysext
             The status should equal "$ERR_NVIDIA_DRIVER_INSTALL"
             The output should include "only supported on Ubuntu"

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
@@ -323,7 +323,7 @@ Describe 'cse_install_mariner.sh'
             # is captured as a status instead of aborting the example.
             ERR_NVIDIA_DRIVER_INSTALL=224
             NVIDIA_GPU_DRIVER_TYPE="grid-v20"
-            MOCK_VM_SKU="Standard_NC128ds_xl_RTXPRO6000BSE_v6"
+            MOCK_VM_SKU="Standard_NC144ds_xl_RTXPRO6000BSE_v6"
             When run downloadGPUDrivers
             The status should equal "$ERR_NVIDIA_DRIVER_INSTALL"
             The output should include "only supported on Ubuntu"


### PR DESCRIPTION
## What

The NC_RTXPRO6000BSE_v6 (NCv6, RTX PRO 6000 Blackwell Server Edition) VM
family transitioned from **preview to GA**, and Azure renamed the VM sizes.
This updates the grid-v20 driver selection map and every reference to the
new GA names.

| Preview (removed) | GA (new) |
| --- | --- |
| `Standard_NC128ds_xl_RTXPRO6000BSE_v6`  | `Standard_NC144ds_xl_RTXPRO6000BSE_v6` |
| `Standard_NC128lds_xl_RTXPRO6000BSE_v6` | `Standard_NC144lds_xl_RTXPRO6000BSE_v6` |
| `Standard_NC256ds_xl_RTXPRO6000BSE_v6`  | `Standard_NC288ds_xl_RTXPRO6000BSE_v6` |
| `Standard_NC256lds_xl_RTXPRO6000BSE_v6` | `Standard_NC288lds_xl_RTXPRO6000BSE_v6` |
| `Standard_NC320ds_xl_RTXPRO6000BSE_v6`  | `Standard_NC288ds_xl_RTXPRO6000BSE_v6` |
| `Standard_NC320lds_xl_RTXPRO6000BSE_v6` | `Standard_NC288lds_xl_RTXPRO6000BSE_v6` |

6 preview sizes collapse to 4 GA sizes (256 and 320 both map to 288).

## Why

Per the [NCv6 GA transition docs](https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nc-rtxpro6000-bse-v6-series-overview#faqs),
the preview sizes (128/256/320 vCPU) "will no longer work correctly and will
not be covered under Azure SLA". Only the new GA sizes deploy. The original
preview names were added in #8666.

## Changes

- `pkg/agent/datamodel/gpu_components.go` — `RTXPro6000GPUDriverSizes` now lists the 4 GA sizes.
- `pkg/agent/baker_test.go` — GPU driver/type/image-SHA tests use GA names.
- `e2e/scenario_test.go` — `Test_Ubuntu2404_GPU_RTXPro6000_GridV20` uses `Standard_NC144ds_xl_RTXPRO6000BSE_v6`.
- `spec/.../cse_install_mariner_spec.sh`, `cse_install_acl_spec.sh` — mock SKU updated.

## Testing

- `go test ./pkg/agent/...` — pass.
- `GENERATE_TEST_DATA=true go test ./pkg/agent/...` — no snapshot diff (driver map only; no snapshot references these SKUs).
- gofmt clean. Shell spec assertions key on `NVIDIA_GPU_DRIVER_TYPE=grid-v20` (unchanged); the SKU string is illustrative.
