### PR TITLE
fix: go test args are used with --rerun-fails the list of packages to test must be specified by the --packages flag

### DIFF
--- a/.pipelines/scripts/e2e_run.sh
+++ b/.pipelines/scripts/e2e_run.sh
@@ -113,7 +113,8 @@ if [ "${E2E_FAILED_TESTS_RETRY_COUNT}" -gt 0 ]; then
   rerun_fails="${E2E_FAILED_TESTS_RETRY_COUNT}"
 fi
 ./bin/gotestsum --format testdox --junitfile "${BUILD_SRC_DIR}/e2e/report.xml" --jsonfile "${BUILD_SRC_DIR}/e2e/test-log.json" \
-  ${rerun_fails:+--rerun-fails=$rerun_fails} -- -parallel 60 -timeout "${E2E_GO_TEST_TIMEOUT}" || test_exit_code=$?
+  ${rerun_fails:+--rerun-fails=$rerun_fails} ${rerun_fails:+--packages=.} \
+  -- -parallel 60 -timeout "${E2E_GO_TEST_TIMEOUT}" || test_exit_code=$?
 
 # Upload test results as Azure DevOps artifacts
 echo "##vso[artifact.upload containerfolder=test-results;artifactname=e2e-test-log]${BUILD_SRC_DIR}/e2e/test-log.json"

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -2555,9 +2555,10 @@ func Test_Ubuntu2404_VHDCaching(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "T",
 		Config: Config{
-			Cluster:    ClusterKubenet,
-			VHD:        config.VHDUbuntu2204Gen2Containerd,
-			VHDCaching: true,
+			Cluster:                ClusterKubenet,
+			VHD:                    config.VHDUbuntu2204Gen2Containerd,
+			VHDCaching:             true,
+			BootstrapConfigMutator: EmptyBootstrapConfigMutator,
 			Validator: func(ctx context.Context, s *Scenario) {
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {


### PR DESCRIPTION
Fix broken VHDCaching test
Test only current e2e package which is required when we re run failed tests