### PR TITLE
chore: update kubelet-kubectl renovate reviewers/assignees to match kube-components

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -166,10 +166,16 @@
       "enabled": true,
       "groupName": "kubelet-kubectl",
       "assignees": [
-        "team:aks-node-lifecycle"
+        "haitch",
+        "wenhug",
+        "gaopenghigh",
+        "jack4it"
       ],
       "reviewers": [
-        "team:aks-node-lifecycle"
+        "haitch",
+        "wenhug",
+        "gaopenghigh",
+        "jack4it"
       ]
     },
     {


### PR DESCRIPTION
Update the `kubelet-kubectl` group in `renovate.json` to use the same individual reviewers and assignees (`haitch`, `wenhug`, `gaopenghigh`, `jack4it`) as the `kube-components` group, replacing the `team:aks-node-lifecycle` reference.

This aligns reviewer/assignee configuration between the two related Kubernetes component groups so PRs like #8796 get the same reviewers as #8509.