### PR TITLE
fix(ubuntu): don't treat benign ESM apt-hook stderr as apt-get failure (CSE exit 99)

### DIFF
--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
@@ -2,6 +2,16 @@
 
 echo "Sourcing cse_helpers_distro.sh for Ubuntu"
 
+# The Ubuntu Pro / ESM apt hooks (apt-news, esm-cache) log connection errors to stderr when they
+# cannot reach their snapd/dbus socket during early boot, e.g.:
+#   Error connecting: Error sending credentials: Error sending message: Broken pipe
+# These are cosmetic — the apt operation itself still succeeds (the repo line shows "Hit: ... InRelease").
+# The generic error grep used by the apt wrappers below matches any line starting with "Error", so it
+# would otherwise treat the whole apt-get run as failed and CSE would exit 99 (the node never joins).
+# Strip these known-benign lines before error detection; real apt failures (E:/W:/Err: prefixed) are
+# still caught. Not marked readonly so the file stays safe to re-source.
+APT_BENIGN_STDERR_REGEX='^Error (connecting|sending (credentials|message)):.*Broken pipe'
+
 
 holdWALinuxAgent() {
     echo $(date),$(hostname), startHoldWALinuxAgent "$1"
@@ -36,7 +46,7 @@ _apt_get_update() {
         export DEBIAN_FRONTEND=noninteractive
         dpkg --configure -a --force-confdef
         apt-get ${apt_opts} -f -y install
-        ! (apt-get ${apt_opts} update 2>&1 | tee $apt_update_output | grep -E "^([WE]:.*)|^([Ee][Rr][Rr][Oo][Rr].*)$") && \
+        ! (apt-get ${apt_opts} update 2>&1 | tee $apt_update_output | grep -vE "${APT_BENIGN_STDERR_REGEX}" | grep -E "^([WE]:.*)|^([Ee][Rr][Rr][Oo][Rr].*)$") && \
         cat $apt_update_output && break || \
         cat $apt_update_output
         if [ $i -eq $retries ]; then
@@ -174,7 +184,7 @@ apt_get_dist_upgrade() {
     # inline (not via /etc/apt/apt.conf.d) so it does not leak into the captured VHD or change node
     # runtime apt behavior. apt_get_dist_upgrade is only invoked during VHD build.
     # https://ubuntu.com/server/docs/explanation/software/about-apt-upgrade-and-phased-updates/#how-do-i-turn-off-phased-updates
-    ! (apt-get -o Dpkg::Options::="--force-confnew" -o APT::Get::Always-Include-Phased-Updates=true dist-upgrade -y 2>&1 | tee $apt_dist_upgrade_output | grep -E "^([WE]:.*)|^([Ee][Rr][Rr][Oo][Rr].*)$") && \
+    ! (apt-get -o Dpkg::Options::="--force-confnew" -o APT::Get::Always-Include-Phased-Updates=true dist-upgrade -y 2>&1 | tee $apt_dist_upgrade_output | grep -vE "${APT_BENIGN_STDERR_REGEX}" | grep -E "^([WE]:.*)|^([Ee][Rr][Rr][Oo][Rr].*)$") && \
     cat $apt_dist_upgrade_output && break || \
     cat $apt_dist_upgrade_output
     if [ $i -eq $retries ]; then

--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
@@ -2,14 +2,19 @@
 
 echo "Sourcing cse_helpers_distro.sh for Ubuntu"
 
-# The Ubuntu Pro / ESM apt hooks (apt-news, esm-cache) log connection errors to stderr when they
-# cannot reach their snapd/dbus socket during early boot, e.g.:
+# The ubuntu-pro-client apt hook (/etc/apt/apt.conf.d/20apt-esm-hook.conf) ships in the stock Ubuntu
+# image and runs on every apt-get update EVEN WHEN the node is NOT attached to Ubuntu Pro/ESM. Its
+# APT::Update::Pre-Invoke starts apt-news.service / esm-cache.service; during early boot (before
+# systemd has finished starting) that D-Bus/systemctl handshake to the local system bus can fail and
+# print to stderr, e.g.:
 #   Error connecting: Error sending credentials: Error sending message: Broken pipe
-# These are cosmetic — the apt operation itself still succeeds (the repo line shows "Hit: ... InRelease").
-# The generic error grep used by the apt wrappers below matches any line starting with "Error", so it
-# would otherwise treat the whole apt-get run as failed and CSE would exit 99 (the node never joins).
-# Strip these known-benign lines before error detection; real apt failures (E:/W:/Err: prefixed) are
-# still caught. Not marked readonly so the file stays safe to re-source.
+# This is a LOCAL IPC error (SCM_CREDENTIALS over the systemd/D-Bus unix socket), NOT a remote-repo
+# reachability problem, and it is cosmetic — the apt operation itself still succeeds ("Hit: ... InRelease").
+# The generic error grep below matches any line starting with "Error", so it would otherwise treat the
+# whole apt-get run as failed and CSE would exit 99 (the node never joins). Strip only this specific
+# benign local-IPC signature before error detection. Genuine repo failures — including an unreachable
+# PMC/Canonical mirror — still surface as apt's own "E:"/"W:"/"Err:"/"Failed to fetch" lines, which do
+# NOT match this pattern and are still caught. Not marked readonly so the file stays safe to re-source.
 APT_BENIGN_STDERR_REGEX='^Error (connecting|sending (credentials|message)):.*Broken pipe'
 
 

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh
@@ -143,4 +143,62 @@ Describe 'apt_get_install budget timeout'
             The stdout should include "dist-upgrade"
         End
     End
+
+    Describe '_apt_get_update error detection'
+        # Isolate the apt-get update retry/error-grep logic. sleep is stubbed so retries are fast.
+        wait_for_apt_locks() { :; }
+        dpkg() { :; }
+        sleep() { :; }
+
+        It "succeeds when apt-get update prints only the benign Ubuntu Pro/ESM hook line"
+            # The apt-news / esm-cache apt hook logs this to stderr during early boot when it cannot
+            # reach its snapd/dbus socket. The apt operation itself still succeeds (Hit: ... InRelease),
+            # so it must NOT be treated as a failure. Regression test for the exit-99 false positive:
+            # apt-get update succeeded yet CSE exited 99 because the error grep matched "Error ...".
+            apt-get() {
+                case "$*" in
+                    *update*)
+                        echo "Hit:1 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease"
+                        echo "Error connecting: Error sending credentials: Error sending message: Broken pipe"
+                        echo "Reading package lists..."
+                        ;;
+                esac
+                return 0
+            }
+            When call _apt_get_update 3 ""
+            The status should eq 0
+            The stdout should include "Executed apt-get update 1 times"
+        End
+
+        It "succeeds on a clean apt-get update"
+            apt-get() {
+                case "$*" in
+                    *update*)
+                        echo "Hit:1 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease"
+                        echo "Reading package lists..."
+                        ;;
+                esac
+                return 0
+            }
+            When call _apt_get_update 3 ""
+            The status should eq 0
+            The stdout should include "Executed apt-get update 1 times"
+        End
+
+        It "fails after exhausting retries on a real apt error (E:/Err: output)"
+            apt-get() {
+                case "$*" in
+                    *update*)
+                        echo "Err:1 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease"
+                        echo "E: Failed to fetch https://packages.microsoft.com/ubuntu/24.04/prod/dists/noble/InRelease  Could not connect"
+                        echo "E: Some index files failed to download."
+                        ;;
+                esac
+                return 0
+            }
+            When call _apt_get_update 2 ""
+            The status should eq 1
+            The stdout should not include "Executed apt-get update"
+        End
+    End
 End

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh
@@ -151,15 +151,16 @@ Describe 'apt_get_install budget timeout'
         sleep() { :; }
 
         It "succeeds when apt-get update prints only the benign Ubuntu Pro/ESM hook line"
