### PR TITLE
fix(gpu): unload resident prebaked nvidia module in cleanUpPrebakedGPUDriver

### DIFF
--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
@@ -235,19 +235,40 @@ removeNvidiaRepos() {
 # NOT install the AKS-managed driver -- the cleanUpGPUDrivers path (GPU_NODE != true OR
 # skip_nvidia_driver_install=true): non-GPU VMs, and GPU VMs opted out via --gpu-driver None or the
 # skip toggle/tag. There the driver is dead weight (wasted disk; nvidia.ko rebuilt on every kernel
-# patch) and, on an opted-out GPU node, unused attack surface. The module is never loaded on these
-# nodes (ensureGPUDrivers doesn't run), so deregistration is safe. No-op unless the marker exists.
+# patch) and, on an opted-out GPU node, unused attack surface.
+#
+# The prebaked module MAY already be loaded when we run: cuda(-lts) prebakes auto-load nvidia.ko at
+# boot (~5s, well before CSE), so on a cuda/cuda-lts SKU opted out via --gpu-driver None the module
+# is resident even though ensureGPUDrivers never ran. (grid prebakes do not auto-load, so grid nodes
+# arrive here with no module.) Deleting the on-disk .ko then leaves a stale loaded module -- unused
+# (refcnt 0, no /dev/nvidia*) but resident until reboot, and a landmine for a subsequent GPU Operator
+# install. So we rmmod it first, when idle, before removing the files. No-op unless the marker exists.
 cleanUpPrebakedGPUDriver() {
     local marker="${GPU_DKMS_MARKER_FILE:-/opt/azure/aks-gpu/dkms-marker}"
     if [ ! -f "${marker}" ]; then
         return 0
     fi
     echo "Removing pre-baked NVIDIA driver inherited from shared VHD (node does not install the managed driver)"
-    local dkms_before=false
+    local dkms_before=false module_before=false module_after=false
     [ -d /var/lib/dkms/nvidia ] && dkms_before=true
 
+    # Unload the prebaked nvidia module if it auto-loaded at boot (cuda/cuda-lts SKUs). Only when idle
+    # (refcnt 0 and no device nodes) -- this node doesn't install a driver, so nothing should be using
+    # it; if something is, leave it and let module_after=true flag an incomplete teardown. Unload the
+    # dependent modules first (modeset/uvm/drm) so nvidia's refcnt drops to 0. Best-effort; failures
+    # do not abort provisioning.
+    if lsmod | grep -q '^nvidia'; then
+        module_before=true
+        if [ "$(cat /sys/module/nvidia/refcnt 2>/dev/null || echo 0)" = "0" ] && ! ls /dev/nvidia* >/dev/null 2>&1; then
+            for mod in nvidia_uvm nvidia_drm nvidia_modeset nvidia_peermem nvidia; do
+                rmmod "${mod}" 2>/dev/null || true
+            done
+        fi
+    fi
+    lsmod | grep -q '^nvidia' && module_after=true
+
     # Deregister the nvidia DKMS module by removing its source tree (avoids the slow `dkms remove
-    # --all`, ~35s). The module isn't loaded here, so no depmod/initramfs refresh is needed.
+    # --all`, ~35s). Any loaded module was unloaded above, so no depmod/initramfs refresh is needed.
     rm -rf /var/lib/dkms/nvidia || true
     rm -f /lib/modules/*/updates/dkms/nvidia*.ko* 2>/dev/null || true
     # The prebake stages libs under the aks-gpu *container's* GPU_DEST=/usr/bin (aks-gpu config.sh),
@@ -264,21 +285,21 @@ cleanUpPrebakedGPUDriver() {
     ldconfig || true
 
     # Stage-1 observability + retry: assess completeness BEFORE dropping the marker. status=incomplete
-    # means the DKMS registration or the setuid nvidia-modprobe binary lingered (a security-coverage
-    # alert). On an incomplete teardown we KEEP the marker so the next provision re-runs this cleanup
-    # (the marker is the "still needs cleanup" flag); on a clean teardown we drop it. status=cleaned
-    # counts toward fleet-wide coverage. Greppable prefix AKS_GPU_PREBAKE.
+    # means the DKMS registration, the setuid nvidia-modprobe binary, or a still-resident nvidia
+    # module lingered (a security-coverage alert). On an incomplete teardown we KEEP the marker so the
+    # next provision re-runs this cleanup (the marker is the "still needs cleanup" flag); on a clean
+    # teardown we drop it. status=cleaned counts toward fleet-wide coverage. Greppable AKS_GPU_PREBAKE.
     local dkms_after=false modprobe_after=false marker_after=true status=cleaned
     [ -d /var/lib/dkms/nvidia ] && dkms_after=true
     [ -e /usr/bin/nvidia-modprobe ] && modprobe_after=true
-    if [ "${dkms_after}" = false ] && [ "${modprobe_after}" = false ]; then
+    if [ "${dkms_after}" = false ] && [ "${modprobe_after}" = false ] && [ "${module_after}" = false ]; then
         rm -f "${marker}" || true
         [ -f "${marker}" ] || marker_after=false
     fi
-    if [ "${marker_after}" = true ] || [ "${dkms_after}" = true ] || [ "${modprobe_after}" = true ]; then
+    if [ "${marker_after}" = true ] || [ "${dkms_after}" = true ] || [ "${modprobe_after}" = true ] || [ "${module_after}" = true ]; then
         status=incomplete
     fi
-    echo "AKS_GPU_PREBAKE event=teardown gpu_node=${GPU_NODE:-} status=${status} dkms_before=${dkms_before} marker_after=${marker_after} dkms_after=${dkms_after} modprobe_after=${modprobe_after}"
+    echo "AKS_GPU_PREBAKE event=teardown gpu_node=${GPU_NODE:-} status=${status} dkms_before=${dkms_before} module_before=${module_before} module_after=${module_after} marker_after=${marker_after} dkms_after=${dkms_after} modprobe_after=${modprobe_after}"
 }
 
 cleanUpGPUDrivers() {

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
@@ -16,6 +16,7 @@ Describe 'cse_install_ubuntu.sh'
             GPU_DKMS_MARKER_FILE="${marker}"
             rm() { echo "mock rm $*"; }
             ldconfig() { echo "mock ldconfig"; }
+            lsmod() { echo ""; }  # no nvidia module loaded
             When call cleanUpPrebakedGPUDriver
             The status should be success
             The output should include "Removing pre-baked NVIDIA driver"
@@ -39,6 +40,7 @@ Describe 'cse_install_ubuntu.sh'
             marker="$(mktemp)"
             GPU_DKMS_MARKER_FILE="${marker}"
             ldconfig() { echo "mock ldconfig"; }
+            lsmod() { echo ""; }  # no nvidia module loaded (grid-style prebake)
             When call cleanUpPrebakedGPUDriver
             The status should be success
             The output should include "AKS_GPU_PREBAKE event=teardown"
@@ -46,6 +48,42 @@ Describe 'cse_install_ubuntu.sh'
             The output should include "marker_after=false"
             # the setuid nvidia-modprobe is part of the security-coverage check
             The output should include "modprobe_after=false"
+            The output should include "module_before=false"
+            The output should include "module_after=false"
+        End
+
+        It 'unloads an idle prebaked nvidia module that auto-loaded at boot (cuda/cuda-lts SKUs)'
+            marker="$(mktemp)"
+            GPU_DKMS_MARKER_FILE="${marker}"
+            ldconfig() { echo "mock ldconfig"; }
+            # simulate a loaded-but-idle module: lsmod shows nvidia until rmmod is "run"
+            _nvidia_loaded=true
+            lsmod() { if [ "${_nvidia_loaded}" = true ]; then echo "nvidia 104165376 0"; else echo ""; fi; }
+            cat() { echo "0"; }        # /sys/module/nvidia/refcnt = 0 (idle)
+            ls() { return 1; }          # no /dev/nvidia* device nodes
+            rmmod() { _nvidia_loaded=false; echo "mock rmmod $*"; }
+            When call cleanUpPrebakedGPUDriver
+            The status should be success
+            The output should include "mock rmmod nvidia"
+            The output should include "module_before=true"
+            The output should include "module_after=false"
+            The output should include "status=cleaned"
+        End
+
+        It 'keeps the marker (incomplete) when a busy nvidia module cannot be unloaded'
+            marker="$(mktemp)"
+            GPU_DKMS_MARKER_FILE="${marker}"
+            ldconfig() { echo "mock ldconfig"; }
+            lsmod() { echo "nvidia 104165376 2"; }  # stays loaded (refcnt shows in-use)
+            cat() { echo "2"; }                       # refcnt != 0 -> do not rmmod
+            ls() { return 1; }
+            rmmod() { echo "mock rmmod $*"; }         # should NOT be called
+            When call cleanUpPrebakedGPUDriver
+            The status should be success
+            The output should not include "mock rmmod"
+            The output should include "module_before=true"
+            The output should include "module_after=true"
+            The output should include "status=incomplete"
         End
     End
 End


### PR DESCRIPTION
## Problem

On **cuda / cuda-lts** GPU SKUs opted out of the AKS driver via `--gpu-driver None` (or the skip toggle/tag), the CUDA driver pre-baked into the shared Ubuntu VHD **auto-loads `nvidia.ko` at boot** (~5s in, well before CSE runs). `cleanUpPrebakedGPUDriver` then deletes the on-disk `.ko` + userspace libs — but the module is **already resident in the running kernel**, so deleting the file leaves a **stale loaded module** (unused: refcnt 0, no `/dev/nvidia*`, but resident until reboot). It also violates the function's own comment — *"The module is never loaded on these nodes"* — which only held for **grid** prebakes (they don't auto-load).

## Why it matters: NVIDIA GPU Operator crashloop (concrete mechanism)

`--gpu-driver None` is the sanctioned way to run the **NVIDIA GPU Operator** (bring-your-own driver). But the Operator's driver-container assumes a clean-ish host. Its `init()` flow (`NVIDIA/gpu-driver-container` → `nvidia-driver`) is:

```
_prepare_exclusive → _unload_driver || exit 1 → _build → _load
```

`_unload_driver` `rmmod`s the host modules first — **but refuses if the module is in use**:

```bash
if [ ${nvidia_refs} -gt ${nvidia_deps} ] || [ ${nvidia_uvm_refs} -gt 0 ] || ... ; then
    echo "Could not unload NVIDIA driver kernel modules, driver is in use" >&2
    return 1
fi
```
and `init()` does `_unload_driver || exit 1` — **a failed unload crashes the driver container.**

So the stale baked module is a real hazard, not cosmetic:
- If **anything grabs the resident module** before the Operator's driver-container runs (nvidia-persistenced auto-start, a probe, a fast-scheduled GPU workload → refcnt > 0), the Operator's `_unload_driver` returns 1 → `init()` exits 1 → **driver container CrashLoops → Operator never comes up**.
- NVIDIA's code has **no special handling for a pre-existing different-version host module** — it blindly tries to unload whatever is loaded. AKS shipping a resident `580.159.04` module violates that assumption.

Doing the unload in **CSE — early in boot, before workloads/persistenced can hold the module** — has a far better shot at refcnt-0 than leaving it for the Operator to attempt later, and removes the hazard at the source.

## Repro (real nodes, image `AKSUbuntu-2404gen2containerd-202607.02.0`)

| SKU / driver type | `--gpu-driver None` result |
|---|---|
| `Standard_NV6ads_A10_v5` (grid) | fully clean — module **not** loaded |
| `Standard_NC24ads_A100_v4` (cuda-lts) | disk artifacts gone, but `lsmod` still shows **`nvidia` loaded (580.159.04)**; `/proc/driver/nvidia/version` confirms 580.159.04, refcnt 0, no `/dev/nvidia*` |

CSE log on the A100 node confirmed `gpu_node=false`, teardown ran (`status=cleaned dkms_after=false`), yet the module stayed resident because CSE had no unload step. Grid (A10) nodes were already clean because grid prebakes don't auto-load.

_Not yet reproduced: the Operator crashloop itself (would need an Operator install with the module held). The mechanism above is read directly from NVIDIA's driver-container source, not observed end-to-end._

## Fix

In `cleanUpPrebakedGPUDriver` (`parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh`):
- **`rmmod`** the nvidia module chain (`nvidia_uvm`, `nvidia_drm`, `nvidia_modeset`, `nvidia_peermem`, `nvidia`) **only when idle** (`/sys/module/nvidia/refcnt == 0` and no `/dev/nvidia*`), before deleting files. Best-effort; failures don't abort provisioning.
- If the module is **busy**, leave it and let `module_after=true` mark the teardown **incomplete**, which **keeps the marker** so the next provision retries (existing retry mechanism).
- Add `module_before` / `module_after` to the `AKS_GPU_PREBAKE event=teardown` observability line and the completeness gate.
- Correct the stale "module is never loaded" comment.

## Tests

- Added shellspec coverage: idle module → unloaded + `status=cleaned`; busy module → not unloaded + `status=incomplete` (marker kept).
- `make shellspec` (docker/bash): **5 examples, 0 failures**.
- `make generate` runs clean for this change (testdata + manifest regenerate with no diff; this script is VHD-build-uploaded, not embedded in CSE-gen testdata). Note: full `make generate` also trips `validate-shell` on **pre-existing** SC3014 warnings in untouched files (`init-aks-custom-cloud.sh`, `disk_queue.sh`) under local shellcheck 0.11.0 — reproduces on pristine `main`, unrelated to this PR.
- shellcheck: no new findings on the changed region.

## Risk

🟢 Low. Scoped to the opted-out / non-GPU cleanup path (never runs when AKS installs a driver). Unload is guarded on refcnt-0 + no device nodes, and best-effort. Backward compatible: on grid/no-module nodes the new code is a no-op (`module_before=false`).