### PR TITLE
fix(azurelinux): update nvidia-container-toolkit to 1.17.8

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1949,7 +1949,7 @@
             "versionsV2": [
               {
                 "renovateTag": "<DO_NOT_UPDATE>",
-                "latestVersion": "1.17.3"
+                "latestVersion": "1.17.8"
               }
             ],
             "downloadURL": ""


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Azure Linux nvidia-container-toolkit family pin from `1.17.3` to `1.17.8` to consume upstream security and bug fixes.

The Azure Linux repository provides matching `1.17.8` packages for the toolkit and its dependencies. The existing install logic selects the common upstream version and lets DNF resolve the appropriate package release.

OS coverage: Azure Linux only. Ubuntu obtains the toolkit from the aks-gpu image.

Validation:

- `make validate-components`
- `go test ./pkg/agent/...`
- `make generate` generated no additional diffs; its unit/generation stages passed, then the repository-wide shellcheck stage stopped on existing SC3014 warnings in unrelated files
- Verified the required RPMs are available in the Azure Linux repository

**Which issue(s) this PR fixes**:

N/A

**Release note**:

```release-note
none
```