### PR TITLE
fix: bump moby-containerd to 2.3.2-ubuntu24.04u2 for Ubuntu 24.04

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1069,7 +1069,7 @@
             "versionsV2": [
               {
                 "renovateTag": "name=moby-containerd, repository=production, os=ubuntu, release=24.04",
-                "latestVersion": "2.3.2-ubuntu24.04u1"
+                "latestVersion": "2.3.2-ubuntu24.04u2"
               }
             ]
           },


### PR DESCRIPTION
## Summary
Bump moby-containerd version from `2.3.2-ubuntu24.04u1` to `2.3.2-ubuntu24.04u2` for Ubuntu 24.04 in `components.json`.

## Why
PMC published `moby-containerd 2.3.2-ubuntu24.04u2` on July 14. The VHD build installs containerd via apt wildcard (`moby-containerd=2.3.2*` in `cse_install_ubuntu.sh:611`), so it picks up the latest `u2` package. However, `components.json` still referenced `u1`.

The e2e validator (`ValidateInstalledPackageVersion` in `validators.go:1056`) does an exact string match of the version from `components.json` against `apt list --installed` output:
- Expected (from components.json): `2.3.2-ubuntu24.04u1`
- Actual (on VHD): `2.3.2-ubuntu24.04u2`
- Result: match fails → `Test_Ubuntu2404Gen2_McrChinaCloud` fails

The VHD content test (`linux-vhd-content-test.sh:2004`) only compares `major.minor.patch` (`cut -d- -f1` strips the hotfix suffix), so VHD builds pass but e2e fails.

This blocks **all PRs** that trigger the `AKS Linux VHD Build - PR check-in gate` required check.

Confirmed by SSH into a 2404 VHD-based VM:
```
$ apt list --installed 2>/dev/null | grep containerd
moby-containerd/noble,now 2.3.2-ubuntu24.04u2 amd64 [installed,upgradable to: 2.3.3-ubuntu24.04u2]
```

## Follow-up items
1. **Fix version pinning in VHD build**: `installContainerdWithAptGet` (`cse_install_ubuntu.sh:567`) and `downloadContainerdFromVersion` (`cse_install_ubuntu.sh:611`) use wildcard matching (`moby-containerd=2.3.2*`), discarding the hotfix suffix parsed from `components.json`. This should pin to the exact version to prevent future drift.
2. **Align content test with e2e validator**: The VHD content test (`linux-vhd-content-test.sh:2004`) only validates `major.minor.patch`, while the e2e validator checks the full version string. These should be consistent to catch mismatches earlier.

## Test plan
- [x] SSH into 2404 VHD VM and confirmed `apt list --installed` shows `2.3.2-ubuntu24.04u2`
- [x] `AKS Linux VHD Build - PR check-in gate` e2e passes with this change