### PR TITLE
fix: tme pipeline is unnecessarily prompting for sub id, make it a variable

### DIFF
--- a/.pipelines/e2e-tme.yaml
+++ b/.pipelines/e2e-tme.yaml
@@ -1,12 +1,8 @@
 name: $(Date:yyyyMMdd)$(Rev:.r)
-parameters:
-  - name: subscriptionId
-    type: string
-    displayName: Subscription ID to use for E2E tests (empty = use variable group default)
-    default: ""
 variables:
   SKIP_E2E_TESTS: false
   E2E_FAILED_TESTS_RETRY_COUNT: 2
+  SUBSCRIPTION_ID: ""
 
 jobs:
   - template: ./templates/e2e-template.yaml
@@ -15,5 +11,5 @@ jobs:
       IgnoreScenariosWithMissingVhd: false
       failedTestsRetryCount: ${{ variables.E2E_FAILED_TESTS_RETRY_COUNT }}
       variableGroup: ab-e2e-tme
-      subscriptionId: ${{ parameters.subscriptionId }}
+      subscriptionId: ${{ variables.SUBSCRIPTION_ID }}
 


### PR DESCRIPTION
<img width="525" height="445" alt="image" src="https://github.com/user-attachments/assets/3795e743-609c-44cd-b213-c0fd129e80d4" />
This blocks manual runs