### PR TITLE
fix: add credential provider config for custom cloud network isolated clusters

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1579,6 +1579,17 @@ writeCredentialProviderConfig() {
       - ${arg}"
         done
     fi
+    # Network isolated cluster required match image and registry args
+    local bootstrap_container_registry_match_image=""
+    local bootstrap_container_registry_args=""
+    if [ -n "${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}" ]; then
+            MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE:=mcr.microsoft.com}"
+            MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE%/}"
+            bootstrap_container_registry_match_image="
+        - \"${MCR_REPOSITORY_BASE}\""
+            bootstrap_container_registry_args="
+        - --registry-mirror=${MCR_REPOSITORY_BASE}:${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}"
+    fi
 
     if [ -n "$AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX" ]; then
         echo "configure credential provider for custom cloud"
@@ -1596,11 +1607,11 @@ providers:
       - "*.*.geo.azurecr.cn"
       - "*.*.geo.azurecr.de"
       - "*.*.geo.azurecr.us"
-      - "*$AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX"
+      - "*$AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX"${bootstrap_container_registry_match_image}
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1${ib_token_attributes}
     args:
-      - /etc/kubernetes/azure.json${ib_args}
+      - /etc/kubernetes/azure.json${bootstrap_container_registry_args}${ib_args}
 EOF
     else
         echo "configure credential provider with default settings"
@@ -1617,20 +1628,12 @@ providers:
       - "*.*.geo.azurecr.io"
       - "*.*.geo.azurecr.cn"
       - "*.*.geo.azurecr.de"
-      - "*.*.geo.azurecr.us"
+      - "*.*.geo.azurecr.us"${bootstrap_container_registry_match_image}
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1${ib_token_attributes}
     args:
-      - /etc/kubernetes/azure.json${ib_args}
+      - /etc/kubernetes/azure.json${bootstrap_container_registry_args}${ib_args}
 EOF
-    fi
-    # append network isolated cluster configs
-    if [ -n "${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}" ]; then
-        MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE:=mcr.microsoft.com}"
-        MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE%/}"
-
-        sed -i "/^    matchImages:$/a\\      - \"${MCR_REPOSITORY_BASE}\"" "${config_file_path}"
-        sed -i "\$a\\      - --registry-mirror=${MCR_REPOSITORY_BASE}:${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}" "${config_file_path}"
     fi
 }
 

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1580,29 +1580,7 @@ writeCredentialProviderConfig() {
         done
     fi
 
-    if [ -n "$AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX" ] && [ -n "${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}" ]; then
-        echo "configure credential provider for custom cloud network isolated cluster"
-        MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE:=mcr.microsoft.com}"
-        MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE%/}"
-        tee "${config_file_path}" > /dev/null <<EOF
-apiVersion: kubelet.config.k8s.io/v1
-kind: CredentialProviderConfig
-providers:
-  - name: acr-credential-provider
-    matchImages:
-      - "*.azurecr.io"
-      - "*.azurecr.cn"
-      - "*.azurecr.de"
-      - "*.azurecr.us"
-      - "*$AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX"
-      - "${MCR_REPOSITORY_BASE}"
-    defaultCacheDuration: "10m"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1${ib_token_attributes}
-    args:
-      - /etc/kubernetes/azure.json
-      - --registry-mirror=${MCR_REPOSITORY_BASE}:$BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER${ib_args}
-EOF
-    elif [ -n "$AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX" ]; then
+    if [ -n "$AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX" ]; then
         echo "configure credential provider for custom cloud"
         tee "${config_file_path}" > /dev/null <<EOF
 apiVersion: kubelet.config.k8s.io/v1
@@ -1623,31 +1601,6 @@ providers:
     apiVersion: credentialprovider.kubelet.k8s.io/v1${ib_token_attributes}
     args:
       - /etc/kubernetes/azure.json${ib_args}
