### PR TITLE
revert(e2e): remove branch-CSE override once RCV1P ships in published…

### DIFF
--- a/e2e/scenario_rcv1p_test.go
+++ b/e2e/scenario_rcv1p_test.go
@@ -15,20 +15,16 @@
 package e2e
 
 import (
-	"archive/zip"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/Azure/agentbaker/e2e/config"
-	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
@@ -157,142 +153,6 @@ func rcv1pVMConfigMutator() func(*armcompute.VirtualMachineScaleSet) {
 	return rcv1pOptInVMConfigMutator
 }
 
-// REVERT ME: build and upload a CSE zip from the branch's staging/cse/windows/ so that
-// Windows RCV1P E2E tests exercise the actual RCV1P code instead of the published v0.0.52 package.
-var (
-	branchCSEZipURL  string
-	branchCSEZipErr  error
-	branchCSEZipOnce sync.Once
-)
-
-// getOrBuildBranchCSEPackageURL builds a CSE zip from staging/cse/windows/ (matching the
-// pipeline packaging in .pipelines/scripts/windows_package_cse.sh) and uploads it to the
-// E2E blob storage. Returns a SAS-signed URL. Uses sync.Once so the zip is built and
-// uploaded exactly once across all parallel tests.
-func getOrBuildBranchCSEPackageURL(t *testing.T) string {
-	t.Helper()
-	branchCSEZipOnce.Do(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-		defer cancel()
-		branchCSEZipURL, branchCSEZipErr = buildAndUploadCSEZip(ctx)
-	})
-	if branchCSEZipErr != nil {
-		t.Fatalf("failed to build/upload branch CSE zip: %v", branchCSEZipErr)
-	}
-	t.Logf("using branch CSE package URL: %s", branchCSEZipURL)
-	return branchCSEZipURL
-}
-
-func buildAndUploadCSEZip(ctx context.Context) (string, error) {
-	repoRoot, err := findRepoRoot()
-	if err != nil {
-		return "", fmt.Errorf("find repo root: %w", err)
-	}
-	cseDir := filepath.Join(repoRoot, "staging", "cse", "windows")
-
-	tmpFile, err := os.CreateTemp("", "aks-windows-cse-scripts-branch-*.zip")
-	if err != nil {
-		return "", fmt.Errorf("create temp file: %w", err)
-	}
-	defer os.Remove(tmpFile.Name())
-	defer tmpFile.Close()
-
-	zw := zip.NewWriter(tmpFile)
-	err = filepath.Walk(cseDir, func(path string, info os.FileInfo, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		rel, err := filepath.Rel(cseDir, path)
-		if err != nil {
-			return err
-		}
-		// normalize to forward slashes for zip
-		rel = filepath.ToSlash(rel)
-		if rel == "." {
-			return nil
-		}
-		// skip test files and debug helper (matches windows_package_cse.sh)
-		if strings.HasSuffix(rel, ".tests.ps1") || strings.Contains(rel, ".tests.suites") {
-			if info.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if rel == "README" || rel == "debug/update-scripts.ps1" {
-			return nil
-		}
-		if info.IsDir() {
-			return nil
-		}
-		w, err := zw.Create(rel)
-		if err != nil {
-			return fmt.Errorf("create zip entry %s: %w", rel, err)
-		}
-		f, err := os.Open(path)
-		if err != nil {
-			return fmt.Errorf("open %s: %w", path, err)
-		}
-		_, copyErr := io.Copy(w, f)
-		closeErr := f.Close()
-		if copyErr != nil {
-			return fmt.Errorf("copy %s: %w", path, copyErr)
-		}
-		if closeErr != nil {
-			return fmt.Errorf("close %s: %w", path, closeErr)
-		}
-		return nil
-	})
-	if err != nil {
-		return "", fmt.Errorf("build zip: %w", err)
-	}
-	if err := zw.Close(); err != nil {
-		return "", fmt.Errorf("close zip writer: %w", err)
-	}
-
-	// seek to start for upload
-	if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
-		return "", fmt.Errorf("seek temp file: %w", err)
-	}
-
-	blobName := fmt.Sprintf("cse-packages/aks-windows-cse-scripts-branch-%s.zip",
-		time.Now().UTC().Format("20060102-150405"))
-	url, err := config.Azure.UploadAndGetSignedLink(ctx, blobName, tmpFile)
-	if err != nil {
-		return "", fmt.Errorf("upload CSE zip: %w", err)
-	}
-	return url, nil
-}
-
-func findRepoRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			// e2e/ has its own go.mod, go up one more
-			if filepath.Base(dir) == "e2e" {
-				dir = filepath.Dir(dir)
-				continue
-			}
-			return dir, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("could not find repo root (go.mod) from %s", dir)
-		}
-		dir = parent
-	}
-}
-
-// rcv1pWindowsCSEMutator returns a BootstrapConfigMutator that overrides CseScriptsPackageURL
-// to use the branch-built CSE zip containing the RCV1P code.
-func rcv1pWindowsCSEMutator(t *testing.T) func(*Cluster, *datamodel.NodeBootstrappingConfiguration) {
-	cseURL := getOrBuildBranchCSEPackageURL(t)
-	return func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-		nbc.ContainerService.Properties.WindowsProfile.CseScriptsPackageURL = cseURL
-	}
-}
 
 // rcv1pOptInVMConfigMutator sets the platform opt-in tag on the VMSS resource level.
 // VMSS resource-level tags are automatically inherited by VM instances at creation time,

