### PR TITLE
chore(pipelines): rename e2e-rcv1p.yaml -> e2e-rcv1p-not-opted-in.yaml

### DIFF
--- a/.pipelines/e2e-rcv1p-not-opted-in.yaml
+++ b/.pipelines/e2e-rcv1p-not-opted-in.yaml
@@ -1,10 +1,9 @@
 name: $(Date:yyyyMMdd)$(Rev:.r)
-# NOTE: Despite the generic filename, this pipeline runs ONLY the "not-opted-in"
-# (negative) RCV1P scenarios by setting rcv1pTagsAutoInjected: false below. The
-# positive/opt-in RCV1P scenarios run via aks-rp's linux-release-orchestration
+# This pipeline runs ONLY the "not-opted-in" (negative) RCV1P scenarios by
+# setting rcv1pTagsAutoInjected: false below. The positive/opt-in RCV1P
+# scenarios run via aks-rp's linux-release-orchestration
 # (--run-tags rcv1pcertmode=true) against the TME-RCV1P subscription that
-# auto-injects the opt-in VMSS tag. A follow-up PR will rename this file to
-# e2e-rcv1p-not-opted-in.yaml to make the intent obvious.
+# auto-injects the opt-in VMSS tag.
 variables:
   TAGS_TO_RUN: "rcv1pcertmode=true"
   SKIP_E2E_TESTS: false


### PR DESCRIPTION
Addresses review feedback (r3554432549, cameronmeissner) on PR #8096: the .pipelines/e2e-rcv1p.yaml pipeline is named generically but actually runs ONLY the "not-opted-in" (negative) RCV1P suite. It forces `rcv1pTagsAutoInjected: false` so tests like Test_RCV1P_*_NotOptedIn can validate behavior in a subscription that does NOT auto-inject the opt-in VMSS tag. The opt-in/positive RCV1P run lives in aks-rp (linux-release-orchestration.yaml, JOB_NAME=abe2e_rcv1p, TAGS_TO_RUN=rcv1pcertmode=true) against the TME-RCV1P subscription that auto-injects the tag.

Renaming makes the intent obvious and removes the confusion the reviewer called out. Also drops the stale "A follow-up PR will rename this file..." comment inside the YAML, since the follow-up is now this PR.

Dependency analysis
-------------------
AgentBaker (this repo):
  * `git grep e2e-rcv1p` -> only .pipelines/e2e-rcv1p.yaml itself (now renamed). No workflows, no scripts, no README references the filename.

aks-rp (msazure/CloudNativeCompute/aks-rp):
  * `git grep e2e-rcv1p` -> 0 hits.
  * `git grep -i rcv1p` -> only .pipelines/agentbaker/templates/linux-release-orchestration.yaml, which references RCV1P purely by test tag (TAGS_TO_RUN=rcv1pcertmode=true) and by subscription id ($(E2E_SUBSCRIPTION_ID_RCV1P)). It queues the "Agentbaker E2E - TME Tenant" definition (id 451455, yaml path .pipelines/e2e-tme.yaml) via `vhdbuilder e2e ab --run-tags rcv1pcertmode=true`, NOT the pipeline being renamed here. => No aks-rp change required.

Azure DevOps
------------
Enumerated all 20 CloudNativeCompute pipeline definitions bound to the Azure/AgentBaker GitHub repo (via `az pipelines list ... --repository Azure/AgentBaker --repository-type gitHub` and `az pipelines show --query process.yamlFilename`). NONE of them are currently registered against `.pipelines/e2e-rcv1p.yaml`, so this rename requires no ADO-side pipeline definition edit.

If/when someone later registers an ADO pipeline for the not-opted-in suite, they should point it at the new path
`.pipelines/e2e-rcv1p-not-opted-in.yaml`. Any ADO pipeline that is later found to still reference the old path can be updated at: https://dev.azure.com/msazure/CloudNativeCompute/_build (Edit -> Triggers -> YAML file path).

Verification
------------
  * git grep e2e-rcv1p.yaml -> 0 hits after rename.
  * git grep e2e-rcv1p-not-opted-in.yaml -> 1 hit (the renamed file itself).

<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
