### PR TITLE
feat(compliance): integrate compliance-engine-assessor scanning

### DIFF
--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -383,8 +383,9 @@ steps:
         cis-report.txt
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
-  # Compliance Engine native JSON results (+ assessor logs). Non-blocking: the
-  # glob simply matches nothing when the scan is disabled or produced no output.
+  # Compliance Engine native JSON results (+ assessor logs) and rendered JUnit.
+  # Non-blocking: the glob simply matches nothing when the scan is disabled or
+  # produced no output.
   - task: CopyFiles@2
     condition: and(eq(variables.OS_SKU, 'Ubuntu'), in(variables.OS_VERSION, '22.04', '24.04'))
     continueOnError: true
@@ -394,7 +395,23 @@ steps:
       Contents: |
         compliance-engine-*.json
         compliance-engine-*.log
+        compliance-engine-*.junit.xml
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  # Publish the Compliance Engine JUnit to the test tab. Non-blocking: compliance
+  # findings must not fail the build, and the step no-ops (with a warning) when
+  # no JUnit was produced (e.g. an assessor without the `render` subcommand).
+  - task: PublishTestResults@2
+    condition: and(eq(variables.OS_SKU, 'Ubuntu'), in(variables.OS_VERSION, '22.04', '24.04'))
+    continueOnError: true
+    displayName: Publish Compliance Engine JUnit Results
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: 'compliance-engine-*.junit.xml'
+      searchFolder: '$(System.DefaultWorkingDirectory)'
+      testRunTitle: 'Compliance Engine Scan - $(OS_SKU) $(OS_VERSION)'
+      failTaskOnFailedTests: false
+      mergeTestResults: true
 
   - task: PublishPipelineArtifact@0
     displayName: Publish Release Notes

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -36,7 +36,11 @@ steps:
   # (System.AccessToken) is used and the build identity needs Feed Reader there.
   - template: ./.compliance-engine-scan-template.yaml
     parameters:
-      condition: and(succeeded(), eq(variables['ENABLE_COMPLIANCE_ENGINE_SCAN'], 'true'), eq(variables['OS_SKU'], 'Ubuntu'), in(variables['OS_VERSION'], '22.04', '24.04'))
+      # TEMPORARY (testing): the ENABLE_COMPLIANCE_ENGINE_SCAN gate is removed so
+      # the scan runs on every Ubuntu 22.04/24.04 build without setting the
+      # variable. RESTORE before merge:
+      #   and(succeeded(), eq(variables['ENABLE_COMPLIANCE_ENGINE_SCAN'], 'true'), eq(variables['OS_SKU'], 'Ubuntu'), in(variables['OS_VERSION'], '22.04', '24.04'))
+      condition: and(succeeded(), eq(variables['OS_SKU'], 'Ubuntu'), in(variables['OS_VERSION'], '22.04', '24.04'))
       feedName: ComplianceEnginePackages
 
   - task: DownloadPipelineArtifact@2

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -42,9 +42,6 @@ steps:
       #   and(succeeded(), eq(variables['ENABLE_COMPLIANCE_ENGINE_SCAN'], 'true'), eq(variables['OS_SKU'], 'Ubuntu'), in(variables['OS_VERSION'], '22.04', '24.04'))
       condition: and(succeeded(), eq(variables['OS_SKU'], 'Ubuntu'), in(variables['OS_VERSION'], '22.04', '24.04'))
       feedName: ComplianceEnginePackages
-      # ComplianceEnginePackages is a project-scoped feed; the flat2 URL must
-      # include the project or downloads 404. Verify the project in the feed URL
-      # (ADO Artifacts) and change this if it is not 'One'.
       feedProject: One
 
   - task: DownloadPipelineArtifact@2

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -24,6 +24,21 @@ steps:
       vstsPackageVersion: '0.0.230'
       downloadDirectory: vhdbuilder/
 
+  # Compliance Engine (benchmark-agnostic) scan — opt-in shadow of the CIS-CAT
+  # scan above. Downloads the assessor + Ubuntu benchmark MOFs onto the agent;
+  # vhd-scanning.sh then stages them onto the scan VM and publishes native JSON.
+  # This is fully additive: it no-ops unless ENABLE_COMPLIANCE_ENGINE_SCAN=true.
+  #
+  # Package names + versions are pinned (PR-gated) in the manifest
+  # vhdbuilder/packer/compliance-versions.json — bumping requires a PR, exactly
+  # like the CIS scanner version pin above. The compliance-engine packages live
+  # on the ComplianceEnginePackages feed in the SAME ADO org, so basic auth
+  # (System.AccessToken) is used and the build identity needs Feed Reader there.
+  - template: ./.compliance-engine-scan-template.yaml
+    parameters:
+      condition: and(succeeded(), eq(variables['ENABLE_COMPLIANCE_ENGINE_SCAN'], 'true'), eq(variables['OS_SKU'], 'Ubuntu'), in(variables['OS_VERSION'], '22.04', '24.04'))
+      feedName: ComplianceEnginePackages
+
   - task: DownloadPipelineArtifact@2
     condition: and(or(eq(variables.OS_SKU, 'CBLMariner'), eq(variables.OS_SKU, 'AzureLinux')), eq(variables.IMG_OFFER, 'cbl-mariner'))
     displayName: 'Download Kata CC UVM artifact'
@@ -361,6 +376,19 @@ steps:
       Contents: |
         cis-report.html
         cis-report.txt
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  # Compliance Engine native JSON results (+ assessor logs). Non-blocking: the
+  # glob simply matches nothing when the scan is disabled or produced no output.
+  - task: CopyFiles@2
+    condition: and(eq(variables.OS_SKU, 'Ubuntu'), in(variables.OS_VERSION, '22.04', '24.04'))
+    continueOnError: true
+    displayName: Copy Compliance Engine Reports
+    inputs:
+      SourceFolder: '$(System.DefaultWorkingDirectory)'
+      Contents: |
+        compliance-engine-*.json
+        compliance-engine-*.log
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
   - task: PublishPipelineArtifact@0

--- a/.pipelines/templates/.builder-release-template.yaml
+++ b/.pipelines/templates/.builder-release-template.yaml
@@ -42,6 +42,10 @@ steps:
       #   and(succeeded(), eq(variables['ENABLE_COMPLIANCE_ENGINE_SCAN'], 'true'), eq(variables['OS_SKU'], 'Ubuntu'), in(variables['OS_VERSION'], '22.04', '24.04'))
       condition: and(succeeded(), eq(variables['OS_SKU'], 'Ubuntu'), in(variables['OS_VERSION'], '22.04', '24.04'))
       feedName: ComplianceEnginePackages
+      # ComplianceEnginePackages is a project-scoped feed; the flat2 URL must
+      # include the project or downloads 404. Verify the project in the feed URL
+      # (ADO Artifacts) and change this if it is not 'One'.
+      feedProject: One
 
   - task: DownloadPipelineArtifact@2
     condition: and(or(eq(variables.OS_SKU, 'CBLMariner'), eq(variables.OS_SKU, 'AzureLinux')), eq(variables.IMG_OFFER, 'cbl-mariner'))

--- a/.pipelines/templates/.compliance-engine-scan-template.yaml
+++ b/.pipelines/templates/.compliance-engine-scan-template.yaml
@@ -197,6 +197,12 @@ steps:
     split_pin "assessor" "${a_pin}"; a_name="${_name}"; a_ver="${_ver}"
     warn_if_stale "compliance-engine-assessor" "${a_ver}"
     download_pkg "${a_name}" "${a_ver}" "${tmp_dir}/assessor"