--- a/e2e/scenario_rcv1p_win_test.go
+++ b/e2e/scenario_rcv1p_win_test.go
@@ -1,6 +1,3 @@
-// REVERT ME: this file uses rcv1pWindowsCSEMutator to override CseScriptsPackageURL with a
-// branch-built CSE zip. Remove those overrides once the RCV1P code ships in a published CSE package.
-//
 // scenario_rcv1p_win_test.go contains end-to-end tests for the RCV1P cert mode on Windows.
 // Windows uses a different cert installation path than Linux: certificates are downloaded to
 // C:\ca and imported into the Windows certificate store (Cert:\LocalMachine\Root) via
@@ -20,7 +17,6 @@ import (
 // installation on Windows Server 2022.
 func Test_RCV1P_Windows2022(t *testing.T) {
 	skipIfRCV1PNotConfigured(t)
-	cseMutator := rcv1pWindowsCSEMutator(t) // REVERT ME: use branch CSE zip
 	RunScenario(t, &Scenario{
 		Description: "Tests RCV1P cert mode on Windows Server 2022 with VM opt-in tag",
 		Tags: Tags{
@@ -30,7 +26,6 @@ func Test_RCV1P_Windows2022(t *testing.T) {
 			Cluster:                ClusterAzureNetwork,
 			VHD:                    config.VHDWindows2022Containerd,
 			VMConfigMutator:        rcv1pVMConfigMutator(),
-			BootstrapConfigMutator: cseMutator,
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateRCV1PCertModeWindows(ctx, s)
 			},
@@ -41,7 +36,6 @@ func Test_RCV1P_Windows2022(t *testing.T) {
 // Test_RCV1P_Windows2025 validates RCV1P on Windows Server 2025 (non-gen2).
 func Test_RCV1P_Windows2025(t *testing.T) {
 	skipIfRCV1PNotConfigured(t)
-	cseMutator := rcv1pWindowsCSEMutator(t) // REVERT ME: use branch CSE zip
 	RunScenario(t, &Scenario{
 		Description: "Tests RCV1P cert mode on Windows Server 2025 with VM opt-in tag",
 		Tags: Tags{
@@ -52,7 +46,6 @@ func Test_RCV1P_Windows2025(t *testing.T) {
 			VHD:             config.VHDWindows2025,
 			VMConfigMutator: rcv1pVMConfigMutator(),
 			BootstrapConfigMutator: func(c *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				cseMutator(c, nbc)
 				Windows2025BootstrapConfigMutator(t, nbc)
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -66,7 +59,6 @@ func Test_RCV1P_Windows2025(t *testing.T) {
 // installation on Windows Server 2022 Gen2. Covers the gen2 pipeline job.
 func Test_RCV1P_Windows2022Gen2(t *testing.T) {
 	skipIfRCV1PNotConfigured(t)
-	cseMutator := rcv1pWindowsCSEMutator(t) // REVERT ME: use branch CSE zip
 	RunScenario(t, &Scenario{
 		Description: "Tests RCV1P cert mode on Windows Server 2022 Gen2 with VM opt-in tag",
 		Tags: Tags{
@@ -76,7 +68,6 @@ func Test_RCV1P_Windows2022Gen2(t *testing.T) {
 			Cluster:                ClusterAzureNetwork,
 			VHD:                    config.VHDWindows2022ContainerdGen2,
 			VMConfigMutator:        rcv1pVMConfigMutator(),
-			BootstrapConfigMutator: cseMutator,
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateRCV1PCertModeWindows(ctx, s)
 			},
@@ -87,7 +78,6 @@ func Test_RCV1P_Windows2022Gen2(t *testing.T) {
 // Test_RCV1P_Windows2025Gen2 validates RCV1P on Windows Server 2025 Gen2. Covers the gen2 pipeline job.
 func Test_RCV1P_Windows2025Gen2(t *testing.T) {
 	skipIfRCV1PNotConfigured(t)
-	cseMutator := rcv1pWindowsCSEMutator(t) // REVERT ME: use branch CSE zip
 	RunScenario(t, &Scenario{
 		Description: "Tests RCV1P cert mode on Windows Server 2025 Gen2 with VM opt-in tag",
 		Tags: Tags{
@@ -98,7 +88,6 @@ func Test_RCV1P_Windows2025Gen2(t *testing.T) {
 			VHD:             config.VHDWindows2025Gen2,
 			VMConfigMutator: rcv1pVMConfigMutator(),
 			BootstrapConfigMutator: func(c *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				cseMutator(c, nbc)
 				Windows2025BootstrapConfigMutator(t, nbc)
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
@@ -117,16 +106,14 @@ func Test_RCV1P_Windows2025Gen2(t *testing.T) {
 // the opt-in tag on the default E2E subscription, making the negative test invalid.
 func Test_RCV1P_Windows_NotOptedIn(t *testing.T) {
 	skipIfRCV1PNotExplicit(t)
-	cseMutator := rcv1pWindowsCSEMutator(t) // REVERT ME: use branch CSE zip
 	RunScenario(t, &Scenario{
 		Description: "Tests RCV1P cert mode on Windows without VM opt-in tag; expects no cert installation",
 		Tags: Tags{
 			RCV1PCertMode: true,
 		},
 		Config: Config{
-			Cluster:                ClusterAzureNetwork,
-			VHD:                    config.VHDWindows2022Containerd,
-			BootstrapConfigMutator: cseMutator,
+			Cluster: ClusterAzureNetwork,
+			VHD:     config.VHDWindows2022Containerd,
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateRCV1PNotOptedInWindows(ctx, s)
 			},


### PR DESCRIPTION
… package

The Windows RCV1P E2E tests currently side-step the published Windows CSE scripts package (v0.0.52 from packages.aks.azure.com) because that release predates the RCV1P cert bootstrap code. To exercise the branch code end-to- end, PR #8096 added:

  * a helper (getOrBuildBranchCSEPackageURL / buildAndUploadCSEZip) that zips staging/cse/windows/ at test time (mirroring .pipelines/scripts/windows_package_cse.sh), uploads it to the E2E blob storage account, and returns a SAS URL;
  * rcv1pWindowsCSEMutator, a BootstrapConfigMutator that rewrites WindowsProfile.CseScriptsPackageURL on the NBC to that SAS URL;
  * per-test wiring in scenario_rcv1p_win_test.go (5 tests) that installs the mutator either directly or composed with Windows2025BootstrapConfigMutator.

All of the above were tagged "REVERT ME" in the source. This PR performs that revert:

  * e2e/scenario_rcv1p_test.go   -> drop the REVERT ME block (helper,
    mutator, sync.Once caching, unused imports: archive/zip, path/filepath,
    time, datamodel).
  * e2e/scenario_rcv1p_win_test.go -> drop the file-header REVERT ME note
    and, for each of the 5 Windows RCV1P tests
    (Test_RCV1P_Windows2022, _Windows2025, _Windows2022Gen2, _Windows2025Gen2,
    _Windows_NotOptedIn), remove the cseMutator plumbing so the tests rely
    on the published CSE package. Windows2025 tests keep their existing
    Windows2025BootstrapConfigMutator (unrelated to RCV1P).

Verified: `go vet ./...` and `go build ./...` clean in the e2e module.

DO NOT MERGE until BOTH of the following are true:
  1. A new Windows CSE scripts package (aks-windows-cse-scripts-v0.0.NN.zip with NN > 52) containing the RCV1P code from PR #8096 has been published to https://packages.aks.azure.com/aks/windows/cse/ AND
  2. That new version is what `packages.aks.azure.com/aks/windows/cse/ aks-windows-cse-scripts-current.zip` resolves to (i.e., "current" points at the RCV1P-capable release), OR `parts/common/components.json` has been bumped so the Windows profile resolves to the new version.

Suggested validation before merge:
  * curl -sL <new zip URL> | unzip -l | grep -E "(kubernetesfunc|Get-CertEndpointModeFromLocation|aks-ca-certs-refresh-task)" to confirm the RCV1P entry points are present.
  * Run one of the Test_RCV1P_Windows* scenarios against the RCV1P subscription without this revert applied to confirm the published package satisfies the tests; then apply the revert and re-run to confirm the tests still pass.

If merged prematurely, all 5 Test_RCV1P_Windows* scenarios will regress because the published v0.0.52 CSE package has no RCV1P support and cert installation will not happen (ValidateRCV1PCertModeWindows will fail).

<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
