### PR TITLE
fix: stabilize sysext Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -591,7 +591,8 @@
         "oss/v2/kubernetes/*-sysext"
       ],
       "matchCurrentVersion": "/-azlinux3$/",
-      "extractVersion": "^(?<version>.+-azlinux3)-"
+      "extractVersion": "^(?<version>.+-azlinux3)-x86-64$",
+      "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<compatibility>azlinux3)$"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Summary
- use the x86-64 sysext tag as the canonical version source
  - if only x86-64 is published but arm64 is not, we will catch it with VHD build.
- parse the Azure Linux package revision as a build number

This prevents duplicate architecture tags from causing inconsistent Renovate updates.