### PR TITLE
chore: enable renovate updates for ORAS

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,20 +30,6 @@
       "enabled": false
     },
     {
-      "matchDatasources": [
-        "custom.oras-github-releases"
-      ],
-      "matchPackageNames": [
-        "oras-project/oras"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "automerge": false,
-      "enabled": true
-    },
-    {
       "matchPackageNames": [
         "oss/v2/**",
         "!oss/v2/kubernetes/*-sysext"
@@ -820,20 +806,6 @@
     },
     {
       "customType": "regex",
-      "description": "auto update ORAS GitHub release versions with required assets in components.json",
-      "managerFilePatterns": [
-        "/parts/common/components.json/"
-      ],
-      "matchStringsStrategy": "any",
-      "matchStrings": [
-        "\"renovateTag\":\\s*\"github-releases-with-assets=(?<packageName>oras-project/oras)\",\\s*\"latestVersion\":\\s*\"(?<currentValue>[^\"]+)\""
-      ],
-      "datasourceTemplate": "custom.oras-github-releases",
-      "versioningTemplate": "semver",
-      "autoReplaceStringTemplate": "\"renovateTag\": \"github-releases-with-assets={{{packageName}}}\",\n                \"latestVersion\": \"{{{newValue}}}\""
-    },
-    {
-      "customType": "regex",
       "description": "auto update GitHub release versions in components.json",
       "managerFilePatterns": [
         "/parts/common/components.json/"
@@ -881,13 +853,6 @@
     }
   ],
   "customDatasources": {
-    "oras-github-releases": {
-      "defaultRegistryUrlTemplate": "https://api.github.com/repos/{{packageName}}/releases",
-      "format": "json",
-      "transformTemplates": [
-        "{\"releases\": $map($[draft = false and prerelease = false], function($v) { ($version := $substringAfter($v.tag_name, \"v\"); $count($v.assets[name = \"oras_\" & $version & \"_linux_amd64.tar.gz\"]) > 0 and $count($v.assets[name = \"oras_\" & $version & \"_linux_arm64.tar.gz\"]) > 0 and $count($v.assets[name = \"oras_\" & $version & \"_windows_amd64.zip\"]) > 0 ? {\"version\": $version, \"releaseTimestamp\": $v.published_at, \"sourceUrl\": $v.html_url, \"changelogUrl\": $v.html_url} : undefined) }), \"sourceUrl\": \"https://github.com/oras-project/oras\", \"homepage\": \"https://oras.land/\"}"
-      ]
-    },
     "deb2004": {
       "defaultRegistryUrlTemplate": "https://packages.microsoft.com/ubuntu/20.04/prod/dists/focal/main/binary-amd64/Packages",
       "format": "plain",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,6 +30,20 @@
       "enabled": false
     },
     {
+      "matchDatasources": [
+        "custom.oras-github-releases"
+      ],
+      "matchPackageNames": [
+        "oras-project/oras"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": false,
+      "enabled": true
+    },
+    {
       "matchPackageNames": [
         "oss/v2/**",
         "!oss/v2/kubernetes/*-sysext"
@@ -806,6 +820,20 @@
     },
     {
       "customType": "regex",
+      "description": "auto update ORAS GitHub release versions with required assets in components.json",
+      "managerFilePatterns": [
+        "/parts/common/components.json/"
+      ],
+      "matchStringsStrategy": "any",
+      "matchStrings": [
+        "\"renovateTag\":\\s*\"github-releases-with-assets=(?<packageName>oras-project/oras)\",\\s*\"latestVersion\":\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "custom.oras-github-releases",
+      "versioningTemplate": "semver",
+      "autoReplaceStringTemplate": "\"renovateTag\": \"github-releases-with-assets={{{packageName}}}\",\n                \"latestVersion\": \"{{{newValue}}}\""
+    },
+    {
+      "customType": "regex",
       "description": "auto update GitHub release versions in components.json",
       "managerFilePatterns": [
         "/parts/common/components.json/"
@@ -853,6 +881,13 @@
     }
   ],
   "customDatasources": {
+    "oras-github-releases": {
+      "defaultRegistryUrlTemplate": "https://api.github.com/repos/{{packageName}}/releases",
+      "format": "json",
+      "transformTemplates": [
+        "{\"releases\": $map($[draft = false and prerelease = false], function($v) { ($version := $substringAfter($v.tag_name, \"v\"); $count($v.assets[name = \"oras_\" & $version & \"_linux_amd64.tar.gz\"]) > 0 and $count($v.assets[name = \"oras_\" & $version & \"_linux_arm64.tar.gz\"]) > 0 and $count($v.assets[name = \"oras_\" & $version & \"_windows_amd64.zip\"]) > 0 ? {\"version\": $version, \"releaseTimestamp\": $v.published_at, \"sourceUrl\": $v.html_url, \"changelogUrl\": $v.html_url} : undefined) }), \"sourceUrl\": \"https://github.com/oras-project/oras\", \"homepage\": \"https://oras.land/\"}"
+      ]
+    },
     "deb2004": {
       "defaultRegistryUrlTemplate": "https://packages.microsoft.com/ubuntu/20.04/prod/dists/focal/main/binary-amd64/Packages",
       "format": "plain",

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -917,8 +917,8 @@
           "current": {
             "versionsV2": [
               {
-                "renovateTag": "<DO_NOT_UPDATE>",
-                "latestVersion": "1.2.2"
+                "renovateTag": "github-releases-with-assets=oras-project/oras",
+                "latestVersion": "1.3.3"
               }
             ],
             "downloadURL": "https://github.com/oras-project/oras/releases/download/v${version}/oras_${version}_linux_${CPU_ARCH}.tar.gz"
@@ -938,8 +938,8 @@
           "default": {
             "versionsV2": [
               {
-                "renovateTag": "<DO_NOT_UPDATE>",
-                "latestVersion": "1.3.0"
+                "renovateTag": "github-releases-with-assets=oras-project/oras",
+                "latestVersion": "1.3.3"
               }
             ],
             "downloadURL": "https://github.com/oras-project/oras/releases/download/v${version}/oras_${version}_windows_amd64.zip"

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -917,7 +917,7 @@
           "current": {
             "versionsV2": [
               {
-                "renovateTag": "github-releases-with-assets=oras-project/oras",
+                "renovateTag": "github-releases=oras-project/oras",
                 "latestVersion": "1.3.3"
               }
             ],
@@ -938,7 +938,7 @@
           "default": {
             "versionsV2": [
               {
-                "renovateTag": "github-releases-with-assets=oras-project/oras",
+                "renovateTag": "github-releases=oras-project/oras",
                 "latestVersion": "1.3.3"
               }
             ],

--- a/staging/cse/windows/networkisolatedclusterfunc.tests.ps1
+++ b/staging/cse/windows/networkisolatedclusterfunc.tests.ps1
@@ -53,7 +53,7 @@ Describe "Install-Oras" {
     }
 
     Mock Get-ChildItem -MockWith {
-      return [pscustomobject]@{ Name = "oras_1.3.0_windows_amd64.zip"; FullName = "C:\akse-cache\oras\oras_1.3.0_windows_amd64.zip" }
+      return [pscustomobject]@{ Name = "oras_1.3.3_windows_amd64.zip"; FullName = "C:\akse-cache\oras\oras_1.3.3_windows_amd64.zip" }
     }
 
     Mock Expand-Archive -MockWith {
@@ -95,7 +95,7 @@ Describe "Install-Oras" {
     }
 
     Mock Get-ChildItem -MockWith {
-      return [pscustomobject]@{ Name = "oras_1.3.0_windows_amd64.tar.gz"; FullName = "C:\akse-cache\oras\oras_1.3.0_windows_amd64.tar.gz" }
+      return [pscustomobject]@{ Name = "oras_1.3.3_windows_amd64.tar.gz"; FullName = "C:\akse-cache\oras\oras_1.3.3_windows_amd64.tar.gz" }
     }
 
     Mock tar -MockWith { $global:LASTEXITCODE = 1 }

--- a/vhdbuilder/packer/test/windows-files-check.ps1
+++ b/vhdbuilder/packer/test/windows-files-check.ps1
@@ -21,7 +21,7 @@ $SkipMapForSignature = @{
     "aks-windows-cse-scripts-v0.0.32.zip"      = @();
     "azure-vnet-cni-windows-amd64-v1.6.21.zip" = @();
     "azure-vnet-cni-windows-amd64-v1.5.38.zip" = @();
-    "oras_1.3.0_windows_amd64.zip"             = @();
+    "oras_1.3.3_windows_amd64.zip"             = @();
 }
 
 $SkipSignatureCheckForBinaries = @{

--- a/vhdbuilder/packer/windows/components_json_helpers.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.ps1
@@ -15,6 +15,48 @@ function SafeReplaceString {
     return $stringToReplace
 }
 
+function GetWindowsDownloadPartForPackage
+{
+    Param(
+        [Parameter(Mandatory = $true)][Object]
+        $package
+    )
+
+    $downloadUrls = $package.downloadURIs.windows
+    if ($downloadUrls -eq $null)
+    {
+        return $package.downloadURIs.default.current
+    }
+
+    $part = $downloadUrls.default
+    switch -Regex ($windowsSku)
+    {
+        "2019-containerd" {
+            $part = $downloadUrls.ws2019
+            break
+        }
+        "2022-containerd*" {
+            $part = $downloadUrls.ws2022
+            break
+        }
+        "23H2*" {
+            $part = $downloadUrls.ws32h2
+            break
+        }
+        "2025*" {
+            $part = $downloadUrls.ws2025
+            break
+        }
+    }
+
+    if ($part -eq $null)
+    {
+        return $downloadUrls.default
+    }
+
+    return $part
+}
+
 
 function GetComponentsFromComponentsJson
 {
@@ -86,40 +128,7 @@ function GetPackagesFromComponentsJson
             $thisList = New-Object System.Collections.ArrayList
         }
 
-        $downloadUrls = $package.downloadURIs.windows
-        if ($downloadUrls -eq $null)
-        {
-            $part = $package.downloadURIs.default.current
-        }
-        else
-        {
-            $part = $downloadUrls.default
-            switch -Regex ($windowsSku)
-            {
-                "2019-containerd" {
-                    $part = $downloadUrls.ws2019
-                    break
-                }
-                "2022-containerd*" {
-                    $part = $downloadUrls.ws2022
-                    break
-                }
-                "23H2*" {
-                    $part = $downloadUrls.ws32h2
-                    break
-                }
-                "2025*" {
-                    $part = $downloadUrls.ws2025
-                    break
-                }
-            }
-
-            if ($part -eq $null)
-            {
-                $part = $downloadUrls.default
-            }
-        }
-
+        $part = GetWindowsDownloadPartForPackage $package
         $downloadUrl = $part.windowsDownloadUrl
         $items = $part.versionsV2
 
@@ -150,6 +159,41 @@ function GetPackagesFromComponentsJson
     }
 
     return $output
+}
+
+function GetWindowsPackageVersionFromComponentsJson
+{
+    Param(
+        [Parameter(Mandatory = $true)][Object]
+        $componentsJsonContent,
+
+        [Parameter(Mandatory = $true)][String]
+        $packageName
+    )
+
+    foreach ($package in $componentsJsonContent.Packages)
+    {
+        if ($package.name -ne $packageName)
+        {
+            continue
+        }
+
+        $part = GetWindowsDownloadPartForPackage $package
+        if ($part -eq $null -or $part.versionsV2 -eq $null -or $part.versionsV2.Count -eq 0)
+        {
+            throw "Could not find Windows versions for package '$packageName' in components.json"
+        }
+
+        $latestVersion = $part.versionsV2[0].latestVersion
+        if ([string]::IsNullOrEmpty($latestVersion) -or $latestVersion -eq "<SKIP>")
+        {
+            throw "Could not find a valid Windows version for package '$packageName' in components.json"
+        }
+
+        return $latestVersion
+    }
+
+    throw "Could not find package '$packageName' in components.json"
 }
 
 function GetOCIArtifactsFromComponentsJson

--- a/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
@@ -638,6 +638,19 @@ Describe 'Gets the Binaries' {
         $packages["location"] | Should -Contain "https://acs-mirror.azureedge.net/aks/windows/cse/aks-windows-cse-scripts-v1.8.22.zip"
     }
 
+    It 'can get the latest Windows package version by name' {
+        $componentsJson.Packages[0] | Add-Member -NotePropertyName "name" -NotePropertyValue "oras"
+        $componentsJson.Packages[0].downloadUris.windows.default.versionsV2 = @(
+            [PSCustomObject]@{
+                latestVersion = "1.3.3"
+            }
+        )
+
+        $version = GetWindowsPackageVersionFromComponentsJson $componentsJson "oras"
+
+        $version | Should -Be "1.3.3"
+    }
+
     It 'given there are two packages in the same directory, it combines them' {
         $testString = '{
   "Packages": [

--- a/vhdbuilder/packer/windows/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/windows/configure-windows-vhd.ps1
@@ -172,7 +172,11 @@ function Pull-OCIArtifact
             New-Item -ItemType Directory $global:aksTempDir -Force
         }
 
-        $orasVersion = '1.2.3'
+        $orasVersion = $global:orasVersion
+        if ([string]::IsNullOrEmpty($orasVersion)) {
+            throw "Unable to resolve ORAS version from components.json"
+        }
+
         $orasZip = "oras_${orasVersion}_windows_amd64.zip"
         $orasUrl = "https://github.com/oras-project/oras/releases/download/v${orasVersion}/${orasZip}"
 

--- a/vhdbuilder/packer/windows/windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/windows/windows-vhd-configuration.ps1
@@ -85,6 +85,7 @@ if (-not ($validSKU -contains $windowsSKU))
 # specified by AKS PR for most of the cases. BUT as long as there's a new unpacked image version, we should keep the
 # versions synced.
 $global:defaultContainerdPackageUrl = GetDefaultContainerDFromComponentsJson $componentsJson
+$global:orasVersion = GetWindowsPackageVersionFromComponentsJson $componentsJson "oras"
 
 # defenderUpdateUrl refers to the latest windows defender platform update
 $global:defenderUpdateUrl = GetDefenderUpdateUrl $windowsSettingsJson
@@ -101,4 +102,3 @@ $global:excludeHashComparisionListInAzureChinaCloud = @(
     # so we can ignore the different hash values.
     "v1.26.0-1int.zip"
 )
-


### PR DESCRIPTION
**What this PR does / why we need it**:

ORAS was pinned behind `<DO_NOT_UPDATE>`, so Renovate could not track upstream GitHub releases. This PR enables ORAS updates through the existing generic `github-releases` Renovate manager for `oras-project/oras`, keeping the configuration simple and letting the VHD/CSE build validation catch any unexpected upstream asset issues.

The default Linux and Windows ORAS versions are aligned at `1.3.3`, and the Windows ORAS test fixtures now reference the same archive version. Because the ORAS Windows binary is still unsigned, the existing Windows cached-package signature exception has also been moved from `oras_1.3.0_windows_amd64.zip` to `oras_1.3.3_windows_amd64.zip`. The Windows VHD build-time ORAS bootstrap used for OCI pulls now resolves its version from `parts/common/components.json` as well, so the cached node package and temporary build helper stay aligned. The Azure Linux OS Guard ORAS entry remains disabled with `<DO_NOT_UPDATE>` / `<SKIP>` as requested, and this path does not write `previousLatestVersion`.

Validation performed:
- Parsed `.github/renovate.json` and `parts/common/components.json` with `jq`.
- Ran `git diff --check`.
- Confirmed no stale `oras_1.3.0` references remain and no hardcoded Windows build-time ORAS `1.2.3` pin remains.
- Ran `make generate`; Go testdata and manifest generation completed, then the existing shell validation step failed on unrelated baseline `SC3014` warnings in files not touched by this PR.
- PowerShell/Pester validation was not run locally because `pwsh` is not installed in this environment.

Note: The current latest `renovate-config-validator` rejects existing repo config fields such as `managerFilePatterns` and `commitHourlyLimit`, so it is not a useful signal for this focused change without a broader Renovate config migration.

**Which issue(s) this PR fixes**:

N/A

🤖 *Generated by GitHub Copilot*