### PR TITLE
feat: upgrade blobfuse version to v2.5.4 on Ubuntu node

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -684,7 +684,7 @@ func Test_Ubuntu2204(t *testing.T) {
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateInstalledPackageVersion(ctx, s, "moby-containerd", components.GetExpectedPackageVersions("containerd", "ubuntu", "r2204")[0])
 				ValidateInstalledPackageVersion(ctx, s, "moby-runc", components.GetExpectedPackageVersions("runc", "ubuntu", "r2204")[0])
-				ValidateInstalledPackageVersion(ctx, s, "blobfuse2", "2.5.3")
+				ValidateInstalledPackageVersion(ctx, s, "blobfuse2", components.GetExpectedPackageVersions("blobfuse2", "ubuntu", "r2204")[0])
 				ValidateSSHServiceEnabled(ctx, s)
 				ValidateFileHasContent(ctx, s, "/etc/motd", "foobar")
 				ValidateFileHasContent(ctx, s, "/etc/update-motd.d/99-aks-custom-motd", "cat /etc/motd")
@@ -2222,7 +2222,7 @@ func Test_Ubuntu2404Gen2(t *testing.T) {
 				ValidateContainerd2Properties(ctx, s, containerdVersions)
 				ValidateRuncVersion(ctx, s, runcVersions)
 				ValidateContainerRuntimePlugins(ctx, s)
-				ValidateInstalledPackageVersion(ctx, s, "blobfuse2", "2.5.3")
+				ValidateInstalledPackageVersion(ctx, s, "blobfuse2", components.GetExpectedPackageVersions("blobfuse2", "ubuntu", "r2404")[0])
 				ValidateSSHServiceEnabled(ctx, s)
 			},
 		},

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -2339,7 +2339,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=blobfuse2, repository=production, os=ubuntu, release=20.04",
-                "latestVersion": "2.5.3"
+                "latestVersion": "2.5.4"
               }
             ]
           },
@@ -2347,7 +2347,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=blobfuse2, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "2.5.3"
+                "latestVersion": "2.5.4"
               }
             ]
           },
@@ -2355,7 +2355,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=blobfuse2, repository=production, os=ubuntu, release=24.04",
-                "latestVersion": "2.5.3"
+                "latestVersion": "2.5.4"
               }
             ]
           }

--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
@@ -13,7 +13,7 @@ blobfuseFallbackPackages() {
     # This combination is unlikely, so this fallback can be removed
     # 6 months after the April 2026 release.
     local LEGACY_FALLBACK_BLOBFUSE_VERSION="1.4.5"
-    local LEGACY_FALLBACK_BLOBFUSE2_VERSION="2.5.3"
+    local LEGACY_FALLBACK_BLOBFUSE2_VERSION="2.5.4"
     local HAS_BLOBFUSE_COMPONENT="false"
     local HAS_BLOBFUSE2_COMPONENT="false"
 


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:

Upgrades the fallback blobfuse2 version on Ubuntu nodes from **v2.5.3 → v2.5.4** in `parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh` (`LEGACY_FALLBACK_BLOBFUSE2_VERSION`).

This fallback is only used when the VHD image lacks the pre-baked blobfuse2 component (e.g. old images or unusual component combinations), so most nodes with recent VHDs will not hit this code path. Keeping the fallback aligned with the latest upstream release ensures those nodes still get an up-to-date binary with the latest fixes.

**What's new in blobfuse2 v2.5.4** (release: https://github.com/Azure/azure-storage-fuse/releases/tag/blobfuse2-2.5.4):

Features
- FIPS-compliant binary built with Microsoft Go toolchain (`systemcrypto` GOEXPERIMENT, `CGO_ENABLED=1`), routing all `crypto/*` calls through system OpenSSL FIPS provider (#2226).
- Memory-bounded attribute cache with LRU eviction and background TTL sweeper; new `max-size-mb` / `--attr-cache-max-size-mb` (auto-tuned to 1% of RAM, clamped to [64 MB, 1 GB] by default).
- Kernel directory-listing cache (fuse3 only) via `libfuse.kernel-list-cache-expiration-sec` (default 120s, set 0 to disable) — repeat `ls` served entirely from kernel page cache.

Bug fixes
- Fix CPK-encrypted blob attribute lookup duplicating prefix path when subdirectory is configured (#2199).
- Return `ENAMETOOLONG` instead of `EIO` when creating/renaming a directory path exceeding ADLS 63-segment depth limit (#2221, #2251).
- Fix Debian 13 (trixie) release by publishing a dedicated package built against `libfuse3.so.4` (libfuse 3.17+) (#2264).
- Fixed filtering of blobs by blob index tags via `azstorage.filter` / `--filter` (#2261).

Other
- CBL-Mariner 2.0 EOL — no more Blobfuse2 packages published to Mariner 2.0 repos.
- Default block-cache memory pool reduced from 80% of free memory to 60% of available memory when `block_cache.mem-size-mb` is not set (#2260).
- Mirror Go runtime panic/fatal stack traces into the Blobfuse2 log file (in addition to per-mount `.trace`).

**Which issue(s) this PR fixes**:
Fixes #
