### PR TITLE
feat: produce vhd info and consume them in e2e so we dont get throttled

### DIFF
--- a/.pipelines/.vsts-vhd-builder-release.yaml
+++ b/.pipelines/.vsts-vhd-builder-release.yaml
@@ -947,3 +947,4 @@ stages:
         parameters:
           name: All Linux
           IgnoreScenariosWithMissingVhd: true
+          useVhdMetadataArtifacts: true

--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -308,3 +308,4 @@ stages:
       - template: ./templates/e2e-template.yaml
         parameters:
           IgnoreScenariosWithMissingVhd: true
+          useVhdMetadataArtifacts: true

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -271,6 +271,46 @@ steps:
       RESOURCE_GROUP_NAME: $(AZURE_RESOURCE_GROUP_NAME)
       DRY_RUN: $(DRY_RUN)
 
+  - bash: |
+      set -euo pipefail
+
+      metadata_dir="$(Build.ArtifactStagingDirectory)/e2e-vhd-metadata"
+      metadata_file="${metadata_dir}/${VHD_ARTIFACT_NAME}.json"
+      mkdir -p "$metadata_dir"
+
+      if [ -z "${MANAGED_SIG_ID}" ]; then
+        echo "##vso[task.logissue type=error]Packer did not return a managed SIG image version ID" >&2
+        exit 1
+      fi
+
+      regions="$(jq -nc \
+        --arg buildLocation "${PACKER_BUILD_LOCATION}" \
+        --arg replications "${REPLICATIONS:-}" \
+        '([$buildLocation] + ($replications | split(",") | map(split("=")[0] | gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)))) | unique')"
+
+      jq -n \
+        --arg imageName "${SIG_IMAGE_NAME}" \
+        --arg resourceId "${MANAGED_SIG_ID}" \
+        --arg version "${CAPTURED_SIG_VERSION}" \
+        --argjson regions "$regions" \
+        '{($imageName): {resourceId: $resourceId, version: $version, regions: $regions}}' > "$metadata_file"
+    condition: succeeded()
+    displayName: Create E2E VHD metadata
+    env:
+      VHD_ARTIFACT_NAME: ${{ parameters.artifactName }}
+      SIG_IMAGE_NAME: $(SIG_IMAGE_NAME)
+      CAPTURED_SIG_VERSION: $(CAPTURED_SIG_VERSION)
+      MANAGED_SIG_ID: $(MANAGED_SIG_ID)
+      PACKER_BUILD_LOCATION: $(PACKER_BUILD_LOCATION)
+      REPLICATIONS: $(REPLICATIONS)
+
+  - task: PublishPipelineArtifact@0
+    condition: succeeded()
+    displayName: Publish E2E VHD metadata
+    inputs:
+      artifactName: 'e2e-vhd-metadata-${{ parameters.artifactName }}-stage$(System.StageAttempt)-job$(System.JobAttempt)'
+      targetPath: '$(Build.ArtifactStagingDirectory)/e2e-vhd-metadata/${{ parameters.artifactName }}.json'
+
   - task: AzureCLI@2
     inputs:
       azureSubscription: $(VHD_ARM_SERVICE_CONNECTION)

--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -18,6 +18,10 @@ parameters:
     type: number
     displayName: Number of times to retry failed E2E tests
     default: 0
+  - name: useVhdMetadataArtifacts
+    type: boolean
+    displayName: Resolve VHDs from metadata artifacts produced by this pipeline
+    default: false
   - name: rcv1pTagsAutoInjected
     type: boolean
     displayName: |
@@ -51,6 +55,31 @@ jobs:
         fetchTags: false
         fetchDepth: 1
 
+      - ${{ if eq(parameters.useVhdMetadataArtifacts, true) }}:
+        - task: DownloadPipelineArtifact@2
+          displayName: Download E2E VHD metadata
+          inputs:
+            buildType: current
+            itemPattern: 'e2e-vhd-metadata-*/**/*.json'
+            targetPath: $(Pipeline.Workspace)/e2e-vhd-metadata
+
+        - bash: |
+            set -euo pipefail
+
+            metadata_dir="$(Pipeline.Workspace)/e2e-vhd-metadata"
+            metadata_file="$(Build.SourcesDirectory)/e2e-vhd-metadata.json"
+            # Pipeline artifacts are immutable, so rerun attempts publish uniquely suffixed
+            # artifacts. Sort naturally by attempt so metadata from the latest attempt wins.
+            mapfile -d '' metadata_files < <(find "$metadata_dir" -type f -name '*.json' -print0 | sort -zV)
+            if [ "${#metadata_files[@]}" -eq 0 ]; then
+              echo "##vso[task.logissue type=error]No E2E VHD metadata artifacts were downloaded" >&2
+              exit 1
+            fi
+
+            jq -s 'reduce .[] as $item ({}; . * $item)' "${metadata_files[@]}" > "$metadata_file"
+            echo "##vso[task.setvariable variable=E2E_VHD_METADATA_FILE]$metadata_file"
+          displayName: Merge E2E VHD metadata
+
       - task: AzureCLI@2
         inputs:
           azureSubscription: $(E2E_ARM_SERVICE_CONNECTION)
