### PR TITLE
fix(renovate): correct ama-metrics version parsing

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -618,7 +618,7 @@
       "matchDatasources": [
         "docker"
       ],
-      "versioning": "regex:^(\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?-(\\w+)-(\\d+)-(\\d+)-(\\d+)-(\\w+-*)(?<compatibility>.*)$",
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-main-(?<prerelease>\\d{2}-\\d{2}-\\d{4}-[0-9a-f]+)(?:-(?<compatibility>cfg|targetallocator|ccp|win))?$",
       "groupName": "ama-metrics",
       "automerge": false,
       "enabled": true,


### PR DESCRIPTION
## What this PR does / why we need it

Two-commit fix for the ama-metrics Renovate rule:

**Commit 1** — added named `major` group to fix the `6.27.0 > 7.0.0` mis-ordering that caused a downgrade PR (#8897).

**Commit 2** — removed the named `prerelease` group introduced in commit 1. Having a `prerelease` group causes Renovate to mark all ama-metrics tags as unstable and skip them entirely (no updates detected).

The final regex:
- Named `major`/`minor`/`patch` → correct version ordering
- Date/SHA segment left as a non-capturing group `(?:...)` → not treated as prerelease, so tags are considered stable
- Named `compatibility` → differentiates `cfg`, `targetallocator`, `ccp`, `win` variants

## Related
- Downgrade PR that exposed the problem: #8897