### PR TITLE
feat: add Azure Linux GPU driver versions to release notes

### DIFF
--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -113,8 +113,11 @@ getLatestAzureLinuxNvidiaDriverPackageForKernel() {
 getAzureLinuxNvidiaDriverVersionFromPackage() {
     local package=$1
     local package_prefix=$2
+    local version_with_epoch
 
-    echo "${package#"${package_prefix}"}" | cut -d- -f1
+    version_with_epoch=${package#"${package_prefix}"}
+    version_with_epoch=${version_with_epoch%%-*}
+    echo "${version_with_epoch#*:}"
 }
 
 getAzureLinuxNvidiaDriverReleaseNotes() {

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -128,7 +128,7 @@ getAzureLinuxNvidiaDriverReleaseNotes() {
     local cuda_package
     local grid_package
     cuda_open_package=$(getLatestAzureLinuxNvidiaDriverPackageForKernel "cuda-open*" "^cuda-open-[0-9]" "${kernel_version}")
-    cuda_package=$(getLatestAzureLinuxNvidiaDriverPackageForKernel "cuda-[0-9]*" "^cuda-[0-9]" "${kernel_version}")
+    cuda_package=$(getLatestAzureLinuxNvidiaDriverPackageForKernel "cuda" "^cuda-[0-9]" "${kernel_version}")
     grid_package=$(getLatestAzureLinuxNvidiaDriverPackageForKernel "nvidia-vgpu-guest-driver*" "^nvidia-vgpu-guest-driver-[0-9]" "${kernel_version}")
 
     if [ -z "${cuda_open_package}" ] && [ -z "${cuda_package}" ] && [ -z "${grid_package}" ]; then
@@ -195,7 +195,7 @@ downloadGPUDrivers() {
         CUDA_PACKAGE=$(dnf repoquery -y --available "cuda-open*" | grep -E "^cuda-open-[0-9]+.*_${KERNEL_VERSION}" | sort -V | tail -n 1)
     else
         echo "VM SKU ${VM_SKU} uses NVIDIA proprietary driver (cuda)"
-        CUDA_PACKAGE=$(dnf repoquery -y --available "cuda-[0-9]*" | grep -E "^cuda-[0-9]+.*_${KERNEL_VERSION}" | sort -V | tail -n 1)
+        CUDA_PACKAGE=$(dnf repoquery -y --available "cuda" | grep -E "^cuda-[0-9]+.*_${KERNEL_VERSION}" | sort -V | tail -n 1)
     fi
 
     if [ -z "$CUDA_PACKAGE" ]; then

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -101,6 +101,42 @@ downloadGridDrivers() {
     dnf_install 30 1 600 ${GRID_PACKAGE} || exit $ERR_APT_INSTALL_TIMEOUT
 }
 
+getLatestAzureLinuxNvidiaDriverPackageForKernel() {
+    local package_query=$1
+    local package_regex=$2
+    local kernel_version=$3
+
+    dnf repoquery -y --available "${package_query}" 2>/dev/null | \
+        grep -E "${package_regex}.*_${kernel_version}" | sort -V | tail -n 1 || true
+}
+
+getAzureLinuxNvidiaDriverReleaseNotes() {
+    local kernel_version
+    kernel_version=$(uname -r | sed 's/-/./g')
+
+    local cuda_open_package
+    local cuda_package
+    local grid_package
+    cuda_open_package=$(getLatestAzureLinuxNvidiaDriverPackageForKernel "cuda-open*" "^cuda-open-[0-9]" "${kernel_version}")
+    cuda_package=$(getLatestAzureLinuxNvidiaDriverPackageForKernel "cuda-[0-9]*" "^cuda-[0-9]" "${kernel_version}")
+    grid_package=$(getLatestAzureLinuxNvidiaDriverPackageForKernel "nvidia-vgpu-guest-driver*" "^nvidia-vgpu-guest-driver-[0-9]" "${kernel_version}")
+
+    if [ -z "${cuda_open_package}" ] && [ -z "${cuda_package}" ] && [ -z "${grid_package}" ]; then
+        return 0
+    fi
+
+    echo "Components installed at node provisioning time (CSE) for supported Azure Linux GPU VM sizes (kernel ${kernel_version}):"
+    if [ -n "${cuda_open_package}" ]; then
+        echo "  - nvidia-cuda-open-driver=${cuda_open_package}"
+    fi
+    if [ -n "${cuda_package}" ]; then
+        echo "  - nvidia-cuda-driver=${cuda_package}"
+    fi
+    if [ -n "${grid_package}" ]; then
+        echo "  - nvidia-grid-driver=${grid_package}"
+    fi
+}
+
 downloadGPUDrivers() {
     # Mariner CUDA rpm name comes in the following format:
     #

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -107,7 +107,7 @@ getLatestAzureLinuxNvidiaDriverPackageForKernel() {
     local kernel_version=$3
 
     dnf repoquery -y --available "${package_query}" 2>/dev/null | \
-        grep -E "${package_regex}.*_${kernel_version}" | sort -V | tail -n 1 || true
+        grep -E "${package_regex}" | grep -F "_${kernel_version}." | sort -V | tail -n 1 || true
 }
 
 getAzureLinuxNvidiaDriverReleaseNotes() {
@@ -125,7 +125,7 @@ getAzureLinuxNvidiaDriverReleaseNotes() {
         return 0
     fi
 
-    echo "Components installed at node provisioning time (CSE) for supported Azure Linux GPU VM sizes (kernel ${kernel_version}):"
+    echo "NVIDIA GPU driver packages available at VHD build time for supported Azure Linux GPU VM sizes (kernel ${kernel_version}):"
     if [ -n "${cuda_open_package}" ]; then
         echo "  - nvidia-cuda-open-driver=${cuda_open_package}"
     fi

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -110,6 +110,13 @@ getLatestAzureLinuxNvidiaDriverPackageForKernel() {
         grep -E "${package_regex}" | grep -F "_${kernel_version}." | sort -V | tail -n 1 || true
 }
 
+getAzureLinuxNvidiaDriverVersionFromPackage() {
+    local package=$1
+    local package_prefix=$2
+
+    echo "${package#"${package_prefix}"}" | cut -d- -f1
+}
+
 getAzureLinuxNvidiaDriverReleaseNotes() {
     local kernel_version
     kernel_version=$(uname -r | sed 's/-/./g')
@@ -125,15 +132,15 @@ getAzureLinuxNvidiaDriverReleaseNotes() {
         return 0
     fi
 
-    echo "NVIDIA GPU driver packages available at VHD build time for supported Azure Linux GPU VM sizes (kernel ${kernel_version}):"
+    echo "NVIDIA GPU driver versions available at VHD build time for supported Azure Linux GPU VM sizes:"
     if [ -n "${cuda_open_package}" ]; then
-        echo "  - nvidia-cuda-open-driver=${cuda_open_package}"
+        echo "  - nvidia-cuda-open-driver version $(getAzureLinuxNvidiaDriverVersionFromPackage "${cuda_open_package}" "cuda-open-")"
     fi
     if [ -n "${cuda_package}" ]; then
-        echo "  - nvidia-cuda-driver=${cuda_package}"
+        echo "  - nvidia-cuda-driver version $(getAzureLinuxNvidiaDriverVersionFromPackage "${cuda_package}" "cuda-")"
     fi
     if [ -n "${grid_package}" ]; then
-        echo "  - nvidia-grid-driver=${grid_package}"
+        echo "  - nvidia-grid-driver version $(getAzureLinuxNvidiaDriverVersionFromPackage "${grid_package}" "nvidia-vgpu-guest-driver-")"
     fi
 }
 

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -145,6 +145,7 @@ getAzureLinuxNvidiaDriverReleaseNotes() {
     if [ -n "${grid_package}" ]; then
         echo "  - nvidia-grid-driver version $(getAzureLinuxNvidiaDriverVersionFromPackage "${grid_package}" "nvidia-vgpu-guest-driver-")"
     fi
+    echo "  Note: build-time snapshot only; Azure Linux GPU nodes install the latest kernel-compatible RPM available at node provisioning time, so the installed version is not pinned to this VHD."
 }
 
 downloadGPUDrivers() {

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -195,7 +195,7 @@ downloadGPUDrivers() {
         CUDA_PACKAGE=$(dnf repoquery -y --available "cuda-open*" | grep -E "^cuda-open-[0-9]+.*_${KERNEL_VERSION}" | sort -V | tail -n 1)
     else
         echo "VM SKU ${VM_SKU} uses NVIDIA proprietary driver (cuda)"
-        CUDA_PACKAGE=$(dnf repoquery -y --available "cuda" | grep -E "^cuda-[0-9]+.*_${KERNEL_VERSION}" | sort -V | tail -n 1)
+        CUDA_PACKAGE=$(dnf repoquery -y --available "cuda-[0-9]*" | grep -E "^cuda-[0-9]+.*_${KERNEL_VERSION}" | sort -V | tail -n 1)
     fi
 
     if [ -z "$CUDA_PACKAGE" ]; then

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
@@ -391,7 +391,7 @@ Describe 'cse_install_mariner.sh'
                     "cuda-open*")
                         echo "cuda-open-580.126.09-2_6.6.121.1.1.azl3.x86_64"
                         ;;
-                    "cuda-[0-9]*")
+                    "cuda")
                         echo "cuda-570.195.03-1_6.6.121.1.1.azl3.x86_64"
                         ;;
                     "nvidia-vgpu-guest-driver*")

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
@@ -361,6 +361,56 @@ Describe 'cse_install_mariner.sh'
         End
     End
 
+    Describe 'Azure Linux NVIDIA driver release notes'
+        uname() { echo "6.6.121.1-1.azl3"; }
+
+        It 'selects the latest package matching the current kernel'
+            dnf() {
+                echo "cuda-open-570.195.03-1_6.6.121.1.1.azl3.x86_64"
+                echo "cuda-open-580.126.09-2_6.6.121.1.1.azl3.x86_64"
+                echo "cuda-open-580.126.09-2_6.6.120.1.1.azl3.x86_64"
+            }
+
+            When call getLatestAzureLinuxNvidiaDriverPackageForKernel "cuda-open*" "^cuda-open-[0-9]" "6.6.121.1.1.azl3"
+
+            The status should be success
+            The output should equal "cuda-open-580.126.09-2_6.6.121.1.1.azl3.x86_64"
+        End
+
+        It 'formats CUDA open, CUDA proprietary, and GRID driver package versions for release notes'
+            dnf() {
+                case "$4" in
+                    "cuda-open*")
+                        echo "cuda-open-580.126.09-2_6.6.121.1.1.azl3.x86_64"
+                        ;;
+                    "cuda-[0-9]*")
+                        echo "cuda-570.195.03-1_6.6.121.1.1.azl3.x86_64"
+                        ;;
+                    "nvidia-vgpu-guest-driver*")
+                        echo "nvidia-vgpu-guest-driver-570.211.01-1_6.6.121.1.1.azl3.x86_64"
+                        ;;
+                esac
+            }
+
+            When call getAzureLinuxNvidiaDriverReleaseNotes
+
+            The status should be success
+            The output should include "Components installed at node provisioning time (CSE) for supported Azure Linux GPU VM sizes (kernel 6.6.121.1.1.azl3):"
+            The output should include "  - nvidia-cuda-open-driver=cuda-open-580.126.09-2_6.6.121.1.1.azl3.x86_64"
+            The output should include "  - nvidia-cuda-driver=cuda-570.195.03-1_6.6.121.1.1.azl3.x86_64"
+            The output should include "  - nvidia-grid-driver=nvidia-vgpu-guest-driver-570.211.01-1_6.6.121.1.1.azl3.x86_64"
+        End
+
+        It 'emits no release-note section when no driver packages match the current kernel'
+            dnf() { return 0; }
+
+            When call getAzureLinuxNvidiaDriverReleaseNotes
+
+            The status should be success
+            The output should equal ""
+        End
+    End
+
     Describe 'installAznfsPackage'
         ERR_AZNFS_INSTALL_FAIL=242
         aznfs_test_dir="$PWD/spec/tmp/aznfs-test"

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
@@ -396,10 +396,10 @@ Describe 'cse_install_mariner.sh'
             When call getAzureLinuxNvidiaDriverReleaseNotes
 
             The status should be success
-            The output should include "NVIDIA GPU driver packages available at VHD build time for supported Azure Linux GPU VM sizes (kernel 6.6.121.1.1.azl3):"
-            The output should include "  - nvidia-cuda-open-driver=cuda-open-580.126.09-2_6.6.121.1.1.azl3.x86_64"
-            The output should include "  - nvidia-cuda-driver=cuda-570.195.03-1_6.6.121.1.1.azl3.x86_64"
-            The output should include "  - nvidia-grid-driver=nvidia-vgpu-guest-driver-570.211.01-1_6.6.121.1.1.azl3.x86_64"
+            The output should include "NVIDIA GPU driver versions available at VHD build time for supported Azure Linux GPU VM sizes:"
+            The output should include "  - nvidia-cuda-open-driver version 580.126.09"
+            The output should include "  - nvidia-cuda-driver version 570.195.03"
+            The output should include "  - nvidia-grid-driver version 570.211.01"
         End
 
         It 'emits no release-note section when no driver packages match the current kernel'

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
@@ -378,6 +378,13 @@ Describe 'cse_install_mariner.sh'
             The output should equal "cuda-open-580.126.09-2_6.6.121.1.1.azl3.x86_64"
         End
 
+        It 'strips the RPM epoch when formatting a driver version'
+            When call getAzureLinuxNvidiaDriverVersionFromPackage "cuda-open-0:580.159.04-1_6.6.143.1.1.azl3.x86_64" "cuda-open-"
+
+            The status should be success
+            The output should equal "580.159.04"
+        End
+
         It 'formats CUDA open, CUDA proprietary, and GRID driver package versions for release notes'
             dnf() {
                 case "$4" in

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
@@ -368,6 +368,7 @@ Describe 'cse_install_mariner.sh'
             dnf() {
                 echo "cuda-open-570.195.03-1_6.6.121.1.1.azl3.x86_64"
                 echo "cuda-open-580.126.09-2_6.6.121.1.1.azl3.x86_64"
+                echo "cuda-open-590.1.0-1_6x6x121x1x1xazl3.x86_64"
                 echo "cuda-open-580.126.09-2_6.6.120.1.1.azl3.x86_64"
             }
 
@@ -395,7 +396,7 @@ Describe 'cse_install_mariner.sh'
             When call getAzureLinuxNvidiaDriverReleaseNotes
 
             The status should be success
-            The output should include "Components installed at node provisioning time (CSE) for supported Azure Linux GPU VM sizes (kernel 6.6.121.1.1.azl3):"
+            The output should include "NVIDIA GPU driver packages available at VHD build time for supported Azure Linux GPU VM sizes (kernel 6.6.121.1.1.azl3):"
             The output should include "  - nvidia-cuda-open-driver=cuda-open-580.126.09-2_6.6.121.1.1.azl3.x86_64"
             The output should include "  - nvidia-cuda-driver=cuda-570.195.03-1_6.6.121.1.1.azl3.x86_64"
             The output should include "  - nvidia-grid-driver=nvidia-vgpu-guest-driver-570.211.01-1_6.6.121.1.1.azl3.x86_64"

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
@@ -407,6 +407,8 @@ Describe 'cse_install_mariner.sh'
             The output should include "  - nvidia-cuda-open-driver version 580.126.09"
             The output should include "  - nvidia-cuda-driver version 570.195.03"
             The output should include "  - nvidia-grid-driver version 570.211.01"
+            The output should include "build-time snapshot only"
+            The output should include "the installed version is not pinned to this VHD"
         End
 
         It 'emits no release-note section when no driver packages match the current kernel'

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -1233,12 +1233,12 @@ cacheGPUContainerImageComponents
 buildNVIDIAKernelModule
 capture_benchmark "${SCRIPT_NAME}_caching_gpu_container_images_and_build_nvidia_kernel_module"
 
-if [ "$OS" = "$AZURELINUX_OS_NAME" ] && [ "$(isARM64)" -ne 1 ] && ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
+if [ "$OS" = "$AZURELINUX_OS_NAME" ] && [ "$(isARM64)" -ne 1 ] && ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT" && ! isACL "$OS" "$OS_VARIANT"; then
   AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES=$(getAzureLinuxNvidiaDriverReleaseNotes)
   if [ -n "$AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES" ]; then
     printf '%s\n' "$AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES" >> "${VHD_LOGS_FILEPATH}"
   else
-    echo "Warning: no Azure Linux NVIDIA GPU driver packages found for kernel $(uname -r)"
+    echo "Warning: no Azure Linux NVIDIA GPU driver packages found for kernel $(uname -r)" | tee -a "${VHD_LOGS_FILEPATH}" >&2
   fi
 fi
 

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -1233,6 +1233,15 @@ cacheGPUContainerImageComponents
 buildNVIDIAKernelModule
 capture_benchmark "${SCRIPT_NAME}_caching_gpu_container_images_and_build_nvidia_kernel_module"
 
+if [ "$OS" = "$AZURELINUX_OS_NAME" ] && [ "$(isARM64)" -ne 1 ] && ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
+  AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES=$(getAzureLinuxNvidiaDriverReleaseNotes)
+  if [ -n "$AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES" ]; then
+    printf '%s\n' "$AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES" >> "${VHD_LOGS_FILEPATH}"
+  else
+    echo "Warning: no Azure Linux NVIDIA GPU driver packages found for kernel $(uname -r)"
+  fi
+fi
+
 # Start eBPF tool installation in the background while we pull container images in the foreground
 startEBPFToolsInstallation
 capture_benchmark "${SCRIPT_NAME}_start_install_ebpf_tools"

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -854,6 +854,15 @@ Components installed at node provisioning time (CSE) for supported GPU VM sizes 
 EOF
 fi
 
+if [ "$OS" = "$AZURELINUX_OS_NAME" ] && [ "$(isARM64)" -ne 1 ] && ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
+  AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES=$(getAzureLinuxNvidiaDriverReleaseNotes)
+  if [ -n "$AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES" ]; then
+    printf '%s\n' "$AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES" >> "${VHD_LOGS_FILEPATH}"
+  else
+    echo "Warning: no Azure Linux NVIDIA GPU driver packages found for kernel $(uname -r)"
+  fi
+fi
+
 echo "images pre-pulled:" >> ${VHD_LOGS_FILEPATH}
 capture_benchmark "${SCRIPT_NAME}_pull_nvidia_driver_and_start_ebpf_downloads"
 

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -854,12 +854,12 @@ Components installed at node provisioning time (CSE) for supported GPU VM sizes 
 EOF
 fi
 
-if [ "$OS" = "$AZURELINUX_OS_NAME" ] && [ "$(isARM64)" -ne 1 ] && ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
+if [ "$OS" = "$AZURELINUX_OS_NAME" ] && [ "$(isARM64)" -ne 1 ] && ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT" && ! isACL "$OS" "$OS_VARIANT"; then
   AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES=$(getAzureLinuxNvidiaDriverReleaseNotes)
   if [ -n "$AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES" ]; then
     printf '%s\n' "$AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES" >> "${VHD_LOGS_FILEPATH}"
   else
-    echo "Warning: no Azure Linux NVIDIA GPU driver packages found for kernel $(uname -r)"
+    echo "Warning: no Azure Linux NVIDIA GPU driver packages found for kernel $(uname -r)" | tee -a "${VHD_LOGS_FILEPATH}" >&2
   fi
 fi
 

--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -1233,15 +1233,6 @@ cacheGPUContainerImageComponents
 buildNVIDIAKernelModule
 capture_benchmark "${SCRIPT_NAME}_caching_gpu_container_images_and_build_nvidia_kernel_module"
 
-if [ "$OS" = "$AZURELINUX_OS_NAME" ] && [ "$(isARM64)" -ne 1 ] && ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT" && ! isACL "$OS" "$OS_VARIANT"; then
-  AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES=$(getAzureLinuxNvidiaDriverReleaseNotes)
-  if [ -n "$AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES" ]; then
-    printf '%s\n' "$AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES" >> "${VHD_LOGS_FILEPATH}"
-  else
-    echo "Warning: no Azure Linux NVIDIA GPU driver packages found for kernel $(uname -r)" | tee -a "${VHD_LOGS_FILEPATH}" >&2
-  fi
-fi
-
 # Start eBPF tool installation in the background while we pull container images in the foreground
 startEBPFToolsInstallation
 capture_benchmark "${SCRIPT_NAME}_start_install_ebpf_tools"
@@ -1327,6 +1318,15 @@ rm -f ./azcopy # cleanup immediately after usage will return in two downloads
 extractAndCacheCoreDnsBinary
 
 collect_grid_compatibility_data
+
+if isAzureLinux "$OS" "$OS_VARIANT" && [ "$(isARM64)" -ne 1 ] && ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
+  AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES=$(getAzureLinuxNvidiaDriverReleaseNotes)
+  if [ -n "$AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES" ]; then
+    printf '%s\n' "$AZURELINUX_NVIDIA_DRIVER_RELEASE_NOTES" >> "${VHD_LOGS_FILEPATH}"
+  else
+    echo "Warning: no Azure Linux NVIDIA GPU driver packages found for kernel $(uname -r)" | tee -a "${VHD_LOGS_FILEPATH}" >&2
+  fi
+fi
 
 # nvidia repos are non msft public endpoints and should not be present on VHDs.
 # The installation logic during provisioning time will use the cached rpm/deb files

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1257,12 +1257,9 @@ testAzureLinuxNvidiaGPUDriverReleaseNotes() {
     err "$test" "Azure Linux NVIDIA GPU driver release-note section was not found"
   fi
 
-  if ! grep -E -q '^  - nvidia-cuda-open-driver version [0-9]' "$VHD_LOGS_FILEPATH"; then
-    err "$test" "Expected Azure Linux CUDA open driver release-note line was not found"
-  fi
-
-  if ! grep -E -q '^  - nvidia-cuda-driver version [0-9]' "$VHD_LOGS_FILEPATH"; then
-    err "$test" "Expected Azure Linux proprietary CUDA driver release-note line was not found"
+  # The current image kernel may have either an open or proprietary CUDA driver RPM.
+  if ! grep -E -q '^  - nvidia-cuda-(open-)?driver version [0-9]' "$VHD_LOGS_FILEPATH"; then
+    err "$test" "Expected an Azure Linux CUDA driver release-note line was not found"
   fi
 
   if ! grep -E -q '^  - nvidia-grid-driver version [0-9]' "$VHD_LOGS_FILEPATH"; then

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1214,19 +1214,19 @@ testAzureLinuxNvidiaGPUDriverReleaseNotes() {
     return 0
   fi
 
-  if ! grep -F -q "NVIDIA GPU driver packages available at VHD build time for supported Azure Linux GPU VM sizes" "$VHD_LOGS_FILEPATH"; then
+  if ! grep -F -q "NVIDIA GPU driver versions available at VHD build time for supported Azure Linux GPU VM sizes" "$VHD_LOGS_FILEPATH"; then
     err "$test" "Azure Linux NVIDIA GPU driver release-note section was not found"
   fi
 
-  if ! grep -E -q '^  - nvidia-cuda-open-driver=cuda-open-[0-9]' "$VHD_LOGS_FILEPATH"; then
+  if ! grep -E -q '^  - nvidia-cuda-open-driver version [0-9]' "$VHD_LOGS_FILEPATH"; then
     err "$test" "Expected Azure Linux CUDA open driver release-note line was not found"
   fi
 
-  if ! grep -E -q '^  - nvidia-cuda-driver=cuda-[0-9]' "$VHD_LOGS_FILEPATH"; then
+  if ! grep -E -q '^  - nvidia-cuda-driver version [0-9]' "$VHD_LOGS_FILEPATH"; then
     err "$test" "Expected Azure Linux proprietary CUDA driver release-note line was not found"
   fi
 
-  if ! grep -E -q '^  - nvidia-grid-driver=nvidia-vgpu-guest-driver-[0-9]' "$VHD_LOGS_FILEPATH"; then
+  if ! grep -E -q '^  - nvidia-grid-driver version [0-9]' "$VHD_LOGS_FILEPATH"; then
     err "$test" "Expected Azure Linux GRID driver release-note line was not found"
   fi
 

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1214,12 +1214,16 @@ testAzureLinuxNvidiaGPUDriverReleaseNotes() {
     return 0
   fi
 
-  if ! grep -F -q "Components installed at node provisioning time (CSE) for supported Azure Linux GPU VM sizes" "$VHD_LOGS_FILEPATH"; then
+  if ! grep -F -q "NVIDIA GPU driver packages available at VHD build time for supported Azure Linux GPU VM sizes" "$VHD_LOGS_FILEPATH"; then
     err "$test" "Azure Linux NVIDIA GPU driver release-note section was not found"
   fi
 
-  if ! grep -E -q '^  - nvidia-cuda-(open-)?driver=cuda(-open)?-[0-9]' "$VHD_LOGS_FILEPATH"; then
-    err "$test" "Expected Azure Linux CUDA driver release-note line was not found"
+  if ! grep -E -q '^  - nvidia-cuda-open-driver=cuda-open-[0-9]' "$VHD_LOGS_FILEPATH"; then
+    err "$test" "Expected Azure Linux CUDA open driver release-note line was not found"
+  fi
+
+  if ! grep -E -q '^  - nvidia-cuda-driver=cuda-[0-9]' "$VHD_LOGS_FILEPATH"; then
+    err "$test" "Expected Azure Linux proprietary CUDA driver release-note line was not found"
   fi
 
   if ! grep -E -q '^  - nvidia-grid-driver=nvidia-vgpu-guest-driver-[0-9]' "$VHD_LOGS_FILEPATH"; then

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1205,6 +1205,30 @@ testVHDBuildLogsExist() {
   echo "$test:Finish"
 }
 
+testAzureLinuxNvidiaGPUDriverReleaseNotes() {
+  local test="testAzureLinuxNvidiaGPUDriverReleaseNotes"
+  local enable_fips="${ENABLE_FIPS,,}"
+
+  if [ "$OS_SKU" != "AzureLinux" ] || [ "$OS_VERSION" != "3.0" ] || [ "$enable_fips" = "true" ] || [ "$(isARM64)" -eq 1 ] || echo "$FEATURE_FLAGS" | grep -q "kata"; then
+    echo "$test: Skipping check for $OS_SKU $OS_VERSION (fips=$ENABLE_FIPS, feature_flags=$FEATURE_FLAGS)"
+    return 0
+  fi
+
+  if ! grep -F -q "Components installed at node provisioning time (CSE) for supported Azure Linux GPU VM sizes" "$VHD_LOGS_FILEPATH"; then
+    err "$test" "Azure Linux NVIDIA GPU driver release-note section was not found"
+  fi
+
+  if ! grep -E -q '^  - nvidia-cuda-(open-)?driver=cuda(-open)?-[0-9]' "$VHD_LOGS_FILEPATH"; then
+    err "$test" "Expected Azure Linux CUDA driver release-note line was not found"
+  fi
+
+  if ! grep -E -q '^  - nvidia-grid-driver=nvidia-vgpu-guest-driver-[0-9]' "$VHD_LOGS_FILEPATH"; then
+    err "$test" "Expected Azure Linux GRID driver release-note line was not found"
+  fi
+
+  echo "$test:Finish"
+}
+
 # Ensures that /etc/login.defs is valid. This is a best-effort test, as we aren't going to
 # re-implement everything that uses this file.
 testLoginDefs() {
@@ -2499,6 +2523,7 @@ testContainerNetworkingPluginsInstalled() {
 checkPerformanceData
 testBccTools $OS_SKU
 testVHDBuildLogsExist
+testAzureLinuxNvidiaGPUDriverReleaseNotes
 testCriticalTools
 testPackagesInstalled
 testFuseInstalled

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1253,12 +1253,16 @@ testAzureLinuxNvidiaGPUDriverReleaseNotes() {
     return 0
   fi
 
-  if ! grep -F -q "Components installed at node provisioning time (CSE) for supported Azure Linux GPU VM sizes" "$VHD_LOGS_FILEPATH"; then
+  if ! grep -F -q "NVIDIA GPU driver packages available at VHD build time for supported Azure Linux GPU VM sizes" "$VHD_LOGS_FILEPATH"; then
     err "$test" "Azure Linux NVIDIA GPU driver release-note section was not found"
   fi
 
-  if ! grep -E -q '^  - nvidia-cuda-(open-)?driver=cuda(-open)?-[0-9]' "$VHD_LOGS_FILEPATH"; then
-    err "$test" "Expected Azure Linux CUDA driver release-note line was not found"
+  if ! grep -E -q '^  - nvidia-cuda-open-driver=cuda-open-[0-9]' "$VHD_LOGS_FILEPATH"; then
+    err "$test" "Expected Azure Linux CUDA open driver release-note line was not found"
+  fi
+
+  if ! grep -E -q '^  - nvidia-cuda-driver=cuda-[0-9]' "$VHD_LOGS_FILEPATH"; then
+    err "$test" "Expected Azure Linux proprietary CUDA driver release-note line was not found"
   fi
 
   if ! grep -E -q '^  - nvidia-grid-driver=nvidia-vgpu-guest-driver-[0-9]' "$VHD_LOGS_FILEPATH"; then

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1253,19 +1253,19 @@ testAzureLinuxNvidiaGPUDriverReleaseNotes() {
     return 0
   fi
 
-  if ! grep -F -q "NVIDIA GPU driver packages available at VHD build time for supported Azure Linux GPU VM sizes" "$VHD_LOGS_FILEPATH"; then
+  if ! grep -F -q "NVIDIA GPU driver versions available at VHD build time for supported Azure Linux GPU VM sizes" "$VHD_LOGS_FILEPATH"; then
     err "$test" "Azure Linux NVIDIA GPU driver release-note section was not found"
   fi
 
-  if ! grep -E -q '^  - nvidia-cuda-open-driver=cuda-open-[0-9]' "$VHD_LOGS_FILEPATH"; then
+  if ! grep -E -q '^  - nvidia-cuda-open-driver version [0-9]' "$VHD_LOGS_FILEPATH"; then
     err "$test" "Expected Azure Linux CUDA open driver release-note line was not found"
   fi
 
-  if ! grep -E -q '^  - nvidia-cuda-driver=cuda-[0-9]' "$VHD_LOGS_FILEPATH"; then
+  if ! grep -E -q '^  - nvidia-cuda-driver version [0-9]' "$VHD_LOGS_FILEPATH"; then
     err "$test" "Expected Azure Linux proprietary CUDA driver release-note line was not found"
   fi
 
-  if ! grep -E -q '^  - nvidia-grid-driver=nvidia-vgpu-guest-driver-[0-9]' "$VHD_LOGS_FILEPATH"; then
+  if ! grep -E -q '^  - nvidia-grid-driver version [0-9]' "$VHD_LOGS_FILEPATH"; then
     err "$test" "Expected Azure Linux GRID driver release-note line was not found"
   fi
 

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1244,6 +1244,30 @@ testVHDBuildLogsExist() {
   echo "$test:Finish"
 }
 
+testAzureLinuxNvidiaGPUDriverReleaseNotes() {
+  local test="testAzureLinuxNvidiaGPUDriverReleaseNotes"
+  local enable_fips="${ENABLE_FIPS,,}"
+
+  if [ "$OS_SKU" != "AzureLinux" ] || [ "$OS_VERSION" != "3.0" ] || [ "$enable_fips" = "true" ] || [ "$(isARM64)" -eq 1 ] || echo "$FEATURE_FLAGS" | grep -q "kata"; then
+    echo "$test: Skipping check for $OS_SKU $OS_VERSION (fips=$ENABLE_FIPS, feature_flags=$FEATURE_FLAGS)"
+    return 0
+  fi
+
+  if ! grep -F -q "Components installed at node provisioning time (CSE) for supported Azure Linux GPU VM sizes" "$VHD_LOGS_FILEPATH"; then
+    err "$test" "Azure Linux NVIDIA GPU driver release-note section was not found"
+  fi
+
+  if ! grep -E -q '^  - nvidia-cuda-(open-)?driver=cuda(-open)?-[0-9]' "$VHD_LOGS_FILEPATH"; then
+    err "$test" "Expected Azure Linux CUDA driver release-note line was not found"
+  fi
+
+  if ! grep -E -q '^  - nvidia-grid-driver=nvidia-vgpu-guest-driver-[0-9]' "$VHD_LOGS_FILEPATH"; then
+    err "$test" "Expected Azure Linux GRID driver release-note line was not found"
+  fi
+
+  echo "$test:Finish"
+}
+
 # Ensures that /etc/login.defs is valid. This is a best-effort test, as we aren't going to
 # re-implement everything that uses this file.
 testLoginDefs() {
@@ -2662,6 +2686,7 @@ testContainerNetworkingPluginsInstalled() {
 checkPerformanceData
 testBccTools $OS_SKU $OS_VERSION
 testVHDBuildLogsExist
+testAzureLinuxNvidiaGPUDriverReleaseNotes
 testCriticalTools
 testPackagesInstalled
 testFuseInstalled

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1269,6 +1269,10 @@ testAzureLinuxNvidiaGPUDriverReleaseNotes() {
     err "$test" "Expected Azure Linux GRID driver release-note line was not found"
   fi
 
+  if ! grep -F -q "the installed version is not pinned to this VHD" "$VHD_LOGS_FILEPATH"; then
+    err "$test" "Expected Azure Linux GPU driver release-note snapshot disclaimer was not found"
+  fi
+
   echo "$test:Finish"
 }
 

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1257,9 +1257,12 @@ testAzureLinuxNvidiaGPUDriverReleaseNotes() {
     err "$test" "Azure Linux NVIDIA GPU driver release-note section was not found"
   fi
 
-  # The current image kernel may have either an open or proprietary CUDA driver RPM.
-  if ! grep -E -q '^  - nvidia-cuda-(open-)?driver version [0-9]' "$VHD_LOGS_FILEPATH"; then
-    err "$test" "Expected an Azure Linux CUDA driver release-note line was not found"
+  if ! grep -E -q '^  - nvidia-cuda-open-driver version [0-9]' "$VHD_LOGS_FILEPATH"; then
+    err "$test" "Expected an Azure Linux CUDA open driver release-note line was not found"
+  fi
+
+  if ! grep -E -q '^  - nvidia-cuda-driver version [0-9]' "$VHD_LOGS_FILEPATH"; then
+    err "$test" "Expected an Azure Linux proprietary CUDA driver release-note line was not found"
   fi
 
   if ! grep -E -q '^  - nvidia-grid-driver version [0-9]' "$VHD_LOGS_FILEPATH"; then


### PR DESCRIPTION
**What this PR does / why we need it**:

Azure Linux GPU nodes already install NVIDIA driver RPMs at node provisioning time via CSE, but the Azure Linux VHD release notes only list other GPU components. This adds a build-time snapshot of the kernel-compatible driver packages to the Azure Linux release notes, matching Ubuntu's driver-version visibility while preserving the existing Azure Linux installation model.

This PR reports the latest kernel-matching Azure Linux packages available when the VHD is built for:
- nvidia-cuda-open-driver
- nvidia-cuda-driver
- nvidia-grid-driver

Azure Linux driver releases are not pinned to a VHD version. At node provisioning time, CSE queries the configured package repository and installs the latest RPM compatible with the image kernel. The generated release notes explicitly identify these versions as a build-time snapshot and state that the installed version can differ after the repository publishes a newer compatible package. Existing node-provisioning behavior is unchanged.

The proprietary release-note lookup queries the exact RPM package name, `cuda`, so it does not mix proprietary results with `cuda-open`. The NVIDIA section is emitted after the normal component logging so unrelated entries are not grouped beneath it.

It also adds ShellSpec coverage for package selection, formatting, and the snapshot disclaimer, plus a VHD content test requiring all three driver lines and the disclaimer on Azure Linux 3.0.

ADO work item: https://dev.azure.com/msazure/CloudNativeCompute/_workitems/edit/36670509

**Testing**:

- `make validate-shell`
- Targeted `cse_install_mariner_spec.sh` after rebasing onto latest `main` (42 examples, 0 failures)
- `git diff --check`
- `bash -n` on the modified shell scripts
- Earlier Azure Linux V3 Gen2 VHD build and real VM content test passed: https://msazure.visualstudio.com/09706533-03bf-4b43-9a9b-b49c75429646/_build/results?buildId=176375329
- Verified that VHD release-note artifact contains `nvidia-cuda-open-driver 580.159.04`, `nvidia-cuda-driver 580.159.04`, and `nvidia-grid-driver 570.195.03`

No GPU node was created for this PR. The change does not alter GPU node-provisioning behavior; validation covers the real VHD build, VM content test, RPM package lookup, and final release-note artifact.

**Which issue(s) this PR fixes**:

Fixes https://dev.azure.com/msazure/CloudNativeCompute/_workitems/edit/36670509
