### PR TITLE
fix: make anc even faster by 7s

### DIFF
--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -453,7 +453,7 @@ func ValidateInspektorGadget(ctx context.Context, s *Scenario) {
 	s.T.Logf("skip_vhd_ig sentinel file found, validating Inspektor Gadget installation")
 
 	ValidateSystemdUnitIsNotFailed(ctx, s, serviceName)
-	execScriptOnVMForScenarioValidateExitCode(ctx, s, fmt.Sprintf("systemctl is-enabled %s", serviceName), 0, fmt.Sprintf("%s should be enabled", serviceName))
+	execScriptOnVMForScenarioValidateExitCode(ctx, s, fmt.Sprintf("systemctl is-enabled %s | grep -qx disabled", serviceName), 0, fmt.Sprintf("%s should be disabled", serviceName))
 
 	ValidateFileExists(ctx, s, skipFile)
 	ValidateFileExists(ctx, s, servicePath)

--- a/packer.mk
+++ b/packer.mk
@@ -129,7 +129,7 @@ cleanup-prefetch: az-login
 
 generate-prefetch-scripts:
 	@echo "${MODE}: Generating prefetch scripts"
-	@bash -c "pushd vhdbuilder/prefetch; go run cmd/main.go --components-path=../../parts/common/components.json --output-path=../packer/prefetch.sh || exit 1; popd"
+	@bash -c "pushd vhdbuilder/prefetch; go run cmd/main.go --components-path=../../parts/common/components.json --postfix-path=../../parts/linux/cloud-init/artifacts/cse_preload.sh --output-path=../packer/prefetch.sh || exit 1; popd"
 
 setup-golang:
 	@echo "Setting up Go environment"

--- a/parts/linux/cloud-init/artifacts/aks-node-controller.service
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Parse contract and run csecmd
-After=network-online.target ssh.service sshd.service
+After=network-online.target
 Wants=network-online.target
 
 [Service]

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1469,17 +1469,8 @@ disableSSH() {
     systemctlDisableAndStop sshd || exit $ERR_DISABLE_SSH
 }
 
-configureSSHPubkeyAuth() {
-  local disable_pubkey_auth="$1"
-  local ssh_use_pubkey_auth
-
-  # Determine the desired pubkey auth setting
-  if [ "${disable_pubkey_auth}" = "true" ]; then
-    ssh_use_pubkey_auth="no"
-  else
-    ssh_use_pubkey_auth="yes"
-  fi
-  local SSHD_CONFIG="/etc/ssh/sshd_config"
+disableSSHPubkeyAuth() {
+  local SSHD_CONFIG="${SSHD_CONFIG_FILE:-/etc/ssh/sshd_config}"
   local TMP
   TMP="$(mktemp)"
 
@@ -1490,7 +1481,7 @@ configureSSHPubkeyAuth() {
   # PubkeyAuthentication yes
   # AuthorizedKeysCommand /usr/sbin/aad_certhandler %u %k
   # AuthorizedKeysCommandUser root
-  awk -v desired="$ssh_use_pubkey_auth" '
+  awk -v desired="no" '
     BEGIN { in_match=0; replaced=0; inserted=0 }
     /^Match([[:space:]]|$)/ {
       if (!replaced && !inserted) { print "PubkeyAuthentication " desired; inserted=1 }
@@ -1503,6 +1494,12 @@ configureSSHPubkeyAuth() {
     END { if (!replaced && !inserted) print "PubkeyAuthentication " desired }
   ' "$SSHD_CONFIG" > "$TMP"
 
+  local ssh_service="sshd.service"
+  if systemctl cat ssh.service >/dev/null 2>&1; then
+    ssh_service="ssh.service"
+  fi
+  systemctl is-active --quiet "$ssh_service" || systemctl start "$ssh_service" || exit $ERR_CONFIG_PUBKEY_AUTH_SSH
+
   # Validate the candidate config
   sshd -t -f "$TMP" || { rm -f "$TMP"; exit $ERR_CONFIG_PUBKEY_AUTH_SSH; }
 
@@ -1510,8 +1507,8 @@ configureSSHPubkeyAuth() {
   install -m 644 -o root -g root "$TMP" "$SSHD_CONFIG"
   rm -f "$TMP"
 
-  # Reload sshd
-  systemctl reload sshd || systemctl restart sshd || exit $ERR_CONFIG_PUBKEY_AUTH_SSH
+  # Reload or restart ssh service
+  systemctl reload-or-restart "$ssh_service" || exit $ERR_CONFIG_PUBKEY_AUTH_SSH
 }
 
 # Internal function that writes credential provider config to a specified path

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -103,11 +103,6 @@ function basePrep {
         systemctl restart systemd-timesyncd
     fi
 
-    # pre-warm coredns by checking its version.
-    if [ "${SHOULD_ENABLE_LOCALDNS}" = "true" ]; then
-        nohup /bin/sh -c '/opt/azure/containers/localdns/binary/coredns --version >/dev/null 2>&1' >/dev/null 2>&1 &
-    fi
-
     # Eval proxy vars to ensure curl commands use proxy if configured.
     # e.g. PROXY_VARS=`export HTTPS_PROXY="https://proxy.example.com:8080"; export http_proxy="http://proxy.example.com:8080"; export NO_PROXY="127.0.0.1,localhost";`
     # Setting vars in etc environment (configureEtcEnvironment) won't take effect in current shell session.
@@ -128,11 +123,10 @@ function basePrep {
 
     logs_to_events "AKS.CSE.installSecureTLSBootstrapClient" installSecureTLSBootstrapClient
 
-    logs_to_events "AKS.CSE.configureSSHPubkeyAuth" configureSSHPubkeyAuth "${DISABLE_PUBKEY_AUTH}"
-
-
     if [ "${DISABLE_SSH}" = "true" ]; then
-        disableSSH || exit $ERR_DISABLE_SSH
+        disableSSH || exit "$ERR_DISABLE_SSH"
+    elif [ "${DISABLE_PUBKEY_AUTH}" = "true" ]; then
+        logs_to_events "AKS.CSE.disableSSHPubkeyAuth" disableSSHPubkeyAuth
     fi
 
     # This involves using proxy, log the config before fetching packages

--- a/parts/linux/cloud-init/artifacts/cse_preload.sh
+++ b/parts/linux/cloud-init/artifacts/cse_preload.sh
@@ -4,10 +4,16 @@
 # boot so that node provisioning runs against an already-warm page cache.
 # This is best-effort: every command is backgrounded and its output and exit
 # status are intentionally ignored. It must never block or fail provisioning.
+preload() {
+    "$@" >/dev/null 2>&1 &
+}
 
-/usr/bin/containerd --version >/dev/null 2>&1 &
-cat /var/lib/containerd/io.containerd.metadata.v1.bolt/meta.db >/dev/null 2>&1 &
-find /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots -maxdepth 1 >/dev/null 2>&1 &
-/sbin/modprobe overlay >/dev/null 2>&1 &
+preload /opt/azure/containers/aks-node-controller version
+preload /usr/bin/containerd --version
+preload cat /var/lib/containerd/io.containerd.metadata.v1.bolt/meta.db
+preload find /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots -maxdepth 1
+preload /sbin/modprobe overlay
+preload cat /opt/bin/aks-secure-tls-bootstrap-client
+preload /opt/azure/containers/localdns/binary/coredns --version
 
-wait
+wait || true

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -161,6 +161,128 @@ Describe 'cse_config.sh'
         End
     End
 
+    Describe 'disableSSHPubkeyAuth'
+        setup() {
+            SSHD_CONFIG_FILE="$(mktemp)"
+            SSH_SERVICE_ACTIVE="true"
+            SSH_SERVICE_EXISTS="true"
+        }
+
+        cleanup() {
+            rm -f "${SSHD_CONFIG_FILE}"
+            unset SSHD_CONFIG_FILE
+            unset SSH_SERVICE_ACTIVE
+            unset SSH_SERVICE_EXISTS
+        }
+
+        systemctl() {
+            echo "systemctl $*" >&2
+            if [ "$1" = "cat" ] && [ "${SSH_SERVICE_EXISTS}" != "true" ]; then
+                return 1
+            fi
+            if [ "$1" = "is-active" ] && [ "${SSH_SERVICE_ACTIVE}" != "true" ]; then
+                return 3
+            fi
+            return 0
+        }
+
+        sshd() {
+            echo "sshd $*" >&2
+            return 0
+        }
+
+        install() {
+            while [ "$#" -gt 2 ]; do
+                shift
+            done
+            command cp "$1" "$2"
+        }
+
+        run_disable_ssh_pubkey_auth() {
+            disableSSHPubkeyAuth
+            cat "${SSHD_CONFIG_FILE}"
+        }
+
+        BeforeEach 'setup'
+        AfterEach 'cleanup'
+
+        It 'disables the global setting without changing a Match block'
+            cat > "${SSHD_CONFIG_FILE}" <<'EOF'
+PasswordAuthentication no
+PubkeyAuthentication yes
+Match User entra
+  AuthenticationMethods publickey
+  PubkeyAuthentication yes
+EOF
+            expected='PasswordAuthentication no
+PubkeyAuthentication no
+Match User entra
+  AuthenticationMethods publickey
+  PubkeyAuthentication yes'
+
+            When call run_disable_ssh_pubkey_auth
+
+            The status should be success
+            The output should equal "${expected}"
+            The stderr should include "sshd -t -f"
+        End
+
+        It 'inserts the global setting before the first Match block'
+            cat > "${SSHD_CONFIG_FILE}" <<'EOF'
+PasswordAuthentication no
+Match User entra
+  PubkeyAuthentication yes
+EOF
+            expected='PasswordAuthentication no
+PubkeyAuthentication no
+Match User entra
+  PubkeyAuthentication yes'
+
+            When call run_disable_ssh_pubkey_auth
+
+            The status should be success
+            The output should equal "${expected}"
+            The stderr should include "sshd -t -f"
+        End
+
+        It 'appends the setting when the config has no Match block'
+            echo "PasswordAuthentication no" > "${SSHD_CONFIG_FILE}"
+            expected='PasswordAuthentication no
+PubkeyAuthentication no'
+
+            When call run_disable_ssh_pubkey_auth
+
+            The status should be success
+            The output should equal "${expected}"
+            The stderr should include "sshd -t -f"
+        End
+
+        It 'starts ssh.service when the Ubuntu service is not active'
+            echo "PasswordAuthentication no" > "${SSHD_CONFIG_FILE}"
+            SSH_SERVICE_ACTIVE="false"
+
+            When call run_disable_ssh_pubkey_auth
+
+            The status should be success
+            The output should equal "PasswordAuthentication no
+PubkeyAuthentication no"
+            The stderr should include "systemctl start ssh.service"
+        End
+
+        It 'starts sshd.service when ssh.service does not exist'
+            echo "PasswordAuthentication no" > "${SSHD_CONFIG_FILE}"
+            SSH_SERVICE_ACTIVE="false"
+            SSH_SERVICE_EXISTS="false"
+
+            When call run_disable_ssh_pubkey_auth
+
+            The status should be success
+            The output should equal "PasswordAuthentication no
+PubkeyAuthentication no"
+            The stderr should include "systemctl start sshd.service"
+        End
+    End
+
     Describe 'configureAzureJson'
         AZURE_JSON_PATH="azure.json"
         AKS_CUSTOM_CLOUD_JSON_PATH="customcloud.json"

--- a/vhdbuilder/packer/install-ig.sh
+++ b/vhdbuilder/packer/install-ig.sh
@@ -108,6 +108,27 @@ ig_enable_service_unit() {
     return 0
 }
 
+ig_disable_service_unit() {
+    local unit_path="/usr/lib/systemd/system/${IG_SERVICE_NAME}"
+
+    if [[ ! -f "${unit_path}" ]]; then
+        echo "[ig] ${IG_SERVICE_NAME} not present; skipping disablement"
+        return 0
+    fi
+
+    if ! systemctl daemon-reload; then
+        echo "[ig] systemctl daemon-reload failed"
+        return 1
+    fi
+
+    if ! systemctl disable --now "${IG_SERVICE_NAME}"; then
+        echo "[ig] Failed to disable ${IG_SERVICE_NAME}"
+        return 1
+    fi
+
+    return 0
+}
+
 ig_import_gadgets() {
     if [[ ! -x /usr/share/inspektor-gadget/import_gadgets.sh ]]; then
         echo "[ig] import_gadgets.sh not found"
@@ -220,8 +241,8 @@ installIG() {
         fi
     fi
 
-    # Enable the systemd service (baseline files copied by packer_source.sh)
-    ig_enable_service_unit || echo "[ig] Failed to enable ${IG_SERVICE_NAME}"
+    # disable the systemd service (baseline files copied by packer_source.sh)
+    ig_disable_service_unit || echo "[ig] Failed to disable ${IG_SERVICE_NAME}"
     ig_import_gadgets || echo "[ig] Gadget import failed during build"
 
     # Create skip sentinel file to indicate IG was installed from VHD

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -2383,17 +2383,19 @@ testInspektorGadgetAssets() {
     err $test "Unit file missing at $unit_file"
   fi
 
-  local service_state
-  service_state=$(systemctl is-enabled "$service_name" 2>/dev/null || true)
-  if [ "$service_state" != "enabled" ]; then
-    err $test "$service_name not enabled, state: ${service_state:-absent}"
-  fi
-
   # Verify gadgets were imported during VHD build (tracking file should exist and have content)
   if [ ! -f "$tracking_file" ]; then
     err $test "Tracking file missing at $tracking_file - gadget import may have failed"
   elif [ ! -s "$tracking_file" ]; then
     err $test "Tracking file is empty at $tracking_file - no gadgets were imported"
+  fi
+
+  local image_list
+  if ! image_list=$(ig image list 2>&1); then
+    err $test "ig image list failed: $image_list"
+  else
+    echo "$test: ig image list"
+    printf '%s\n' "$image_list"
   fi
 
   # Verify ig / ig-gadgets compatibility by upstream IG version.

--- a/vhdbuilder/prefetch/cmd/main.go
+++ b/vhdbuilder/prefetch/cmd/main.go
@@ -12,6 +12,7 @@ import (
 type options struct {
 	componentsPath string
 	outputPath     string
+	postfixPath    string
 }
 
 func (o options) validate() error {
@@ -20,6 +21,9 @@ func (o options) validate() error {
 	}
 	if o.outputPath == "" {
 		return fmt.Errorf("output path must be specified")
+	}
+	if o.postfixPath == "" {
+		return fmt.Errorf("postfix path must be specified")
 	}
 	return nil
 }
@@ -31,6 +35,7 @@ var (
 func parseFlags() {
 	flag.StringVar(&opts.componentsPath, "components-path", "", "path to the component list JSON file.")
 	flag.StringVar(&opts.outputPath, "output-path", "", "where to place the newly generated container image prefetch script.")
+	flag.StringVar(&opts.postfixPath, "postfix-path", "", "path to the script to append to the generated prefetch script.")
 	flag.Parse()
 }
 
@@ -47,7 +52,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	content, err := containerimage.GeneratePrefetchScript(list)
+	postfix, err := os.ReadFile(opts.postfixPath)
+	if err != nil {
+		fmt.Printf("reading postfix script %s: %s", opts.postfixPath, err)
+		os.Exit(1)
+	}
+
+	content, err := containerimage.GeneratePrefetchScript(list, postfix)
 	if err != nil {
 		fmt.Printf("generating container prefetch script content: %s", err)
 		os.Exit(1)

--- a/vhdbuilder/prefetch/internal/containerimage/containerimage.go
+++ b/vhdbuilder/prefetch/internal/containerimage/containerimage.go
@@ -17,9 +17,12 @@ var (
 )
 
 // GeneratePrefetchScript generates the container image prefetch script based on the specified component list.
-func GeneratePrefetchScript(list *components.List) ([]byte, error) {
+func GeneratePrefetchScript(list *components.List, postfix []byte) ([]byte, error) {
 	if list == nil {
 		return nil, fmt.Errorf("components list must be non-nil")
+	}
+	if len(postfix) == 0 {
+		return nil, fmt.Errorf("postfix script must be non-empty")
 	}
 	var args TemplateArgs
 	for _, image := range list.Images {
@@ -54,5 +57,12 @@ func GeneratePrefetchScript(list *components.List) ([]byte, error) {
 	if err := prefetchScriptTemplate.Execute(&buf, args); err != nil {
 		return nil, fmt.Errorf("unable to execute container image prefetch template: %w", err)
 	}
+	if bytes.HasPrefix(postfix, []byte("#!")) {
+		if newline := bytes.IndexByte(postfix, '\n'); newline >= 0 {
+			postfix = postfix[newline+1:]
+		}
+	}
+	buf.WriteByte('\n')
+	buf.Write(postfix)
 	return buf.Bytes(), nil
 }

--- a/vhdbuilder/prefetch/internal/containerimage/containerimage_test.go
+++ b/vhdbuilder/prefetch/internal/containerimage/containerimage_test.go
@@ -35,7 +35,10 @@ func TestContainerImage(t *testing.T) {
 	list, err := components.ParseList(componentsPath)
 	assert.NoError(t, err)
 
-	actualContent, err := containerimage.GeneratePrefetchScript(list)
+	postfixContent, err := os.ReadFile(resolvePostfixPath(t))
+	assert.NoError(t, err)
+
+	actualContent, err := containerimage.GeneratePrefetchScript(list, postfixContent)
 	assert.NoError(t, err)
 
 	assert.Equal(t, expectedContent, actualContent)
@@ -50,7 +53,10 @@ func generate(t *testing.T, componentsPath string) {
 	list, err := components.ParseList(componentsPath)
 	assert.NoError(t, err)
 
-	content, err := containerimage.GeneratePrefetchScript(list)
+	postfixContent, err := os.ReadFile(resolvePostfixPath(t))
+	assert.NoError(t, err)
+
+	content, err := containerimage.GeneratePrefetchScript(list, postfixContent)
 	assert.NoError(t, err)
 
 	err = os.WriteFile(prefetchScriptTestDataPath, content, os.ModePerm)
@@ -63,4 +69,11 @@ func resolveComponentsPath(t *testing.T) string {
 	assert.NoError(t, err, "unable to determine repo root with git rev-parse")
 	basePath := strings.ReplaceAll(string(repoBasePath), "\n", "")
 	return filepath.Join(filepath.Join(basePath, artifactsRelPath), "components.json")
+}
+
+func resolvePostfixPath(t *testing.T) string {
+	repoBasePath, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	assert.NoError(t, err, "unable to determine repo root with git rev-parse")
+	basePath := strings.TrimSpace(string(repoBasePath))
+	return filepath.Join(basePath, artifactsRelPath, "cse_preload.sh")
 }

--- a/vhdbuilder/prefetch/internal/containerimage/testdata/prefetch.sh
+++ b/vhdbuilder/prefetch/internal/containerimage/testdata/prefetch.sh
@@ -4,7 +4,7 @@ set -eux
 prefetch() {
     local image=$1
     local files=$2
-    
+
     mount_dir=$(mktemp -d)
     ctr -n k8s.io images mount "$image" "$mount_dir"
 
@@ -31,3 +31,21 @@ prefetch "mcr.microsoft.com/containernetworking/azure-cns:v1.6.13" "/usr/local/b
 prefetch "mcr.microsoft.com/containernetworking/azure-cns:v1.6.18" "/usr/local/bin/azure-cns"
 prefetch "mcr.microsoft.com/containernetworking/azure-ipam:v0.0.7" "/dropgz"
 prefetch "mcr.microsoft.com/containernetworking/azure-ipam:v0.2.0" "/dropgz"
+
+# cse_preload.sh warms binaries and containerd caches needed by CSE early in
+# boot so that node provisioning runs against an already-warm page cache.
+# This is best-effort: every command is backgrounded and its output and exit
+# status are intentionally ignored. It must never block or fail provisioning.
+preload() {
+    "$@" >/dev/null 2>&1 &
+}
+
+preload /opt/azure/containers/aks-node-controller version
+preload /usr/bin/containerd --version
+preload cat /var/lib/containerd/io.containerd.metadata.v1.bolt/meta.db
+preload find /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots -maxdepth 1
+preload /sbin/modprobe overlay
+preload cat /opt/bin/aks-secure-tls-bootstrap-client
+preload /opt/azure/containers/localdns/binary/coredns --version
+
+wait || true


### PR DESCRIPTION
- warm up aks node controller saves about 3s.
- warm up coredns and stls bootstrap binaries saving about 13s.
- disable pub key auth only when requested, so regular path remains fast 4s.
- disable ig service because we have already imported the gadgets we dont need to do it again at startup, its unnecessarily competing for resources.
- add cse_preload.sh to prefetch

```
 ig service only imports OCI artifacts.

 ig image import :

1. Opens the gadget tar bundle.
2. Copies its blobs using ORAS.
3. Stores them under  /var/lib/ig/oci-store .
4. Updates the OCI index and tracking file.

It does not run gadgets, load eBPF programs, call  modprobe , or load kernel modules. eBPF programs are loaded later by commands such as  ig run .

Disabling the boot service is safe provided  ig image list  works directly from the newly booted VHD. It also avoids  ExecStop  removing the baked images during shutdown.
```