### PR TITLE
fix(gpu): unload full nvidia module stack in prebake cleanup, not just idle bare module

### DIFF
--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
@@ -240,9 +240,9 @@ removeNvidiaRepos() {
 # The prebaked module MAY already be loaded when we run: cuda(-lts) prebakes auto-load nvidia.ko at
 # boot (~5s, well before CSE), so on a cuda/cuda-lts SKU opted out via --gpu-driver None the module
 # is resident even though ensureGPUDrivers never ran. (grid prebakes do not auto-load, so grid nodes
-# arrive here with no module.) Deleting the on-disk .ko then leaves a stale loaded module -- unused
-# (refcnt 0, no /dev/nvidia*) but resident until reboot, and a landmine for a subsequent GPU Operator
-# install. So we rmmod it first, when idle, before removing the files. No-op unless the marker exists.
+# arrive here with no module.) Deleting the on-disk .ko then leaves a stale loaded module -- a landmine
+# for a subsequent GPU Operator install (its driver-container's unload-then-load fails against the
+# resident module). So we rmmod it first, before removing the files. No-op unless the marker exists.
 cleanUpPrebakedGPUDriver() {
     local marker="${GPU_DKMS_MARKER_FILE:-/opt/azure/aks-gpu/dkms-marker}"
     if [ ! -f "${marker}" ]; then
@@ -252,18 +252,22 @@ cleanUpPrebakedGPUDriver() {
     local dkms_before=false module_before=false module_after=false
     [ -d /var/lib/dkms/nvidia ] && dkms_before=true
 
-    # Unload the prebaked nvidia module if it auto-loaded at boot (cuda/cuda-lts SKUs). Only when idle
-    # (refcnt 0 and no device nodes) -- this node doesn't install a driver, so nothing should be using
-    # it; if something is, leave it and let module_after=true flag an incomplete teardown. Unload the
-    # dependent modules first (modeset/uvm/drm) so nvidia's refcnt drops to 0. Best-effort; failures
-    # do not abort provisioning.
+    # Unload the prebaked nvidia module stack if it auto-loaded at boot (cuda/cuda-lts SKUs). The
+    # dependent modules (nvidia_modeset/uvm/drm/peermem) hold a reference on nvidia -- i.e. they are
+    # exactly what keeps /sys/module/nvidia/refcnt nonzero -- so we must unload THEM first, then
+    # nvidia. (A refcnt==0 pre-check would be self-defeating: on a normal auto-loaded stack nvidia's
+    # refcnt is already >=1 from those dependents, so it would skip the very unloads that free it.)
+    # rmmod without -f refuses to unload a module in genuine use (a running GPU process pinning it),
+    # so this is safe: a truly busy stack simply stays loaded and is reported as incomplete below.
+    # nvidia-persistenced (if the prebake started it) holds an open device handle -- not a module
+    # dependency, so refcnt would not reflect it -- so stop it first, mirroring NVIDIA's own
+    # gpu-driver-container _unload_driver. Best-effort throughout; failures do not abort provisioning.
     if lsmod | grep -q '^nvidia'; then
         module_before=true
-        if [ "$(cat /sys/module/nvidia/refcnt 2>/dev/null || echo 0)" = "0" ] && ! ls /dev/nvidia* >/dev/null 2>&1; then
-            for mod in nvidia_uvm nvidia_drm nvidia_modeset nvidia_peermem nvidia; do
-                rmmod "${mod}" 2>/dev/null || true
-            done
-        fi
+        systemctl stop nvidia-persistenced 2>/dev/null || true
+        for mod in nvidia_drm nvidia_uvm nvidia_modeset nvidia_peermem nvidia; do
+            rmmod "${mod}" 2>/dev/null || true
+        done
     fi
     lsmod | grep -q '^nvidia' && module_after=true
 

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
@@ -52,38 +52,51 @@ Describe 'cse_install_ubuntu.sh'
             The output should include "module_after=false"
         End
 
-        It 'unloads an idle prebaked nvidia module that auto-loaded at boot (cuda/cuda-lts SKUs)'
+        It 'unloads a full auto-loaded module stack: dependents (modeset/uvm/drm) before nvidia'
+            # Regression guard for the refcnt trap: a real cuda/cuda-lts auto-load leaves nvidia with
+            # refcnt>=1 because nvidia_modeset/uvm/drm depend on it. The unload must remove those
+            # dependents FIRST, then nvidia. (A refcnt==0 pre-check would skip the whole stack and
+            # leave nvidia resident -- the exact bug this replaces.)
             marker="$(mktemp)"
             GPU_DKMS_MARKER_FILE="${marker}"
             ldconfig() { echo "mock ldconfig"; }
-            # simulate a loaded-but-idle module: lsmod shows nvidia until rmmod is "run"
-            _nvidia_loaded=true
-            lsmod() { if [ "${_nvidia_loaded}" = true ]; then echo "nvidia 104165376 0"; else echo ""; fi; }
-            cat() { echo "0"; }        # /sys/module/nvidia/refcnt = 0 (idle)
-            ls() { return 1; }          # no /dev/nvidia* device nodes
-            rmmod() { _nvidia_loaded=false; echo "mock rmmod $*"; }
+            systemctl() { echo "mock systemctl $*"; }
+            # Model a live stack: lsmod reports nvidia until every module has been rmmod'd.
+            _loaded="nvidia nvidia_modeset nvidia_uvm nvidia_drm"
+            lsmod() { case "${_loaded}" in *nvidia*) echo "nvidia 104165376 3";; *) echo "";; esac; }
+            rmmod() { echo "mock rmmod $1"; _loaded="${_loaded//$1/}"; }
             When call cleanUpPrebakedGPUDriver
             The status should be success
-            The output should include "mock rmmod nvidia"
             The output should include "module_before=true"
+            # persistenced stopped first (holds a device handle, not a module dependency)
+            The output should include "mock systemctl stop nvidia-persistenced"
+            # dependents unloaded before the base nvidia module
+            The output should include "mock rmmod nvidia_drm"
+            The output should include "mock rmmod nvidia_uvm"
+            The output should include "mock rmmod nvidia_modeset"
+            The output should include "mock rmmod nvidia"
+            # after the full-stack unload the module is gone -> complete
             The output should include "module_after=false"
             The output should include "status=cleaned"
         End
 
-        It 'keeps the marker (incomplete) when a busy nvidia module cannot be unloaded'
+        It 'keeps the marker (incomplete) when a genuinely busy module refuses to unload'
+            # rmmod without -f refuses an in-use module and returns nonzero; nvidia stays loaded. The
+            # teardown must report module_after=true and KEEP the marker so the next provision retries.
             marker="$(mktemp)"
             GPU_DKMS_MARKER_FILE="${marker}"
             ldconfig() { echo "mock ldconfig"; }
-            lsmod() { echo "nvidia 104165376 2"; }  # stays loaded (refcnt shows in-use)
-            cat() { echo "2"; }                       # refcnt != 0 -> do not rmmod
-            ls() { return 1; }
-            rmmod() { echo "mock rmmod $*"; }         # should NOT be called
+            systemctl() { echo "mock systemctl $*"; }
+            lsmod() { echo "nvidia 104165376 1"; }        # stays loaded regardless of rmmod attempts
+            rmmod() { echo "mock rmmod $1 (in use)"; return 1; }
             When call cleanUpPrebakedGPUDriver
             The status should be success
-            The output should not include "mock rmmod"
             The output should include "module_before=true"
+            # rmmod IS attempted now (no self-defeating refcnt pre-check), it just fails on a busy module
+            The output should include "mock rmmod nvidia"
             The output should include "module_after=true"
             The output should include "status=incomplete"
+            The output should include "marker_after=true"
         End
     End
 End

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
@@ -61,20 +61,35 @@ Describe 'cse_install_ubuntu.sh'
             GPU_DKMS_MARKER_FILE="${marker}"
             ldconfig() { echo "mock ldconfig"; }
             systemctl() { echo "mock systemctl $*"; }
-            # Model a live stack: lsmod reports nvidia until every module has been rmmod'd.
-            _loaded="nvidia nvidia_modeset nvidia_uvm nvidia_drm"
-            lsmod() { case "${_loaded}" in *nvidia*) echo "nvidia 104165376 3";; *) echo "";; esac; }
-            rmmod() { echo "mock rmmod $1"; _loaded="${_loaded//$1/}"; }
+            # Realistic kernel model: dependents each hold a ref on nvidia. rmmod of a dependent
+            # succeeds; rmmod of nvidia FAILS (returns 1, module stays) while any dependent is still
+            # loaded -- so if the code attempted nvidia first, it would fail and nvidia_after=true, and
+            # the ordering assertions below would not see the required sequence. Space-delimited set
+            # with guard spaces so removal is exact-token (avoids the "nvidia" substring stripping
+            # "nvidia_modeset"). Each rmmod line is emitted so line-based order can be asserted.
+            _loaded=" nvidia nvidia_modeset nvidia_uvm nvidia_drm nvidia_peermem "
+            _deps_loaded() { case "${_loaded}" in *" nvidia_modeset "*|*" nvidia_uvm "*|*" nvidia_drm "*|*" nvidia_peermem "*) return 0;; *) return 1;; esac; }
+            lsmod() { case "${_loaded}" in *" nvidia "*) echo "nvidia 104165376 4";; *) echo "";; esac; }
+            rmmod() {
+                if [ "$1" = "nvidia" ] && _deps_loaded; then
+                    echo "mock rmmod nvidia FAILED (deps still loaded)"; return 1
+                fi
+                _loaded="${_loaded/ $1 / }"; echo "mock rmmod $1"
+            }
             When call cleanUpPrebakedGPUDriver
             The status should be success
             The output should include "module_before=true"
             # persistenced stopped first (holds a device handle, not a module dependency)
             The output should include "mock systemctl stop nvidia-persistenced"
