### PR TITLE
chore(components): align coredns, cluster-proportional-autoscaler, ad…

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -74,7 +74,7 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/autoscaler/addon-resizer",
-          "latestVersion": "v1.8.23-14"
+          "latestVersion": "v1.8.23-28"
         }
       ],
       "windowsVersions": []
@@ -134,19 +134,19 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/coredns",
-          "latestVersion": "v1.13.2-9"
+          "latestVersion": "v1.14.3-11"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/coredns",
-          "latestVersion": "v1.13.1-9"
+          "latestVersion": "v1.13.1-20"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/coredns",
-          "latestVersion": "v1.12.1-14"
+          "latestVersion": "v1.12.1-25"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/coredns",
-          "latestVersion": "v1.11.3-22"
+          "latestVersion": "v1.11.3-32"
         }
       ],
       "windowsVersions": []
@@ -491,7 +491,7 @@
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/autoscaler/cluster-proportional-autoscaler",
-          "latestVersion": "v1.9.0-12"
+          "latestVersion": "v1.9.0-21"
         }
       ],
       "windowsVersions": []


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the cached VHD image tags in `parts/common/components.json` to match the tags that **aks-rp master** now deploys, following the merge of two aks-rp dependabot addon-image PRs:

- aks-rp PR 16430340 — addon-coredns group (coredns + cluster-proportional-autoscaler)
- aks-rp PR 16430330 — addon-metrics-server group (addon-resizer)

Keeping these in sync ensures the images pre-pulled onto the node VHD match what the control plane actually schedules, avoiding a cold image pull at pod start.

| Image | Old | New |
|---|---|---|
| `oss/v2/kubernetes/coredns` | `v1.13.2-9` | `v1.14.3-11` (v1.13.2 no longer in aks-rp; newest 1.36 line) |
| `oss/v2/kubernetes/coredns` | `v1.13.1-9` | `v1.13.1-20` |
| `oss/v2/kubernetes/coredns` | `v1.12.1-14` | `v1.12.1-25` |
| `oss/v2/kubernetes/coredns` | `v1.11.3-22` | `v1.11.3-32` |
| `oss/v2/kubernetes/autoscaler/cluster-proportional-autoscaler` | `v1.9.0-12` | `v1.9.0-21` |
| `oss/v2/kubernetes/autoscaler/addon-resizer` | `v1.8.23-14` | `v1.8.23-28` |

Notes:
- The CPA `v1.8.11-14` line is left unchanged — aks-rp pins it as `no-update` and caches the identical tag.
- metrics-server is intentionally **not** added (not currently cached in this `components.json`).

Validation:
- `components.json` is valid JSON and `make validate-components` (schema check) passes.
- `make generate` produces no other file changes — these Linux multiArch tags don't feed `windows_settings.json` or Go snapshots.

**Which issue(s) this PR fixes**:

N/A