### PR TITLE
fix: correct matchPackageNames and update rebaseWhen config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,7 +15,7 @@
   "labels": [
     "renovate"
   ],
-  "rebaseWhen": "conflicted",
+  "rebaseWhen": "never",
   "logLevelRemap": [
     {
       "matchMessage": "/^Custom manager fetcher/",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -386,7 +386,7 @@
     },
     {
       "matchPackageNames": [
-        "azure-acr-credential-provider-sysext"
+        "oss/v2/kubernetes/azure-acr-credential-provider-sysext"
       ],
       "groupName": "acr-credential-provider-sysext",
       "assignees": [


### PR DESCRIPTION
Fix `matchPackageNames` for `azure-acr-credential-provider-sysext` to use the full OCI path `oss/v2/kubernetes/azure-acr-credential-provider-sysext` that Renovate actually detects, so the groupName/assignees/reviewers rule takes effect.

Also update `rebaseWhen` from `"conflicted"` to `"never"` to prevent Renovate from automatically rebasing PRs when conflicts occur. This was causing multiple dependency PRs to be rebased simultaneously, making it harder to track which PRs had actual conflicts vs. were caught in a cascade rebase.