@@ -68,6 +97,8 @@ jobs:
           IGNORE_SCENARIOS_WITH_MISSING_VHD: ${{parameters.IgnoreScenariosWithMissingVhd}}
           E2E_FAILED_TESTS_RETRY_COUNT: ${{parameters.failedTestsRetryCount}}
           RCV1P_TAGS_AUTO_INJECTED: ${{parameters.rcv1pTagsAutoInjected}}
+          ${{ if eq(parameters.useVhdMetadataArtifacts, true) }}:
+            E2E_VHD_METADATA_FILE: $(E2E_VHD_METADATA_FILE)
 
       - task: PublishTestResults@2
         displayName: Upload test results

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -91,10 +91,12 @@ type Configuration struct {
 	TestGalleryNamePrefix                  string        `env:"TEST_GALLERY_NAME_PREFIX" envDefault:"abe2etest"`
 	TestPreProvision                       bool          `env:"TEST_PRE_PROVISION" envDefault:"false"`
 	TestTimeout                            time.Duration `env:"TEST_TIMEOUT" envDefault:"50m"`
+	VHDMetadataFile                        string        `env:"E2E_VHD_METADATA_FILE"`
 	// Must cover cluster-create AND bastion-create (run serially in prepareCluster, ~10-11m each).
 	TestTimeoutCluster   time.Duration `env:"TEST_TIMEOUT_CLUSTER" envDefault:"30m"`
 	TestTimeoutVMSS      time.Duration `env:"TEST_TIMEOUT_VMSS" envDefault:"17m"`
 	WindowsAdminPassword string        `env:"WINDOWS_ADMIN_PASSWORD"`
+	vhdMetadata          map[string]vhdMetadataEntry
 }
 
 func (c *Configuration) BlobStorageAccount() string {
@@ -150,6 +152,12 @@ func mustLoadConfig() *Configuration {
 	cfg := &Configuration{}
 	if err := env.Parse(cfg); err != nil {
 		panic(err)
+	}
+	if cfg.VHDMetadataFile != "" {
+		cfg.vhdMetadata, err = loadVHDMetadata(cfg.VHDMetadataFile)
+		if err != nil {
+			panic(fmt.Sprintf("failed to load E2E VHD metadata: %v", err))
+		}
 	}
 	if cfg.SysSSHPublicKey == "" {
 		SysSSHPublicKey = VMSSHPublicKey

--- a/e2e/config/vhd.go
+++ b/e2e/config/vhd.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
+	"os"
 	"strings"
 	"sync"
 
@@ -265,6 +267,12 @@ var (
 
 var ErrNotFound = fmt.Errorf("not found")
 
+type vhdMetadataEntry struct {
+	ResourceID VHDResourceID `json:"resourceId"`
+	Version    string        `json:"version"`
+	Regions    []string      `json:"regions"`
+}
+
 type perLocationVHDCache struct {
 	vhd  VHDResourceID
 	err  error
@@ -299,6 +307,15 @@ func (i *Image) SupportsScriptless() bool {
 }
 
 func GetVHDResourceID(ctx context.Context, i Image, location string) (VHDResourceID, error) {
+	if i.Version == "" && Config.vhdMetadata != nil {
+		vhd, err := getVHDResourceIDFromMetadata(Config.vhdMetadata, i, location)
+		if err != nil {
+			return "", err
+		}
+		toolkit.Logf(ctx, "Got image from E2E VHD metadata: %s", vhd)
+		return vhd, nil
+	}
+
 	switch {
 	case i.Version != "":
 		vhd, err := Azure.EnsureSIGImageVersion(ctx, &i, location)
@@ -319,6 +336,48 @@ func GetVHDResourceID(ctx context.Context, i Image, location string) (VHDResourc
 		}
 		return vhd, nil
 	}
+}
+
+func loadVHDMetadata(path string) (map[string]vhdMetadataEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	metadata := make(map[string]vhdMetadataEntry)
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if len(metadata) == 0 {
+		return nil, fmt.Errorf("%s contains no VHD metadata", path)
+	}
+	for imageName, entry := range metadata {
+		if imageName == "" || entry.ResourceID == "" || len(entry.Regions) == 0 {
+			return nil, fmt.Errorf("%s contains incomplete metadata for image %q", path, imageName)
+		}
+	}
+	return metadata, nil
+}
+
+func getVHDResourceIDFromMetadata(metadata map[string]vhdMetadataEntry, image Image, location string) (VHDResourceID, error) {
+	var entry vhdMetadataEntry
+	var found bool
+	for imageName, candidate := range metadata {
+		if strings.EqualFold(imageName, image.Name) {
+			entry = candidate
+			found = true
+			break
+		}
+	}
+	if !found {
+		return "", fmt.Errorf("%w: image %s is not present in E2E VHD metadata", ErrNotFound, image.Name)
+	}
+	for _, region := range entry.Regions {
+		if strings.EqualFold(region, location) {
+			return entry.ResourceID, nil
+		}
+	}
+	return "", fmt.Errorf("%w: image %s is not replicated to %s according to E2E VHD metadata", ErrNotFound, image.Name, location)
 }
 
 func (i *Image) azurePortalImageUrl() string {


### PR DESCRIPTION
We are constantly throttled trying to get VHD info using tags in our E2E for PR checkin

1. Publish VHD metadata from VHD builds
2. Consume this metadata to get VHD information to be used in tests.

This saves going to azure for VHD info.