-            # The apt-news / esm-cache apt hook logs this to stderr during early boot when it cannot
-            # reach its snapd/dbus socket. The apt operation itself still succeeds (Hit: ... InRelease),
-            # so it must NOT be treated as a failure. Regression test for the exit-99 false positive:
-            # apt-get update succeeded yet CSE exited 99 because the error grep matched "Error ...".
+            # The ubuntu-pro-client apt hook (esm-cache/apt-news) writes this to STDERR during early
+            # boot when the local systemd/D-Bus handshake isn't ready. The real code merges it via
+            # 2>&1, and the apt operation itself still succeeds (Hit: ... InRelease), so it must NOT be
+            # treated as a failure. Regression test for the exit-99 false positive: apt-get update
+            # succeeded yet CSE exited 99 because the error grep matched "Error ...".
             apt-get() {
                 case "$*" in
                     *update*)
                         echo "Hit:1 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease"
-                        echo "Error connecting: Error sending credentials: Error sending message: Broken pipe"
+                        echo "Error connecting: Error sending credentials: Error sending message: Broken pipe" >&2
                         echo "Reading package lists..."
                         ;;
                 esac
@@ -185,13 +186,16 @@ Describe 'apt_get_install budget timeout'
             The stdout should include "Executed apt-get update 1 times"
         End
 
-        It "fails after exhausting retries on a real apt error (E:/Err: output)"
+        It "still FAILS when PMC/Canonical is genuinely unreachable"
+            # Guards against masking real remote-repo failures: an unreachable mirror surfaces as apt's
+            # own E:/Err:/Failed-to-fetch lines, which do NOT match the benign filter and must still fail.
             apt-get() {
                 case "$*" in
                     *update*)