+
+    # The package currently ships a single assessor binary (it is not
+    # RID-structured with per-architecture subdirectories), so take the one
+    # binary present. TODO: once the package publishes per-RID binaries, select
+    # the one matching the scan VM architecture ($(ARCHITECTURE)) and verify its
+    # ELF machine, so an arm64 build does not pick up an x86-64 binary.
     assessor_bin=$(find "${tmp_dir}/assessor" -name 'compliance-engine-assessor' -type f | head -1)
     if [ -z "${assessor_bin}" ]; then
         echo "##[error]compliance-engine-assessor binary not found in package ${a_name}"
@@ -205,7 +211,7 @@ steps:
     fi
     cp "${assessor_bin}" "${download_root}/compliance-engine-assessor"
     chmod +x "${download_root}/compliance-engine-assessor"
-    echo "Assessor staged at ${download_root}/compliance-engine-assessor"
+    echo "Assessor (${arch_label}) staged at ${download_root}/compliance-engine-assessor"
 
     # Benchmark MOFs: one per key under .benchmarks (each value a
     # '<package>@<version>' pin), renamed to mof/<key>.mof.

--- a/.pipelines/templates/.compliance-engine-scan-template.yaml
+++ b/.pipelines/templates/.compliance-engine-scan-template.yaml
@@ -1,0 +1,236 @@
+#################################################################################
+# .compliance-engine-scan-template.yaml                                         #
+#                                                                               #
+# Shared ADO steps template that downloads the compliance-engine-assessor       #
+# binary and the benchmark MOF packages from an Azure Artifacts NuGet feed onto #
+# the build agent. It is the AgentBaker counterpart of the Augmentation         #
+# Engine's .pipelines/templates/test/compliance-engine-scan.yml, and is meant   #
+# to be the shared entry point for evolving compliance/benchmark integrations   #
+# (CIS today, STIG next) in the ADO VHD builder.                                #
+#                                                                               #
+# Package NAMES and VERSIONS are NOT hard-coded here: they are pinned in the    #
+# repo manifest vhdbuilder/packer/compliance-versions.json and read at runtime  #
+# with jq. Bumping a version therefore always requires a PR (PR-gating), the    #
+# same model ACL uses. A non-blocking staleness warning fires when a pin is     #
+# older than stalenessThresholdDays.                                            #
+#                                                                               #
+# Unlike the Augmentation Engine template, this one does NOT run the audit on   #
+# the agent: the assessor must audit the live node OS, so the actual audit runs #
+# on the scan VM built from the VHD (see vhdbuilder/packer/vhd-scanning.sh ->    #
+# compliance-engine-report.sh). This template only performs the reusable,        #
+# benchmark-agnostic download and lays artifacts down at a predictable path.    #
+#                                                                               #
+# Output layout (under downloadRoot):                                           #
+#   compliance-engine-assessor        the assessor binary (chmod +x)             #
+#   mof/<key>.mof                     one MOF per benchmark key in the manifest  #
+#                                                                               #
+# Dependencies (agent tools): curl, unzip, jq, bash.                            #
+#                                                                               #
+# Feed auth:                                                                     #
+#   authMode=basic (default): System.AccessToken basic auth, same ADO org as    #
+#     the running pipeline. The build identity needs Feed Reader on the feed.    #
+#   authMode=bearer: workload-identity Azure service connection (Feed Reader),   #
+#     for a feed in a different ADO org. Provide feedServiceConnection.          #
+#################################################################################
+
+parameters:
+- name: condition
+  type: string
+  default: succeeded()
+  displayName: 'Runtime condition gating every step (e.g. restrict to specific OS/versions)'
+
+- name: manifestPath
+  type: string
+  default: '$(Build.SourcesDirectory)/vhdbuilder/packer/compliance-versions.json'
+  displayName: 'Path to the PR-gated version manifest'
+
+- name: stalenessThresholdDays
+  type: number
+  default: 180
+  displayName: 'Emit a non-blocking warning when a pinned version is older than this many days'
+
+- name: feedName
+  type: string
+  default: 'ComplianceEnginePackages'
+  displayName: 'Azure Artifacts NuGet feed name hosting the assessor + benchmark packages'
+
+- name: feedProject
+  type: string
+  default: ''
+  displayName: 'ADO project hosting the feed (empty = org-scoped feed)'
+
+- name: feedOrg
+  type: string
+  default: ''
+  displayName: 'ADO organization hosting the feed (empty = derive from System.CollectionUri)'
+
+- name: authMode
+  type: string
+  default: 'basic'
+  values:
+  - basic
+  - bearer
+  displayName: 'Feed auth: basic (System.AccessToken, same org) or bearer (service connection, cross-org)'
+
+- name: feedServiceConnection
+  type: string
+  default: ''
+  displayName: 'Azure service connection with Feed Reader (required when authMode=bearer)'
+
+- name: downloadRoot
+  type: string
+  default: '$(Build.SourcesDirectory)/vhdbuilder/compliance-engine'
+  displayName: 'Agent directory to place the assessor binary and MOF files'
+
+steps:
+# ── Phase 0: resolve a feed auth header ────────────────────────────────────────
+# Both auth modes converge on a single secret variable, ceFeedAuthHeader, so the
+# download step below stays identical regardless of how the feed is reached.
+- ${{ if eq(parameters.authMode, 'bearer') }}:
+  - task: AzureCLI@2
+    displayName: 'Compliance Engine: resolve feed auth (bearer)'
+    condition: ${{ parameters.condition }}
+    inputs:
+      azureSubscription: ${{ parameters.feedServiceConnection }}
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -euo pipefail
+        # 499b84ac-... is the well-known Azure DevOps resource ID; the token it
+        # returns is accepted by the Azure Artifacts flat2 API.
+        token=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+        echo "##vso[task.setvariable variable=ceFeedAuthHeader;issecret=true]Authorization: Bearer ${token}"
+- ${{ else }}:
+  - script: |
+      set -euo pipefail
+      # Basic auth with the build identity's token (username empty, password=token).
+      header="Authorization: Basic $(printf ':%s' "${SYSTEM_ACCESSTOKEN}" | base64 | tr -d '\n')"
+      echo "##vso[task.setvariable variable=ceFeedAuthHeader;issecret=true]${header}"
+    displayName: 'Compliance Engine: resolve feed auth (basic)'
+    condition: ${{ parameters.condition }}
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+# ── Phase 1: download assessor + benchmark MOFs (manifest-driven) ──────────────
+- script: |
+    set -euo pipefail
+
+    manifest="${{ parameters.manifestPath }}"
+    if [ ! -f "${manifest}" ]; then
+        echo "##[error]Compliance version manifest not found: ${manifest}"
+        exit 1
+    fi
+    command -v jq >/dev/null 2>&1 || { echo "##[error]jq is required but not installed"; exit 1; }
+
+    # Derive the flat2 base URL.
+    feed_org="${{ parameters.feedOrg }}"
+    if [ -z "${feed_org}" ]; then
+        col_uri="${SYSTEM_COLLECTIONURI%/}"
+        if [ "${col_uri#https://dev.azure.com/}" != "${col_uri}" ]; then
+            feed_org="${col_uri#https://dev.azure.com/}"
+        else
+            feed_org="${col_uri#https://}"; feed_org="${feed_org%%.*}"
+        fi
+    fi
+    feed_project="${{ parameters.feedProject }}"
+    feed_name="${{ parameters.feedName }}"
+    if [ -n "${feed_project}" ]; then
+        base_url="https://pkgs.dev.azure.com/${feed_org}/${feed_project}/_packaging/${feed_name}/nuget/v3/flat2"
+    else
+        base_url="https://pkgs.dev.azure.com/${feed_org}/_packaging/${feed_name}/nuget/v3/flat2"
+    fi
+
+    download_root="${{ parameters.downloadRoot }}"
+    mof_dir="${download_root}/mof"
+    tmp_dir="${download_root}/.download"
+    rm -rf "${download_root}"
+    mkdir -p "${mof_dir}" "${tmp_dir}"
+
+    threshold="${{ parameters.stalenessThresholdDays }}"
+    now=$(date -u +%s)
+    # Splits a '<package>@<version>' pin into _name / _ver (package names contain
+    # no '@'). Fails on a malformed pin.
+    split_pin() {
+        local label="$1" pin="$2"
+        _name="${pin%@*}"; _ver="${pin##*@}"
+        if [ "${_name}" = "${pin}" ] || [ -z "${_name}" ] || [ -z "${_ver}" ]; then
+            echo "##[error]'${label}' pin must be '<package>@<version>' (got '${pin}')"
+            exit 1
+        fi
+    }
+    # Compliance package versions are '<YYYYMMDD>.<buildid>[-suffix]', so the pin
+    # date is the version's leading 8 digits — no separate 'updated' field.
+    warn_if_stale() {
+        local label="$1" ver="$2" datestr upd_epoch age
+        datestr="${ver:0:8}"
+        if ! printf '%s' "$datestr" | grep -Eq '^[0-9]{8}$' || ! upd_epoch=$(date -u -d "${datestr:0:4}-${datestr:4:2}-${datestr:6:2}" +%s 2>/dev/null); then
+            echo "##vso[task.logissue type=warning]${label}: cannot derive a date from version '${ver}'; skipping staleness check."
+            return 0
+        fi
+        age=$(( (now - upd_epoch) / 86400 ))
+        if [ "${age}" -gt "${threshold}" ]; then
+            echo "##vso[task.logissue type=warning]${label} version '${ver}' is ${age} days old (threshold ${threshold}). Open a PR to bump vhdbuilder/packer/compliance-versions.json."
+        fi
+    }
+
+    # Downloads and extracts a NuGet package via the flat2 API.
+    #   $1 = package name, $2 = version, $3 = extract dir
+    download_pkg() {
+        local name="$1" ver="$2" out="$3"
+        # NuGet normalizes 2-part versions (X.Y[-pre] -> X.Y.0[-pre]) in flat2 URLs.
+        if printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+(-.*)?$'; then
+            local pre=""
+            case "$ver" in *-*) pre="-${ver#*-}"; ver="${ver%%-*}";; esac
+            ver="${ver}.0${pre}"
+        fi
+        local url="${base_url}/${name}/${ver}/${name}.${ver}.nupkg"
+        echo "Downloading ${name} ${ver}"
+        echo "  URL: ${url}"
+        curl -sSfL -H "${CE_FEED_AUTH_HEADER}" "${url}" -o "${tmp_dir}/${name}.nupkg"
+        mkdir -p "${out}"
+        unzip -q -o "${tmp_dir}/${name}.nupkg" -d "${out}"
+    }
+
+    # Assessor pin ('<package>@<version>') from the manifest.
+    a_pin=$(jq -r '.assessor // empty' "${manifest}")
+    [ -n "${a_pin}" ] || { echo "##[error]'assessor' pin missing in ${manifest}"; exit 1; }
+    split_pin "assessor" "${a_pin}"; a_name="${_name}"; a_ver="${_ver}"
+    warn_if_stale "compliance-engine-assessor" "${a_ver}"
+    download_pkg "${a_name}" "${a_ver}" "${tmp_dir}/assessor"
+    assessor_bin=$(find "${tmp_dir}/assessor" -name 'compliance-engine-assessor' -type f | head -1)
+    if [ -z "${assessor_bin}" ]; then
+        echo "##[error]compliance-engine-assessor binary not found in package ${a_name}"
+        find "${tmp_dir}/assessor" -type f || true
+        exit 1
+    fi
+    cp "${assessor_bin}" "${download_root}/compliance-engine-assessor"
+    chmod +x "${download_root}/compliance-engine-assessor"
+    echo "Assessor staged at ${download_root}/compliance-engine-assessor"
+
+    # Benchmark MOFs: one per key under .benchmarks (each value a
+    # '<package>@<version>' pin), renamed to mof/<key>.mof.
+    bench_count=$(jq -r '(.benchmarks // {}) | length' "${manifest}")
+    [ "${bench_count}" -ge 1 ] || { echo "##[error]'benchmarks' must contain at least one entry in ${manifest}"; exit 1; }
+    for key in $(jq -r '.benchmarks | keys[]' "${manifest}"); do
+        b_pin=$(jq -r --arg k "$key" '.benchmarks[$k]' "${manifest}")
+        split_pin "${key}" "${b_pin}"; b_name="${_name}"; b_ver="${_ver}"
+        warn_if_stale "${key}" "${b_ver}"
+        download_pkg "${b_name}" "${b_ver}" "${tmp_dir}/${key}"
+        mof=$(find "${tmp_dir}/${key}" -name '*.mof' -type f | head -1)
+        if [ -z "${mof}" ]; then
+            echo "##[error]No .mof found in benchmark package ${b_name} (key ${key})"
+            find "${tmp_dir}/${key}" -type f || true
+            exit 1
+        fi
+        cp "${mof}" "${mof_dir}/${key}.mof"
+        echo "MOF for ${key} staged at ${mof_dir}/${key}.mof"
+    done
+
+    rm -rf "${tmp_dir}"
+    echo "Compliance Engine artifacts ready under ${download_root}:"
+    ls -lR "${download_root}" || true
+  displayName: 'Compliance Engine: download assessor + benchmark MOFs'
+  condition: ${{ parameters.condition }}
+  env:
+    CE_FEED_AUTH_HEADER: $(ceFeedAuthHeader)
+    SYSTEM_COLLECTIONURI: $(System.CollectionUri)

