### PR TITLE
fix: ensure kubelet and containerd in kube.slice via systemd drop-ins

### DIFF
--- a/aks-node-controller/pkg/gen/aksnodeconfig/v1/kubelet_config.pb.go
+++ b/aks-node-controller/pkg/gen/aksnodeconfig/v1/kubelet_config.pb.go
@@ -522,7 +522,7 @@ type KubeletConfigFileConfig struct {
 	EvictionMaxPodGracePeriod int32 `protobuf:"varint,43,opt,name=eviction_max_pod_grace_period,json=evictionMaxPodGracePeriod,proto3" json:"eviction_max_pod_grace_period,omitempty"`
 	// kubeReservedCgroup is the absolute name of the cgroup the kubelet should manage for the
 	// kube-reserved compute resources. When enforce-node-allocatable contains "kube-reserved",
-	// this cgroup must exist before kubelet starts. Example: "/kube-reserved.slice".
+	// this cgroup must exist before kubelet starts. Example: "/kubereserved.slice".
 	// Used by AKS Node Memory Hardening (F2/F5).
 	// +optional.
 	KubeReservedCgroup string `protobuf:"bytes,44,opt,name=kube_reserved_cgroup,json=kubeReservedCgroup,proto3" json:"kube_reserved_cgroup,omitempty"`

--- a/aks-node-controller/pkg/gen/aksnodeconfig/v1/kubelet_config.pb.go
+++ b/aks-node-controller/pkg/gen/aksnodeconfig/v1/kubelet_config.pb.go
@@ -7,10 +7,11 @@
 package aksnodeconfigv1
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -521,7 +522,7 @@ type KubeletConfigFileConfig struct {
 	EvictionMaxPodGracePeriod int32 `protobuf:"varint,43,opt,name=eviction_max_pod_grace_period,json=evictionMaxPodGracePeriod,proto3" json:"eviction_max_pod_grace_period,omitempty"`
 	// kubeReservedCgroup is the absolute name of the cgroup the kubelet should manage for the
 	// kube-reserved compute resources. When enforce-node-allocatable contains "kube-reserved",
-	// this cgroup must exist before kubelet starts. Example: "/kubelet.slice".
+	// this cgroup must exist before kubelet starts. Example: "/kube.slice".
 	// Used by AKS Node Memory Hardening (F2/F5).
 	// +optional.
 	KubeReservedCgroup string `protobuf:"bytes,44,opt,name=kube_reserved_cgroup,json=kubeReservedCgroup,proto3" json:"kube_reserved_cgroup,omitempty"`

--- a/aks-node-controller/pkg/gen/aksnodeconfig/v1/kubelet_config.pb.go
+++ b/aks-node-controller/pkg/gen/aksnodeconfig/v1/kubelet_config.pb.go
@@ -522,7 +522,7 @@ type KubeletConfigFileConfig struct {
 	EvictionMaxPodGracePeriod int32 `protobuf:"varint,43,opt,name=eviction_max_pod_grace_period,json=evictionMaxPodGracePeriod,proto3" json:"eviction_max_pod_grace_period,omitempty"`
 	// kubeReservedCgroup is the absolute name of the cgroup the kubelet should manage for the
 	// kube-reserved compute resources. When enforce-node-allocatable contains "kube-reserved",
-	// this cgroup must exist before kubelet starts. Example: "/kube.slice".
+	// this cgroup must exist before kubelet starts. Example: "/kube-reserved.slice".
 	// Used by AKS Node Memory Hardening (F2/F5).
 	// +optional.
 	KubeReservedCgroup string `protobuf:"bytes,44,opt,name=kube_reserved_cgroup,json=kubeReservedCgroup,proto3" json:"kube_reserved_cgroup,omitempty"`

--- a/aks-node-controller/proto/aksnodeconfig/v1/kubelet_config.proto
+++ b/aks-node-controller/proto/aksnodeconfig/v1/kubelet_config.proto
@@ -416,7 +416,7 @@ message KubeletConfigFileConfig {
 
   /* kubeReservedCgroup is the absolute name of the cgroup the kubelet should manage for the
    kube-reserved compute resources. When enforce-node-allocatable contains "kube-reserved",
-   this cgroup must exist before kubelet starts. Example: "/kube-reserved.slice".
+   this cgroup must exist before kubelet starts. Example: "/kubereserved.slice".
    Used by AKS Node Memory Hardening (F2/F5).
    +optional. */
   string kube_reserved_cgroup = 44;

--- a/aks-node-controller/proto/aksnodeconfig/v1/kubelet_config.proto
+++ b/aks-node-controller/proto/aksnodeconfig/v1/kubelet_config.proto
@@ -416,7 +416,7 @@ message KubeletConfigFileConfig {
 
   /* kubeReservedCgroup is the absolute name of the cgroup the kubelet should manage for the
    kube-reserved compute resources. When enforce-node-allocatable contains "kube-reserved",
-   this cgroup must exist before kubelet starts. Example: "/kubelet.slice".
+   this cgroup must exist before kubelet starts. Example: "/kube.slice".
    Used by AKS Node Memory Hardening (F2/F5).
    +optional. */
   string kube_reserved_cgroup = 44;

--- a/aks-node-controller/proto/aksnodeconfig/v1/kubelet_config.proto
+++ b/aks-node-controller/proto/aksnodeconfig/v1/kubelet_config.proto
@@ -416,7 +416,7 @@ message KubeletConfigFileConfig {
 
   /* kubeReservedCgroup is the absolute name of the cgroup the kubelet should manage for the
    kube-reserved compute resources. When enforce-node-allocatable contains "kube-reserved",
-   this cgroup must exist before kubelet starts. Example: "/kube.slice".
+   this cgroup must exist before kubelet starts. Example: "/kube-reserved.slice".
    Used by AKS Node Memory Hardening (F2/F5).
    +optional. */
   string kube_reserved_cgroup = 44;

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -2680,7 +2680,7 @@ func Test_AzureLinuxV3_MANA(t *testing.T) {
 
 func Test_Ubuntu2204_NodeHardening_KubeletSlice(t *testing.T) {
 	RunScenario(t, &Scenario{
-		Description: "validates kubelet and containerd run in kube.slice when node hardening cgroup hierarchy is enabled",
+		Description: "validates kubelet and containerd run in kube-reserved.slice when node hardening cgroup hierarchy is enabled",
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
@@ -2688,18 +2688,18 @@ func Test_Ubuntu2204_NodeHardening_KubeletSlice(t *testing.T) {
 			// with the Slice= drop-ins are uploaded via custom data.
 			CustomDataWriteFiles: []CustomDataWriteFile{{Path: "/etc/aks-node-hardening-test", Content: "sentinel"}},
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.KubeletConfig["--kube-reserved-cgroup"] = "/kube.slice"
+				nbc.KubeletConfig["--kube-reserved-cgroup"] = "/kube-reserved.slice"
 				nbc.AgentPoolProfile.CustomKubeletConfig = &datamodel.CustomKubeletConfig{}
-				// Disable scriptless CSE so that the current cse_helpers.sh (with kube.slice drop-in)
+				// Disable scriptless CSE so that the current cse_helpers.sh (with kube-reserved.slice drop-in)
 				// is uploaded via custom data instead of relying on potentially stale VHD scripts.
 				nbc.EnableScriptlessCSECmd = false
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				ValidateFileExists(ctx, s, "/etc/systemd/system/kube.slice")
-				ValidateFileHasContent(ctx, s, "/etc/systemd/system/kubelet.service.d/10-kube-slice.conf", "Slice=kube.slice")
-				ValidateFileHasContent(ctx, s, "/etc/systemd/system/containerd.service.d/10-kube-slice.conf", "Slice=kube.slice")
-				ValidateServiceInSlice(ctx, s, "kubelet.service", "kube.slice")
-				ValidateServiceInSlice(ctx, s, "containerd.service", "kube.slice")
+				ValidateFileExists(ctx, s, "/etc/systemd/system/kube-reserved.slice")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/kubelet.service.d/10-kube-reserved-slice.conf", "Slice=kube-reserved.slice")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/containerd.service.d/10-kube-reserved-slice.conf", "Slice=kube-reserved.slice")
+				ValidateServiceInSlice(ctx, s, "kubelet.service", "kube-reserved.slice")
+				ValidateServiceInSlice(ctx, s, "containerd.service", "kube-reserved.slice")
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -2688,7 +2688,9 @@ func Test_Ubuntu2204_NodeHardening_KubeReservedSlice(t *testing.T) {
 			// with the Slice= drop-ins are uploaded via custom data.
 			CustomDataWriteFiles: []CustomDataWriteFile{{Path: "/etc/aks-node-hardening-test", Content: "sentinel"}},
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.KubeletConfig["--kube-reserved-cgroup"] = "/kube-reserved.slice"
+				// AgentBaker (not the RP) now owns --kube-reserved-cgroup/--system-reserved-cgroup;
+				// it derives them from --enforce-node-allocatable (see setNodeHardeningCgroupFlags).
+				nbc.KubeletConfig["--enforce-node-allocatable"] = "pods,kube-reserved,system-reserved"
 				nbc.AgentPoolProfile.CustomKubeletConfig = &datamodel.CustomKubeletConfig{}
 				// Disable scriptless CSE so that the current cse_helpers.sh (with kube-reserved.slice drop-in)
 				// is uploaded via custom data instead of relying on potentially stale VHD scripts.

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -2680,25 +2680,26 @@ func Test_AzureLinuxV3_MANA(t *testing.T) {
 
 func Test_Ubuntu2204_NodeHardening_KubeletSlice(t *testing.T) {
 	RunScenario(t, &Scenario{
-		Description: "validates kubelet runs in kubelet.slice and containerd runs in containerd.slice when node hardening cgroup hierarchy is enabled",
+		Description: "validates kubelet and containerd run in kube.slice when node hardening cgroup hierarchy is enabled",
 		Config: Config{
-			Cluster:           ClusterKubenet,
-			VHD:               config.VHDUbuntu2204Gen2Containerd,
-			SkipScriptlessNBC: true, // VHD scripts may lack the Slice= directive; force fresh upload until VHDs catch up
+			Cluster: ClusterKubenet,
+			VHD:     config.VHDUbuntu2204Gen2Containerd,
+			// Force the "default" (non-scriptless) subtest path so that fresh CSE scripts
+			// with the Slice= drop-ins are uploaded via custom data.
+			CustomDataWriteFiles: []CustomDataWriteFile{{Path: "/etc/aks-node-hardening-test", Content: "sentinel"}},
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.KubeletConfig["--kube-reserved-cgroup"] = "/kubelet.slice"
+				nbc.KubeletConfig["--kube-reserved-cgroup"] = "/kube.slice"
 				nbc.AgentPoolProfile.CustomKubeletConfig = &datamodel.CustomKubeletConfig{}
-				// Disable scriptless CSE so that the current cse_helpers.sh (with Slice= in the drop-in)
+				// Disable scriptless CSE so that the current cse_helpers.sh (with kube.slice drop-in)
 				// is uploaded via custom data instead of relying on potentially stale VHD scripts.
 				nbc.EnableScriptlessCSECmd = false
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				ValidateFileExists(ctx, s, "/etc/systemd/system/kubelet.slice")
-				ValidateFileExists(ctx, s, "/etc/systemd/system/containerd.slice")
-				ValidateFileHasContent(ctx, s, "/etc/systemd/system/kubelet.service.d/10-kubelet-slice.conf", "Slice=kubelet.slice")
-				ValidateFileHasContent(ctx, s, "/etc/systemd/system/containerd.service.d/10-containerd-slice.conf", "Slice=containerd.slice")
-				ValidateServiceInSlice(ctx, s, "kubelet.service", "kubelet.slice")
-				ValidateServiceInSlice(ctx, s, "containerd.service", "containerd.slice")
+				ValidateFileExists(ctx, s, "/etc/systemd/system/kube.slice")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/kubelet.service.d/10-kube-slice.conf", "Slice=kube.slice")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/containerd.service.d/10-kube-slice.conf", "Slice=kube.slice")
+				ValidateServiceInSlice(ctx, s, "kubelet.service", "kube.slice")
+				ValidateServiceInSlice(ctx, s, "containerd.service", "kube.slice")
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -2677,3 +2677,28 @@ func Test_AzureLinuxV3_MANA(t *testing.T) {
 		},
 	})
 }
+
+func Test_Ubuntu2204_NodeHardening_KubeletSlice(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "validates kubelet and containerd run in kubelet.slice when node hardening cgroup hierarchy is enabled",
+		Config: Config{
+			Cluster:           ClusterKubenet,
+			VHD:               config.VHDUbuntu2204Gen2Containerd,
+			SkipScriptlessNBC: true, // VHD scripts may lack the Slice= directive; force fresh upload until VHDs catch up
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.KubeletConfig["--kube-reserved-cgroup"] = "/kubelet.slice"
+				nbc.AgentPoolProfile.CustomKubeletConfig = &datamodel.CustomKubeletConfig{}
+				// Disable scriptless CSE so that the current cse_helpers.sh (with Slice= in the drop-in)
+				// is uploaded via custom data instead of relying on potentially stale VHD scripts.
+				nbc.EnableScriptlessCSECmd = false
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateFileExists(ctx, s, "/etc/systemd/system/kubelet.slice")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/kubelet.service.d/10-kubelet-slice.conf", "Slice=kubelet.slice")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/containerd.service.d/10-kubelet-slice.conf", "Slice=kubelet.slice")
+				ValidateServiceInSlice(ctx, s, "kubelet.service", "kubelet.slice")
+				ValidateServiceInSlice(ctx, s, "containerd.service", "kubelet.slice")
+			},
+		},
+	})
+}

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -2678,9 +2678,12 @@ func Test_AzureLinuxV3_MANA(t *testing.T) {
 	})
 }
 
-func Test_Ubuntu2204_NodeHardening_KubeReservedSlice(t *testing.T) {
+// Test_Ubuntu2204_NodeHardening_KubeReservedSlice_ConfigFile validates the config-file
+// kubelet path (kubelet reads /etc/default/kubeletconfig.json), which is selected whenever
+// AgentPoolProfile.CustomKubeletConfig is non-nil (see IsKubeletConfigFileEnabled).
+func Test_Ubuntu2204_NodeHardening_KubeReservedSlice_ConfigFile(t *testing.T) {
 	RunScenario(t, &Scenario{
-		Description: "validates kubelet and containerd run in kube-reserved.slice when node hardening cgroup hierarchy is enabled",
+		Description: "validates kubelet and containerd run in kubereserved.slice when node hardening cgroup hierarchy is enabled (kubelet config-file mode)",
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
@@ -2691,17 +2694,77 @@ func Test_Ubuntu2204_NodeHardening_KubeReservedSlice(t *testing.T) {
 				// AgentBaker (not the RP) now owns --kube-reserved-cgroup/--system-reserved-cgroup;
 				// it derives them from --enforce-node-allocatable (see setNodeHardeningCgroupFlags).
 				nbc.KubeletConfig["--enforce-node-allocatable"] = "pods,kube-reserved,system-reserved"
+				// kubelet refuses to enforce limits on a reserved cgroup unless a matching
+				// resource list is also supplied; the base config only sets --kube-reserved,
+				// so --system-reserved must be added here too or kubelet fails to start with
+				// "system.slice cgroup is not configured properly".
+				nbc.KubeletConfig["--system-reserved"] = "cpu=200m,memory=500Mi"
+				// Simulate the RP still sending its legacy (stale) cgroup slice name today;
+				// setNodeHardeningCgroupFlags must overwrite these with the values AgentBaker
+				// owns rather than trusting them, or the node would end up in the wrong slice.
+				nbc.KubeletConfig["--kube-reserved-cgroup"] = "/kubelet.slice"
+				nbc.KubeletConfig["--system-reserved-cgroup"] = "/kubelet.slice"
+				// Non-nil (even empty) CustomKubeletConfig switches AgentBaker to the
+				// config-file (kubeletconfig.json) path instead of CLI flags.
 				nbc.AgentPoolProfile.CustomKubeletConfig = &datamodel.CustomKubeletConfig{}
-				// Disable scriptless CSE so that the current cse_helpers.sh (with kube-reserved.slice drop-in)
+				// Disable scriptless CSE so that the current cse_helpers.sh (with kubereserved.slice drop-in)
 				// is uploaded via custom data instead of relying on potentially stale VHD scripts.
 				nbc.EnableScriptlessCSECmd = false
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
-				ValidateFileExists(ctx, s, "/etc/systemd/system/kube-reserved.slice")
-				ValidateFileHasContent(ctx, s, "/etc/systemd/system/kubelet.service.d/10-kube-reserved-slice.conf", "Slice=kube-reserved.slice")
-				ValidateFileHasContent(ctx, s, "/etc/systemd/system/containerd.service.d/10-kube-reserved-slice.conf", "Slice=kube-reserved.slice")
-				ValidateServiceInSlice(ctx, s, "kubelet.service", "kube-reserved.slice")
-				ValidateServiceInSlice(ctx, s, "containerd.service", "kube-reserved.slice")
+				ValidateFileExists(ctx, s, "/etc/systemd/system/kubereserved.slice")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/kubelet.service.d/10-kubereserved-slice.conf", "Slice=kubereserved.slice")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/containerd.service.d/10-kubereserved-slice.conf", "Slice=kubereserved.slice")
+				ValidateFileHasContent(ctx, s, "/etc/default/kubeletconfig.json", `"kubeReservedCgroup": "/kubereserved.slice"`)
+				ValidateFileHasContent(ctx, s, "/etc/default/kubeletconfig.json", `"systemReservedCgroup": "/system.slice"`)
+				ValidateServiceInSlice(ctx, s, "kubelet.service", "kubereserved.slice")
+				ValidateServiceInSlice(ctx, s, "containerd.service", "kubereserved.slice")
+			},
+		},
+	})
+}
+
+// Test_Ubuntu2204_NodeHardening_KubeReservedSlice_CLIFlags validates the legacy CLI-flags
+// kubelet path (kubelet reads flags from /etc/default/kubelet's KUBELET_FLAGS), which is
+// used whenever AgentPoolProfile.CustomKubeletConfig/CustomLinuxOSConfig are both nil.
+func Test_Ubuntu2204_NodeHardening_KubeReservedSlice_CLIFlags(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "validates kubelet and containerd run in kubereserved.slice when node hardening cgroup hierarchy is enabled (kubelet CLI-flags mode)",
+		Config: Config{
+			Cluster: ClusterKubenet,
+			VHD:     config.VHDUbuntu2204Gen2Containerd,
+			// Force the "default" (non-scriptless) subtest path so that fresh CSE scripts
+			// with the Slice= drop-ins are uploaded via custom data.
+			CustomDataWriteFiles: []CustomDataWriteFile{{Path: "/etc/aks-node-hardening-test", Content: "sentinel"}},
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				// AgentBaker (not the RP) now owns --kube-reserved-cgroup/--system-reserved-cgroup;
+				// it derives them from --enforce-node-allocatable (see setNodeHardeningCgroupFlags).
+				nbc.KubeletConfig["--enforce-node-allocatable"] = "pods,kube-reserved,system-reserved"
+				// kubelet refuses to enforce limits on a reserved cgroup unless a matching
+				// resource list is also supplied; the base config only sets --kube-reserved,
+				// so --system-reserved must be added here too or kubelet fails to start with
+				// "system.slice cgroup is not configured properly".
+				nbc.KubeletConfig["--system-reserved"] = "cpu=200m,memory=500Mi"
+				// Simulate the RP still sending its legacy (stale) cgroup slice name today;
+				// setNodeHardeningCgroupFlags must overwrite these with the values AgentBaker
+				// owns rather than trusting them, or the node would end up in the wrong slice.
+				nbc.KubeletConfig["--kube-reserved-cgroup"] = "/kubelet.slice"
+				nbc.KubeletConfig["--system-reserved-cgroup"] = "/kubelet.slice"
+				// CustomKubeletConfig/CustomLinuxOSConfig left nil so kubelet reads its
+				// flags from the CLI (KUBELET_FLAGS in /etc/default/kubelet) instead of
+				// the config-file path.
+				// Disable scriptless CSE so that the current cse_helpers.sh (with kubereserved.slice drop-in)
+				// is uploaded via custom data instead of relying on potentially stale VHD scripts.
+				nbc.EnableScriptlessCSECmd = false
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateFileExists(ctx, s, "/etc/systemd/system/kubereserved.slice")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/kubelet.service.d/10-kubereserved-slice.conf", "Slice=kubereserved.slice")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/containerd.service.d/10-kubereserved-slice.conf", "Slice=kubereserved.slice")
+				ValidateFileHasContent(ctx, s, "/etc/default/kubelet", "--kube-reserved-cgroup=/kubereserved.slice")
+				ValidateFileHasContent(ctx, s, "/etc/default/kubelet", "--system-reserved-cgroup=/system.slice")
+				ValidateServiceInSlice(ctx, s, "kubelet.service", "kubereserved.slice")
+				ValidateServiceInSlice(ctx, s, "containerd.service", "kubereserved.slice")
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -2680,7 +2680,7 @@ func Test_AzureLinuxV3_MANA(t *testing.T) {
 
 func Test_Ubuntu2204_NodeHardening_KubeletSlice(t *testing.T) {
 	RunScenario(t, &Scenario{
-		Description: "validates kubelet and containerd run in kubelet.slice when node hardening cgroup hierarchy is enabled",
+		Description: "validates kubelet runs in kubelet.slice and containerd runs in containerd.slice when node hardening cgroup hierarchy is enabled",
 		Config: Config{
 			Cluster:           ClusterKubenet,
 			VHD:               config.VHDUbuntu2204Gen2Containerd,
@@ -2694,10 +2694,11 @@ func Test_Ubuntu2204_NodeHardening_KubeletSlice(t *testing.T) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateFileExists(ctx, s, "/etc/systemd/system/kubelet.slice")
+				ValidateFileExists(ctx, s, "/etc/systemd/system/containerd.slice")
 				ValidateFileHasContent(ctx, s, "/etc/systemd/system/kubelet.service.d/10-kubelet-slice.conf", "Slice=kubelet.slice")
-				ValidateFileHasContent(ctx, s, "/etc/systemd/system/containerd.service.d/10-kubelet-slice.conf", "Slice=kubelet.slice")
+				ValidateFileHasContent(ctx, s, "/etc/systemd/system/containerd.service.d/10-containerd-slice.conf", "Slice=containerd.slice")
 				ValidateServiceInSlice(ctx, s, "kubelet.service", "kubelet.slice")
-				ValidateServiceInSlice(ctx, s, "containerd.service", "kubelet.slice")
+				ValidateServiceInSlice(ctx, s, "containerd.service", "containerd.slice")
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -2678,7 +2678,7 @@ func Test_AzureLinuxV3_MANA(t *testing.T) {
 	})
 }
 
-func Test_Ubuntu2204_NodeHardening_KubeletSlice(t *testing.T) {
+func Test_Ubuntu2204_NodeHardening_KubeReservedSlice(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "validates kubelet and containerd run in kube-reserved.slice when node hardening cgroup hierarchy is enabled",
 		Config: Config{

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -3489,8 +3489,12 @@ func ValidateRCV1PNotOptedInWindows(ctx context.Context, s *Scenario) {
 // ValidateServiceInSlice asserts that the given systemd service is running in the expected slice.
 func ValidateServiceInSlice(ctx context.Context, s *Scenario, service, expectedSlice string) {
 	s.T.Helper()
+	// Avoid accidental shell injection / option smuggling.
+	if !regexp.MustCompile(`^[A-Za-z0-9_.@:-]+$`).MatchString(service) {
+		s.T.Fatalf("invalid systemd unit name: %q", service)
+	}
 	result := execScriptOnVMForScenarioValidateExitCode(ctx, s,
-		fmt.Sprintf("systemctl show %s -p Slice --value", service), 0,
+		fmt.Sprintf("systemctl show --property=Slice --value -- %s", service), 0,
 		fmt.Sprintf("could not query Slice property of %s", service))
 	actual := strings.TrimSpace(result.stdout)
 	require.Equal(s.T, expectedSlice, actual,

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -3485,3 +3485,14 @@ func ValidateRCV1PNotOptedInWindows(ctx context.Context, s *Scenario) {
 	execScriptOnVMForScenarioValidateExitCode(ctx, s, strings.Join(command, "\n"), 0,
 		"expected no aks-ca-certs-refresh-task scheduled task when not opted in")
 }
+
+// ValidateServiceInSlice asserts that the given systemd service is running in the expected slice.
+func ValidateServiceInSlice(ctx context.Context, s *Scenario, service, expectedSlice string) {
+	s.T.Helper()
+	result := execScriptOnVMForScenarioValidateExitCode(ctx, s,
+		fmt.Sprintf("systemctl show %s -p Slice --value", service), 0,
+		fmt.Sprintf("could not query Slice property of %s", service))
+	actual := strings.TrimSpace(result.stdout)
+	require.Equal(s.T, expectedSlice, actual,
+		"expected %s to be in %s, but got %s", service, expectedSlice, actual)
+}

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -535,7 +535,7 @@ func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachine
 			customData, err = injectWriteFilesEntriesToCustomData(customData, s.Config.CustomDataWriteFiles)
 			require.NoError(s.T, err, "failed to inject customData write_files entries")
 		}
-		if !scriptlessNBCCSECmdEnabled && s.VHD.SupportsScriptless() {
+		if s.Runtime.NBC.EnableScriptlessCSECmd && !scriptlessNBCCSECmdEnabled && s.VHD.SupportsScriptless() {
 			// Validate that the custom data doesn't contain any script content,
 			// which indicates that the scriptless CSE is working as intended
 			decodedCustomData, err := base64.StdEncoding.DecodeString(customData)

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -536,8 +536,8 @@ func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachine
 			require.NoError(s.T, err, "failed to inject customData write_files entries")
 		}
 		if s.Runtime.NBC.EnableScriptlessCSECmd && !scriptlessNBCCSECmdEnabled && s.VHD.SupportsScriptless() {
-			// Validate that the custom data doesn't contain any script content,
-			// which indicates that the scriptless CSE is working as intended
+			// Validate that the custom data indicates scriptless CSE is enabled by checking
+			// for the scriptless overrides sentinel file path.
 			decodedCustomData, err := base64.StdEncoding.DecodeString(customData)
 			require.NoError(s.T, err, "failed to decode custom data")
 			reader, err := gzip.NewReader(bytes.NewReader(decodedCustomData))

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -866,6 +866,27 @@ EOF
     local tls_bootstrapping_start_time_filepath="/opt/azure/containers/tls-bootstrap-start-time"
     date +"%F %T.%3N" > "${tls_bootstrapping_start_time_filepath}"
 
+    # Node Memory Hardening (F2/F5): idempotent refresh for PIS real nodes booting
+    # from older cached VHDs where basePrep (ensureContainerd) may not have created
+    # the Slice= drop-ins. No-op when neither value is set (non-hardened pools).
+    resolveKubeletReservedCgroups
+    if [ -n "${KUBE_RESERVED_CGROUP}" ] || [ -n "${SYSTEM_RESERVED_CGROUP}" ]; then
+        if ! logs_to_events "AKS.CSE.ensureKubelet.ensureKubeletCgroupHierarchy" ensureKubeletCgroupHierarchy; then
+            exit $ERR_KUBELET_START_FAIL
+        fi
+    fi
+
+    # Refresh --runtime-cgroups for PIS nodes where basePrep may have baked an older
+    # 10-containerd-base-flag.conf pointing at /system.slice/containerd.service.
+    local containerd_runtime_cgroups="/system.slice/containerd.service"
+    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kubelet.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kubelet.slice" ]; then
+        containerd_runtime_cgroups="/kubelet.slice/containerd.service"
+    fi
+    tee "/etc/systemd/system/kubelet.service.d/10-containerd-base-flag.conf" > /dev/null <<EOF
+[Service]
+Environment="KUBELET_CONTAINERD_FLAGS=--runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=${containerd_runtime_cgroups}"
+EOF
+
     # start kubelet.service without waiting for the main process to start, though check whether it has entered a failed state after enablement
     if ! systemctlEnableAndStartNoBlock kubelet 240; then
         # append kubelet status to CSE output to ensure we can see it

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -384,7 +384,7 @@ net.bridge.bridge-nf-call-iptables = 1
 EOF
   retrycmd_if_failure 120 5 25 sysctl --system || exit $ERR_SYSCTL_RELOAD
 
-  # Node Memory Hardening: create kube.slice and drop-ins BEFORE starting
+  # Node Memory Hardening: create kube-reserved.slice and drop-ins BEFORE starting
   # containerd/kubelet so both services start in the correct slice from the
   # beginning — avoids needing a disruptive restart after the fact.
   resolveKubeletReservedCgroups
@@ -879,8 +879,8 @@ EOF
     # Refresh --runtime-cgroups for PIS nodes where basePrep may have baked an older
     # 10-containerd-base-flag.conf pointing at /system.slice/containerd.service.
     local containerd_runtime_cgroups="/system.slice/containerd.service"
-    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube.slice" ]; then
-        containerd_runtime_cgroups="/kube.slice/containerd.service"
+    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube-reserved.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube-reserved.slice" ]; then
+        containerd_runtime_cgroups="/kube-reserved.slice/containerd.service"
     fi
     tee "/etc/systemd/system/kubelet.service.d/10-containerd-base-flag.conf" > /dev/null <<EOF
 [Service]

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -384,7 +384,7 @@ net.bridge.bridge-nf-call-iptables = 1
 EOF
   retrycmd_if_failure 120 5 25 sysctl --system || exit $ERR_SYSCTL_RELOAD
 
-  # Node Memory Hardening: create kubelet.slice and drop-ins BEFORE starting
+  # Node Memory Hardening: create kube.slice and drop-ins BEFORE starting
   # containerd/kubelet so both services start in the correct slice from the
   # beginning — avoids needing a disruptive restart after the fact.
   resolveKubeletReservedCgroups
@@ -879,8 +879,8 @@ EOF
     # Refresh --runtime-cgroups for PIS nodes where basePrep may have baked an older
     # 10-containerd-base-flag.conf pointing at /system.slice/containerd.service.
     local containerd_runtime_cgroups="/system.slice/containerd.service"
-    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kubelet.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kubelet.slice" ]; then
-        containerd_runtime_cgroups="/containerd.slice/containerd.service"
+    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube.slice" ]; then
+        containerd_runtime_cgroups="/kube.slice/containerd.service"
     fi
     tee "/etc/systemd/system/kubelet.service.d/10-containerd-base-flag.conf" > /dev/null <<EOF
 [Service]

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -887,6 +887,9 @@ EOF
 Environment="KUBELET_CONTAINERD_FLAGS=--runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=${containerd_runtime_cgroups}"
 EOF
 
+    if ! systemctl daemon-reload; then
+        exit $ERR_KUBELET_START_FAIL
+    fi
     # start kubelet.service without waiting for the main process to start, though check whether it has entered a failed state after enablement
     if ! systemctlEnableAndStartNoBlock kubelet 240; then
         # append kubelet status to CSE output to ensure we can see it

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -880,7 +880,7 @@ EOF
     # 10-containerd-base-flag.conf pointing at /system.slice/containerd.service.
     local containerd_runtime_cgroups="/system.slice/containerd.service"
     if [ "${KUBE_RESERVED_CGROUP:-}" = "/kubelet.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kubelet.slice" ]; then
-        containerd_runtime_cgroups="/kubelet.slice/containerd.service"
+        containerd_runtime_cgroups="/containerd.slice/containerd.service"
     fi
     tee "/etc/systemd/system/kubelet.service.d/10-containerd-base-flag.conf" > /dev/null <<EOF
 [Service]

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -384,7 +384,7 @@ net.bridge.bridge-nf-call-iptables = 1
 EOF
   retrycmd_if_failure 120 5 25 sysctl --system || exit $ERR_SYSCTL_RELOAD
 
-  # Node Memory Hardening: create kube-reserved.slice and drop-ins BEFORE starting
+  # Node Memory Hardening: create kubereserved.slice and drop-ins BEFORE starting
   # containerd/kubelet so both services start in the correct slice from the
   # beginning — avoids needing a disruptive restart after the fact.
   resolveKubeletReservedCgroups
@@ -879,8 +879,8 @@ EOF
     # Refresh --runtime-cgroups for PIS nodes where basePrep may have baked an older
     # 10-containerd-base-flag.conf pointing at /system.slice/containerd.service.
     local containerd_runtime_cgroups="/system.slice/containerd.service"
-    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube-reserved.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube-reserved.slice" ]; then
-        containerd_runtime_cgroups="/kube-reserved.slice/containerd.service"
+    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kubereserved.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kubereserved.slice" ]; then
+        containerd_runtime_cgroups="/kubereserved.slice/containerd.service"
     fi
     tee "/etc/systemd/system/kubelet.service.d/10-containerd-base-flag.conf" > /dev/null <<EOF
 [Service]

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -879,8 +879,7 @@ EOF
     # Refresh --runtime-cgroups for PIS nodes where basePrep may have baked an older
     # 10-containerd-base-flag.conf pointing at /system.slice/containerd.service.
     local containerd_runtime_cgroups="/system.slice/containerd.service"
-    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube-reserved.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube-reserved.slice" ] \
-       || [ "${KUBE_RESERVED_CGROUP:-}" = "/kubelet.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kubelet.slice" ]; then
+    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube-reserved.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube-reserved.slice" ]; then
         containerd_runtime_cgroups="/kube-reserved.slice/containerd.service"
     fi
     tee "/etc/systemd/system/kubelet.service.d/10-containerd-base-flag.conf" > /dev/null <<EOF

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -383,6 +383,17 @@ net.ipv6.conf.all.forwarding = 1
 net.bridge.bridge-nf-call-iptables = 1
 EOF
   retrycmd_if_failure 120 5 25 sysctl --system || exit $ERR_SYSCTL_RELOAD
+
+  # Node Memory Hardening: create kubelet.slice and drop-ins BEFORE starting
+  # containerd/kubelet so both services start in the correct slice from the
+  # beginning — avoids needing a disruptive restart after the fact.
+  resolveKubeletReservedCgroups
+  if [ -n "${KUBE_RESERVED_CGROUP}" ] || [ -n "${SYSTEM_RESERVED_CGROUP}" ]; then
+      if ! logs_to_events "AKS.CSE.ensureKubelet.ensureKubeletCgroupHierarchy" ensureKubeletCgroupHierarchy; then
+          exit $ERR_KUBELET_START_FAIL
+      fi
+  fi
+
   systemctlEnableAndStartNoBlock containerd 30 || exit $ERR_SYSTEMCTL_START_FAIL
 }
 
@@ -854,17 +865,6 @@ EOF
 
     local tls_bootstrapping_start_time_filepath="/opt/azure/containers/tls-bootstrap-start-time"
     date +"%F %T.%3N" > "${tls_bootstrapping_start_time_filepath}"
-
-    # Node Memory Hardening (F2/F5): if the RP rendered --kube-reserved-cgroup or
-    # --system-reserved-cgroup, ensure the corresponding systemd slices exist before
-    # kubelet starts so its NodeAllocatable enforcement loop can find them. The
-    # helper is a no-op when neither value is present (back-compat with non-hardened pools).
-    resolveKubeletReservedCgroups
-    if [ -n "${KUBE_RESERVED_CGROUP}" ] || [ -n "${SYSTEM_RESERVED_CGROUP}" ]; then
-        if ! logs_to_events "AKS.CSE.ensureKubelet.ensureKubeletCgroupHierarchy" ensureKubeletCgroupHierarchy; then
-            exit $ERR_KUBELET_START_FAIL
-        fi
-    fi
 
     # start kubelet.service without waiting for the main process to start, though check whether it has entered a failed state after enablement
     if ! systemctlEnableAndStartNoBlock kubelet 240; then

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -879,7 +879,8 @@ EOF
     # Refresh --runtime-cgroups for PIS nodes where basePrep may have baked an older
     # 10-containerd-base-flag.conf pointing at /system.slice/containerd.service.
     local containerd_runtime_cgroups="/system.slice/containerd.service"
-    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube-reserved.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube-reserved.slice" ]; then
+    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube-reserved.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube-reserved.slice" ] \
+       || [ "${KUBE_RESERVED_CGROUP:-}" = "/kubelet.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kubelet.slice" ]; then
         containerd_runtime_cgroups="/kube-reserved.slice/containerd.service"
     fi
     tee "/etc/systemd/system/kubelet.service.d/10-containerd-base-flag.conf" > /dev/null <<EOF

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -1541,8 +1541,8 @@ ensureKubeletCgroupHierarchy() {
     fi
 
     # Validate supported values: /kubereserved.slice (or bare kubereserved.slice) is
-    # the only value accepted for KUBE_RESERVED_CGROUP. Only /system.slice is supported
-    # for SYSTEM_RESERVED_CGROUP (a built-in systemd slice). Reject any other value
+    # the only value accepted for KUBE_RESERVED_CGROUP. Only /system.slice (or bare system.slice)
+    # is supported for SYSTEM_RESERVED_CGROUP (a built-in systemd slice). Reject any other value
     # explicitly so kubelet doesn't fail later with an opaque enforcement error.
     case "${KUBE_RESERVED_CGROUP:-}" in
         ""|"/kubereserved.slice"|"kubereserved.slice") ;;

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -1608,14 +1608,12 @@ EOF
             return 1
         fi
 
-        # Enable the slice so it is started on subsequent boots.
-        if ! systemctl enable kubereserved.slice; then
-            echo "ensureKubeletCgroupHierarchy: failed to enable kubereserved.slice"
-            return 1
-        fi
-        # Materialise the cgroup tree at /sys/fs/cgroup/kubereserved.slice before kubelet starts on this boot.
-        if ! systemctl start kubereserved.slice; then
-            echo "ensureKubeletCgroupHierarchy: failed to start kubereserved.slice"
+        # Enable the slice for subsequent boots AND materialise the cgroup tree
+        # at /sys/fs/cgroup/kubereserved.slice on this boot before kubelet starts.
+        # systemctlEnableAndStart wraps both operations with retry logic to
+        # survive transient systemd failures during CSE.
+        if ! systemctlEnableAndStart kubereserved.slice 30; then
+            echo "ensureKubeletCgroupHierarchy: failed to enable and start kubereserved.slice"
             return 1
         fi
     fi

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -1572,10 +1572,6 @@ Before=slices.target
 DefaultDependencies=no
 
 [Slice]
-# Delegate all available controllers (cpu, memory, pids, hugetlb, ...) into this
-# slice's cgroup.subtree_control. Without this, kubelet/runc fail to enforce
-# hugetlb (and other) resource limits on the slice with "missing controllers".
-Delegate=yes
 
 [Install]
 WantedBy=slices.target

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -1540,14 +1540,14 @@ ensureKubeletCgroupHierarchy() {
         return 1
     fi
 
-    # Validate supported values: only /kube-reserved.slice (or bare kube-reserved.slice) is
-    # supported for KUBE_RESERVED_CGROUP, and only /system.slice for
-    # SYSTEM_RESERVED_CGROUP (a built-in systemd slice). Reject any other value
-    # explicitly so kubelet doesn't fail later with an opaque enforcement error.
+    # Validate supported values: /kube-reserved.slice (or bare kube-reserved.slice) and
+    # the legacy /kubelet.slice are accepted for KUBE_RESERVED_CGROUP. Only /system.slice
+    # is supported for SYSTEM_RESERVED_CGROUP (a built-in systemd slice). Reject any other
+    # value explicitly so kubelet doesn't fail later with an opaque enforcement error.
     case "${KUBE_RESERVED_CGROUP:-}" in
-        ""|"/kube-reserved.slice"|"kube-reserved.slice") ;;
+        ""|"/kube-reserved.slice"|"kube-reserved.slice"|"/kubelet.slice"|"kubelet.slice") ;;
         *)
-            echo "ensureKubeletCgroupHierarchy: unsupported KUBE_RESERVED_CGROUP=${KUBE_RESERVED_CGROUP}; only /kube-reserved.slice is supported"
+            echo "ensureKubeletCgroupHierarchy: unsupported KUBE_RESERVED_CGROUP=${KUBE_RESERVED_CGROUP}; only /kube-reserved.slice (or legacy /kubelet.slice) is supported"
             return 1
             ;;
     esac
@@ -1560,7 +1560,9 @@ ensureKubeletCgroupHierarchy() {
     esac
 
     # /system.slice is a built-in systemd slice; we only need to create kube-reserved.slice.
-    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube-reserved.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube-reserved.slice" ]; then
+    # Accept the legacy /kubelet.slice value for backward compatibility with older RPs.
+    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube-reserved.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube-reserved.slice" ] \
+       || [ "${KUBE_RESERVED_CGROUP:-}" = "/kubelet.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kubelet.slice" ]; then
         # Write all unit/drop-in files unconditionally (idempotent). This ensures
         # upgraded nodes that already have an older version of these files get the
         # latest content (e.g. the Slice= directive added for kubelet/containerd).

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -1484,18 +1484,18 @@ function get_sandbox_image_from_containerd_config() {
 
 # ensureKubeletCgroupHierarchy creates the systemd slices used by kubelet for the
 # kube-reserved and system-reserved enforcement tiers (Node Memory Hardening F2/F5).
-# It MUST be called before kubelet starts so that /kube-reserved.slice and /system.slice
+# It MUST be called before kubelet starts so that /kubereserved.slice and /system.slice
 # exist and are managed by systemd before the first kubelet enforcement pass.
 #
 # The function:
 #   - Asserts cgroupv2 unified hierarchy (cgroupv1 is not supported by this feature
 #     because mixed/legacy hierarchies cannot reliably enforce per-slice MemoryMax).
-#   - Drops a /etc/systemd/system/kube-reserved.slice unit (system.slice ships with systemd).
-#   - Triggers `systemctl daemon-reload` and `systemctl start kube-reserved.slice` so the
-#     cgroup is materialised at /sys/fs/cgroup/kube-reserved.slice prior to kubelet boot.
+#   - Drops a /etc/systemd/system/kubereserved.slice unit (system.slice ships with systemd).
+#   - Triggers `systemctl daemon-reload` and `systemctl start kubereserved.slice` so the
+#     cgroup is materialised at /sys/fs/cgroup/kubereserved.slice prior to kubelet boot.
 #
 # Inputs (env, all optional — the function is a no-op if the RP did not opt in):
-#   KUBE_RESERVED_CGROUP    — absolute cgroup name, e.g. "/kube-reserved.slice"
+#   KUBE_RESERVED_CGROUP    — absolute cgroup name, e.g. "/kubereserved.slice"
 #   SYSTEM_RESERVED_CGROUP  — absolute cgroup name, e.g. "/system.slice"
 
 # resolveKubeletReservedCgroups exports KUBE_RESERVED_CGROUP and SYSTEM_RESERVED_CGROUP
@@ -1529,7 +1529,7 @@ ensureKubeletCgroupHierarchy() {
     # Path overrides exist for ShellSpec coverage; production callers leave them at
     # their defaults.
     local cgroupv2_marker="${CGROUPV2_MARKER_PATH:-/sys/fs/cgroup/cgroup.controllers}"
-    local kube_reserved_slice_unit="${KUBE_RESERVED_SLICE_UNIT_PATH:-/etc/systemd/system/kube-reserved.slice}"
+    local kube_reserved_slice_unit="${KUBE_RESERVED_SLICE_UNIT_PATH:-/etc/systemd/system/kubereserved.slice}"
     local kubelet_dropin_dir="${KUBELET_SERVICE_DROPIN_DIR:-/etc/systemd/system/kubelet.service.d}"
     local containerd_dropin_dir="${CONTAINERD_SERVICE_DROPIN_DIR:-/etc/systemd/system/containerd.service.d}"
 
@@ -1540,14 +1540,14 @@ ensureKubeletCgroupHierarchy() {
         return 1
     fi
 
-    # Validate supported values: /kube-reserved.slice (or bare kube-reserved.slice) is
+    # Validate supported values: /kubereserved.slice (or bare kubereserved.slice) is
     # the only value accepted for KUBE_RESERVED_CGROUP. Only /system.slice is supported
     # for SYSTEM_RESERVED_CGROUP (a built-in systemd slice). Reject any other value
     # explicitly so kubelet doesn't fail later with an opaque enforcement error.
     case "${KUBE_RESERVED_CGROUP:-}" in
-        ""|"/kube-reserved.slice"|"kube-reserved.slice") ;;
+        ""|"/kubereserved.slice"|"kubereserved.slice") ;;
         *)
-            echo "ensureKubeletCgroupHierarchy: unsupported KUBE_RESERVED_CGROUP=${KUBE_RESERVED_CGROUP}; only /kube-reserved.slice is supported"
+            echo "ensureKubeletCgroupHierarchy: unsupported KUBE_RESERVED_CGROUP=${KUBE_RESERVED_CGROUP}; only /kubereserved.slice is supported"
             return 1
             ;;
     esac
@@ -1559,8 +1559,8 @@ ensureKubeletCgroupHierarchy() {
             ;;
     esac
 
-    # /system.slice is a built-in systemd slice; we only need to create kube-reserved.slice.
-    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube-reserved.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube-reserved.slice" ]; then
+    # /system.slice is a built-in systemd slice; we only need to create kubereserved.slice.
+    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kubereserved.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kubereserved.slice" ]; then
         # Write all unit/drop-in files unconditionally (idempotent). This ensures
         # upgraded nodes that already have an older version of these files get the
         # latest content (e.g. the Slice= directive added for kubelet/containerd).
@@ -1572,36 +1572,40 @@ Before=slices.target
 DefaultDependencies=no
 
 [Slice]
+# Delegate all available controllers (cpu, memory, pids, hugetlb, ...) into this
+# slice's cgroup.subtree_control. Without this, kubelet/runc fail to enforce
+# hugetlb (and other) resource limits on the slice with "missing controllers".
+Delegate=yes
 
 [Install]
 WantedBy=slices.target
 EOF
         chmod 0644 "${kube_reserved_slice_unit}"
 
-        # Drop-in on kubelet.service so systemd starts kube-reserved.slice first
+        # Drop-in on kubelet.service so systemd starts kubereserved.slice first
         # on every boot and places kubelet inside the slice.
         mkdir -p "${kubelet_dropin_dir}"
-        tee "${kubelet_dropin_dir}/10-kube-reserved-slice.conf" > /dev/null <<'EOF'
+        tee "${kubelet_dropin_dir}/10-kubereserved-slice.conf" > /dev/null <<'EOF'
 [Unit]
-Wants=kube-reserved.slice
-After=kube-reserved.slice
+Wants=kubereserved.slice
+After=kubereserved.slice
 
 [Service]
-Slice=kube-reserved.slice
+Slice=kubereserved.slice
 EOF
-        chmod 0644 "${kubelet_dropin_dir}/10-kube-reserved-slice.conf"
+        chmod 0644 "${kubelet_dropin_dir}/10-kubereserved-slice.conf"
 
-        # Drop-in on containerd.service to place it in kube-reserved.slice.
+        # Drop-in on containerd.service to place it in kubereserved.slice.
         mkdir -p "${containerd_dropin_dir}"
-        tee "${containerd_dropin_dir}/10-kube-reserved-slice.conf" > /dev/null <<'EOF'
+        tee "${containerd_dropin_dir}/10-kubereserved-slice.conf" > /dev/null <<'EOF'
 [Unit]
-Wants=kube-reserved.slice
-After=kube-reserved.slice
+Wants=kubereserved.slice
+After=kubereserved.slice
 
 [Service]
-Slice=kube-reserved.slice
+Slice=kubereserved.slice
 EOF
-        chmod 0644 "${containerd_dropin_dir}/10-kube-reserved-slice.conf"
+        chmod 0644 "${containerd_dropin_dir}/10-kubereserved-slice.conf"
 
         if ! systemctl daemon-reload; then
             echo "ensureKubeletCgroupHierarchy: failed to daemon-reload systemd"
@@ -1609,13 +1613,13 @@ EOF
         fi
 
         # Enable the slice so it is started on subsequent boots.
-        if ! systemctl enable kube-reserved.slice; then
-            echo "ensureKubeletCgroupHierarchy: failed to enable kube-reserved.slice"
+        if ! systemctl enable kubereserved.slice; then
+            echo "ensureKubeletCgroupHierarchy: failed to enable kubereserved.slice"
             return 1
         fi
-        # Materialise the cgroup tree at /sys/fs/cgroup/kube-reserved.slice before kubelet starts on this boot.
-        if ! systemctl start kube-reserved.slice; then
-            echo "ensureKubeletCgroupHierarchy: failed to start kube-reserved.slice"
+        # Materialise the cgroup tree at /sys/fs/cgroup/kubereserved.slice before kubelet starts on this boot.
+        if ! systemctl start kubereserved.slice; then
+            echo "ensureKubeletCgroupHierarchy: failed to start kubereserved.slice"
             return 1
         fi
     fi

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -1532,6 +1532,7 @@ ensureKubeletCgroupHierarchy() {
     local kubelet_slice_unit="${KUBELET_SLICE_UNIT_PATH:-/etc/systemd/system/kubelet.slice}"
     local kubelet_dropin_dir="${KUBELET_SERVICE_DROPIN_DIR:-/etc/systemd/system/kubelet.service.d}"
     local containerd_dropin_dir="${CONTAINERD_SERVICE_DROPIN_DIR:-/etc/systemd/system/containerd.service.d}"
+    local containerd_slice_unit="${CONTAINERD_SLICE_UNIT_PATH:-/etc/systemd/system/containerd.slice}"
 
     # Assert cgroupv2 unified hierarchy. The canonical marker is the presence of
     # /sys/fs/cgroup/cgroup.controllers, which only exists under cgroupv2.
@@ -1591,17 +1592,32 @@ Slice=kubelet.slice
 EOF
         chmod 0644 "${kubelet_dropin_dir}/10-kubelet-slice.conf"
 
-        # Drop-in on containerd.service to place it in kubelet.slice as well.
-        mkdir -p "${containerd_dropin_dir}"
-        tee "${containerd_dropin_dir}/10-kubelet-slice.conf" > /dev/null <<'EOF'
+        # Create containerd.slice so containerd runs in its own dedicated slice.
+        mkdir -p "$(dirname "${containerd_slice_unit}")"
+        tee "${containerd_slice_unit}" > /dev/null <<'EOF'
 [Unit]
-Wants=kubelet.slice
-After=kubelet.slice
+Description=Slice for containerd cgroup isolation (AKS Node Memory Hardening)
+Before=slices.target
+DefaultDependencies=no
+
+[Slice]
+
+[Install]
+WantedBy=slices.target
+EOF
+        chmod 0644 "${containerd_slice_unit}"
+
+        # Drop-in on containerd.service to place it in containerd.slice.
+        mkdir -p "${containerd_dropin_dir}"
+        tee "${containerd_dropin_dir}/10-containerd-slice.conf" > /dev/null <<'EOF'
+[Unit]
+Wants=containerd.slice
+After=containerd.slice
 
 [Service]
-Slice=kubelet.slice
+Slice=containerd.slice
 EOF
-        chmod 0644 "${containerd_dropin_dir}/10-kubelet-slice.conf"
+        chmod 0644 "${containerd_dropin_dir}/10-containerd-slice.conf"
 
         if ! systemctl daemon-reload; then
             echo "ensureKubeletCgroupHierarchy: failed to daemon-reload systemd"
@@ -1616,6 +1632,14 @@ EOF
         # Materialise the cgroup tree at /sys/fs/cgroup/kubelet.slice before kubelet starts on this boot.
         if ! systemctl start kubelet.slice; then
             echo "ensureKubeletCgroupHierarchy: failed to start kubelet.slice"
+            return 1
+        fi
+        if ! systemctl enable containerd.slice; then
+            echo "ensureKubeletCgroupHierarchy: failed to enable containerd.slice"
+            return 1
+        fi
+        if ! systemctl start containerd.slice; then
+            echo "ensureKubeletCgroupHierarchy: failed to start containerd.slice"
             return 1
         fi
     fi

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -1561,15 +1561,11 @@ ensureKubeletCgroupHierarchy() {
 
     # /system.slice is a built-in systemd slice; we only need to create kubelet.slice.
     if [ "${KUBE_RESERVED_CGROUP:-}" = "/kubelet.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kubelet.slice" ]; then
-        local needs_reload=0
-        if [ ! -f "${kubelet_slice_unit}" ]; then
-            mkdir -p "$(dirname "${kubelet_slice_unit}")"
-            # [Install] WantedBy=slices.target ensures the slice is pulled in by
-            # systemd on every boot (including post-reboot), not only the current
-            # provisioning boot. Combined with the Before=kubelet.service drop-in
-            # below this guarantees /sys/fs/cgroup/kubelet.slice is materialised
-            # before kubelet starts, so NodeAllocatable enforcement does not race.
-            tee "${kubelet_slice_unit}" > /dev/null <<'EOF'
+        # Write all unit/drop-in files unconditionally (idempotent). This ensures
+        # upgraded nodes that already have an older version of these files get the
+        # latest content (e.g. the Slice= directive added for kubelet/containerd).
+        mkdir -p "$(dirname "${kubelet_slice_unit}")"
+        tee "${kubelet_slice_unit}" > /dev/null <<'EOF'
 [Unit]
 Description=Slice for kubelet kube-reserved enforcement (AKS Node Memory Hardening)
 Before=slices.target
@@ -1580,17 +1576,12 @@ DefaultDependencies=no
 [Install]
 WantedBy=slices.target
 EOF
-            chmod 0644 "${kubelet_slice_unit}"
-            needs_reload=1
+        chmod 0644 "${kubelet_slice_unit}"
 
-
-        fi
-        if [ ! -f "${kubelet_dropin_dir}/10-kubelet-slice.conf" ]; then
-            # Drop-in on kubelet.service so systemd starts kubelet.slice first
-            # on every boot. This survives reboots without depending on the
-            # one-shot `systemctl start` below.
-            mkdir -p "${kubelet_dropin_dir}"
-            tee "${kubelet_dropin_dir}/10-kubelet-slice.conf" > /dev/null <<'EOF'
+        # Drop-in on kubelet.service so systemd starts kubelet.slice first
+        # on every boot and places kubelet inside the slice.
+        mkdir -p "${kubelet_dropin_dir}"
+        tee "${kubelet_dropin_dir}/10-kubelet-slice.conf" > /dev/null <<'EOF'
 [Unit]
 Wants=kubelet.slice
 After=kubelet.slice
@@ -1598,13 +1589,11 @@ After=kubelet.slice
 [Service]
 Slice=kubelet.slice
 EOF
-            chmod 0644 "${kubelet_dropin_dir}/10-kubelet-slice.conf"
-            needs_reload=1
-        fi
-        if [ ! -f "${containerd_dropin_dir}/10-kubelet-slice.conf" ]; then
-            # Drop-in on containerd.service to place it in kubelet.slice as well.
-            mkdir -p "${containerd_dropin_dir}"
-            tee "${containerd_dropin_dir}/10-kubelet-slice.conf" > /dev/null <<'EOF'
+        chmod 0644 "${kubelet_dropin_dir}/10-kubelet-slice.conf"
+
+        # Drop-in on containerd.service to place it in kubelet.slice as well.
+        mkdir -p "${containerd_dropin_dir}"
+        tee "${containerd_dropin_dir}/10-kubelet-slice.conf" > /dev/null <<'EOF'
 [Unit]
 Wants=kubelet.slice
 After=kubelet.slice
@@ -1612,13 +1601,9 @@ After=kubelet.slice
 [Service]
 Slice=kubelet.slice
 EOF
-            chmod 0644 "${containerd_dropin_dir}/10-kubelet-slice.conf"
-            needs_reload=1
-        fi
+        chmod 0644 "${containerd_dropin_dir}/10-kubelet-slice.conf"
 
-        if [ "${needs_reload}" -eq 1 ]; then
-            systemctl daemon-reload
-        fi
+        systemctl daemon-reload
 
         # Enable the slice so it is started on subsequent boots.
         if ! systemctl enable kubelet.slice; then

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -1540,14 +1540,14 @@ ensureKubeletCgroupHierarchy() {
         return 1
     fi
 
-    # Validate supported values: /kube-reserved.slice (or bare kube-reserved.slice) and
-    # the legacy /kubelet.slice are accepted for KUBE_RESERVED_CGROUP. Only /system.slice
-    # is supported for SYSTEM_RESERVED_CGROUP (a built-in systemd slice). Reject any other
-    # value explicitly so kubelet doesn't fail later with an opaque enforcement error.
+    # Validate supported values: /kube-reserved.slice (or bare kube-reserved.slice) is
+    # the only value accepted for KUBE_RESERVED_CGROUP. Only /system.slice is supported
+    # for SYSTEM_RESERVED_CGROUP (a built-in systemd slice). Reject any other value
+    # explicitly so kubelet doesn't fail later with an opaque enforcement error.
     case "${KUBE_RESERVED_CGROUP:-}" in
-        ""|"/kube-reserved.slice"|"kube-reserved.slice"|"/kubelet.slice"|"kubelet.slice") ;;
+        ""|"/kube-reserved.slice"|"kube-reserved.slice") ;;
         *)
-            echo "ensureKubeletCgroupHierarchy: unsupported KUBE_RESERVED_CGROUP=${KUBE_RESERVED_CGROUP}; only /kube-reserved.slice (or legacy /kubelet.slice) is supported"
+            echo "ensureKubeletCgroupHierarchy: unsupported KUBE_RESERVED_CGROUP=${KUBE_RESERVED_CGROUP}; only /kube-reserved.slice is supported"
             return 1
             ;;
     esac
@@ -1560,9 +1560,7 @@ ensureKubeletCgroupHierarchy() {
     esac
 
     # /system.slice is a built-in systemd slice; we only need to create kube-reserved.slice.
-    # Accept the legacy /kubelet.slice value for backward compatibility with older RPs.
-    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube-reserved.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube-reserved.slice" ] \
-       || [ "${KUBE_RESERVED_CGROUP:-}" = "/kubelet.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kubelet.slice" ]; then
+    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube-reserved.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube-reserved.slice" ]; then
         # Write all unit/drop-in files unconditionally (idempotent). This ensures
         # upgraded nodes that already have an older version of these files get the
         # latest content (e.g. the Slice= directive added for kubelet/containerd).

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -1603,7 +1603,10 @@ Slice=kubelet.slice
 EOF
         chmod 0644 "${containerd_dropin_dir}/10-kubelet-slice.conf"
 
-        systemctl daemon-reload
+        if ! systemctl daemon-reload; then
+            echo "ensureKubeletCgroupHierarchy: failed to daemon-reload systemd"
+            return 1
+        fi
 
         # Enable the slice so it is started on subsequent boots.
         if ! systemctl enable kubelet.slice; then

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -1561,6 +1561,7 @@ ensureKubeletCgroupHierarchy() {
 
     # /system.slice is a built-in systemd slice; we only need to create kubelet.slice.
     if [ "${KUBE_RESERVED_CGROUP:-}" = "/kubelet.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kubelet.slice" ]; then
+        local needs_reload=0
         if [ ! -f "${kubelet_slice_unit}" ]; then
             mkdir -p "$(dirname "${kubelet_slice_unit}")"
             # [Install] WantedBy=slices.target ensures the slice is pulled in by
@@ -1580,7 +1581,11 @@ DefaultDependencies=no
 WantedBy=slices.target
 EOF
             chmod 0644 "${kubelet_slice_unit}"
+            needs_reload=1
 
+
+        fi
+        if [ ! -f "${kubelet_dropin_dir}/10-kubelet-slice.conf" ]; then
             # Drop-in on kubelet.service so systemd starts kubelet.slice first
             # on every boot. This survives reboots without depending on the
             # one-shot `systemctl start` below.
@@ -1594,7 +1599,9 @@ After=kubelet.slice
 Slice=kubelet.slice
 EOF
             chmod 0644 "${kubelet_dropin_dir}/10-kubelet-slice.conf"
-
+            needs_reload=1
+        fi
+        if [ ! -f "${containerd_dropin_dir}/10-kubelet-slice.conf" ]; then
             # Drop-in on containerd.service to place it in kubelet.slice as well.
             mkdir -p "${containerd_dropin_dir}"
             tee "${containerd_dropin_dir}/10-kubelet-slice.conf" > /dev/null <<'EOF'
@@ -1606,16 +1613,18 @@ After=kubelet.slice
 Slice=kubelet.slice
 EOF
             chmod 0644 "${containerd_dropin_dir}/10-kubelet-slice.conf"
-
-            systemctl daemon-reload
-
-            # Enable the slice so it is started on subsequent boots.
-            if ! systemctl enable kubelet.slice; then
-                echo "ensureKubeletCgroupHierarchy: failed to enable kubelet.slice"
-                return 1
-            fi
+            needs_reload=1
         fi
 
+        if [ "${needs_reload}" -eq 1 ]; then
+            systemctl daemon-reload
+        fi
+
+        # Enable the slice so it is started on subsequent boots.
+        if ! systemctl enable kubelet.slice; then
+            echo "ensureKubeletCgroupHierarchy: failed to enable kubelet.slice"
+            return 1
+        fi
         # Materialise the cgroup tree at /sys/fs/cgroup/kubelet.slice before kubelet starts on this boot.
         if ! systemctl start kubelet.slice; then
             echo "ensureKubeletCgroupHierarchy: failed to start kubelet.slice"

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -1484,18 +1484,18 @@ function get_sandbox_image_from_containerd_config() {
 
 # ensureKubeletCgroupHierarchy creates the systemd slices used by kubelet for the
 # kube-reserved and system-reserved enforcement tiers (Node Memory Hardening F2/F5).
-# It MUST be called before kubelet starts so that /kubelet.slice and /system.slice
+# It MUST be called before kubelet starts so that /kube.slice and /system.slice
 # exist and are managed by systemd before the first kubelet enforcement pass.
 #
 # The function:
 #   - Asserts cgroupv2 unified hierarchy (cgroupv1 is not supported by this feature
 #     because mixed/legacy hierarchies cannot reliably enforce per-slice MemoryMax).
-#   - Drops a /etc/systemd/system/kubelet.slice unit (system.slice ships with systemd).
-#   - Triggers `systemctl daemon-reload` and `systemctl start kubelet.slice` so the
-#     cgroup is materialised at /sys/fs/cgroup/kubelet.slice prior to kubelet boot.
+#   - Drops a /etc/systemd/system/kube.slice unit (system.slice ships with systemd).
+#   - Triggers `systemctl daemon-reload` and `systemctl start kube.slice` so the
+#     cgroup is materialised at /sys/fs/cgroup/kube.slice prior to kubelet boot.
 #
 # Inputs (env, all optional — the function is a no-op if the RP did not opt in):
-#   KUBE_RESERVED_CGROUP    — absolute cgroup name, e.g. "/kubelet.slice"
+#   KUBE_RESERVED_CGROUP    — absolute cgroup name, e.g. "/kube.slice"
 #   SYSTEM_RESERVED_CGROUP  — absolute cgroup name, e.g. "/system.slice"
 
 # resolveKubeletReservedCgroups exports KUBE_RESERVED_CGROUP and SYSTEM_RESERVED_CGROUP
@@ -1529,10 +1529,9 @@ ensureKubeletCgroupHierarchy() {
     # Path overrides exist for ShellSpec coverage; production callers leave them at
     # their defaults.
     local cgroupv2_marker="${CGROUPV2_MARKER_PATH:-/sys/fs/cgroup/cgroup.controllers}"
-    local kubelet_slice_unit="${KUBELET_SLICE_UNIT_PATH:-/etc/systemd/system/kubelet.slice}"
+    local kube_slice_unit="${KUBE_SLICE_UNIT_PATH:-/etc/systemd/system/kube.slice}"
     local kubelet_dropin_dir="${KUBELET_SERVICE_DROPIN_DIR:-/etc/systemd/system/kubelet.service.d}"
     local containerd_dropin_dir="${CONTAINERD_SERVICE_DROPIN_DIR:-/etc/systemd/system/containerd.service.d}"
-    local containerd_slice_unit="${CONTAINERD_SLICE_UNIT_PATH:-/etc/systemd/system/containerd.slice}"
 
     # Assert cgroupv2 unified hierarchy. The canonical marker is the presence of
     # /sys/fs/cgroup/cgroup.controllers, which only exists under cgroupv2.
@@ -1541,14 +1540,14 @@ ensureKubeletCgroupHierarchy() {
         return 1
     fi
 
-    # Validate supported values: only /kubelet.slice (or bare kubelet.slice) is
+    # Validate supported values: only /kube.slice (or bare kube.slice) is
     # supported for KUBE_RESERVED_CGROUP, and only /system.slice for
     # SYSTEM_RESERVED_CGROUP (a built-in systemd slice). Reject any other value
     # explicitly so kubelet doesn't fail later with an opaque enforcement error.
     case "${KUBE_RESERVED_CGROUP:-}" in
-        ""|"/kubelet.slice"|"kubelet.slice") ;;
+        ""|"/kube.slice"|"kube.slice") ;;
         *)
-            echo "ensureKubeletCgroupHierarchy: unsupported KUBE_RESERVED_CGROUP=${KUBE_RESERVED_CGROUP}; only /kubelet.slice is supported"
+            echo "ensureKubeletCgroupHierarchy: unsupported KUBE_RESERVED_CGROUP=${KUBE_RESERVED_CGROUP}; only /kube.slice is supported"
             return 1
             ;;
     esac
@@ -1560,15 +1559,15 @@ ensureKubeletCgroupHierarchy() {
             ;;
     esac
 
-    # /system.slice is a built-in systemd slice; we only need to create kubelet.slice.
-    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kubelet.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kubelet.slice" ]; then
+    # /system.slice is a built-in systemd slice; we only need to create kube.slice.
+    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube.slice" ]; then
         # Write all unit/drop-in files unconditionally (idempotent). This ensures
         # upgraded nodes that already have an older version of these files get the
         # latest content (e.g. the Slice= directive added for kubelet/containerd).
-        mkdir -p "$(dirname "${kubelet_slice_unit}")"
-        tee "${kubelet_slice_unit}" > /dev/null <<'EOF'
+        mkdir -p "$(dirname "${kube_slice_unit}")"
+        tee "${kube_slice_unit}" > /dev/null <<'EOF'
 [Unit]
-Description=Slice for kubelet kube-reserved enforcement (AKS Node Memory Hardening)
+Description=Slice for kube-reserved enforcement (AKS Node Memory Hardening)
 Before=slices.target
 DefaultDependencies=no
 
@@ -1577,47 +1576,32 @@ DefaultDependencies=no
 [Install]
 WantedBy=slices.target
 EOF
-        chmod 0644 "${kubelet_slice_unit}"
+        chmod 0644 "${kube_slice_unit}"
 
-        # Drop-in on kubelet.service so systemd starts kubelet.slice first
+        # Drop-in on kubelet.service so systemd starts kube.slice first
         # on every boot and places kubelet inside the slice.
         mkdir -p "${kubelet_dropin_dir}"
-        tee "${kubelet_dropin_dir}/10-kubelet-slice.conf" > /dev/null <<'EOF'
+        tee "${kubelet_dropin_dir}/10-kube-slice.conf" > /dev/null <<'EOF'
 [Unit]
-Wants=kubelet.slice
-After=kubelet.slice
+Wants=kube.slice
+After=kube.slice
 
 [Service]
-Slice=kubelet.slice
+Slice=kube.slice
 EOF
-        chmod 0644 "${kubelet_dropin_dir}/10-kubelet-slice.conf"
+        chmod 0644 "${kubelet_dropin_dir}/10-kube-slice.conf"
 
-        # Create containerd.slice so containerd runs in its own dedicated slice.
-        mkdir -p "$(dirname "${containerd_slice_unit}")"
-        tee "${containerd_slice_unit}" > /dev/null <<'EOF'
-[Unit]
-Description=Slice for containerd cgroup isolation (AKS Node Memory Hardening)
-Before=slices.target
-DefaultDependencies=no
-
-[Slice]
-
-[Install]
-WantedBy=slices.target
-EOF
-        chmod 0644 "${containerd_slice_unit}"
-
-        # Drop-in on containerd.service to place it in containerd.slice.
+        # Drop-in on containerd.service to place it in kube.slice.
         mkdir -p "${containerd_dropin_dir}"
-        tee "${containerd_dropin_dir}/10-containerd-slice.conf" > /dev/null <<'EOF'
+        tee "${containerd_dropin_dir}/10-kube-slice.conf" > /dev/null <<'EOF'
 [Unit]
-Wants=containerd.slice
-After=containerd.slice
+Wants=kube.slice
+After=kube.slice
 
 [Service]
-Slice=containerd.slice
+Slice=kube.slice
 EOF
-        chmod 0644 "${containerd_dropin_dir}/10-containerd-slice.conf"
+        chmod 0644 "${containerd_dropin_dir}/10-kube-slice.conf"
 
         if ! systemctl daemon-reload; then
             echo "ensureKubeletCgroupHierarchy: failed to daemon-reload systemd"
@@ -1625,21 +1609,13 @@ EOF
         fi
 
         # Enable the slice so it is started on subsequent boots.
-        if ! systemctl enable kubelet.slice; then
-            echo "ensureKubeletCgroupHierarchy: failed to enable kubelet.slice"
+        if ! systemctl enable kube.slice; then
+            echo "ensureKubeletCgroupHierarchy: failed to enable kube.slice"
             return 1
         fi
-        # Materialise the cgroup tree at /sys/fs/cgroup/kubelet.slice before kubelet starts on this boot.
-        if ! systemctl start kubelet.slice; then
-            echo "ensureKubeletCgroupHierarchy: failed to start kubelet.slice"
-            return 1
-        fi
-        if ! systemctl enable containerd.slice; then
-            echo "ensureKubeletCgroupHierarchy: failed to enable containerd.slice"
-            return 1
-        fi
-        if ! systemctl start containerd.slice; then
-            echo "ensureKubeletCgroupHierarchy: failed to start containerd.slice"
+        # Materialise the cgroup tree at /sys/fs/cgroup/kube.slice before kubelet starts on this boot.
+        if ! systemctl start kube.slice; then
+            echo "ensureKubeletCgroupHierarchy: failed to start kube.slice"
             return 1
         fi
     fi

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -1484,18 +1484,18 @@ function get_sandbox_image_from_containerd_config() {
 
 # ensureKubeletCgroupHierarchy creates the systemd slices used by kubelet for the
 # kube-reserved and system-reserved enforcement tiers (Node Memory Hardening F2/F5).
-# It MUST be called before kubelet starts so that /kube.slice and /system.slice
+# It MUST be called before kubelet starts so that /kube-reserved.slice and /system.slice
 # exist and are managed by systemd before the first kubelet enforcement pass.
 #
 # The function:
 #   - Asserts cgroupv2 unified hierarchy (cgroupv1 is not supported by this feature
 #     because mixed/legacy hierarchies cannot reliably enforce per-slice MemoryMax).
-#   - Drops a /etc/systemd/system/kube.slice unit (system.slice ships with systemd).
-#   - Triggers `systemctl daemon-reload` and `systemctl start kube.slice` so the
-#     cgroup is materialised at /sys/fs/cgroup/kube.slice prior to kubelet boot.
+#   - Drops a /etc/systemd/system/kube-reserved.slice unit (system.slice ships with systemd).
+#   - Triggers `systemctl daemon-reload` and `systemctl start kube-reserved.slice` so the
+#     cgroup is materialised at /sys/fs/cgroup/kube-reserved.slice prior to kubelet boot.
 #
 # Inputs (env, all optional — the function is a no-op if the RP did not opt in):
-#   KUBE_RESERVED_CGROUP    — absolute cgroup name, e.g. "/kube.slice"
+#   KUBE_RESERVED_CGROUP    — absolute cgroup name, e.g. "/kube-reserved.slice"
 #   SYSTEM_RESERVED_CGROUP  — absolute cgroup name, e.g. "/system.slice"
 
 # resolveKubeletReservedCgroups exports KUBE_RESERVED_CGROUP and SYSTEM_RESERVED_CGROUP
@@ -1529,7 +1529,7 @@ ensureKubeletCgroupHierarchy() {
     # Path overrides exist for ShellSpec coverage; production callers leave them at
     # their defaults.
     local cgroupv2_marker="${CGROUPV2_MARKER_PATH:-/sys/fs/cgroup/cgroup.controllers}"
-    local kube_slice_unit="${KUBE_SLICE_UNIT_PATH:-/etc/systemd/system/kube.slice}"
+    local kube_reserved_slice_unit="${KUBE_RESERVED_SLICE_UNIT_PATH:-/etc/systemd/system/kube-reserved.slice}"
     local kubelet_dropin_dir="${KUBELET_SERVICE_DROPIN_DIR:-/etc/systemd/system/kubelet.service.d}"
     local containerd_dropin_dir="${CONTAINERD_SERVICE_DROPIN_DIR:-/etc/systemd/system/containerd.service.d}"
 
@@ -1540,14 +1540,14 @@ ensureKubeletCgroupHierarchy() {
         return 1
     fi
 
-    # Validate supported values: only /kube.slice (or bare kube.slice) is
+    # Validate supported values: only /kube-reserved.slice (or bare kube-reserved.slice) is
     # supported for KUBE_RESERVED_CGROUP, and only /system.slice for
     # SYSTEM_RESERVED_CGROUP (a built-in systemd slice). Reject any other value
     # explicitly so kubelet doesn't fail later with an opaque enforcement error.
     case "${KUBE_RESERVED_CGROUP:-}" in
-        ""|"/kube.slice"|"kube.slice") ;;
+        ""|"/kube-reserved.slice"|"kube-reserved.slice") ;;
         *)
-            echo "ensureKubeletCgroupHierarchy: unsupported KUBE_RESERVED_CGROUP=${KUBE_RESERVED_CGROUP}; only /kube.slice is supported"
+            echo "ensureKubeletCgroupHierarchy: unsupported KUBE_RESERVED_CGROUP=${KUBE_RESERVED_CGROUP}; only /kube-reserved.slice is supported"
             return 1
             ;;
     esac
@@ -1559,13 +1559,13 @@ ensureKubeletCgroupHierarchy() {
             ;;
     esac
 
-    # /system.slice is a built-in systemd slice; we only need to create kube.slice.
-    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube.slice" ]; then
+    # /system.slice is a built-in systemd slice; we only need to create kube-reserved.slice.
+    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kube-reserved.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kube-reserved.slice" ]; then
         # Write all unit/drop-in files unconditionally (idempotent). This ensures
         # upgraded nodes that already have an older version of these files get the
         # latest content (e.g. the Slice= directive added for kubelet/containerd).
-        mkdir -p "$(dirname "${kube_slice_unit}")"
-        tee "${kube_slice_unit}" > /dev/null <<'EOF'
+        mkdir -p "$(dirname "${kube_reserved_slice_unit}")"
+        tee "${kube_reserved_slice_unit}" > /dev/null <<'EOF'
 [Unit]
 Description=Slice for kube-reserved enforcement (AKS Node Memory Hardening)
 Before=slices.target
@@ -1576,32 +1576,32 @@ DefaultDependencies=no
 [Install]
 WantedBy=slices.target
 EOF
-        chmod 0644 "${kube_slice_unit}"
+        chmod 0644 "${kube_reserved_slice_unit}"
 
-        # Drop-in on kubelet.service so systemd starts kube.slice first
+        # Drop-in on kubelet.service so systemd starts kube-reserved.slice first
         # on every boot and places kubelet inside the slice.
         mkdir -p "${kubelet_dropin_dir}"
-        tee "${kubelet_dropin_dir}/10-kube-slice.conf" > /dev/null <<'EOF'
+        tee "${kubelet_dropin_dir}/10-kube-reserved-slice.conf" > /dev/null <<'EOF'
 [Unit]
-Wants=kube.slice
-After=kube.slice
+Wants=kube-reserved.slice
+After=kube-reserved.slice
 
 [Service]
-Slice=kube.slice
+Slice=kube-reserved.slice
 EOF
-        chmod 0644 "${kubelet_dropin_dir}/10-kube-slice.conf"
+        chmod 0644 "${kubelet_dropin_dir}/10-kube-reserved-slice.conf"
 
-        # Drop-in on containerd.service to place it in kube.slice.
+        # Drop-in on containerd.service to place it in kube-reserved.slice.
         mkdir -p "${containerd_dropin_dir}"
-        tee "${containerd_dropin_dir}/10-kube-slice.conf" > /dev/null <<'EOF'
+        tee "${containerd_dropin_dir}/10-kube-reserved-slice.conf" > /dev/null <<'EOF'
 [Unit]
-Wants=kube.slice
-After=kube.slice
+Wants=kube-reserved.slice
+After=kube-reserved.slice
 
 [Service]
-Slice=kube.slice
+Slice=kube-reserved.slice
 EOF
-        chmod 0644 "${containerd_dropin_dir}/10-kube-slice.conf"
+        chmod 0644 "${containerd_dropin_dir}/10-kube-reserved-slice.conf"
 
         if ! systemctl daemon-reload; then
             echo "ensureKubeletCgroupHierarchy: failed to daemon-reload systemd"
@@ -1609,13 +1609,13 @@ EOF
         fi
 
         # Enable the slice so it is started on subsequent boots.
-        if ! systemctl enable kube.slice; then
-            echo "ensureKubeletCgroupHierarchy: failed to enable kube.slice"
+        if ! systemctl enable kube-reserved.slice; then
+            echo "ensureKubeletCgroupHierarchy: failed to enable kube-reserved.slice"
             return 1
         fi
-        # Materialise the cgroup tree at /sys/fs/cgroup/kube.slice before kubelet starts on this boot.
-        if ! systemctl start kube.slice; then
-            echo "ensureKubeletCgroupHierarchy: failed to start kube.slice"
+        # Materialise the cgroup tree at /sys/fs/cgroup/kube-reserved.slice before kubelet starts on this boot.
+        if ! systemctl start kube-reserved.slice; then
+            echo "ensureKubeletCgroupHierarchy: failed to start kube-reserved.slice"
             return 1
         fi
     fi

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -1531,6 +1531,7 @@ ensureKubeletCgroupHierarchy() {
     local cgroupv2_marker="${CGROUPV2_MARKER_PATH:-/sys/fs/cgroup/cgroup.controllers}"
     local kubelet_slice_unit="${KUBELET_SLICE_UNIT_PATH:-/etc/systemd/system/kubelet.slice}"
     local kubelet_dropin_dir="${KUBELET_SERVICE_DROPIN_DIR:-/etc/systemd/system/kubelet.service.d}"
+    local containerd_dropin_dir="${CONTAINERD_SERVICE_DROPIN_DIR:-/etc/systemd/system/containerd.service.d}"
 
     # Assert cgroupv2 unified hierarchy. The canonical marker is the presence of
     # /sys/fs/cgroup/cgroup.controllers, which only exists under cgroupv2.
@@ -1588,8 +1589,23 @@ EOF
 [Unit]
 Wants=kubelet.slice
 After=kubelet.slice
+
+[Service]
+Slice=kubelet.slice
 EOF
             chmod 0644 "${kubelet_dropin_dir}/10-kubelet-slice.conf"
+
+            # Drop-in on containerd.service to place it in kubelet.slice as well.
+            mkdir -p "${containerd_dropin_dir}"
+            tee "${containerd_dropin_dir}/10-kubelet-slice.conf" > /dev/null <<'EOF'
+[Unit]
+Wants=kubelet.slice
+After=kubelet.slice
+
+[Service]
+Slice=kubelet.slice
+EOF
+            chmod 0644 "${containerd_dropin_dir}/10-kubelet-slice.conf"
 
             systemctl daemon-reload
 

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -288,15 +288,9 @@ EOF
     # We now have 2 drop-in's, one with the still valid flags that will be applied to all k8s versions,
     # the flags are --runtime-request-timeout, --container-runtime-endpoint, --runtime-cgroups
     # For k8s >= 1.27, the flag --container-runtime will not be passed.
-    # When Node Memory Hardening places containerd in kubelet.slice, update --runtime-cgroups
-    # so kubelet monitors the correct cgroup path for runtime resource accounting.
-    local containerd_runtime_cgroups="/system.slice/containerd.service"
-    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kubelet.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kubelet.slice" ]; then
-        containerd_runtime_cgroups="/kubelet.slice/containerd.service"
-    fi
-    tee "/etc/systemd/system/kubelet.service.d/10-containerd-base-flag.conf" > /dev/null <<EOF
+    tee "/etc/systemd/system/kubelet.service.d/10-containerd-base-flag.conf" > /dev/null <<'EOF'
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=${containerd_runtime_cgroups}"
+Environment="KUBELET_CONTAINERD_FLAGS=--runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"
 EOF
 
     if ! semverCompare ${KUBERNETES_VERSION:-"0.0.0"} "1.27.0"; then

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -288,9 +288,15 @@ EOF
     # We now have 2 drop-in's, one with the still valid flags that will be applied to all k8s versions,
     # the flags are --runtime-request-timeout, --container-runtime-endpoint, --runtime-cgroups
     # For k8s >= 1.27, the flag --container-runtime will not be passed.
-    tee "/etc/systemd/system/kubelet.service.d/10-containerd-base-flag.conf" > /dev/null <<'EOF'
+    # When Node Memory Hardening places containerd in kubelet.slice, update --runtime-cgroups
+    # so kubelet monitors the correct cgroup path for runtime resource accounting.
+    local containerd_runtime_cgroups="/system.slice/containerd.service"
+    if [ "${KUBE_RESERVED_CGROUP:-}" = "/kubelet.slice" ] || [ "${KUBE_RESERVED_CGROUP:-}" = "kubelet.slice" ]; then
+        containerd_runtime_cgroups="/kubelet.slice/containerd.service"
+    fi
+    tee "/etc/systemd/system/kubelet.service.d/10-containerd-base-flag.conf" > /dev/null <<EOF
 [Service]
-Environment="KUBELET_CONTAINERD_FLAGS=--runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service"
+Environment="KUBELET_CONTAINERD_FLAGS=--runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=${containerd_runtime_cgroups}"
 EOF
 
     if ! semverCompare ${KUBERNETES_VERSION:-"0.0.0"} "1.27.0"; then

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -670,6 +670,15 @@ func ValidateAndSetLinuxNodeBootstrappingConfiguration(config *datamodel.NodeBoo
 		kubeletFlags["--feature-gates"] = addFeatureGateString(kubeletFlags["--feature-gates"], "DynamicKubeletConfig", false)
 	}
 
+	// Node Hardening: AgentBaker, not the RP, owns the cgroup slice
+	// names that --kube-reserved-cgroup/--system-reserved-cgroup resolve to, since
+	// AgentBaker is what actually creates (or doesn't create) the systemd slice unit
+	// on the node (see cse_helpers.sh::ensureKubeletCgroupHierarchy). The RP only
+	// signals intent via --enforce-node-allocatable=pods,kube-reserved,system-reserved;
+	// any value it may still send for the two cgroup flags themselves is ignored and
+	// overwritten here so there is a single source of truth for the slice names.
+	setNodeHardeningCgroupFlags(kubeletFlags)
+
 	/* ContainerInsights depends on GPU accelerator Usage metrics from Kubelet cAdvisor endpoint but
 	deprecation of this feature moved to beta which breaks the ContainerInsights customers with K8s
 		version 1.20 or higher */

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -2326,7 +2326,7 @@ type AKSKubeletConfiguration struct {
 	EnforceNodeAllocatable []string `json:"enforceNodeAllocatable,omitempty"`
 	/* kubeReservedCgroup is the absolute name of the cgroup the kubelet should manage
 	for the kube-reserved compute resources. When enforce-node-allocatable contains
-	this cgroup must exist before kubelet starts. Example: "/kube-reserved.slice".
+	this cgroup must exist before kubelet starts. Example: "/kubereserved.slice".
 	+optional. */
 	KubeReservedCgroup string `json:"kubeReservedCgroup,omitempty"`
 	/* systemReservedCgroup is the absolute name of the cgroup the kubelet should manage

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -2326,7 +2326,7 @@ type AKSKubeletConfiguration struct {
 	EnforceNodeAllocatable []string `json:"enforceNodeAllocatable,omitempty"`
 	/* kubeReservedCgroup is the absolute name of the cgroup the kubelet should manage
 	for the kube-reserved compute resources. When enforce-node-allocatable contains
-	this cgroup must exist before kubelet starts. Example: "/kube.slice".
+	this cgroup must exist before kubelet starts. Example: "/kube-reserved.slice".
 	+optional. */
 	KubeReservedCgroup string `json:"kubeReservedCgroup,omitempty"`
 	/* systemReservedCgroup is the absolute name of the cgroup the kubelet should manage

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -2326,7 +2326,7 @@ type AKSKubeletConfiguration struct {
 	EnforceNodeAllocatable []string `json:"enforceNodeAllocatable,omitempty"`
 	/* kubeReservedCgroup is the absolute name of the cgroup the kubelet should manage
 	for the kube-reserved compute resources. When enforce-node-allocatable contains
-	"kube-reserved", this cgroup must exist before kubelet starts. Example: "/kubelet.slice".
+	this cgroup must exist before kubelet starts. Example: "/kube.slice".
 	+optional. */
 	KubeReservedCgroup string `json:"kubeReservedCgroup,omitempty"`
 	/* systemReservedCgroup is the absolute name of the cgroup the kubelet should manage

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -489,7 +489,7 @@ func IsKubeletServingCertificateRotationEnabled(config *datamodel.NodeBootstrapp
 // is what actually creates (or validates) the systemd slice unit on the node, so
 // the name must be decided here rather than accepted verbatim from the RP.
 const (
-	nodeHardeningKubeReservedCgroup   = "/kube-reserved.slice"
+	nodeHardeningKubeReservedCgroup   = "/kubereserved.slice"
 	nodeHardeningSystemReservedCgroup = "/system.slice"
 )
 

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -484,6 +484,62 @@ func IsKubeletServingCertificateRotationEnabled(config *datamodel.NodeBootstrapp
 	return config.KubeletConfig["--rotate-server-certificates"] == "true"
 }
 
+// Node Hardening cgroup slice names. AgentBaker is the single
+// source of truth for these values: cse_helpers.sh::ensureKubeletCgroupHierarchy
+// is what actually creates (or validates) the systemd slice unit on the node, so
+// the name must be decided here rather than accepted verbatim from the RP.
+const (
+	nodeHardeningKubeReservedCgroup   = "/kube-reserved.slice"
+	nodeHardeningSystemReservedCgroup = "/system.slice"
+)
+
+// isNodeHardeningEnabled reports whether the RP has requested Node Hardening
+// cgroup enforcement for this node. The RP signals intent solely via
+// --enforce-node-allocatable containing both "kube-reserved" and "system-reserved"
+// (see ApplyNodeAllocatableEnforcement in aks-rp); any values it may additionally
+// send for --kube-reserved-cgroup/--system-reserved-cgroup are ignored, since
+// AgentBaker owns those slice names (see setNodeHardeningCgroupFlags).
+//
+// TODO: this detection is a proxy inferred from a flag the RP happens to set
+// today. If/when Node Hardening's own logic (the enable/disable decision,
+// --system-reserved formula, etc.) moves into AgentBaker, this should be
+// replaced with a real, explicit signal (e.g. a typed field on
+// CustomKubeletConfig) instead of inferring intent from --enforce-node-allocatable.
+func isNodeHardeningEnabled(kubeletFlags map[string]string) bool {
+	raw := strings.TrimSpace(kubeletFlags["--enforce-node-allocatable"])
+	raw = strings.TrimPrefix(raw, "[")
+	raw = strings.TrimSuffix(raw, "]")
+	enforced := strings.Split(raw, ",")
+	hasKubeReserved, hasSystemReserved := false, false
+	for _, v := range enforced {
+		switch strings.TrimSpace(v) {
+		case "kube-reserved":
+			hasKubeReserved = true
+		case "system-reserved":
+			hasSystemReserved = true
+		}
+	}
+	return hasKubeReserved && hasSystemReserved
+}
+
+// setNodeHardeningCgroupFlags assigns (or clears) --kube-reserved-cgroup and
+// --system-reserved-cgroup based solely on whether Node Hardening is
+// enabled (isNodeHardeningEnabled), overwriting/deleting any value the RP
+// may have set for these two keys directly.
+func setNodeHardeningCgroupFlags(kubeletFlags map[string]string) {
+	if isNodeHardeningEnabled(kubeletFlags) {
+		kubeletFlags["--kube-reserved-cgroup"] = nodeHardeningKubeReservedCgroup
+		kubeletFlags["--system-reserved-cgroup"] = nodeHardeningSystemReservedCgroup
+		// TODO: this is currently the only piece of Node Hardening logic owned by
+		// AgentBaker; --enforce-node-allocatable, --system-reserved, --kube-reserved,
+		// and the eviction-soft* flags are still computed and sent as raw values by
+		// the RP. If/when that logic moves into AgentBaker too, set those flags here.
+		return
+	}
+	delete(kubeletFlags, "--kube-reserved-cgroup")
+	delete(kubeletFlags, "--system-reserved-cgroup")
+}
+
 func getAKSKubeletConfiguration(kc map[string]string) *datamodel.AKSKubeletConfiguration {
 	kubeletConfig := &datamodel.AKSKubeletConfiguration{
 		APIVersion:    "kubelet.config.k8s.io/v1beta1",

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -599,7 +599,7 @@ func TestGetKubeletConfigFileNodeMemoryHardeningFields(t *testing.T) {
 	kc["--eviction-soft-grace-period"] = "memory.available=30s,nodefs.available=2m,imagefs.available=2m"
 	kc["--eviction-max-pod-grace-period"] = "60"
 	kc["--enforce-node-allocatable"] = "pods,kube-reserved,system-reserved"
-	kc["--kube-reserved-cgroup"] = "/kube-reserved.slice"
+	kc["--kube-reserved-cgroup"] = "/kubereserved.slice"
 	kc["--system-reserved-cgroup"] = "/system.slice"
 
 	configFileStr := GetKubeletConfigFileContent(kc, nil)
@@ -643,8 +643,8 @@ func TestGetKubeletConfigFileNodeMemoryHardeningFields(t *testing.T) {
 		t.Errorf("enforceNodeAllocatable mismatch (-want +got):\n%s", diff)
 	}
 
-	if got.KubeReservedCgroup != "/kube-reserved.slice" {
-		t.Errorf("kubeReservedCgroup=%q, want %q", got.KubeReservedCgroup, "/kube-reserved.slice")
+	if got.KubeReservedCgroup != "/kubereserved.slice" {
+		t.Errorf("kubeReservedCgroup=%q, want %q", got.KubeReservedCgroup, "/kubereserved.slice")
 	}
 	if got.SystemReservedCgroup != "/system.slice" {
 		t.Errorf("systemReservedCgroup=%q, want %q", got.SystemReservedCgroup, "/system.slice")
@@ -669,19 +669,19 @@ func TestSetNodeHardeningCgroupFlags(t *testing.T) {
 			enforceNodeAllocatable:   "pods,kube-reserved,system-reserved",
 			rpKubeReservedCgroup:     "/kubelet.slice", // stale/legacy value the RP might still send
 			rpSystemReservedCgroup:   "/system.slice",
-			wantKubeReservedCgroup:   "/kube-reserved.slice",
+			wantKubeReservedCgroup:   "/kubereserved.slice",
 			wantSystemReservedCgroup: "/system.slice",
 		},
 		{
 			name:                     "hardening enabled with no RP value set",
 			enforceNodeAllocatable:   "pods,kube-reserved,system-reserved",
-			wantKubeReservedCgroup:   "/kube-reserved.slice",
+			wantKubeReservedCgroup:   "/kubereserved.slice",
 			wantSystemReservedCgroup: "/system.slice",
 		},
 		{
 			name:                     "hardening disabled clears any stale RP value",
 			enforceNodeAllocatable:   "pods",
-			rpKubeReservedCgroup:     "/kube-reserved.slice",
+			rpKubeReservedCgroup:     "/kubereserved.slice",
 			rpSystemReservedCgroup:   "/system.slice",
 			wantKubeReservedCgroup:   "",
 			wantSystemReservedCgroup: "",
@@ -694,7 +694,7 @@ func TestSetNodeHardeningCgroupFlags(t *testing.T) {
 		{
 			name:                     "hardening enabled with bracketed list format",
 			enforceNodeAllocatable:   "[pods,kube-reserved,system-reserved]",
-			wantKubeReservedCgroup:   "/kube-reserved.slice",
+			wantKubeReservedCgroup:   "/kubereserved.slice",
 			wantSystemReservedCgroup: "/system.slice",
 		},
 	}

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -599,7 +599,7 @@ func TestGetKubeletConfigFileNodeMemoryHardeningFields(t *testing.T) {
 	kc["--eviction-soft-grace-period"] = "memory.available=30s,nodefs.available=2m,imagefs.available=2m"
 	kc["--eviction-max-pod-grace-period"] = "60"
 	kc["--enforce-node-allocatable"] = "pods,kube-reserved,system-reserved"
-	kc["--kube-reserved-cgroup"] = "/kubelet.slice"
+	kc["--kube-reserved-cgroup"] = "/kube.slice"
 	kc["--system-reserved-cgroup"] = "/system.slice"
 
 	configFileStr := GetKubeletConfigFileContent(kc, nil)
@@ -643,8 +643,8 @@ func TestGetKubeletConfigFileNodeMemoryHardeningFields(t *testing.T) {
 		t.Errorf("enforceNodeAllocatable mismatch (-want +got):\n%s", diff)
 	}
 
-	if got.KubeReservedCgroup != "/kubelet.slice" {
-		t.Errorf("kubeReservedCgroup=%q, want %q", got.KubeReservedCgroup, "/kubelet.slice")
+	if got.KubeReservedCgroup != "/kube.slice" {
+		t.Errorf("kubeReservedCgroup=%q, want %q", got.KubeReservedCgroup, "/kube.slice")
 	}
 	if got.SystemReservedCgroup != "/system.slice" {
 		t.Errorf("systemReservedCgroup=%q, want %q", got.SystemReservedCgroup, "/system.slice")

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -599,7 +599,7 @@ func TestGetKubeletConfigFileNodeMemoryHardeningFields(t *testing.T) {
 	kc["--eviction-soft-grace-period"] = "memory.available=30s,nodefs.available=2m,imagefs.available=2m"
 	kc["--eviction-max-pod-grace-period"] = "60"
 	kc["--enforce-node-allocatable"] = "pods,kube-reserved,system-reserved"
-	kc["--kube-reserved-cgroup"] = "/kube.slice"
+	kc["--kube-reserved-cgroup"] = "/kube-reserved.slice"
 	kc["--system-reserved-cgroup"] = "/system.slice"
 
 	configFileStr := GetKubeletConfigFileContent(kc, nil)
@@ -643,8 +643,8 @@ func TestGetKubeletConfigFileNodeMemoryHardeningFields(t *testing.T) {
 		t.Errorf("enforceNodeAllocatable mismatch (-want +got):\n%s", diff)
 	}
 
-	if got.KubeReservedCgroup != "/kube.slice" {
-		t.Errorf("kubeReservedCgroup=%q, want %q", got.KubeReservedCgroup, "/kube.slice")
+	if got.KubeReservedCgroup != "/kube-reserved.slice" {
+		t.Errorf("kubeReservedCgroup=%q, want %q", got.KubeReservedCgroup, "/kube-reserved.slice")
 	}
 	if got.SystemReservedCgroup != "/system.slice" {
 		t.Errorf("systemReservedCgroup=%q, want %q", got.SystemReservedCgroup, "/system.slice")

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -651,6 +651,79 @@ func TestGetKubeletConfigFileNodeMemoryHardeningFields(t *testing.T) {
 	}
 }
 
+func TestSetNodeHardeningCgroupFlags(t *testing.T) {
+	// AgentBaker, not the RP, must own the cgroup slice names: it overwrites
+	// --kube-reserved-cgroup/--system-reserved-cgroup based solely on whether
+	// --enforce-node-allocatable signals hardening is on, regardless of any
+	// (possibly stale or wrong) value the RP put on those two keys directly.
+	cases := []struct {
+		name                     string
+		enforceNodeAllocatable   string
+		rpKubeReservedCgroup     string
+		rpSystemReservedCgroup   string
+		wantKubeReservedCgroup   string
+		wantSystemReservedCgroup string
+	}{
+		{
+			name:                     "hardening enabled overwrites RP-supplied legacy value",
+			enforceNodeAllocatable:   "pods,kube-reserved,system-reserved",
+			rpKubeReservedCgroup:     "/kubelet.slice", // stale/legacy value the RP might still send
+			rpSystemReservedCgroup:   "/system.slice",
+			wantKubeReservedCgroup:   "/kube-reserved.slice",
+			wantSystemReservedCgroup: "/system.slice",
+		},
+		{
+			name:                     "hardening enabled with no RP value set",
+			enforceNodeAllocatable:   "pods,kube-reserved,system-reserved",
+			wantKubeReservedCgroup:   "/kube-reserved.slice",
+			wantSystemReservedCgroup: "/system.slice",
+		},
+		{
+			name:                     "hardening disabled clears any stale RP value",
+			enforceNodeAllocatable:   "pods",
+			rpKubeReservedCgroup:     "/kube-reserved.slice",
+			rpSystemReservedCgroup:   "/system.slice",
+			wantKubeReservedCgroup:   "",
+			wantSystemReservedCgroup: "",
+		},
+		{
+			name:                     "hardening flags absent entirely",
+			wantKubeReservedCgroup:   "",
+			wantSystemReservedCgroup: "",
+		},
+		{
+			name:                     "hardening enabled with bracketed list format",
+			enforceNodeAllocatable:   "[pods,kube-reserved,system-reserved]",
+			wantKubeReservedCgroup:   "/kube-reserved.slice",
+			wantSystemReservedCgroup: "/system.slice",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			kubeletFlags := map[string]string{}
+			if c.enforceNodeAllocatable != "" {
+				kubeletFlags["--enforce-node-allocatable"] = c.enforceNodeAllocatable
+			}
+			if c.rpKubeReservedCgroup != "" {
+				kubeletFlags["--kube-reserved-cgroup"] = c.rpKubeReservedCgroup
+			}
+			if c.rpSystemReservedCgroup != "" {
+				kubeletFlags["--system-reserved-cgroup"] = c.rpSystemReservedCgroup
+			}
+
+			setNodeHardeningCgroupFlags(kubeletFlags)
+
+			if got := kubeletFlags["--kube-reserved-cgroup"]; got != c.wantKubeReservedCgroup {
+				t.Errorf("--kube-reserved-cgroup=%q, want %q", got, c.wantKubeReservedCgroup)
+			}
+			if got := kubeletFlags["--system-reserved-cgroup"]; got != c.wantSystemReservedCgroup {
+				t.Errorf("--system-reserved-cgroup=%q, want %q", got, c.wantSystemReservedCgroup)
+			}
+		})
+	}
+}
+
 func TestGetKubeletConfigFileNodeMemoryHardeningFieldsOmittedByDefault(t *testing.T) {
 	// Backward-compat: when the RP does not pass the new flags, the generated
 	// kubelet config must NOT contain the new fields. This guards the 6-month

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
@@ -904,7 +904,7 @@ EOF
             The output should include "cgroupv2 unified hierarchy not detected"
         End
 
-        It 'creates kubelet.slice and the kubelet.service drop-in for /kubelet.slice'
+        It 'creates kubelet.slice and the kubelet.service and containerd.service drop-in for /kubelet.slice'
             setup_paths
             systemctl() { return 0; }
             KUBE_RESERVED_CGROUP="/kubelet.slice"
@@ -922,6 +922,25 @@ EOF
             The variable dropin_contents should include "Slice=kubelet.slice"
             The variable containerd_dropin_contents should include "Wants=kubelet.slice"
             The variable containerd_dropin_contents should include "After=kubelet.slice"
+            The variable containerd_dropin_contents should include "Slice=kubelet.slice"
+        End
+
+        It 'creates drop-ins even when kubelet.slice already exists (upgrade scenario)'
+            setup_paths
+            # Pre-create kubelet.slice to simulate an older VHD that already has it
+            mkdir -p "$(dirname "${KUBELET_SLICE_UNIT_PATH}")"
+            echo "[Unit]" > "${KUBELET_SLICE_UNIT_PATH}"
+            systemctl() { return 0; }
+            KUBE_RESERVED_CGROUP="/kubelet.slice"
+            SYSTEM_RESERVED_CGROUP="/system.slice"
+            When call ensureKubeletCgroupHierarchy
+            dropin_contents=$(cat "${KUBELET_SERVICE_DROPIN_DIR}/10-kubelet-slice.conf" 2>/dev/null)
+            containerd_dropin_contents=$(cat "${CONTAINERD_SERVICE_DROPIN_DIR}/10-kubelet-slice.conf" 2>/dev/null)
+            cleanup_paths
+            The status should be success
+            The variable dropin_contents should include "Wants=kubelet.slice"
+            The variable dropin_contents should include "Slice=kubelet.slice"
+            The variable containerd_dropin_contents should include "Wants=kubelet.slice"
             The variable containerd_dropin_contents should include "Slice=kubelet.slice"
         End
 

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
@@ -819,9 +819,9 @@ EOF
         It 'extracts cgroup names from KUBELET_FLAGS in flag mode'
             KUBELET_CONFIG_FILE_ENABLED="false"
             KUBELET_CONFIG_FILE_CONTENT=""
-            KUBELET_FLAGS="--kube-reserved-cgroup=/kube-reserved.slice --system-reserved-cgroup=/system.slice --node-ip=10.0.0.1"
+            KUBELET_FLAGS="--kube-reserved-cgroup=/kubereserved.slice --system-reserved-cgroup=/system.slice --node-ip=10.0.0.1"
             When call resolveKubeletReservedCgroups
-            The variable KUBE_RESERVED_CGROUP should equal "/kube-reserved.slice"
+            The variable KUBE_RESERVED_CGROUP should equal "/kubereserved.slice"
             The variable SYSTEM_RESERVED_CGROUP should equal "/system.slice"
             The status should be success
         End
@@ -832,7 +832,7 @@ EOF
             # Even though flags carry the values, config-file mode must win.
             KUBELET_FLAGS="--kube-reserved-cgroup=/wrong.slice --system-reserved-cgroup=/wrong.slice"
             When call resolveKubeletReservedCgroups
-            The variable KUBE_RESERVED_CGROUP should equal "/kube-reserved.slice"
+            The variable KUBE_RESERVED_CGROUP should equal "/kubereserved.slice"
             The variable SYSTEM_RESERVED_CGROUP should equal "/system.slice"
             The status should be success
         End
@@ -856,7 +856,7 @@ EOF
         setup_paths() {
             ENSURE_CGROUP_TMPDIR=$(mktemp -d)
             export CGROUPV2_MARKER_PATH="${ENSURE_CGROUP_TMPDIR}/cgroup.controllers"
-            export KUBE_RESERVED_SLICE_UNIT_PATH="${ENSURE_CGROUP_TMPDIR}/kube-reserved.slice"
+            export KUBE_RESERVED_SLICE_UNIT_PATH="${ENSURE_CGROUP_TMPDIR}/kubereserved.slice"
             export KUBELET_SERVICE_DROPIN_DIR="${ENSURE_CGROUP_TMPDIR}/kubelet.service.d"
             export CONTAINERD_SERVICE_DROPIN_DIR="${ENSURE_CGROUP_TMPDIR}/containerd.service.d"
             : > "${CGROUPV2_MARKER_PATH}" # cgroupv2 present by default
@@ -896,7 +896,7 @@ EOF
         It 'fails when the cgroupv2 unified hierarchy is not detected'
             setup_paths
             rm -f "${CGROUPV2_MARKER_PATH}"
-            KUBE_RESERVED_CGROUP="/kube-reserved.slice"
+            KUBE_RESERVED_CGROUP="/kubereserved.slice"
             SYSTEM_RESERVED_CGROUP=""
             When call ensureKubeletCgroupHierarchy
             cleanup_paths
@@ -904,28 +904,28 @@ EOF
             The output should include "cgroupv2 unified hierarchy not detected"
         End
 
-        It 'creates kube-reserved.slice and the kubelet.service and containerd.service drop-ins'
+        It 'creates kubereserved.slice and the kubelet.service and containerd.service drop-ins'
             setup_paths
             systemctl() { return 0; }
-            KUBE_RESERVED_CGROUP="/kube-reserved.slice"
+            KUBE_RESERVED_CGROUP="/kubereserved.slice"
             SYSTEM_RESERVED_CGROUP="/system.slice"
             When call ensureKubeletCgroupHierarchy
             slice_contents=$(cat "${KUBE_RESERVED_SLICE_UNIT_PATH}" 2>/dev/null)
-            dropin_contents=$(cat "${KUBELET_SERVICE_DROPIN_DIR}/10-kube-reserved-slice.conf" 2>/dev/null)
-            containerd_dropin_contents=$(cat "${CONTAINERD_SERVICE_DROPIN_DIR}/10-kube-reserved-slice.conf" 2>/dev/null)
+            dropin_contents=$(cat "${KUBELET_SERVICE_DROPIN_DIR}/10-kubereserved-slice.conf" 2>/dev/null)
+            containerd_dropin_contents=$(cat "${CONTAINERD_SERVICE_DROPIN_DIR}/10-kubereserved-slice.conf" 2>/dev/null)
             cleanup_paths
             The status should be success
             The variable slice_contents should include "Description=Slice for kube-reserved enforcement"
             The variable slice_contents should include "WantedBy=slices.target"
-            The variable dropin_contents should include "Wants=kube-reserved.slice"
-            The variable dropin_contents should include "After=kube-reserved.slice"
-            The variable dropin_contents should include "Slice=kube-reserved.slice"
-            The variable containerd_dropin_contents should include "Wants=kube-reserved.slice"
-            The variable containerd_dropin_contents should include "After=kube-reserved.slice"
-            The variable containerd_dropin_contents should include "Slice=kube-reserved.slice"
+            The variable dropin_contents should include "Wants=kubereserved.slice"
+            The variable dropin_contents should include "After=kubereserved.slice"
+            The variable dropin_contents should include "Slice=kubereserved.slice"
+            The variable containerd_dropin_contents should include "Wants=kubereserved.slice"
+            The variable containerd_dropin_contents should include "After=kubereserved.slice"
+            The variable containerd_dropin_contents should include "Slice=kubereserved.slice"
         End
 
-        It 'returns failure when systemctl enable kube-reserved.slice fails'
+        It 'returns failure when systemctl enable kubereserved.slice fails'
             setup_paths
             systemctl() {
                 if [ "$1" = "enable" ]; then
@@ -933,15 +933,15 @@ EOF
                 fi
                 return 0
             }
-            KUBE_RESERVED_CGROUP="/kube-reserved.slice"
+            KUBE_RESERVED_CGROUP="/kubereserved.slice"
             SYSTEM_RESERVED_CGROUP=""
             When call ensureKubeletCgroupHierarchy
             cleanup_paths
             The status should be failure
-            The output should include "failed to enable kube-reserved.slice"
+            The output should include "failed to enable kubereserved.slice"
         End
 
-        It 'returns failure when systemctl start kube-reserved.slice fails'
+        It 'returns failure when systemctl start kubereserved.slice fails'
             setup_paths
             systemctl() {
                 if [ "$1" = "start" ]; then
@@ -949,12 +949,12 @@ EOF
                 fi
                 return 0
             }
-            KUBE_RESERVED_CGROUP="/kube-reserved.slice"
+            KUBE_RESERVED_CGROUP="/kubereserved.slice"
             SYSTEM_RESERVED_CGROUP=""
             When call ensureKubeletCgroupHierarchy
             cleanup_paths
             The status should be failure
-            The output should include "failed to start kube-reserved.slice"
+            The output should include "failed to start kubereserved.slice"
         End
     End
 End

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
@@ -858,6 +858,7 @@ EOF
             export CGROUPV2_MARKER_PATH="${ENSURE_CGROUP_TMPDIR}/cgroup.controllers"
             export KUBELET_SLICE_UNIT_PATH="${ENSURE_CGROUP_TMPDIR}/kubelet.slice"
             export KUBELET_SERVICE_DROPIN_DIR="${ENSURE_CGROUP_TMPDIR}/kubelet.service.d"
+            export CONTAINERD_SERVICE_DROPIN_DIR="${ENSURE_CGROUP_TMPDIR}/containerd.service.d"
             : > "${CGROUPV2_MARKER_PATH}" # cgroupv2 present by default
         }
         cleanup_paths() {
@@ -911,12 +912,17 @@ EOF
             When call ensureKubeletCgroupHierarchy
             slice_contents=$(cat "${KUBELET_SLICE_UNIT_PATH}" 2>/dev/null)
             dropin_contents=$(cat "${KUBELET_SERVICE_DROPIN_DIR}/10-kubelet-slice.conf" 2>/dev/null)
+            containerd_dropin_contents=$(cat "${CONTAINERD_SERVICE_DROPIN_DIR}/10-kubelet-slice.conf" 2>/dev/null)
             cleanup_paths
             The status should be success
             The variable slice_contents should include "Description=Slice for kubelet kube-reserved enforcement"
             The variable slice_contents should include "WantedBy=slices.target"
             The variable dropin_contents should include "Wants=kubelet.slice"
             The variable dropin_contents should include "After=kubelet.slice"
+            The variable dropin_contents should include "Slice=kubelet.slice"
+            The variable containerd_dropin_contents should include "Wants=kubelet.slice"
+            The variable containerd_dropin_contents should include "After=kubelet.slice"
+            The variable containerd_dropin_contents should include "Slice=kubelet.slice"
         End
 
         It 'returns failure when systemctl enable kubelet.slice fails'

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
@@ -857,6 +857,7 @@ EOF
             ENSURE_CGROUP_TMPDIR=$(mktemp -d)
             export CGROUPV2_MARKER_PATH="${ENSURE_CGROUP_TMPDIR}/cgroup.controllers"
             export KUBELET_SLICE_UNIT_PATH="${ENSURE_CGROUP_TMPDIR}/kubelet.slice"
+            export CONTAINERD_SLICE_UNIT_PATH="${ENSURE_CGROUP_TMPDIR}/containerd.slice"
             export KUBELET_SERVICE_DROPIN_DIR="${ENSURE_CGROUP_TMPDIR}/kubelet.service.d"
             export CONTAINERD_SERVICE_DROPIN_DIR="${ENSURE_CGROUP_TMPDIR}/containerd.service.d"
             : > "${CGROUPV2_MARKER_PATH}" # cgroupv2 present by default
@@ -904,25 +905,28 @@ EOF
             The output should include "cgroupv2 unified hierarchy not detected"
         End
 
-        It 'creates kubelet.slice and the kubelet.service and containerd.service drop-in for /kubelet.slice'
+        It 'creates kubelet.slice, containerd.slice, and the kubelet.service and containerd.service drop-ins'
             setup_paths
             systemctl() { return 0; }
             KUBE_RESERVED_CGROUP="/kubelet.slice"
             SYSTEM_RESERVED_CGROUP="/system.slice"
             When call ensureKubeletCgroupHierarchy
             slice_contents=$(cat "${KUBELET_SLICE_UNIT_PATH}" 2>/dev/null)
+            containerd_slice_contents=$(cat "${CONTAINERD_SLICE_UNIT_PATH}" 2>/dev/null)
             dropin_contents=$(cat "${KUBELET_SERVICE_DROPIN_DIR}/10-kubelet-slice.conf" 2>/dev/null)
-            containerd_dropin_contents=$(cat "${CONTAINERD_SERVICE_DROPIN_DIR}/10-kubelet-slice.conf" 2>/dev/null)
+            containerd_dropin_contents=$(cat "${CONTAINERD_SERVICE_DROPIN_DIR}/10-containerd-slice.conf" 2>/dev/null)
             cleanup_paths
             The status should be success
             The variable slice_contents should include "Description=Slice for kubelet kube-reserved enforcement"
             The variable slice_contents should include "WantedBy=slices.target"
+            The variable containerd_slice_contents should include "Description=Slice for containerd cgroup isolation"
+            The variable containerd_slice_contents should include "WantedBy=slices.target"
             The variable dropin_contents should include "Wants=kubelet.slice"
             The variable dropin_contents should include "After=kubelet.slice"
             The variable dropin_contents should include "Slice=kubelet.slice"
-            The variable containerd_dropin_contents should include "Wants=kubelet.slice"
-            The variable containerd_dropin_contents should include "After=kubelet.slice"
-            The variable containerd_dropin_contents should include "Slice=kubelet.slice"
+            The variable containerd_dropin_contents should include "Wants=containerd.slice"
+            The variable containerd_dropin_contents should include "After=containerd.slice"
+            The variable containerd_dropin_contents should include "Slice=containerd.slice"
         End
 
         It 'returns failure when systemctl enable kubelet.slice fails'

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
@@ -925,25 +925,6 @@ EOF
             The variable containerd_dropin_contents should include "Slice=kubelet.slice"
         End
 
-        It 'creates drop-ins even when kubelet.slice already exists (upgrade scenario)'
-            setup_paths
-            # Pre-create kubelet.slice to simulate an older VHD that already has it
-            mkdir -p "$(dirname "${KUBELET_SLICE_UNIT_PATH}")"
-            echo "[Unit]" > "${KUBELET_SLICE_UNIT_PATH}"
-            systemctl() { return 0; }
-            KUBE_RESERVED_CGROUP="/kubelet.slice"
-            SYSTEM_RESERVED_CGROUP="/system.slice"
-            When call ensureKubeletCgroupHierarchy
-            dropin_contents=$(cat "${KUBELET_SERVICE_DROPIN_DIR}/10-kubelet-slice.conf" 2>/dev/null)
-            containerd_dropin_contents=$(cat "${CONTAINERD_SERVICE_DROPIN_DIR}/10-kubelet-slice.conf" 2>/dev/null)
-            cleanup_paths
-            The status should be success
-            The variable dropin_contents should include "Wants=kubelet.slice"
-            The variable dropin_contents should include "Slice=kubelet.slice"
-            The variable containerd_dropin_contents should include "Wants=kubelet.slice"
-            The variable containerd_dropin_contents should include "Slice=kubelet.slice"
-        End
-
         It 'returns failure when systemctl enable kubelet.slice fails'
             setup_paths
             systemctl() {

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
@@ -907,6 +907,7 @@ EOF
         It 'creates kubereserved.slice and the kubelet.service and containerd.service drop-ins'
             setup_paths
             systemctl() { return 0; }
+            systemctlEnableAndStart() { return 0; }
             KUBE_RESERVED_CGROUP="/kubereserved.slice"
             SYSTEM_RESERVED_CGROUP="/system.slice"
             When call ensureKubeletCgroupHierarchy
@@ -925,36 +926,16 @@ EOF
             The variable containerd_dropin_contents should include "Slice=kubereserved.slice"
         End
 
-        It 'returns failure when systemctl enable kubereserved.slice fails'
+        It 'returns failure when systemctlEnableAndStart kubereserved.slice fails'
             setup_paths
-            systemctl() {
-                if [ "$1" = "enable" ]; then
-                    return 1
-                fi
-                return 0
-            }
+            systemctl() { return 0; }
+            systemctlEnableAndStart() { return 1; }
             KUBE_RESERVED_CGROUP="/kubereserved.slice"
             SYSTEM_RESERVED_CGROUP=""
             When call ensureKubeletCgroupHierarchy
             cleanup_paths
             The status should be failure
-            The output should include "failed to enable kubereserved.slice"
-        End
-
-        It 'returns failure when systemctl start kubereserved.slice fails'
-            setup_paths
-            systemctl() {
-                if [ "$1" = "start" ]; then
-                    return 1
-                fi
-                return 0
-            }
-            KUBE_RESERVED_CGROUP="/kubereserved.slice"
-            SYSTEM_RESERVED_CGROUP=""
-            When call ensureKubeletCgroupHierarchy
-            cleanup_paths
-            The status should be failure
-            The output should include "failed to start kubereserved.slice"
+            The output should include "failed to enable and start kubereserved.slice"
         End
     End
 End

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
@@ -819,9 +819,9 @@ EOF
         It 'extracts cgroup names from KUBELET_FLAGS in flag mode'
             KUBELET_CONFIG_FILE_ENABLED="false"
             KUBELET_CONFIG_FILE_CONTENT=""
-            KUBELET_FLAGS="--kube-reserved-cgroup=/kube.slice --system-reserved-cgroup=/system.slice --node-ip=10.0.0.1"
+            KUBELET_FLAGS="--kube-reserved-cgroup=/kube-reserved.slice --system-reserved-cgroup=/system.slice --node-ip=10.0.0.1"
             When call resolveKubeletReservedCgroups
-            The variable KUBE_RESERVED_CGROUP should equal "/kube.slice"
+            The variable KUBE_RESERVED_CGROUP should equal "/kube-reserved.slice"
             The variable SYSTEM_RESERVED_CGROUP should equal "/system.slice"
             The status should be success
         End
@@ -832,7 +832,7 @@ EOF
             # Even though flags carry the values, config-file mode must win.
             KUBELET_FLAGS="--kube-reserved-cgroup=/wrong.slice --system-reserved-cgroup=/wrong.slice"
             When call resolveKubeletReservedCgroups
-            The variable KUBE_RESERVED_CGROUP should equal "/kube.slice"
+            The variable KUBE_RESERVED_CGROUP should equal "/kube-reserved.slice"
             The variable SYSTEM_RESERVED_CGROUP should equal "/system.slice"
             The status should be success
         End
@@ -856,7 +856,7 @@ EOF
         setup_paths() {
             ENSURE_CGROUP_TMPDIR=$(mktemp -d)
             export CGROUPV2_MARKER_PATH="${ENSURE_CGROUP_TMPDIR}/cgroup.controllers"
-            export KUBE_SLICE_UNIT_PATH="${ENSURE_CGROUP_TMPDIR}/kube.slice"
+            export KUBE_RESERVED_SLICE_UNIT_PATH="${ENSURE_CGROUP_TMPDIR}/kube-reserved.slice"
             export KUBELET_SERVICE_DROPIN_DIR="${ENSURE_CGROUP_TMPDIR}/kubelet.service.d"
             export CONTAINERD_SERVICE_DROPIN_DIR="${ENSURE_CGROUP_TMPDIR}/containerd.service.d"
             : > "${CGROUPV2_MARKER_PATH}" # cgroupv2 present by default
@@ -896,7 +896,7 @@ EOF
         It 'fails when the cgroupv2 unified hierarchy is not detected'
             setup_paths
             rm -f "${CGROUPV2_MARKER_PATH}"
-            KUBE_RESERVED_CGROUP="/kube.slice"
+            KUBE_RESERVED_CGROUP="/kube-reserved.slice"
             SYSTEM_RESERVED_CGROUP=""
             When call ensureKubeletCgroupHierarchy
             cleanup_paths
@@ -904,28 +904,28 @@ EOF
             The output should include "cgroupv2 unified hierarchy not detected"
         End
 
-        It 'creates kube.slice and the kubelet.service and containerd.service drop-ins'
+        It 'creates kube-reserved.slice and the kubelet.service and containerd.service drop-ins'
             setup_paths
             systemctl() { return 0; }
-            KUBE_RESERVED_CGROUP="/kube.slice"
+            KUBE_RESERVED_CGROUP="/kube-reserved.slice"
             SYSTEM_RESERVED_CGROUP="/system.slice"
             When call ensureKubeletCgroupHierarchy
-            slice_contents=$(cat "${KUBE_SLICE_UNIT_PATH}" 2>/dev/null)
-            dropin_contents=$(cat "${KUBELET_SERVICE_DROPIN_DIR}/10-kube-slice.conf" 2>/dev/null)
-            containerd_dropin_contents=$(cat "${CONTAINERD_SERVICE_DROPIN_DIR}/10-kube-slice.conf" 2>/dev/null)
+            slice_contents=$(cat "${KUBE_RESERVED_SLICE_UNIT_PATH}" 2>/dev/null)
+            dropin_contents=$(cat "${KUBELET_SERVICE_DROPIN_DIR}/10-kube-reserved-slice.conf" 2>/dev/null)
+            containerd_dropin_contents=$(cat "${CONTAINERD_SERVICE_DROPIN_DIR}/10-kube-reserved-slice.conf" 2>/dev/null)
             cleanup_paths
             The status should be success
             The variable slice_contents should include "Description=Slice for kube-reserved enforcement"
             The variable slice_contents should include "WantedBy=slices.target"
-            The variable dropin_contents should include "Wants=kube.slice"
-            The variable dropin_contents should include "After=kube.slice"
-            The variable dropin_contents should include "Slice=kube.slice"
-            The variable containerd_dropin_contents should include "Wants=kube.slice"
-            The variable containerd_dropin_contents should include "After=kube.slice"
-            The variable containerd_dropin_contents should include "Slice=kube.slice"
+            The variable dropin_contents should include "Wants=kube-reserved.slice"
+            The variable dropin_contents should include "After=kube-reserved.slice"
+            The variable dropin_contents should include "Slice=kube-reserved.slice"
+            The variable containerd_dropin_contents should include "Wants=kube-reserved.slice"
+            The variable containerd_dropin_contents should include "After=kube-reserved.slice"
+            The variable containerd_dropin_contents should include "Slice=kube-reserved.slice"
         End
 
-        It 'returns failure when systemctl enable kube.slice fails'
+        It 'returns failure when systemctl enable kube-reserved.slice fails'
             setup_paths
             systemctl() {
                 if [ "$1" = "enable" ]; then
@@ -933,15 +933,15 @@ EOF
                 fi
                 return 0
             }
-            KUBE_RESERVED_CGROUP="/kube.slice"
+            KUBE_RESERVED_CGROUP="/kube-reserved.slice"
             SYSTEM_RESERVED_CGROUP=""
             When call ensureKubeletCgroupHierarchy
             cleanup_paths
             The status should be failure
-            The output should include "failed to enable kube.slice"
+            The output should include "failed to enable kube-reserved.slice"
         End
 
-        It 'returns failure when systemctl start kube.slice fails'
+        It 'returns failure when systemctl start kube-reserved.slice fails'
             setup_paths
             systemctl() {
                 if [ "$1" = "start" ]; then
@@ -949,12 +949,12 @@ EOF
                 fi
                 return 0
             }
-            KUBE_RESERVED_CGROUP="/kube.slice"
+            KUBE_RESERVED_CGROUP="/kube-reserved.slice"
             SYSTEM_RESERVED_CGROUP=""
             When call ensureKubeletCgroupHierarchy
             cleanup_paths
             The status should be failure
-            The output should include "failed to start kube.slice"
+            The output should include "failed to start kube-reserved.slice"
         End
     End
 End

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
@@ -819,9 +819,9 @@ EOF
         It 'extracts cgroup names from KUBELET_FLAGS in flag mode'
             KUBELET_CONFIG_FILE_ENABLED="false"
             KUBELET_CONFIG_FILE_CONTENT=""
-            KUBELET_FLAGS="--kube-reserved-cgroup=/kubelet.slice --system-reserved-cgroup=/system.slice --node-ip=10.0.0.1"
+            KUBELET_FLAGS="--kube-reserved-cgroup=/kube.slice --system-reserved-cgroup=/system.slice --node-ip=10.0.0.1"
             When call resolveKubeletReservedCgroups
-            The variable KUBE_RESERVED_CGROUP should equal "/kubelet.slice"
+            The variable KUBE_RESERVED_CGROUP should equal "/kube.slice"
             The variable SYSTEM_RESERVED_CGROUP should equal "/system.slice"
             The status should be success
         End
@@ -832,7 +832,7 @@ EOF
             # Even though flags carry the values, config-file mode must win.
             KUBELET_FLAGS="--kube-reserved-cgroup=/wrong.slice --system-reserved-cgroup=/wrong.slice"
             When call resolveKubeletReservedCgroups
-            The variable KUBE_RESERVED_CGROUP should equal "/kubelet.slice"
+            The variable KUBE_RESERVED_CGROUP should equal "/kube.slice"
             The variable SYSTEM_RESERVED_CGROUP should equal "/system.slice"
             The status should be success
         End
@@ -856,8 +856,7 @@ EOF
         setup_paths() {
             ENSURE_CGROUP_TMPDIR=$(mktemp -d)
             export CGROUPV2_MARKER_PATH="${ENSURE_CGROUP_TMPDIR}/cgroup.controllers"
-            export KUBELET_SLICE_UNIT_PATH="${ENSURE_CGROUP_TMPDIR}/kubelet.slice"
-            export CONTAINERD_SLICE_UNIT_PATH="${ENSURE_CGROUP_TMPDIR}/containerd.slice"
+            export KUBE_SLICE_UNIT_PATH="${ENSURE_CGROUP_TMPDIR}/kube.slice"
             export KUBELET_SERVICE_DROPIN_DIR="${ENSURE_CGROUP_TMPDIR}/kubelet.service.d"
             export CONTAINERD_SERVICE_DROPIN_DIR="${ENSURE_CGROUP_TMPDIR}/containerd.service.d"
             : > "${CGROUPV2_MARKER_PATH}" # cgroupv2 present by default
@@ -897,7 +896,7 @@ EOF
         It 'fails when the cgroupv2 unified hierarchy is not detected'
             setup_paths
             rm -f "${CGROUPV2_MARKER_PATH}"
-            KUBE_RESERVED_CGROUP="/kubelet.slice"
+            KUBE_RESERVED_CGROUP="/kube.slice"
             SYSTEM_RESERVED_CGROUP=""
             When call ensureKubeletCgroupHierarchy
             cleanup_paths
@@ -905,31 +904,28 @@ EOF
             The output should include "cgroupv2 unified hierarchy not detected"
         End
 
-        It 'creates kubelet.slice, containerd.slice, and the kubelet.service and containerd.service drop-ins'
+        It 'creates kube.slice and the kubelet.service and containerd.service drop-ins'
             setup_paths
             systemctl() { return 0; }
-            KUBE_RESERVED_CGROUP="/kubelet.slice"
+            KUBE_RESERVED_CGROUP="/kube.slice"
             SYSTEM_RESERVED_CGROUP="/system.slice"
             When call ensureKubeletCgroupHierarchy
-            slice_contents=$(cat "${KUBELET_SLICE_UNIT_PATH}" 2>/dev/null)
-            containerd_slice_contents=$(cat "${CONTAINERD_SLICE_UNIT_PATH}" 2>/dev/null)
-            dropin_contents=$(cat "${KUBELET_SERVICE_DROPIN_DIR}/10-kubelet-slice.conf" 2>/dev/null)
-            containerd_dropin_contents=$(cat "${CONTAINERD_SERVICE_DROPIN_DIR}/10-containerd-slice.conf" 2>/dev/null)
+            slice_contents=$(cat "${KUBE_SLICE_UNIT_PATH}" 2>/dev/null)
+            dropin_contents=$(cat "${KUBELET_SERVICE_DROPIN_DIR}/10-kube-slice.conf" 2>/dev/null)
+            containerd_dropin_contents=$(cat "${CONTAINERD_SERVICE_DROPIN_DIR}/10-kube-slice.conf" 2>/dev/null)
             cleanup_paths
             The status should be success
-            The variable slice_contents should include "Description=Slice for kubelet kube-reserved enforcement"
+            The variable slice_contents should include "Description=Slice for kube-reserved enforcement"
             The variable slice_contents should include "WantedBy=slices.target"
-            The variable containerd_slice_contents should include "Description=Slice for containerd cgroup isolation"
-            The variable containerd_slice_contents should include "WantedBy=slices.target"
-            The variable dropin_contents should include "Wants=kubelet.slice"
-            The variable dropin_contents should include "After=kubelet.slice"
-            The variable dropin_contents should include "Slice=kubelet.slice"
-            The variable containerd_dropin_contents should include "Wants=containerd.slice"
-            The variable containerd_dropin_contents should include "After=containerd.slice"
-            The variable containerd_dropin_contents should include "Slice=containerd.slice"
+            The variable dropin_contents should include "Wants=kube.slice"
+            The variable dropin_contents should include "After=kube.slice"
+            The variable dropin_contents should include "Slice=kube.slice"
+            The variable containerd_dropin_contents should include "Wants=kube.slice"
+            The variable containerd_dropin_contents should include "After=kube.slice"
+            The variable containerd_dropin_contents should include "Slice=kube.slice"
         End
 
-        It 'returns failure when systemctl enable kubelet.slice fails'
+        It 'returns failure when systemctl enable kube.slice fails'
             setup_paths
             systemctl() {
                 if [ "$1" = "enable" ]; then
@@ -937,15 +933,15 @@ EOF
                 fi
                 return 0
             }
-            KUBE_RESERVED_CGROUP="/kubelet.slice"
+            KUBE_RESERVED_CGROUP="/kube.slice"
             SYSTEM_RESERVED_CGROUP=""
             When call ensureKubeletCgroupHierarchy
             cleanup_paths
             The status should be failure
-            The output should include "failed to enable kubelet.slice"
+            The output should include "failed to enable kube.slice"
         End
 
-        It 'returns failure when systemctl start kubelet.slice fails'
+        It 'returns failure when systemctl start kube.slice fails'
             setup_paths
             systemctl() {
                 if [ "$1" = "start" ]; then
@@ -953,12 +949,12 @@ EOF
                 fi
                 return 0
             }
-            KUBE_RESERVED_CGROUP="/kubelet.slice"
+            KUBE_RESERVED_CGROUP="/kube.slice"
             SYSTEM_RESERVED_CGROUP=""
             When call ensureKubeletCgroupHierarchy
             cleanup_paths
             The status should be failure
-            The output should include "failed to start kubelet.slice"
+            The output should include "failed to start kube.slice"
         End
     End
 End

--- a/spec/parts/linux/cloud-init/artifacts/kubelet_mocks/config_file/node_hardening_enabled.json
+++ b/spec/parts/linux/cloud-init/artifacts/kubelet_mocks/config_file/node_hardening_enabled.json
@@ -1,6 +1,6 @@
 {
     "kind": "KubeletConfiguration",
     "apiVersion": "kubelet.config.k8s.io/v1beta1",
-    "kubeReservedCgroup": "/kube.slice",
+    "kubeReservedCgroup": "/kube-reserved.slice",
     "systemReservedCgroup": "/system.slice"
 }

--- a/spec/parts/linux/cloud-init/artifacts/kubelet_mocks/config_file/node_hardening_enabled.json
+++ b/spec/parts/linux/cloud-init/artifacts/kubelet_mocks/config_file/node_hardening_enabled.json
@@ -1,6 +1,6 @@
 {
     "kind": "KubeletConfiguration",
     "apiVersion": "kubelet.config.k8s.io/v1beta1",
-    "kubeReservedCgroup": "/kubelet.slice",
+    "kubeReservedCgroup": "/kube.slice",
     "systemReservedCgroup": "/system.slice"
 }

--- a/spec/parts/linux/cloud-init/artifacts/kubelet_mocks/config_file/node_hardening_enabled.json
+++ b/spec/parts/linux/cloud-init/artifacts/kubelet_mocks/config_file/node_hardening_enabled.json
@@ -1,6 +1,6 @@
 {
     "kind": "KubeletConfiguration",
     "apiVersion": "kubelet.config.k8s.io/v1beta1",
-    "kubeReservedCgroup": "/kube-reserved.slice",
+    "kubeReservedCgroup": "/kubereserved.slice",
     "systemReservedCgroup": "/system.slice"
 }


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:

  When node hardening is enabled, `ensureKubeletCgroupHierarchy()` creates a dedicated `kubelet.slice` for kube-reserved cgroup enforcement. However the existing drop-in for `kubelet.service` only declared `Wants=` and `After=` ordering — it did **not** set `Slice=kubelet.slice`, so kubelet remained in `system.slice`. Additionally, `containerd.service` had no drop-in at all and was never placed in the slice.

  This PR fixes both issues:

  1. Adds `Slice=kubelet.slice` to the kubelet drop-in so kubelet actually runs inside the dedicated slice.
  2. Creates an equivalent drop-in for `containerd.service` (`10-kubelet-slice.conf`) so containerd is co-located in the same slice.

  Without this fix, cgroup resource accounting under `kubelet.slice` is incomplete — node hardening's `kube-reserved` budget doesn't capture the real resource usage of `kubelet` and `containerd`, which blocks nodes to be ready since they are affected to `system.slice` which has a low max memory limit

  **Testing**:

  - Updated ShellSpec tests to validate both drop-ins are written with the
    correct `[Service] Slice=kubelet.slice` directive.
  - ```
     $ systemctl status containerd | grep "CGroup"
     CGroup: /kubelet.slice/containerd.service
     $ systemctl status kubelet | grep "CGroup"
     CGroup: /kubelet.slice/kubelet.service
     ```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
