### PR TITLE
feat: bump aznfs to 3.0.19 for Ubuntu 22.04 and 24.04

### DIFF
--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
@@ -60,7 +60,7 @@ installDeps() {
     fi
 
     if [ "${OSVERSION}" = "22.04" ] || [ "${OSVERSION}" = "24.04" ]; then
-        pkg_list+=("aznfs=3.0.14")
+        pkg_list+=("aznfs=3.0.19")
     fi
 
     # Batch install all packages in a single apt_get_install call instead of


### PR DESCRIPTION
Bumps the pinned `aznfs` version installed at CSE/VHD-build time in `parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh` from `3.0.14` to `3.0.19`.

Version `3.0.19` is published on `packages.microsoft.com` for both `jammy` (22.04) and `noble` (24.04) on `amd64` and `arm64`.

No other changes required:
- `parts/common/components.json` only tracks the Azure Linux RPM of aznfs (separate install path via `installAznfsPackage` in `cse_install_mariner.sh`) — Ubuntu aznfs is deliberately not tracked there.
- The `aznfswatchdog` disable logic in `cse_install_ubuntu.sh` is unchanged and remains valid for the `3.0.x` series.
- No references to a specific aznfs version exist in `pkg/`, `aks-node-controller/`, `e2e/`, or shellspec tests.