--- a/.pipelines/templates/.compliance-engine-scan-template.yaml
+++ b/.pipelines/templates/.compliance-engine-scan-template.yaml
@@ -211,7 +211,7 @@ steps:
     fi
     cp "${assessor_bin}" "${download_root}/compliance-engine-assessor"
     chmod +x "${download_root}/compliance-engine-assessor"
-    echo "Assessor (${arch_label}) staged at ${download_root}/compliance-engine-assessor"
+    echo "Assessor staged at ${download_root}/compliance-engine-assessor"
 
     # Benchmark MOFs: one per key under .benchmarks (each value a
     # '<package>@<version>' pin), renamed to mof/<key>.mof.

--- a/vhdbuilder/packer/compliance-engine-report.sh
+++ b/vhdbuilder/packer/compliance-engine-report.sh
@@ -91,7 +91,9 @@ az storage blob download --container-name "$SIG_CONTAINER_NAME" --name "$MOF_BLO
 chmod 0755 "$ASSESSOR_BIN"
 chmod 0644 "$MOF_PATH"
 
-# Run the audit. stdout is the pure JSON result; --log-file captures all
+# Run the audit. `audit` emits the canonical result JSON on stdout. No --format
+# flag: --format is render-only and is rejected on audit by current assessors;
+# JUnit is rendered later on the agent from this JSON. --log-file captures all
 # assessor logging (and disables console logging) so stdout stays parseable.
 # --continue-on-error keeps the audit going when an individual rule's procedure
 # fails: without it the assessor aborts the whole MOF on the first rule error
@@ -102,7 +104,7 @@ chmod 0644 "$MOF_PATH"
 # must not fail the (shadow, non-blocking) scan.
 audit_rc=0
 set +e
