### PR TITLE
test: validate ANC version is non-empty in Linux content test

### DIFF
--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1920,15 +1920,22 @@ testAKSNodeControllerBinary () {
 testAKSNodeControllerVersion() {
   local test="testAKSNodeControllerVersion"
   local go_binary_path="/opt/azure/containers/aks-node-controller"
+  local ancVersionRaw
   local ancVersion
 
-  ancVersion=$("${go_binary_path}" version 2>/dev/null | tr -d '\r\n')
+  ancVersionRaw=$("${go_binary_path}" version 2>&1)
+  if [ "$?" -ne 0 ]; then
+    err "$test" "failed to run '${go_binary_path} version': ${ancVersionRaw}"
+    return 1
+  fi
+
+  ancVersion=$(printf '%s' "$ancVersionRaw" | tr -d '\r\n')
   if [ -z "$ancVersion" ]; then
     err "$test" "aks-node-controller version is empty"
     return 1
   fi
 
-  if ! echo "$ancVersion" | grep -Eq '^(dev|[0-9]{6}\.[0-9]{2}\.[0-9]+)$'; then
+  if ! printf '%s\n' "$ancVersion" | grep -Eq '^(dev|[0-9]{6}\.[0-9]{2}\.[0-9]+)$'; then
     err "$test" "aks-node-controller version format is invalid: '${ancVersion}'. expected 'dev' or YYYYMM.DD.PATCH"
     return 1
   fi

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1917,6 +1917,25 @@ testAKSNodeControllerBinary () {
   echo "$test: aks-node-controller go binary exists at $go_binary_path"
 }
 
+testAKSNodeControllerVersion() {
+  local test="testAKSNodeControllerVersion"
+  local go_binary_path="/opt/azure/containers/aks-node-controller"
+  local ancVersion
+
+  ancVersion=$("${go_binary_path}" version 2>/dev/null | tr -d '\r\n')
+  if [ -z "$ancVersion" ]; then
+    err "$test" "aks-node-controller version is empty"
+    return 1
+  fi
+
+  if ! echo "$ancVersion" | grep -Eq '^(dev|[0-9]{6}\.[0-9]{2}\.[0-9]+)$'; then
+    err "$test" "aks-node-controller version format is invalid: '${ancVersion}'. expected 'dev' or YYYYMM.DD.PATCH"
+    return 1
+  fi
+
+  echo "$test: aks-node-controller version '${ancVersion}' is valid"
+}
+
 testAKSNodeControllerService() {
   local test="testNBCParserService"
   local service_name="aks-node-controller.service"
@@ -2542,6 +2561,7 @@ testUmaskSettings
 testContainerImagePrefetchScript
 testNodeExporter $OS_SKU
 testAKSNodeControllerBinary
+testAKSNodeControllerVersion
 testAKSNodeControllerService
 testLtsKernel $OS_VERSION $OS_SKU $ENABLE_FIPS
 testAutologinDisabled $OS_SKU


### PR DESCRIPTION
## What this PR does

Adds `testAKSNodeControllerVersion` to `vhdbuilder/packer/test/linux-vhd-content-test.sh` as a follow-up to #8926.

The test:
- Runs `/opt/azure/containers/aks-node-controller version` and captures both stdout and stderr
- Fails with the real command error if the binary exits non-zero (exec format error, missing deps, etc.)
- Verifies the reported version is non-empty
- Verifies the version format is either `dev` or `YYYYMM.DD.N` where N ≥ 0 (e.g. `202607.13.0` for a base build, `202607.13.1` / `202607.13.2` for hotfix rebuilds on the same day), matching how `packer.mk` stamps ANC via `date +%Y%m.%d.0` and `-ldflags "-X main.Version=..."`

## Why

Without this check, a broken `ldflags` stamp (as fixed in #8926) would silently ship a VHD with `Version = "dev"` in production builds, and no content test would catch it.