### PR TITLE
fix(renovate): remove prerelease group from ama-metrics versioning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -635,10 +635,11 @@
       "matchDatasources": [
         "docker"
       ],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-main-(?:\\d{2}-\\d{2}-\\d{4}-[0-9a-f]+)(?:-(?<compatibility>cfg|targetallocator|ccp|win))?$",
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-main-(?<prerelease>\\d{2}-\\d{2}-\\d{4}-[0-9a-f]+)(?:-(?<compatibility>cfg|targetallocator|ccp|win))?$",
       "groupName": "ama-metrics",
       "automerge": false,
       "enabled": true,
+      "ignoreUnstable": false,
       "assignees": [
         "gracewehner",
         "vishiy",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -635,7 +635,7 @@
       "matchDatasources": [
         "docker"
       ],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-main-(?<prerelease>\\d{2}-\\d{2}-\\d{4}-[0-9a-f]+)(?:-(?<compatibility>cfg|targetallocator|ccp|win))?$",
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-main-(?:\\d{2}-\\d{2}-\\d{4}-[0-9a-f]+)(?:-(?<compatibility>cfg|targetallocator|ccp|win))?$",
       "groupName": "ama-metrics",
       "automerge": false,
       "enabled": true,


### PR DESCRIPTION
## What this PR does
Fixes ama-metrics Renovate detection.

## Change
- Keep the ama-metrics `prerelease` capture in regex parsing.
- Add `ignoreUnstable: false` for this ama-metrics rule only.

## Why
Renovate treats captured `prerelease` versions as unstable by default. This scoped setting lets it continue detecting ama-metrics updates without affecting other packages.

## Related
Follow-up to #8920.