-"$ASSESSOR_BIN" --verbose --continue-on-error --log-file "$LOG_PATH" --format json audit "$MOF_PATH" > "$RESULT_PATH" 2> "${WORK_DIR}/stderr.log"
+"$ASSESSOR_BIN" --verbose --continue-on-error --log-file "$LOG_PATH" audit "$MOF_PATH" > "$RESULT_PATH" 2> "${WORK_DIR}/stderr.log"
 audit_rc=$?
 set -e
 echo "compliance-engine-assessor exited with code: ${audit_rc}"

--- a/vhdbuilder/packer/compliance-engine-report.sh
+++ b/vhdbuilder/packer/compliance-engine-report.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+set -eux
+
+# compliance-engine-report.sh
+#
+# Runs the Compliance Engine assessor (compliance-engine-assessor) against a
+# single benchmark MOF on the scan VM and uploads the native JSON result to the
+# scanning storage account. This is the benchmark-agnostic successor to the
+# CIS-CAT based cis-report.sh: the same assessor binary audits CIS today and
+# STIG (and any future benchmark) tomorrow, driven entirely by the MOF it is
+# given. It emits JSON only (no HTML report yet).
+#
+# It is invoked ON the scan VM (as root) via `az vm run-command invoke
+# --command-id RunShellScript` from vhd-scanning.sh, mirroring how cis-report.sh
+# is invoked. Parameters arrive as environment variables (the `KEY=VALUE` form
+# passed to --parameters), matching cis-report.sh.
+#
+# This scan is intentionally NON-BLOCKING: a NonCompliant audit result still
+# produces a JSON report and the script exits 0. Only the caller decides how to
+# surface findings; here we never fail the build on compliance content.
+#
+# Parameters (environment variables):
+#   ASSESSOR_BLOB_NAME         Blob holding the compliance-engine-assessor binary
+#   MOF_BLOB_NAME              Blob holding the benchmark .mof to audit
+#   RESULT_BLOB_NAME          Blob name to upload the JSON result to
+#   LOG_BLOB_NAME             Blob name to upload the assessor --log-file output to
+#   STORAGE_ACCOUNT_NAME      Scanning storage account
+#   SIG_CONTAINER_NAME        Container holding the blobs above
+#   AZURE_MSI_RESOURCE_STRING User-assigned MSI resource ID for `az login`
+#   ENABLE_TRUSTED_LAUNCH     "true" adds --allow-no-subscriptions to az login
+#   TEST_VM_ADMIN_USERNAME    Admin user (kept for parity with cis-report.sh)
+#   OS_SKU                    OS SKU (informational)
+
+ASSESSOR_BLOB_NAME=${ASSESSOR_BLOB_NAME:-""}
+MOF_BLOB_NAME=${MOF_BLOB_NAME:-""}
+RESULT_BLOB_NAME=${RESULT_BLOB_NAME:-""}
+LOG_BLOB_NAME=${LOG_BLOB_NAME:-""}
+STORAGE_ACCOUNT_NAME=${STORAGE_ACCOUNT_NAME:-""}
+SIG_CONTAINER_NAME=${SIG_CONTAINER_NAME:-""}
+AZURE_MSI_RESOURCE_STRING=${AZURE_MSI_RESOURCE_STRING:-""}
+ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH:-""}
+TEST_VM_ADMIN_USERNAME=${TEST_VM_ADMIN_USERNAME:-"azureuser"}
+OS_SKU=${OS_SKU:-""}
+
+# Azure login helper (mirrors cis-report.sh)
+login_with_user_assigned_managed_identity() {
+    local TYPE_FLAG="$1"
+    local ID=$2
+    LOGIN_FLAGS="--identity $TYPE_FLAG $ID"
+    if [ "${ENABLE_TRUSTED_LAUNCH,,}" = "true" ]; then
+        LOGIN_FLAGS="$LOGIN_FLAGS --allow-no-subscriptions"
+    fi
+    echo "logging into azure with flags: $LOGIN_FLAGS"
+    az login $LOGIN_FLAGS
+}
+
+if [ -z "$AZURE_MSI_RESOURCE_STRING" ]; then
+    echo "AZURE_MSI_RESOURCE_STRING must be set for az login"
+    exit 1
+fi
+login_with_user_assigned_managed_identity "--resource-id" "$AZURE_MSI_RESOURCE_STRING"
+
+# The assessor's input hardening (azure-osconfig InputSecurity.cpp) refuses to
+# read the MOF, and refuses to write the --log-file, unless the file and its
+# parent directory are owned by root and are not group/world-writable. This
+# script runs as root under RunShellScript, and `mktemp -d` creates a 0700
+# root-owned directory, so staging the assessor, MOF and log there satisfies
+# those checks. The world-writable /tmp grandparent is not consulted.
+WORK_DIR="$(mktemp -d)"
+chmod 0700 "$WORK_DIR"
+cleanup() {
+    rm -rf "$WORK_DIR" || true
+}
+trap cleanup EXIT
+
+ASSESSOR_BIN="${WORK_DIR}/compliance-engine-assessor"
+MOF_PATH="${WORK_DIR}/benchmark.mof"
+RESULT_PATH="${WORK_DIR}/result.json"
+LOG_PATH="${WORK_DIR}/compliance-engine-assessor.log"
+
+# Download the assessor binary and the benchmark MOF from the scanning storage
+# account. Both were staged there by vhd-scanning.sh running on the agent.
+az storage blob download --container-name "$SIG_CONTAINER_NAME" --name "$ASSESSOR_BLOB_NAME" --file "$ASSESSOR_BIN" --account-name "$STORAGE_ACCOUNT_NAME" --auth-mode login
+az storage blob download --container-name "$SIG_CONTAINER_NAME" --name "$MOF_BLOB_NAME" --file "$MOF_PATH" --account-name "$STORAGE_ACCOUNT_NAME" --auth-mode login
+
+chmod 0755 "$ASSESSOR_BIN"
+chmod 0644 "$MOF_PATH"
+
+# Run the audit. stdout is the pure JSON result; --log-file captures all
+# assessor logging (and disables console logging) so stdout stays parseable.
+# Capture the exit code but never abort: a NonCompliant result is expected and
+# must not fail the (shadow, non-blocking) scan.
+audit_rc=0
+set +e
+"$ASSESSOR_BIN" --verbose --log-file "$LOG_PATH" --format json audit "$MOF_PATH" > "$RESULT_PATH" 2> "${WORK_DIR}/stderr.log"
+audit_rc=$?
+set -e
+echo "compliance-engine-assessor exited with code: ${audit_rc}"
+
+# Surface a little context in the run-command output for debugging.
+echo "----- compliance-engine-assessor stderr -----"
+cat "${WORK_DIR}/stderr.log" 2>/dev/null || true
+echo "---------------------------------------------"
+
+# Upload the JSON result and the assessor log even if the audit reported
+# NonCompliant or failed, so the agent always has something to publish.
+if [ -s "$RESULT_PATH" ]; then
+    az storage blob upload --container-name "$SIG_CONTAINER_NAME" --file "$RESULT_PATH" --name "$RESULT_BLOB_NAME" --account-name "$STORAGE_ACCOUNT_NAME" --auth-mode login --overwrite
+else
+    echo "WARNING: assessor produced no JSON result on stdout"
+fi
+if [ -s "$LOG_PATH" ]; then
+    az storage blob upload --container-name "$SIG_CONTAINER_NAME" --file "$LOG_PATH" --name "$LOG_BLOB_NAME" --account-name "$STORAGE_ACCOUNT_NAME" --auth-mode login --overwrite
+fi
+
+echo "compliance-engine report script completed for MOF blob ${MOF_BLOB_NAME}"
+exit 0