-EOF
-    elif [ -n "${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}" ]; then
-        echo "configure credential provider for network isolated cluster"
-        MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE:=mcr.microsoft.com}"
-        MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE%/}"
-        tee "${config_file_path}" > /dev/null <<EOF
-apiVersion: kubelet.config.k8s.io/v1
-kind: CredentialProviderConfig
-providers:
-  - name: acr-credential-provider
-    matchImages:
-      - "*.azurecr.io"
-      - "*.azurecr.cn"
-      - "*.azurecr.de"
-      - "*.azurecr.us"
-      - "*.*.geo.azurecr.io"
-      - "*.*.geo.azurecr.cn"
-      - "*.*.geo.azurecr.de"
-      - "*.*.geo.azurecr.us"
-      - "${MCR_REPOSITORY_BASE}"
-    defaultCacheDuration: "10m"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1${ib_token_attributes}
-    args:
-      - /etc/kubernetes/azure.json
-      - --registry-mirror=${MCR_REPOSITORY_BASE}:$BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER${ib_args}
 EOF
     else
         echo "configure credential provider with default settings"
@@ -1670,6 +1623,14 @@ providers:
     args:
       - /etc/kubernetes/azure.json${ib_args}
 EOF
+    fi
+    # append network isolated cluster configs
+    if [ -n "${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}" ]; then
+        MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE:=mcr.microsoft.com}"
+        MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE%/}"
+
+        sed -i "/^    defaultCacheDuration:/i\\      - \"${MCR_REPOSITORY_BASE}\"" "${config_file_path}"
+        sed -i "\$a\\      - --registry-mirror=${MCR_REPOSITORY_BASE}:${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}" "${config_file_path}"
     fi
 }
 

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1579,7 +1579,7 @@ writeCredentialProviderConfig() {
       - ${arg}"
         done
     fi
-    # Network isolated cluster required match image and registry args
+    # matchImages and argument for network isolated cluster
     local bootstrap_container_registry_match_image=""
     local bootstrap_container_registry_args=""
     if [ -n "${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}" ]; then

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1583,12 +1583,12 @@ writeCredentialProviderConfig() {
     local bootstrap_container_registry_match_image=""
     local bootstrap_container_registry_args=""
     if [ -n "${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}" ]; then
-            MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE:=mcr.microsoft.com}"
-            MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE%/}"
-            bootstrap_container_registry_match_image="
-        - \"${MCR_REPOSITORY_BASE}\""
-            bootstrap_container_registry_args="
-        - --registry-mirror=${MCR_REPOSITORY_BASE}:${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}"
+      MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE:=mcr.microsoft.com}"
+      MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE%/}"
+      bootstrap_container_registry_match_image="
+      - \"${MCR_REPOSITORY_BASE}\""
+      bootstrap_container_registry_args="
+      - --registry-mirror=${MCR_REPOSITORY_BASE}:${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}"
     fi
 
     if [ -n "$AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX" ]; then

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1629,7 +1629,7 @@ EOF
         MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE:=mcr.microsoft.com}"
         MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE%/}"
 