-                        echo "Err:1 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease"
-                        echo "E: Failed to fetch https://packages.microsoft.com/ubuntu/24.04/prod/dists/noble/InRelease  Could not connect"
-                        echo "E: Some index files failed to download."
+                        echo "Err:1 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease" >&2
+                        echo "  Could not connect to packages.microsoft.com:443 (13.107.9.104), connection timed out" >&2
+                        echo "E: Failed to fetch https://packages.microsoft.com/ubuntu/24.04/prod/dists/noble/InRelease  Could not connect" >&2
+                        echo "E: Some index files failed to download." >&2
                         ;;
                 esac
                 return 0
@@ -199,6 +203,44 @@ Describe 'apt_get_install budget timeout'
             When call _apt_get_update 2 ""
             The status should eq 1
             The stdout should not include "Executed apt-get update"
+        End
+    End
+
+    Describe 'apt_get_dist_upgrade error detection (VHD build)'
+        # apt_get_dist_upgrade is VHD-build only; retries=10 is hardcoded, so stub sleep for speed.
+        wait_for_apt_locks() { :; }
+        dpkg() { :; }
+        sleep() { :; }
+
+        It "ignores the benign ESM/D-Bus line on dist-upgrade"
+            apt-get() {
+                case "$*" in
+                    *dist-upgrade*)
+                        echo "Calculating upgrade..."
+                        echo "Error connecting: Error sending credentials: Error sending message: Broken pipe" >&2
+                        echo "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded."
+                        ;;
+                esac
+                return 0
+            }
+            When call apt_get_dist_upgrade
+            The status should eq 0
+            The stdout should include "Executed apt-get dist-upgrade 1 times"
+        End
+
+        It "still fails on a real apt error during dist-upgrade"
+            apt-get() {
+                case "$*" in
+                    *dist-upgrade*)
+                        echo "E: Failed to fetch https://packages.microsoft.com/... Could not connect to packages.microsoft.com:443" >&2
+                        echo "E: Some index files failed to download." >&2
+                        ;;
+                esac
+                return 0
+            }
+            When call apt_get_dist_upgrade
+            The status should eq 1
+            The stdout should not include "Executed apt-get dist-upgrade"
         End
     End
 End


### PR DESCRIPTION
## Problem

Node bootstrap can fail with **CSE `exit 99`** (`ERR_APT_UPDATE_TIMEOUT` / VMSS `AptUpdateTimeoutVMExtensionError`) **even though `apt-get update` actually succeeded**, so the node never joins the cluster.

`_apt_get_update()` / `apt_get_dist_upgrade()` in `parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh` decide success/failure by grepping the **merged stdout+stderr** (`2>&1`) for `^W:`, `^E:`, or the over-broad `^Error.*`:

```bash
! (apt-get ${apt_opts} update 2>&1 | tee $out | grep -E "^([WE]:.*)|^([Ee][Rr][Rr][Oo][Rr].*)$") && ...
```

The Ubuntu Pro / ESM apt hook (`apt-news` / `esm-cache`) logs this to stderr when it can't reach its snapd/dbus socket during **early boot**:

```
Error connecting: Error sending credentials: Error sending message: Broken pipe
```

That line starts with `Error`, so the grep flags the whole run as failed, retries 10×, `return 1` → caller `apt_get_update || exit $ERR_APT_UPDATE_TIMEOUT` → **exit 99**. apt itself succeeded (`Hit:1 …/ubuntu/24.04/prod noble InRelease`, exit 0). It's intermittent because it depends on the early-boot dbus timing race.

Observed live on a real GB300 node (k8s 1.36.1, `2404gen2arm64containerd/202606.19.0`): `aks-node-controller` `exitCode=99`, `apt-get …/microsoft-prod.list update` shows `Hit:1 … noble InRelease` with the benign broken-pipe line as the *only* "error", and `KubeletStartTime` empty.

## Fix

Strip only the known-benign ESM/D-Bus line **before** the existing error grep, at both apt call sites. Intentionally minimal — the existing error regex is unchanged, so real apt failures (`E:` / `W:` / `Err:` prefixed) are still detected. Avoids regressing error detection on VHDs that live in production for 6 months.

- New file-scope `APT_BENIGN_STDERR_REGEX` (documented; not `readonly` so re-sourcing stays safe).
- `| grep -vE "${APT_BENIGN_STDERR_REGEX}"` inserted ahead of the error grep in `_apt_get_update` and `apt_get_dist_upgrade`.

## Tests

Adds a `_apt_get_update error detection` ShellSpec block:
- benign ESM line only → **succeeds** (regression test for this bug)
- clean update → succeeds
- real `E:`/`Err:` output → still **fails** after retries

`shellspec spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh` → **12 examples, 0 failures**. TDD: the benign-line test failed before the fix, passes after.

## Notes

- `make generate` produces no diff (scripts are `go:embed`'d; no committed testdata copy of this script).