--- a/vhdbuilder/packer/compliance-engine-report.sh
+++ b/vhdbuilder/packer/compliance-engine-report.sh
@@ -91,40 +91,18 @@ az storage blob download --container-name "$SIG_CONTAINER_NAME" --name "$MOF_BLO
 chmod 0755 "$ASSESSOR_BIN"
 chmod 0644 "$MOF_PATH"
 
-# Diagnostics: exit code 126 ("cannot execute") is almost always an architecture
-# mismatch (binary built for a different arch than this VM) or the work dir being
-# on a 'noexec' mount. Log enough to tell the two apart from the pipeline output.
-echo "----- assessor exec diagnostics -----"
-echo "VM arch (uname -m): $(uname -m)"
-echo "assessor permissions/owner:"; stat -c '  %A  %U:%G  %s bytes  %n' "$ASSESSOR_BIN" 2>/dev/null || echo "  (stat failed)"
-echo "assessor file type:"; file "$ASSESSOR_BIN" 2>/dev/null || echo "  (file(1) not available)"
-# ELF header e_machine lives at byte offset 18 (0x3e=x86-64, 0xb7=AArch64).
-echo "assessor ELF magic + e_machine (offset 0 and 18):"
-od -An -tx1 -N 20 "$ASSESSOR_BIN" 2>/dev/null || true
-# ldd reveals missing shared libraries ("=> not found") or, on an arch mismatch,
-# prints "not a dynamic executable" / an error — useful either way.
-echo "assessor dynamic dependencies (ldd):"
-ldd "$ASSESSOR_BIN" 2>&1 | sed 's/^/  /' || true
-echo "work dir mount options:"; findmnt -no TARGET,OPTIONS --target "$WORK_DIR" 2>/dev/null || mount 2>/dev/null | grep -E " on / " || true
-# noexec self-test: if a trivial script here cannot run, the fs is noexec; if it
-# runs but the assessor does not, the assessor is the wrong arch/format.
-printf '#!/bin/sh\nexit 0\n' > "${WORK_DIR}/.exec-test.sh"
-chmod 0755 "${WORK_DIR}/.exec-test.sh"
-if "${WORK_DIR}/.exec-test.sh" 2>/dev/null; then
-    echo "noexec self-test: PASS (work dir is exec-permitted)"
-else
-    echo "noexec self-test: FAIL (work dir appears to be mounted noexec)"
-fi
-rm -f "${WORK_DIR}/.exec-test.sh"
-echo "-------------------------------------"
-
 # Run the audit. stdout is the pure JSON result; --log-file captures all
 # assessor logging (and disables console logging) so stdout stays parseable.
+# --continue-on-error keeps the audit going when an individual rule's procedure
+# fails: without it the assessor aborts the whole MOF on the first rule error
+# (returns 1 and emits no JSON, since the JSON formatter only flushes at the
+# end), which would drop every result. For a shadow, non-blocking scan we want
+# the partial JSON plus a logged error rather than nothing.
 # Capture the exit code but never abort: a NonCompliant result is expected and
 # must not fail the (shadow, non-blocking) scan.
 audit_rc=0
 set +e
-"$ASSESSOR_BIN" --verbose --log-file "$LOG_PATH" --format json audit "$MOF_PATH" > "$RESULT_PATH" 2> "${WORK_DIR}/stderr.log"
+"$ASSESSOR_BIN" --verbose --continue-on-error --log-file "$LOG_PATH" --format json audit "$MOF_PATH" > "$RESULT_PATH" 2> "${WORK_DIR}/stderr.log"
 audit_rc=$?
 set -e
 echo "compliance-engine-assessor exited with code: ${audit_rc}"
@@ -133,6 +111,19 @@ echo "compliance-engine-assessor exited with code: ${audit_rc}"
 echo "----- compliance-engine-assessor stderr -----"
 cat "${WORK_DIR}/stderr.log" 2>/dev/null || true
 echo "---------------------------------------------"
+
+# The assessor disables console logging when --log-file is set, so on a failure
+# or an empty result the reason (e.g. "benchmark is not applicable for the
+# current distribution", or a specific rule's procedure error) lives ONLY in the
+# log file. Surface the error lines and the tail inline so the pipeline output
+# shows the cause without having to open the published log artifact.
+if [ "${audit_rc}" -ne 0 ] || [ ! -s "$RESULT_PATH" ]; then
+    echo "----- compliance-engine-assessor log: error lines -----"
+    grep -iE 'error|abort|not applicable|exception|fatal' "$LOG_PATH" 2>/dev/null | tail -n 40 || true
+    echo "----- compliance-engine-assessor log: tail -----"
+    tail -n 40 "$LOG_PATH" 2>/dev/null || true
+    echo "------------------------------------------------------"
+fi
 
 # Upload the JSON result and the assessor log even if the audit reported
 # NonCompliant or failed, so the agent always has something to publish.

--- a/vhdbuilder/packer/compliance-engine-report.sh
+++ b/vhdbuilder/packer/compliance-engine-report.sh
@@ -62,11 +62,16 @@ login_with_user_assigned_managed_identity "--resource-id" "$AZURE_MSI_RESOURCE_S
 
 # The assessor's input hardening (azure-osconfig InputSecurity.cpp) refuses to
 # read the MOF, and refuses to write the --log-file, unless the file and its
