### PR TITLE
fix: set sshd_config permissions to 0600 in configureSSHPubkeyAuth for CIS compliance

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1469,8 +1469,9 @@ configureSSHPubkeyAuth() {
   # Validate the candidate config
   sshd -t -f "$TMP" || { rm -f "$TMP"; exit $ERR_CONFIG_PUBKEY_AUTH_SSH; }
 
-  # Replace the original with the candidate (permissions 644, owned by root)
-  install -m 644 -o root -g root "$TMP" "$SSHD_CONFIG"
+  # Replace the original with the candidate (permissions 600, owned by root)
+  # Mode 0600 is required by CIS Benchmark control 5.1.1
+  install -m 600 -o root -g root "$TMP" "$SSHD_CONFIG"
   rm -f "$TMP"
 
   # Reload sshd

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -2281,4 +2281,31 @@ EOF
             The variable AMD_AMA_DRIVER_VERSION should equal "1.5.0"
         End
     End
+
+    Describe 'configureSSHPubkeyAuth CIS-compliant sshd_config permissions'
+        # These are static assertions on cse_config.sh to guard against a
+        # regression of the CIS Benchmark 5.1.1 fix, which requires
+        # /etc/ssh/sshd_config to be mode 0600 (or more restrictive) and
+        # owned by root:root. Previously, configureSSHPubkeyAuth used
+        # `install -m 644 ...` which overwrote the VHD-hardened 0600 mode
+        # from configureSsh() in cis.sh, causing CIS control 5.1.1 to fail
+        # on Ubuntu 22.04 and 24.04 nodes.
+        #
+        # If configureSSHPubkeyAuth ever reverts to a non-compliant mode
+        # (e.g. 644, 640, 660, 755) when replacing $SSHD_CONFIG, these
+        # tests will fail and flag the regression before it ships.
+        cse_config_path="./parts/linux/cloud-init/artifacts/cse_config.sh"
+
+        It 'replaces sshd_config with mode 0600 (CIS Benchmark 5.1.1)'
+            When call grep -E '^[[:space:]]*install[[:space:]]+-m[[:space:]]+0?600[[:space:]]+-o[[:space:]]+root[[:space:]]+-g[[:space:]]+root[[:space:]]+"\$TMP"[[:space:]]+"\$SSHD_CONFIG"' "$cse_config_path"
+            The status should be success
+            The output should include 'install'
+            The output should include 'SSHD_CONFIG'
+        End
+
+        It 'does not replace sshd_config with a world/group-readable mode'
+            When call grep -E '^[[:space:]]*install[[:space:]]+-m[[:space:]]+(0?(644|640|660|755|777))[[:space:]].*"\$SSHD_CONFIG"' "$cse_config_path"
+            The status should be failure
+        End
+    End
 End


### PR DESCRIPTION
## Summary

`configureSSHPubkeyAuth()` in `cse_config.sh` was using `install -m 644` when atomically replacing `/etc/ssh/sshd_config`, overwriting the CIS-hardened `0600` permission set during VHD build by `configureSsh()` in `cis.sh`.

This caused AKS Linux nodes (Ubuntu 22.04 and 24.04) to fail **CIS Benchmark control 5.1.1**, which requires `sshd_config` to have mode `0600` or more restrictive, with owner `root:root`.

## Changes

- Changed `install -m 644` to `install -m 600` in `configureSSHPubkeyAuth()` to preserve CIS-compliant permissions.

## Testing

- Verified no other occurrences of the `0644` pattern for `sshd_config` exist in the codebase.
- The function's behavior is otherwise unchanged  only the file permission mode on the `install` command is affected.

## Related

- Fixes #8682
- AB#38621432