### PR TITLE
chore(deps): bump go to 1.26.4 across all modules

### DIFF
--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -14,7 +14,7 @@ jobs:
         if: success()
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - name: Checkout code
         uses: actions/checkout@v7
       - name: Run unit tests

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - run: |
           set -ex

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -13,7 +13,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     - run: |
         set -ex
         make test

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,13 +22,14 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - uses: actions/checkout@v7
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v2.8.0
+          # v2.9.0 is the first release built with Go 1.26; required because the modules now target go 1.26.
+          version: v2.9.0
           working-directory: ${{ matrix.dirs }}
 
           # Optional: working directory, useful for monorepos

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v7
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     - run: |
         make validate-shell
       name: Lint shell/bash scripts with ShellCheck

--- a/.github/workflows/shellspec.yaml
+++ b/.github/workflows/shellspec.yaml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v7
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     - run: |
         make shellspec-ci
       name: Run shell/bash script unit tests with shellspec

--- a/.github/workflows/validate-components.yml
+++ b/.github/workflows/validate-components.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - name: Install cue
         run: |
           go version

--- a/aks-node-controller/go.mod
+++ b/aks-node-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/agentbaker/aks-node-controller
 
-go 1.25.11
+go 1.26.4
 
 require (
 	github.com/Azure/agentbaker v0.20240503.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/agentbaker
 
-go 1.25.11
+go 1.26.4
 
 require (
 	github.com/Azure/go-autorest/autorest/to v0.4.1

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/agentbaker/hack/tools
 
-go 1.25.11
+go 1.26.4
 
 require github.com/onsi/ginkgo v1.16.4
 

--- a/image-fetcher/go.mod
+++ b/image-fetcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/agentbaker/image-fetcher
 
-go 1.25.11
+go 1.26.4
 
 require (
 	github.com/containerd/containerd/v2 v2.2.5

--- a/vhdbuilder/lister/go.mod
+++ b/vhdbuilder/lister/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/agentbaker/vhdbuilder/lister
 
-go 1.25.11
+go 1.26.4
 
 require (
 	github.com/containerd/containerd v1.7.33

--- a/vhdbuilder/prefetch/go.mod
+++ b/vhdbuilder/prefetch/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/agentbaker/vhdbuilder/prefetch
 
-go 1.25.11
+go 1.26.4
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
## What this PR does / why we need it

Bump the `go` directive in all modules (agentbaker service, aks-node-controller, e2e, hack/tools, image-fetcher, vhdbuilder/lister, vhdbuilder/prefetch) from `1.25.11` to `1.26.4`, and move the CI `actions/setup-go` pins to `'1.26'`. This picks up the go1.26.5 security fixes (crypto/tls, os) and aligns absvc with e2e/STLS, which are already on the 1.26 line.

### Why 1.26.4 and not 1.26.5?

The `go X.Y.Z` line in `go.mod` is a **minimum-version floor**, not the compiler that's actually used:

- **GitHub CI** installs Go via `actions/setup-go` and runs with `GOTOOLCHAIN=local`. The upstream setup-go manifest currently tops out at **1.26.4** (go1.26.5 was only released 2026-07-07 and isn't published there yet). A `go 1.26.5` directive is therefore unsatisfiable in CI and fails hard with `go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)`.
- **The release/VHD build** compiles with the latest `msft-golang` toolchain (1.26.5), which comfortably satisfies a `1.26.4` floor — so the shipped binaries still carry the go1.26.5 crypto/tls and os security fixes regardless of the directive value.

Setting the floor to `1.26.4` keeps CI green today while still delivering the security fixes at build time. The workflow pins stay on the `'1.26'` major.minor line, so they'll auto-pick 1.26.5 (and a trivial `.4 → .5` directive bump can follow) once it lands in the setup-go manifest.

## Which issue(s) this PR fixes

Fixes #

## Special notes for your reviewer

`e2e/go.mod` is unchanged — it was already on `1.26.4`. Net diff is 13 files (6 `go.mod` + 7 workflow pins).