-# parent directory are owned by root and are not group/world-writable. This
-# script runs as root under RunShellScript, and `mktemp -d` creates a 0700
-# root-owned directory, so staging the assessor, MOF and log there satisfies
-# those checks. The world-writable /tmp grandparent is not consulted.
-WORK_DIR="$(mktemp -d)"
+# parent directory are owned by root and are not group/world-writable.
+#
+# The work dir must ALSO be on an exec-permitted filesystem: CIS-hardened images
+# mount /tmp (and often /var/tmp, /dev/shm) with 'noexec', so running the
+# assessor from the default mktemp location (/tmp) fails with exit code 126
+# ("cannot execute"). We therefore stage under /root — root's home on the root
+# filesystem, which is exec-permitted and mode 0700 — which also satisfies the
+# assessor's root-owned, non-world-writable parent-directory checks. This script
+# runs as root under RunShellScript, so /root is writable.
+WORK_DIR="$(mktemp -d /root/compliance-engine.XXXXXX)"
 chmod 0700 "$WORK_DIR"
 cleanup() {
     rm -rf "$WORK_DIR" || true

--- a/vhdbuilder/packer/compliance-engine-report.sh
+++ b/vhdbuilder/packer/compliance-engine-report.sh
@@ -91,6 +91,33 @@ az storage blob download --container-name "$SIG_CONTAINER_NAME" --name "$MOF_BLO
 chmod 0755 "$ASSESSOR_BIN"
 chmod 0644 "$MOF_PATH"
 
+# Diagnostics: exit code 126 ("cannot execute") is almost always an architecture
+# mismatch (binary built for a different arch than this VM) or the work dir being
+# on a 'noexec' mount. Log enough to tell the two apart from the pipeline output.
+echo "----- assessor exec diagnostics -----"
+echo "VM arch (uname -m): $(uname -m)"
+echo "assessor permissions/owner:"; stat -c '  %A  %U:%G  %s bytes  %n' "$ASSESSOR_BIN" 2>/dev/null || echo "  (stat failed)"
+echo "assessor file type:"; file "$ASSESSOR_BIN" 2>/dev/null || echo "  (file(1) not available)"
+# ELF header e_machine lives at byte offset 18 (0x3e=x86-64, 0xb7=AArch64).
+echo "assessor ELF magic + e_machine (offset 0 and 18):"
+od -An -tx1 -N 20 "$ASSESSOR_BIN" 2>/dev/null || true
+# ldd reveals missing shared libraries ("=> not found") or, on an arch mismatch,
+# prints "not a dynamic executable" / an error — useful either way.
+echo "assessor dynamic dependencies (ldd):"
+ldd "$ASSESSOR_BIN" 2>&1 | sed 's/^/  /' || true
+echo "work dir mount options:"; findmnt -no TARGET,OPTIONS --target "$WORK_DIR" 2>/dev/null || mount 2>/dev/null | grep -E " on / " || true
+# noexec self-test: if a trivial script here cannot run, the fs is noexec; if it
+# runs but the assessor does not, the assessor is the wrong arch/format.
+printf '#!/bin/sh\nexit 0\n' > "${WORK_DIR}/.exec-test.sh"
+chmod 0755 "${WORK_DIR}/.exec-test.sh"
+if "${WORK_DIR}/.exec-test.sh" 2>/dev/null; then
+    echo "noexec self-test: PASS (work dir is exec-permitted)"
+else
+    echo "noexec self-test: FAIL (work dir appears to be mounted noexec)"
+fi
+rm -f "${WORK_DIR}/.exec-test.sh"
+echo "-------------------------------------"
+
 # Run the audit. stdout is the pure JSON result; --log-file captures all
 # assessor logging (and disables console logging) so stdout stays parseable.
 # Capture the exit code but never abort: a NonCompliant result is expected and

--- a/vhdbuilder/packer/compliance-versions.json
+++ b/vhdbuilder/packer/compliance-versions.json
@@ -2,9 +2,9 @@
     "_comment": "PR-gated pins for the Compliance Engine packages consumed from the ComplianceEnginePackages NuGet feed by the VHD builder's (shadow, non-blocking) compliance scan. 'assessor' is a single '<package>@<version>' pin; 'benchmarks' is a map of <key> -> '<package>@<version>' so multiple benchmarks (Ubuntu 22.04/24.04 x L1/L2, or CIS + STIG) can be scanned in one run. The <key> both selects which MOFs apply to the OS being built (vhd-scanning.sh audits mof/ubuntu-<version>-*.mof) and names the result JSON (compliance-engine-<key>.json). Bumping a pin REQUIRES a pull request (PR-gating): publishing a new package to the feed never changes what the pipeline uses until a PR updates the pin here. Versions are '<YYYYMMDD>.<buildid>[-suffix]', so the pin date is intrinsic to the version string; the scan derives a non-blocking staleness warning from the leading YYYYMMDD. Package names must exactly match the NuGet package ids published by the Compliance Augmentation Engine. If L1 and L2 ship as a single combined MOF, collapse the two entries into one. This schema is shared with acl-pipelines' pipelines/compliance-versions.json.",
     "assessor": "compliance-engine-assessor@TODO-pin-published-assessor-version",
     "benchmarks": {
-        "ubuntu-22.04-l1": "cis_ubuntu_linux_22.04_lts_benchmark_v2.0.0__level_1__server@TODO-pin-published-version",
-        "ubuntu-22.04-l2": "cis_ubuntu_linux_22.04_lts_benchmark_v2.0.0__level_2__server@TODO-pin-published-version",
-        "ubuntu-24.04-l1": "cis_ubuntu_linux_24.04_lts_benchmark_v1.0.0__level_1__server@TODO-pin-published-version",
-        "ubuntu-24.04-l2": "cis_ubuntu_linux_24.04_lts_benchmark_v1.0.0__level_2__server@TODO-pin-published-version"
+        "ubuntu-22.04-l1": "cis_ubuntu_linux_22.04_lts_benchmark_v2.0.0@20260714.172110348-unofficial",
+        "ubuntu-22.04-l2": "cis_ubuntu_linux_22.04_lts_benchmark_v2.0.0@20260714.172110348-unofficial",
+        "ubuntu-24.04-l1": "cis_ubuntu_linux_24.04_lts_benchmark_v1.0.0@20260714.172110348-unofficial",
+        "ubuntu-24.04-l2": "cis_ubuntu_linux_24.04_lts_benchmark_v1.0.0@20260714.172110348-unofficial"
     }
 }