-            # dependents unloaded before the base nvidia module
-            The output should include "mock rmmod nvidia_drm"
-            The output should include "mock rmmod nvidia_uvm"
-            The output should include "mock rmmod nvidia_modeset"
-            The output should include "mock rmmod nvidia"
+            # ORDER-SENSITIVE: the loop is nvidia_drm, nvidia_uvm, nvidia_modeset, nvidia_peermem, nvidia.
+            # A wrong order (nvidia before its deps) would emit "FAILED" and leave module_after=true.
+            The line 2 of output should equal "mock systemctl stop nvidia-persistenced"
+            The line 3 of output should equal "mock rmmod nvidia_drm"
+            The line 4 of output should equal "mock rmmod nvidia_uvm"
+            The line 5 of output should equal "mock rmmod nvidia_modeset"
+            The line 6 of output should equal "mock rmmod nvidia_peermem"
+            The line 7 of output should equal "mock rmmod nvidia"
+            The output should not include "FAILED"
             # after the full-stack unload the module is gone -> complete
             The output should include "module_after=false"
             The output should include "status=cleaned"


### PR DESCRIPTION
## Summary

Follow-up to #8933. That PR added an nvidia-module unload to `cleanUpPrebakedGPUDriver` (the `--gpu-driver None` / skip-driver path) but guarded it behind `refcnt==0 && no /dev/nvidia*` — which only works for the exact bare-`nvidia`-only case that was reproduced, and **silently no-ops on the common full-stack case**.

