### PR TITLE
Remove 'dev' from ANC version content-test regex

### DIFF
--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1935,8 +1935,8 @@ testAKSNodeControllerVersion() {
     return 1
   fi
 
-  if ! printf '%s\n' "$ancVersion" | grep -Eq '^(dev|[0-9]{6}\.[0-9]{2}\.[0-9]+)$'; then
-    err "$test" "aks-node-controller version format is invalid: '${ancVersion}'. expected 'dev' or YYYYMM.DD.PATCH"
+  if ! printf '%s\n' "$ancVersion" | grep -Eq '^[0-9]{6}\.[0-9]{2}\.[0-9]+$'; then
+    err "$test" "aks-node-controller version format is invalid: '${ancVersion}'. expected YYYYMM.DD.PATCH"
     return 1
   fi
 


### PR DESCRIPTION
## Summary
- update `testAKSNodeControllerVersion` in `vhdbuilder/packer/test/linux-vhd-content-test.sh` to require only `YYYYMM.DD.PATCH`
- remove the `dev` branch from the regex
- update the failure message to match the stricter validation

## Why this is safe
This content test validates VHDs produced by `packer.mk`, and those builds always stamp a real datetime ANC version via:
- `ANC_VERSION="${IMAGE_VERSION:-$(date +%Y%m.%d.0)}"`
- `-ldflags "-X main.Version=${ANC_VERSION}"`

So a `dev` version on a production VHD indicates ldflags version stamping failed, which should be rejected by the content test. `dev` remains valid for unit tests/local e2e flows that do not use ldflags, and those flows do not run through this VHD content test.
