### PR TITLE
fix: match ACR regional (geo) login server endpoints in credential-provider config

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1525,6 +1525,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
       - "*$AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1${ib_token_attributes}
@@ -1545,6 +1549,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
       - "${MCR_REPOSITORY_BASE}"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1${ib_token_attributes}
@@ -1564,6 +1572,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1${ib_token_attributes}
     args:

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -927,6 +927,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     args:
@@ -934,6 +938,12 @@ providers:
             When call writeCredentialProviderConfig "$TMP_DIR/credential-provider-config.yaml"
             The output should include "configure credential provider with default settings"
             The contents of file "$TMP_DIR/credential-provider-config.yaml" should equal "$expected_config"
+        End
+
+        It 'should not include dedicated data endpoint patterns in matchImages (data endpoints are not login servers)'
+            When call writeCredentialProviderConfig "$TMP_DIR/credential-provider-config.yaml"
+            The output should include "configure credential provider with default settings"
+            The contents of file "$TMP_DIR/credential-provider-config.yaml" should not include "data.azurecr"
         End
 
         It 'should configure credential provider for network isolated cluster'
@@ -947,6 +957,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
       - "mcr.microsoft.com"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
@@ -969,6 +983,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
       - "*.custom.registry.io"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
@@ -994,6 +1012,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     tokenAttributes:
@@ -1028,6 +1050,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     tokenAttributes:
@@ -1061,6 +1087,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     tokenAttributes:
@@ -1094,6 +1124,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     tokenAttributes:
@@ -1127,6 +1161,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
       - "mcr.microsoft.com"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
@@ -1164,6 +1202,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
       - "*.custom.registry.io"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
@@ -1198,6 +1240,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     args:
@@ -1221,6 +1267,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     args:

--- a/staging/cse/windows/configfunc.ps1
+++ b/staging/cse/windows/configfunc.ps1
@@ -374,6 +374,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     args:
@@ -391,6 +395,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
       - "*$CustomCloudContainerRegistryDNSSuffix"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1

--- a/staging/cse/windows/credentialProvider.tests.suites/CustomCloudContainerRegistryDNSSuffixEmpty.config.yaml
+++ b/staging/cse/windows/credentialProvider.tests.suites/CustomCloudContainerRegistryDNSSuffixEmpty.config.yaml
@@ -7,6 +7,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     args:

--- a/staging/cse/windows/credentialProvider.tests.suites/CustomCloudContainerRegistryDNSSuffixNotEmpty.config.yaml
+++ b/staging/cse/windows/credentialProvider.tests.suites/CustomCloudContainerRegistryDNSSuffixNotEmpty.config.yaml
@@ -7,6 +7,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
       - "*.azurecr.microsoft.fakecloud"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1

--- a/staging/cse/windows/credentialProvider.tests.suites/credential-provider-config.yaml
+++ b/staging/cse/windows/credentialProvider.tests.suites/credential-provider-config.yaml
@@ -7,6 +7,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
       - "*.azurecr.microsoft.fakecloud"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1


### PR DESCRIPTION
## What this does

Adds ACR **regional (geo) login server** patterns to the kubelet credential-provider `matchImages` config so kubelet invokes the ACR credential provider for regional endpoints.

Fixes Azure/AgentBaker#8862.

## Why

Kubernetes `URLsMatch` (k8s.io/kubernetes/pkg/credentialprovider) requires the `matchImages` pattern and the image host to have an **equal number of dot-separated parts**. The existing 3-label patterns (`*.azurecr.io`, `*.azurecr.cn`, `*.azurecr.de`, `*.azurecr.us`) therefore never match a 5-label regional host such as `myregistry.eastus2.geo.azurecr.io`. As a result kubelet skips the ACR credential provider and falls back to an anonymous pull, which fails with `401 Unauthorized`.

Adding the 5-label wildcard `*.*.geo.azurecr.*` restores the match for regional hosts.

## Change

Adds the following four entries next to every existing `*.azurecr.us` line in each `matchImages` block:

```
- "*.*.geo.azurecr.io"
- "*.*.geo.azurecr.cn"
- "*.*.geo.azurecr.de"
- "*.*.geo.azurecr.us"
```

Dedicated **data** endpoints (`*.data.*`) are intentionally excluded — they are 307 blob-redirect targets, never image/login hosts. A negative ShellSpec test asserts `data.azurecr` never appears in the generated config.

Files:
- `parts/linux/cloud-init/artifacts/cse_config.sh` (3 blocks)
- `spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh` (11 golden blocks + negative test)
- `staging/cse/windows/configfunc.ps1` (2 blocks)
- `staging/cse/windows/credentialProvider.tests.suites/*.yaml` (3 files)

## Testing

- `pkg/agent` suite: 249 passed / 0 failed.
- ShellSpec `cse_config_spec.sh` blocks updated, including a new negative test.

> Note: `aks-node-controller/parser/testdata/*/generatedCSECommand` goldens are intentionally **not** included. Those goldens capture the bootstrap CSE command string only (not the credential-provider config / CustomData), so this change does not affect them. Any regeneration should be done separately on Linux via `make generate` to avoid unrelated drift.

## Note

The head branch lives in a fork (`lizMSFT/AgentBaker`) because the author does not currently have write access to `Azure/AgentBaker`. The `validate-pull-request-source` gate will flag this — a maintainer may need to adopt the branch into upstream.