-        sed -i "/^    defaultCacheDuration:/i\\      - \"${MCR_REPOSITORY_BASE}\"" "${config_file_path}"
+        sed -i "/^    matchImages:$/a\\      - \"${MCR_REPOSITORY_BASE}\"" "${config_file_path}"
         sed -i "\$a\\      - --registry-mirror=${MCR_REPOSITORY_BASE}:${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}" "${config_file_path}"
     fi
 }

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1580,7 +1580,29 @@ writeCredentialProviderConfig() {
         done
     fi
 
-    if [ -n "$AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX" ]; then
+    if [ -n "$AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX" ] && [ -n "${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}" ]; then
+        echo "configure credential provider for custom cloud network isolated cluster"
+        MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE:=mcr.microsoft.com}"
+        MCR_REPOSITORY_BASE="${MCR_REPOSITORY_BASE%/}"
+        tee "${config_file_path}" > /dev/null <<EOF
+apiVersion: kubelet.config.k8s.io/v1
+kind: CredentialProviderConfig
+providers:
+  - name: acr-credential-provider
+    matchImages:
+      - "*.azurecr.io"
+      - "*.azurecr.cn"
+      - "*.azurecr.de"
+      - "*.azurecr.us"
+      - "*$AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX"
+      - "${MCR_REPOSITORY_BASE}"
+    defaultCacheDuration: "10m"
+    apiVersion: credentialprovider.kubelet.k8s.io/v1${ib_token_attributes}
+    args:
+      - /etc/kubernetes/azure.json
+      - --registry-mirror=${MCR_REPOSITORY_BASE}:$BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER${ib_args}
+EOF
+    elif [ -n "$AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX" ]; then
         echo "configure credential provider for custom cloud"
         tee "${config_file_path}" > /dev/null <<EOF
 apiVersion: kubelet.config.k8s.io/v1

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -1235,35 +1235,6 @@ providers:
             The contents of file "$TMP_DIR/credential-provider-config.yaml" should equal "$expected_config"
         End
 
-        It 'should configure credential provider for custom cloud network isolated cluster with custom MCR repository base'
-            AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX=".custom.registry.io"
-            BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER="test.azurecr.io"
-            MCR_REPOSITORY_BASE="fake.test.com/"
-            expected_config='apiVersion: kubelet.config.k8s.io/v1
-kind: CredentialProviderConfig
-providers:
-  - name: acr-credential-provider
-    matchImages:
-      - "*.azurecr.io"
-      - "*.azurecr.cn"
-      - "*.azurecr.de"
-      - "*.azurecr.us"
-      - "*.*.geo.azurecr.io"
-      - "*.*.geo.azurecr.cn"
-      - "*.*.geo.azurecr.de"
-      - "*.*.geo.azurecr.us"
-      - "*.custom.registry.io"
-      - "fake.test.com"
-    defaultCacheDuration: "10m"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1
-    args:
-      - /etc/kubernetes/azure.json
-      - --registry-mirror=fake.test.com:test.azurecr.io'
-            When call writeCredentialProviderConfig "$TMP_DIR/credential-provider-config.yaml"
-            The output should include "configure credential provider for custom cloud network isolated cluster"
-            The contents of file "$TMP_DIR/credential-provider-config.yaml" should equal "$expected_config"
-        End
-
         It 'should configure credential provider with identity binding enabled and all args'
             SERVICE_ACCOUNT_IMAGE_PULL_ENABLED="true"
             IDENTITY_BINDINGS_LOCAL_AUTHORITY_SNI="test.sni.local"

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -1178,7 +1178,7 @@ providers:
       - /etc/kubernetes/azure.json
       - --registry-mirror=mcr.microsoft.com:test.azurecr.io'
             When call writeCredentialProviderConfig "$TMP_DIR/credential-provider-config.yaml"
-            The output should include "configure credential provider for network isolated cluster"
+            The output should include "configure credential provider with default settings"
             The contents of file "$TMP_DIR/credential-provider-config.yaml" should equal "$expected_config"
         End
 
@@ -1231,7 +1231,7 @@ providers:
       - /etc/kubernetes/azure.json
       - --registry-mirror=mcr.microsoft.com:test.azurecr.io'
             When call writeCredentialProviderConfig "$TMP_DIR/credential-provider-config.yaml"
-            The output should include "configure credential provider for custom cloud network isolated cluster"
+            The output should include "configure credential provider for custom cloud"
             The contents of file "$TMP_DIR/credential-provider-config.yaml" should equal "$expected_config"
         End
 
@@ -1420,7 +1420,7 @@ providers:
       - --ib-default-tenant-id=my-tenant-id
       - --ib-apiserver-ip=apiserver.example.com'
             When call writeCredentialProviderConfig "$TMP_DIR/credential-provider-config.yaml"
