### PR TITLE
chore: pin buf to 1.71.0 in Makefile and CI to fix format drift

### DIFF
--- a/.github/workflows/buf.yaml
+++ b/.github/workflows/buf.yaml
@@ -19,6 +19,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+      - name: Extract buf version from Makefile
+        id: buf-version
+        run: echo "version=$(grep '^BUF_VERSION' aks-node-controller/Makefile | cut -d'=' -f2 | tr -d ' ')" >> "$GITHUB_OUTPUT"
       - uses: bufbuild/buf-action@v1
         with:
           input: aks-node-controller
+          version: ${{ steps.buf-version.outputs.version }}

--- a/aks-node-controller/Makefile
+++ b/aks-node-controller/Makefile
@@ -1,6 +1,7 @@
 # Run buf in docker, mounting the full repo into the container
 # Emulate running "buf" in the current directory
-BUF = docker run --platform linux/amd64 --volume "$(CURDIR)/../:$(CURDIR)/../" --workdir $(CURDIR) bufbuild/buf:1.47.2
+BUF_VERSION = 1.71.0
+BUF = docker run --rm --platform linux/amd64 --volume "$(CURDIR)/../:$(CURDIR)/../" --workdir $(CURDIR) bufbuild/buf:$(BUF_VERSION)
 
 .PHONY: proto-generate
 proto-generate:


### PR DESCRIPTION
## Summary

While working on PR #8812 (remove `streamingConnectionIdleTimeout` for k8s >= 1.34), I ran `make proto-generate` to regenerate `kubelet_config.pb.go` after marking the proto field as `[deprecated = true]`. This produced a 241-line formatting diff — the local `buf format` (v1.47.2 pinned in the Makefile) reformatted all `/* */` comment blocks from 3-space to 5-space indentation.

CI uses `bufbuild/buf-action@v1` which pulls the latest buf version. The latest buf (1.71.0) expects 3-space indentation (matching what's already on main), so the locally-generated 5-space format fails CI's format check.

**Root cause**: Version drift between the Makefile (`bufbuild/buf:1.47.2`) and CI (`bufbuild/buf-action@v1` → unpinned latest).

**Fix**: 
1. Upgrade the Makefile's buf docker image from 1.47.2 to 1.71.0
2. Pin CI's `buf-action` to `version: 1.71.0` so both local and CI use the same version

This ensures `make proto-generate` locally and CI produce identical formatting. Future buf upgrades require changing both files together.

## Changes
- `aks-node-controller/Makefile`: `bufbuild/buf:1.47.2` → `bufbuild/buf:1.71.0`
- `.github/workflows/buf.yaml`: add `version: 1.71.0` to pin CI

## Test plan
- [x] `docker run bufbuild/buf:1.71.0 format --diff` on main produces no output
- [x] `make proto-generate` with 1.71.0 does not change any proto file formatting on main
- [x] Build passes after version bump