### PR TITLE
feat: upgrade azurefile-csi-driver image to v1.35.5

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -542,8 +542,8 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.35.4",
-          "previousLatestVersion": "v1.35.3"
+          "latestVersion": "v1.35.5",
+          "previousLatestVersion": "v1.35.4"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
@@ -559,8 +559,8 @@
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.35.4-windows-hp",
-          "previousLatestVersion": "v1.35.3-windows-hp"
+          "latestVersion": "v1.35.5-windows-hp",
+          "previousLatestVersion": "v1.35.4-windows-hp"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade azurefile-csi-driver image to v1.35.5.

**Changes:**
- Update `latestVersion` from `v1.35.4` to `v1.35.5` (Linux multi-arch)
- Update `latestVersion` from `v1.35.4-windows-hp` to `v1.35.5-windows-hp` (Windows)
- Roll `previousLatestVersion` accordingly (`v1.35.3` → `v1.35.4`, `v1.35.3-windows-hp` → `v1.35.4-windows-hp`)

**Which issue(s) this PR fixes**:
N/A