## The bug

```sh
if [ "$(cat /sys/module/nvidia/refcnt)" = "0" ] && ! ls /dev/nvidia* ; then
    for mod in nvidia_uvm nvidia_drm nvidia_modeset nvidia_peermem nvidia; do rmmod ...; done
fi
```

`/sys/module/nvidia/refcnt` counts **the modules that depend on nvidia** (`nvidia_modeset`, `nvidia_uvm`, `nvidia_drm`). On a normal cuda/cuda-lts auto-load the whole stack is present, so nvidia's refcnt is **1–3, not 0** → the guard fails → the loop **never runs**. The dependents in that loop are *exactly* what keep nvidia's refcnt nonzero, so the guard blocks the very unloads that would free it. Net: on the realistic case the stale stack stays fully resident — the thing #8933 set out to remove.

Second defect: `! ls /dev/nvidia*` as a "busy" proxy is wrong — udev / `nvidia-modprobe` create `/dev/nvidia*` on an idle module, so this also wrongly blocks legitimately-idle nodes.

(Credit: caught in review — the existing test only exercised a bare `nvidia` module, so it passed unrealistically.)

## The fix

- **Drop both pre-checks.** Unload unconditionally in **dependency order** — dependents (`nvidia_drm`, `nvidia_uvm`, `nvidia_modeset`, `nvidia_peermem`) first, then `nvidia`. `rmmod` without `-f` already **refuses** to unload a module in genuine use (returns nonzero, module stays), so no guard is needed to stay safe: a truly busy stack simply remains loaded and is reported below.
- **Stop `nvidia-persistenced` first.** If the prebake started it, it holds an open device handle — *not* a module dependency, so refcnt wouldn't even reflect it. This mirrors NVIDIA's own `gpu-driver-container` `_unload_driver`.
- Best-effort throughout; **never aborts provisioning**. If something is genuinely busy, `module_after=true` → `status=incomplete` → the marker is retained so the next provision retries (existing mechanism, unchanged).

## Why not fail CSE on incomplete cleanup?

Considered and rejected as the default: a `--gpu-driver None` node doesn't need the driver to join and run non-GPU pods; the stale module only bites a *later* GPU-Operator install (whose own `_unload_driver || exit 1` already surfaces a loud CrashLoop signal). Hard-failing CSE would turn a not-yet-a-problem into provisioning failure / autoscaler churn. With this fix, "incomplete" should be essentially unreachable for idle stacks. If stricter behavior is wanted for specific customers, it should be an opt-in toggle, not the default.

## Tests

- Replaces the bare-module test (passed unrealistically) with:
  - **full auto-loaded stack** (`nvidia` + `modeset` + `uvm` + `drm`, refcnt shown as 3): asserts persistenced stopped first, dependents unloaded **before** `nvidia`, and the module is gone → `status=cleaned`.
  - **genuinely busy module** (`rmmod` returns nonzero): asserts rmmod *is* attempted (no self-defeating guard), module stays → `module_after=true` → `status=incomplete` → `marker_after=true` (retained).
- `make shellspec` (docker/bash): **5 examples, 0 failures**.
- `make generate`: no testdata drift (`cse_install_ubuntu.sh` is VHD-build-uploaded, not embedded in CSE-gen snapshots). shellcheck: clean in the changed region.

## Risk

🟢 Low. Scoped to the opted-out / non-GPU cleanup path (never runs when AKS installs a driver). Strictly more correct than the merged guard; `rmmod`'s in-use protection bounds the blast radius, and the change cannot abort provisioning.

Related: #8933 (this fixes its guard), #8919 (grid teardown), #8945 (version-drift teardown).