-            The output should include "configure credential provider for network isolated cluster"
+            The output should include "configure credential provider with default settings"
             The contents of file "$TMP_DIR/credential-provider-config.yaml" should equal "$expected_config"
         End
 

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -1163,6 +1163,7 @@ kind: CredentialProviderConfig
 providers:
   - name: acr-credential-provider
     matchImages:
+      - "mcr.microsoft.com"
       - "*.azurecr.io"
       - "*.azurecr.cn"
       - "*.azurecr.de"
@@ -1171,7 +1172,6 @@ providers:
       - "*.*.geo.azurecr.cn"
       - "*.*.geo.azurecr.de"
       - "*.*.geo.azurecr.us"
-      - "mcr.microsoft.com"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     args:
@@ -1215,6 +1215,7 @@ kind: CredentialProviderConfig
 providers:
   - name: acr-credential-provider
     matchImages:
+      - "mcr.microsoft.com"
       - "*.azurecr.io"
       - "*.azurecr.cn"
       - "*.azurecr.de"
@@ -1224,7 +1225,6 @@ providers:
       - "*.*.geo.azurecr.de"
       - "*.*.geo.azurecr.us"
       - "*.custom.registry.io"
-      - "mcr.microsoft.com"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     args:
@@ -1395,6 +1395,7 @@ kind: CredentialProviderConfig
 providers:
   - name: acr-credential-provider
     matchImages:
+      - "mcr.microsoft.com"
       - "*.azurecr.io"
       - "*.azurecr.cn"
       - "*.azurecr.de"
@@ -1403,7 +1404,6 @@ providers:
       - "*.*.geo.azurecr.cn"
       - "*.*.geo.azurecr.de"
       - "*.*.geo.azurecr.us"
-      - "mcr.microsoft.com"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     tokenAttributes:

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -1119,6 +1119,7 @@ PubkeyAuthentication no"
             API_SERVER_NAME=""
             AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX=""
             BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER=""
