### PR TITLE
fix: pin moby-runc to 1.4.1 for ubuntu 20.04 to prevent 2004 FIPS abe2e break

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1035,7 +1035,7 @@
           "r2004": {
             "versionsV2": [
               {
-                "renovateTag": "name=moby-runc, repository=production, os=ubuntu, release=20.04",
+                "renovateTag": "<DO_NOT_UPDATE>",
                 "latestVersion": "1.4.1-ubuntu20.04u1"
               }
             ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Hard-pins Ubuntu 20.04 `moby-runc` to the 1.4.1 line by marking its entry in
`parts/common/components.json` with `"renovateTag": "<DO_NOT_UPDATE>"`. This
stops Renovate from tracking the 20.04 runc entry, so it no longer proposes bumps for it.

`moby-runc` 1.4.3 breaks AgentBaker E2E (abe2e) on Ubuntu 2004 FIPS VHDs. This
was already hit once: #8714 bumped 20.04 → 1.4.3, and #8741 reverted it back to
1.4.1. With no guard in place, Renovate keeps re-proposing the 20.04 bump —
most recently #8744 (patch → 1.4.3) and the 20.04 line of #8758 (minor → 1.5.0).
Pinning via `<DO_NOT_UPDATE>` stops the recurring re-proposals at the source.

Every Ubuntu 2004 SKU AKS builds is FIPS or CVM, and 20.04 is near end-of-life,
so a hard pin at 1.4.1 is appropriate.

**Scope / safety**:

- Single-line change: the `r2004` `moby-runc` entry in `components.json`.
  `latestVersion` stays `1.4.1-ubuntu20.04u1`.
- 22.04 and 24.04 keep their normal `renovateTag`s and continue receiving runc
  updates — unaffected.
- Uses the existing `<DO_NOT_UPDATE>` convention already applied to other pinned
  components, so no `renovate.json` changes are needed and the shared 20.04
  custom manager stays intact for all other 20.04 components.
- Stopgap: when a FIPS-safe runc is published for focal, restore the real
  `renovateTag` (`name=moby-runc, repository=production, os=ubuntu, release=20.04`)
  to resume updates.

**Follow-up**:

- #8744 (20.04 → 1.4.3) is already closed.
- #8758 has had its 20.04 line manually reverted and now upgrades only
  22.04/24.04 → 1.5.0. Once this merges, #8758 is safe to rebase — Renovate will
  no longer re-add a 20.04 runc bump.

**Which issue(s) this PR fixes**:

Fixes # — N/A (no tracking issue). Related: same break reverted in #8741;
supersedes the recurring 20.04 re-proposals (#8744, and the 20.04 portion of #8758).