--- a/vhdbuilder/packer/compliance-versions.json
+++ b/vhdbuilder/packer/compliance-versions.json
@@ -1,6 +1,6 @@
 {
     "_comment": "PR-gated pins for the Compliance Engine packages consumed from the ComplianceEnginePackages NuGet feed by the VHD builder's (shadow, non-blocking) compliance scan. 'assessor' is a single '<package>@<version>' pin; 'benchmarks' is a map of <key> -> '<package>@<version>' so multiple benchmarks (Ubuntu 22.04/24.04 x L1/L2, or CIS + STIG) can be scanned in one run. The <key> both selects which MOFs apply to the OS being built (vhd-scanning.sh audits mof/ubuntu-<version>-*.mof) and names the result JSON (compliance-engine-<key>.json). Bumping a pin REQUIRES a pull request (PR-gating): publishing a new package to the feed never changes what the pipeline uses until a PR updates the pin here. Versions are '<YYYYMMDD>.<buildid>[-suffix]', so the pin date is intrinsic to the version string; the scan derives a non-blocking staleness warning from the leading YYYYMMDD. Package names must exactly match the NuGet package ids published by the Compliance Augmentation Engine. If L1 and L2 ship as a single combined MOF, collapse the two entries into one. This schema is shared with acl-pipelines' pipelines/compliance-versions.json.",
-    "assessor": "compliance-engine-assessor@20260715.172339732-unofficial",
+    "assessor": "compliance-engine-assessor@20260720.172937301-unofficial",
     "benchmarks": {
         "ubuntu-22.04-l1": "cis_ubuntu_linux_22.04_lts_benchmark_v2.0.0@20260714.172110348-unofficial",
         "ubuntu-22.04-l2": "cis_ubuntu_linux_22.04_lts_benchmark_v2.0.0@20260714.172110348-unofficial",

--- a/vhdbuilder/packer/compliance-versions.json
+++ b/vhdbuilder/packer/compliance-versions.json
@@ -1,0 +1,10 @@
+{
+    "_comment": "PR-gated pins for the Compliance Engine packages consumed from the ComplianceEnginePackages NuGet feed by the VHD builder's (shadow, non-blocking) compliance scan. 'assessor' is a single '<package>@<version>' pin; 'benchmarks' is a map of <key> -> '<package>@<version>' so multiple benchmarks (Ubuntu 22.04/24.04 x L1/L2, or CIS + STIG) can be scanned in one run. The <key> both selects which MOFs apply to the OS being built (vhd-scanning.sh audits mof/ubuntu-<version>-*.mof) and names the result JSON (compliance-engine-<key>.json). Bumping a pin REQUIRES a pull request (PR-gating): publishing a new package to the feed never changes what the pipeline uses until a PR updates the pin here. Versions are '<YYYYMMDD>.<buildid>[-suffix]', so the pin date is intrinsic to the version string; the scan derives a non-blocking staleness warning from the leading YYYYMMDD. Package names must exactly match the NuGet package ids published by the Compliance Augmentation Engine. If L1 and L2 ship as a single combined MOF, collapse the two entries into one. This schema is shared with acl-pipelines' pipelines/compliance-versions.json.",
+    "assessor": "compliance-engine-assessor@TODO-pin-published-assessor-version",
+    "benchmarks": {
+        "ubuntu-22.04-l1": "cis_ubuntu_linux_22.04_lts_benchmark_v2.0.0__level_1__server@TODO-pin-published-version",
+        "ubuntu-22.04-l2": "cis_ubuntu_linux_22.04_lts_benchmark_v2.0.0__level_2__server@TODO-pin-published-version",
+        "ubuntu-24.04-l1": "cis_ubuntu_linux_24.04_lts_benchmark_v1.0.0__level_1__server@TODO-pin-published-version",
+        "ubuntu-24.04-l2": "cis_ubuntu_linux_24.04_lts_benchmark_v1.0.0__level_2__server@TODO-pin-published-version"
+    }
+}

--- a/vhdbuilder/packer/compliance-versions.json
+++ b/vhdbuilder/packer/compliance-versions.json
@@ -1,6 +1,6 @@
 {
     "_comment": "PR-gated pins for the Compliance Engine packages consumed from the ComplianceEnginePackages NuGet feed by the VHD builder's (shadow, non-blocking) compliance scan. 'assessor' is a single '<package>@<version>' pin; 'benchmarks' is a map of <key> -> '<package>@<version>' so multiple benchmarks (Ubuntu 22.04/24.04 x L1/L2, or CIS + STIG) can be scanned in one run. The <key> both selects which MOFs apply to the OS being built (vhd-scanning.sh audits mof/ubuntu-<version>-*.mof) and names the result JSON (compliance-engine-<key>.json). Bumping a pin REQUIRES a pull request (PR-gating): publishing a new package to the feed never changes what the pipeline uses until a PR updates the pin here. Versions are '<YYYYMMDD>.<buildid>[-suffix]', so the pin date is intrinsic to the version string; the scan derives a non-blocking staleness warning from the leading YYYYMMDD. Package names must exactly match the NuGet package ids published by the Compliance Augmentation Engine. If L1 and L2 ship as a single combined MOF, collapse the two entries into one. This schema is shared with acl-pipelines' pipelines/compliance-versions.json.",
-    "assessor": "compliance-engine-assessor@20260714.172155787-unofficial",
+    "assessor": "compliance-engine-assessor@20260715.172339732-unofficial",
     "benchmarks": {
         "ubuntu-22.04-l1": "cis_ubuntu_linux_22.04_lts_benchmark_v2.0.0@20260714.172110348-unofficial",
         "ubuntu-22.04-l2": "cis_ubuntu_linux_22.04_lts_benchmark_v2.0.0@20260714.172110348-unofficial",

--- a/vhdbuilder/packer/compliance-versions.json
+++ b/vhdbuilder/packer/compliance-versions.json
@@ -1,6 +1,6 @@
 {
     "_comment": "PR-gated pins for the Compliance Engine packages consumed from the ComplianceEnginePackages NuGet feed by the VHD builder's (shadow, non-blocking) compliance scan. 'assessor' is a single '<package>@<version>' pin; 'benchmarks' is a map of <key> -> '<package>@<version>' so multiple benchmarks (Ubuntu 22.04/24.04 x L1/L2, or CIS + STIG) can be scanned in one run. The <key> both selects which MOFs apply to the OS being built (vhd-scanning.sh audits mof/ubuntu-<version>-*.mof) and names the result JSON (compliance-engine-<key>.json). Bumping a pin REQUIRES a pull request (PR-gating): publishing a new package to the feed never changes what the pipeline uses until a PR updates the pin here. Versions are '<YYYYMMDD>.<buildid>[-suffix]', so the pin date is intrinsic to the version string; the scan derives a non-blocking staleness warning from the leading YYYYMMDD. Package names must exactly match the NuGet package ids published by the Compliance Augmentation Engine. If L1 and L2 ship as a single combined MOF, collapse the two entries into one. This schema is shared with acl-pipelines' pipelines/compliance-versions.json.",
-    "assessor": "compliance-engine-assessor@TODO-pin-published-assessor-version",
+    "assessor": "compliance-engine-assessor@20260714.172155787-unofficial",
     "benchmarks": {
         "ubuntu-22.04-l1": "cis_ubuntu_linux_22.04_lts_benchmark_v2.0.0@20260714.172110348-unofficial",
         "ubuntu-22.04-l2": "cis_ubuntu_linux_22.04_lts_benchmark_v2.0.0@20260714.172110348-unofficial",

--- a/vhdbuilder/packer/vhd-scanning.sh
+++ b/vhdbuilder/packer/vhd-scanning.sh
@@ -362,7 +362,7 @@ run_compliance_engine_scan() {
     echo "Uploading Compliance Engine assessor to blob ${assessor_blob}"
     az storage blob upload --container-name "${SIG_CONTAINER_NAME}" --file "${CE_ASSESSOR_LOCAL}" --name "${assessor_blob}" --account-name "${STORAGE_ACCOUNT_NAME}" --auth-mode login --overwrite
 
-    local m key mof_blob result_blob log_blob result_local
+    local m key mof_blob result_blob log_blob result_local junit_local
     for m in "${mofs[@]}"; do
         key=$(basename "$m" .mof)
         mof_blob="ce-mof-${key}-${BUILD_ID}-${ce_ts}.mof"
@@ -407,6 +407,18 @@ run_compliance_engine_scan() {
         # Non-blocking validation: warn (never fail) on a missing/invalid result.
         if [ -s "${result_local}" ] && jq -e '.' "${result_local}" >/dev/null 2>&1; then
             echo "Compliance Engine ${key}: valid JSON result at ${result_local}"
+            # Render JUnit centrally on the agent from the canonical JSON. The
+            # assessor's `render` subcommand is root-free and pure over JSON, so
+            # it runs here rather than on the scan VM. Requires a render-capable
+            # assessor; if unsupported (older binary) it is skipped non-blocking
+            # and only the JSON is published.
+            junit_local="compliance-engine-${key}.junit.xml"
+            if "$CE_ASSESSOR_LOCAL" --format junit --suite-name "${key}" render "${result_local}" > "${junit_local}" 2>/dev/null && [ -s "${junit_local}" ]; then
+                echo "Compliance Engine ${key}: rendered JUnit at ${junit_local}"
+            else
+                printf '##vso[task.logissue type=warning]Compliance Engine %s: JUnit render failed or unsupported by the assessor; publishing JSON only.\n' "$key"
+                rm -f "${junit_local}"
+            fi
         else
             printf '##vso[task.logissue type=warning]Compliance Engine %s: missing or invalid JSON result (non-blocking).\n' "$key"
         fi

--- a/vhdbuilder/packer/vhd-scanning.sh
+++ b/vhdbuilder/packer/vhd-scanning.sh
@@ -396,7 +396,8 @@ run_compliance_engine_scan() {
         # Retrieve the JSON result (and the assessor log) for publication.
         az storage blob download --container-name "${SIG_CONTAINER_NAME}" --name "${result_blob}" --file "${result_local}" --account-name "${STORAGE_ACCOUNT_NAME}" --auth-mode login || \
             echo "WARNING: no Compliance Engine result blob for ${key}"
-        az storage blob download --container-name "${SIG_CONTAINER_NAME}" --name "${log_blob}" --file "compliance-engine-${key}.log" --account-name "${STORAGE_ACCOUNT_NAME}" --auth-mode login || true
+        az storage blob download --container-name "${SIG_CONTAINER_NAME}" --name "${log_blob}" --file "compliance-engine-${key}.log" --account-name "${STORAGE_ACCOUNT_NAME}" --auth-mode login || \
+            echo "WARNING: no Compliance Engine log blob for ${key}"
 
         # Clean up per-MOF blobs.
         az storage blob delete --account-name "${STORAGE_ACCOUNT_NAME}" --container-name "${SIG_CONTAINER_NAME}" --name "${mof_blob}" --auth-mode login || true

--- a/vhdbuilder/packer/vhd-scanning.sh
+++ b/vhdbuilder/packer/vhd-scanning.sh
@@ -319,6 +319,106 @@ if ! requiresCISScan "${OS_SKU}" "${OS_VERSION}"; then
     exit 0
 fi
 
+# --- Compliance Engine scan (shadow, non-blocking) ---
+# Runs the benchmark-agnostic compliance-engine-assessor on the same scan VM,
+# alongside (not instead of) the CIS-CAT scan below. Emits native JSON only.
+# This runs BEFORE the CIS-CAT block on purpose, so the CIS-CAT skip/license
+# early-exits do not suppress the Compliance Engine results. It is fully
+# non-blocking: compliance findings never fail the build, and any operational
+# error here is swallowed so it cannot abort the CIS-CAT scan that follows.
+#
+# Inputs are laid down on the agent by
+# .pipelines/templates/.compliance-engine-scan-template.yaml at:
+#   vhdbuilder/compliance-engine/compliance-engine-assessor
+#   vhdbuilder/compliance-engine/mof/ubuntu-<version>-<level>.mof
+CE_SCRIPT_PATH="$CDIR/compliance-engine-report.sh"
+CE_ASSESSOR_LOCAL="$CDIR/../compliance-engine/compliance-engine-assessor"
+CE_MOF_DIR="$CDIR/../compliance-engine/mof"
+
+run_compliance_engine_scan() {
+    local skip="${SKIP_COMPLIANCE_ENGINE:-false}"
+    if [ "${skip,,}" = "true" ]; then
+        echo "Skipping Compliance Engine scan (SKIP_COMPLIANCE_ENGINE=true)"
+        return 0
+    fi
+    if [ ! -x "$CE_ASSESSOR_LOCAL" ]; then
+        echo "Compliance Engine assessor not found at ${CE_ASSESSOR_LOCAL}; skipping (non-blocking)"
+        return 0
+    fi
+    local mofs=()
+    if [ -d "$CE_MOF_DIR" ]; then
+        while IFS= read -r m; do
+            [ -n "$m" ] && mofs+=("$m")
+        done < <(find "$CE_MOF_DIR" -maxdepth 1 -name "ubuntu-${OS_VERSION}-*.mof" -type f | sort)
+    fi
+    if [ "${#mofs[@]}" -eq 0 ]; then
+        echo "No Compliance Engine MOFs for ubuntu ${OS_VERSION} under ${CE_MOF_DIR}; skipping (non-blocking)"
+        return 0
+    fi
+
+    local ce_ts assessor_blob
+    ce_ts=$(date +%s%3N)
+    assessor_blob="compliance-engine-assessor-${BUILD_ID}-${ce_ts}"
+    echo "Uploading Compliance Engine assessor to blob ${assessor_blob}"
+    az storage blob upload --container-name "${SIG_CONTAINER_NAME}" --file "${CE_ASSESSOR_LOCAL}" --name "${assessor_blob}" --account-name "${STORAGE_ACCOUNT_NAME}" --auth-mode login --overwrite
+
+    local m key mof_blob result_blob log_blob result_local
+    for m in "${mofs[@]}"; do
+        key=$(basename "$m" .mof)
+        mof_blob="ce-mof-${key}-${BUILD_ID}-${ce_ts}.mof"
+        result_blob="ce-result-${key}-${BUILD_ID}-${ce_ts}.json"
+        log_blob="ce-log-${key}-${BUILD_ID}-${ce_ts}.log"
+        result_local="compliance-engine-${key}.json"
+
+        echo "Compliance Engine: auditing ${key} (MOF ${m})"
+        az storage blob upload --container-name "${SIG_CONTAINER_NAME}" --file "${m}" --name "${mof_blob}" --account-name "${STORAGE_ACCOUNT_NAME}" --auth-mode login --overwrite
+
+        local ret msg
+        ret=$(az vm run-command invoke \
+            --command-id RunShellScript \
+            --name "$SCAN_VM_NAME" \
+            --resource-group "$RESOURCE_GROUP_NAME" \
+            --scripts @"$CE_SCRIPT_PATH" \
+            --parameters "ASSESSOR_BLOB_NAME=${assessor_blob}" \
+                "MOF_BLOB_NAME=${mof_blob}" \
+                "RESULT_BLOB_NAME=${result_blob}" \
+                "LOG_BLOB_NAME=${log_blob}" \
+                "STORAGE_ACCOUNT_NAME=${STORAGE_ACCOUNT_NAME}" \
+                "SIG_CONTAINER_NAME=${SIG_CONTAINER_NAME}" \
+                "AZURE_MSI_RESOURCE_STRING=${AZURE_MSI_RESOURCE_STRING}" \
+                "ENABLE_TRUSTED_LAUNCH=${ENABLE_TRUSTED_LAUNCH}" \
+                "TEST_VM_ADMIN_USERNAME=${SCAN_VM_ADMIN_USERNAME}" \
+                "OS_SKU=${OS_SKU}")
+        echo "$ret"
+        msg=$(echo -E "$ret" | jq -r '.value[].message' 2>/dev/null || true)
+        echo "$msg"
+
+        # Retrieve the JSON result (and the assessor log) for publication.
+        az storage blob download --container-name "${SIG_CONTAINER_NAME}" --name "${result_blob}" --file "${result_local}" --account-name "${STORAGE_ACCOUNT_NAME}" --auth-mode login || \
+            echo "WARNING: no Compliance Engine result blob for ${key}"
+        az storage blob download --container-name "${SIG_CONTAINER_NAME}" --name "${log_blob}" --file "compliance-engine-${key}.log" --account-name "${STORAGE_ACCOUNT_NAME}" --auth-mode login || true
+
+        # Clean up per-MOF blobs.
+        az storage blob delete --account-name "${STORAGE_ACCOUNT_NAME}" --container-name "${SIG_CONTAINER_NAME}" --name "${mof_blob}" --auth-mode login || true
+        az storage blob delete --account-name "${STORAGE_ACCOUNT_NAME}" --container-name "${SIG_CONTAINER_NAME}" --name "${result_blob}" --auth-mode login || true
+        az storage blob delete --account-name "${STORAGE_ACCOUNT_NAME}" --container-name "${SIG_CONTAINER_NAME}" --name "${log_blob}" --auth-mode login || true
+
+        # Non-blocking validation: warn (never fail) on a missing/invalid result.
+        if [ -s "${result_local}" ] && jq -e '.' "${result_local}" >/dev/null 2>&1; then
+            echo "Compliance Engine ${key}: valid JSON result at ${result_local}"
+        else
+            printf '##vso[task.logissue type=warning]Compliance Engine %s: missing or invalid JSON result (non-blocking).\n' "$key"
+        fi
+    done
+
+    # Clean up the shared assessor blob.
+    az storage blob delete --account-name "${STORAGE_ACCOUNT_NAME}" --container-name "${SIG_CONTAINER_NAME}" --name "${assessor_blob}" --auth-mode login || true
+}
+
+# Isolate in a subshell with `set +e` so nothing here can abort the CIS-CAT scan.
+( set +e; run_compliance_engine_scan ) || true
+capture_benchmark "${SCRIPT_NAME}_compliance_engine_scan"
+
 # Set this pipeline variable to true if CIS scanning is broken
 SKIP_CIS=${SKIP_CIS:-false}
 if [ "${SKIP_CIS,,}" = "true" ]; then


### PR DESCRIPTION
Initial integration of the Compliance Engine Assessor which will replace the current scripted CIS Assessor scanning.

PR descript will be extended later after the initial wiring is set up.