+            MCR_REPOSITORY_BASE=""
         }
         cleanup() {
             rm -rf "$TMP_DIR"
@@ -1218,6 +1219,10 @@ providers:
       - "*.azurecr.cn"
       - "*.azurecr.de"
       - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
       - "*.custom.registry.io"
       - "mcr.microsoft.com"
     defaultCacheDuration: "10m"
@@ -1225,6 +1230,35 @@ providers:
     args:
       - /etc/kubernetes/azure.json
       - --registry-mirror=mcr.microsoft.com:test.azurecr.io'
+            When call writeCredentialProviderConfig "$TMP_DIR/credential-provider-config.yaml"
+            The output should include "configure credential provider for custom cloud network isolated cluster"
+            The contents of file "$TMP_DIR/credential-provider-config.yaml" should equal "$expected_config"
+        End
+
+        It 'should configure credential provider for custom cloud network isolated cluster with custom MCR repository base'
+            AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX=".custom.registry.io"
+            BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER="test.azurecr.io"
+            MCR_REPOSITORY_BASE="fake.test.com/"
+            expected_config='apiVersion: kubelet.config.k8s.io/v1
+kind: CredentialProviderConfig
+providers:
+  - name: acr-credential-provider
+    matchImages:
+      - "*.azurecr.io"
+      - "*.azurecr.cn"
+      - "*.azurecr.de"
+      - "*.azurecr.us"
+      - "*.*.geo.azurecr.io"
+      - "*.*.geo.azurecr.cn"
+      - "*.*.geo.azurecr.de"
+      - "*.*.geo.azurecr.us"
+      - "*.custom.registry.io"
+      - "fake.test.com"
+    defaultCacheDuration: "10m"
+    apiVersion: credentialprovider.kubelet.k8s.io/v1
+    args:
+      - /etc/kubernetes/azure.json
+      - --registry-mirror=fake.test.com:test.azurecr.io'
             When call writeCredentialProviderConfig "$TMP_DIR/credential-provider-config.yaml"
             The output should include "configure credential provider for custom cloud network isolated cluster"
             The contents of file "$TMP_DIR/credential-provider-config.yaml" should equal "$expected_config"

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -1206,6 +1206,30 @@ providers:
             The contents of file "$TMP_DIR/credential-provider-config.yaml" should equal "$expected_config"
         End
 
+        It 'should configure credential provider for custom cloud network isolated cluster'
+            AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFIX=".custom.registry.io"
+            BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER="test.azurecr.io"
+            expected_config='apiVersion: kubelet.config.k8s.io/v1
+kind: CredentialProviderConfig
+providers:
+  - name: acr-credential-provider
+    matchImages:
+      - "*.azurecr.io"
+      - "*.azurecr.cn"
+      - "*.azurecr.de"
+      - "*.azurecr.us"
+      - "*.custom.registry.io"
+      - "mcr.microsoft.com"
+    defaultCacheDuration: "10m"
+    apiVersion: credentialprovider.kubelet.k8s.io/v1
+    args:
+      - /etc/kubernetes/azure.json
+      - --registry-mirror=mcr.microsoft.com:test.azurecr.io'
+            When call writeCredentialProviderConfig "$TMP_DIR/credential-provider-config.yaml"
+            The output should include "configure credential provider for custom cloud network isolated cluster"
+            The contents of file "$TMP_DIR/credential-provider-config.yaml" should equal "$expected_config"
+        End
+
         It 'should configure credential provider with identity binding enabled and all args'
             SERVICE_ACCOUNT_IMAGE_PULL_ENABLED="true"
             IDENTITY_BINDINGS_LOCAL_AUTHORITY_SNI="test.sni.local"

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -1163,7 +1163,6 @@ kind: CredentialProviderConfig
 providers:
   - name: acr-credential-provider
     matchImages:
-      - "mcr.microsoft.com"
       - "*.azurecr.io"
       - "*.azurecr.cn"
       - "*.azurecr.de"
@@ -1172,6 +1171,7 @@ providers:
       - "*.*.geo.azurecr.cn"
       - "*.*.geo.azurecr.de"
       - "*.*.geo.azurecr.us"
+      - "mcr.microsoft.com"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     args:
@@ -1215,7 +1215,6 @@ kind: CredentialProviderConfig
 providers:
   - name: acr-credential-provider
     matchImages:
-      - "mcr.microsoft.com"
       - "*.azurecr.io"
       - "*.azurecr.cn"
       - "*.azurecr.de"
@@ -1225,6 +1224,7 @@ providers:
       - "*.*.geo.azurecr.de"
       - "*.*.geo.azurecr.us"
       - "*.custom.registry.io"
+      - "mcr.microsoft.com"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     args:
@@ -1395,7 +1395,6 @@ kind: CredentialProviderConfig
 providers:
   - name: acr-credential-provider
     matchImages:
-      - "mcr.microsoft.com"
       - "*.azurecr.io"
       - "*.azurecr.cn"
       - "*.azurecr.de"
@@ -1404,6 +1403,7 @@ providers:
       - "*.*.geo.azurecr.cn"
       - "*.*.geo.azurecr.de"
       - "*.*.geo.azurecr.us"
+      - "mcr.microsoft.com"
     defaultCacheDuration: "10m"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
     tokenAttributes:


### PR DESCRIPTION


<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:

When both `AKS_CUSTOM_CLOUD_CONTAINER_REGISTRY_DNS_SUFFI`X and `BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER` are set (custom cloud + NI), the credential provider config was missing the --registry-mirror arg because the custom cloud branch took priority over the NI branch. This caused kubelet to fail authenticating against the bootstrap ACR, resulting in ImagePullBackOff for all system pods (azure-cni-node, kube-proxy, etc.) and nodes stuck in NotReady.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
