### PR TITLE
feat(windows): add 7b non-sec regkeys

### DIFF
--- a/vhdbuilder/packer/windows/windows_settings.json
+++ b/vhdbuilder/packer/windows/windows_settings.json
@@ -642,6 +642,14 @@
       "Name": "1451608719",
       "Value": "1",
       "Type": "DWORD"
+    },
+    {
+      "Comment": "2026-7B",
+      "WindowsSkuMatch": "2025*",
+      "Path": "HKLM:\\SYSTEM\\CurrentControlSet\\Policies\\Microsoft\\FeatureManagement\\Overrides",
+      "Name": "908168846",
+      "Value": "1",
+      "Type": "DWORD"
     }
   ]
 }


### PR DESCRIPTION
This PR introduces the July "7B” non-security registry key updates to ensure consistency and compliance with the latest Windows image configuration requirements for AKS node provisioning.
What’s included

Added/updated non-security (non-sec) registry keys aligned with 7B requirements
Ensured keys are applied across relevant Windows SKUs/images used in AgentBaker
Maintained parity with upstream Windows image expectations and servicing guidance

**Why this change
Enables alignment with monthly Patch Tuesday (7B cycle) configuration updates
Ensures AKS node images remain consistent with latest platform expectations
Prevents drift between base OS images and AgentBaker-applied configuration

**Validation
✅ Verified registry key presence post-image bake
✅ Confirmed no regression in image provisioning / node pool creation
✅ Validated against current test pipelines (Hyper-V / containerd scenarios)

**Risk / Impact
Low risk – non-security configuration only
No expected impact to existing workloads or cluster behavior
Changes are scoped strictly to registry configuration

Notes

Follows established monthly release pattern for non-sec updates
Complements security fixes delivered separately in Patch Tuesday cycle