### PR TITLE
fix: allow DNS failover during CSE connectivity checks

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -510,11 +510,11 @@ function nodePrep {
     VALIDATION_ERR=0
     # shellcheck disable=SC3010
     if ! [[ ${API_SERVER_NAME} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        API_SERVER_CONN_RETRIES=50
+        API_SERVER_CONN_RETRIES=34
         API_SERVER_DNS_RETRY_TIMEOUT=300
         # shellcheck disable=SC3010
         if [[ $API_SERVER_NAME == *.privatelink.* ]]; then
-           API_SERVER_CONN_RETRIES=100
+           API_SERVER_CONN_RETRIES=68
            API_SERVER_DNS_RETRY_TIMEOUT=600
         fi
         if [ "${ENABLE_HOSTS_CONFIG_AGENT}" != "true" ]; then
@@ -532,7 +532,7 @@ function nodePrep {
                 VALIDATION_ERR=$ERR_K8S_API_SERVER_DNS_LOOKUP_FAIL
             fi
         else
-            logs_to_events "AKS.CSE.apiserverCurl" "retrycmd_if_failure ${API_SERVER_CONN_RETRIES} 1 10 curl -v --cacert /etc/kubernetes/certs/ca.crt https://${API_SERVER_NAME}:443" || time curl -v --cacert /etc/kubernetes/certs/ca.crt "https://${API_SERVER_NAME}:443" || VALIDATION_ERR=$ERR_K8S_API_SERVER_CONN_FAIL
+            logs_to_events "AKS.CSE.apiserverCurl" "retrycmd_if_failure ${API_SERVER_CONN_RETRIES} 1 15 curl -v --cacert /etc/kubernetes/certs/ca.crt https://${API_SERVER_NAME}:443" || time curl -v --cacert /etc/kubernetes/certs/ca.crt "https://${API_SERVER_NAME}:443" || VALIDATION_ERR=$ERR_K8S_API_SERVER_CONN_FAIL
         fi
     else
         # an IP address is provided for the API server, skip the DNS lookup

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -388,7 +388,7 @@ function nodePrep {
         if [ -n "${PROXY_VARS}" ]; then
             eval $PROXY_VARS
         fi
-        retrycmd_if_failure 60 1 5 $OUTBOUND_COMMAND >> /var/log/azure/cluster-provision-cse-output.log 2>&1 || exit $ERR_OUTBOUND_CONN_FAIL;
+        retrycmd_if_failure 20 1 15 $OUTBOUND_COMMAND >> /var/log/azure/cluster-provision-cse-output.log 2>&1 || exit $ERR_OUTBOUND_CONN_FAIL;
     fi
     if [ -n "${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}" ]; then
         # This file indicates the cluster doesn't have outbound connectivity and should be excluded in future external outbound checks

--- a/spec/parts/linux/cloud-init/artifacts/cse_main_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_main_spec.sh
@@ -127,10 +127,16 @@ Describe 'select_localdns_corefile()'
     End
 End
 
-Describe 'outbound connectivity preflight'
-    It 'allows DNS failover within each attempt'
+Describe 'connectivity preflight timeouts'
+    It 'allows DNS failover during the outbound check'
         When run awk '/retrycmd_if_failure [0-9]+ [0-9]+ [0-9]+ \$OUTBOUND_COMMAND/ { print $2, $3, $4 }' parts/linux/cloud-init/artifacts/cse_main.sh
         The output should eq "20 1 15"
+        The status should be success
+    End
+
+    It 'allows DNS failover during the API server check'
+        When run grep -F 'retrycmd_if_failure ${API_SERVER_CONN_RETRIES} 1 15 curl' parts/linux/cloud-init/artifacts/cse_main.sh
+        The output should include 'retrycmd_if_failure ${API_SERVER_CONN_RETRIES} 1 15 curl'
         The status should be success
     End
 End

--- a/spec/parts/linux/cloud-init/artifacts/cse_main_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_main_spec.sh
@@ -126,3 +126,11 @@ Describe 'select_localdns_corefile()'
         End
     End
 End
+
+Describe 'outbound connectivity preflight'
+    It 'allows DNS failover within each attempt'
+        When run awk '/retrycmd_if_failure [0-9]+ [0-9]+ [0-9]+ \$OUTBOUND_COMMAND/ { print $2, $3, $4 }' parts/linux/cloud-init/artifacts/cse_main.sh
+        The output should eq "20 1 15"
+        The status should be success
+    End
+End


### PR DESCRIPTION
**What this PR does / why we need it**:

The Linux CSE wraps hostname-based connectivity checks with per-attempt timeouts. With multiple custom DNS servers, an unresponsive primary can consume the timeout before libc tries a responsive secondary.

This gives both affected checks 15 seconds per attempt while preserving or reducing their total retry budgets:

- Outbound registry check: 60 attempts x 5 seconds becomes 20 attempts x 15 seconds. Including one-second sleeps, the worst-case window decreases from about 359 seconds to 319 seconds.
- API server HTTPS check: 50/100 attempts x 10 seconds becomes 34/68 attempts x 15 seconds. The public/private worst-case windows decrease from about 549/1099 seconds to 543/1087 seconds.

Each attempt can now cover the normal primary DNS timeout, secondary DNS fallback, and TCP/TLS setup. The rendered endpoints and failure behavior are unchanged.

Tests:
- ShellSpec: `spec/parts/linux/cloud-init/artifacts/cse_main_spec.sh`
- `GENERATE_TEST_DATA=true go test ./pkg/agent...`
- repository shellcheck rules for `cse_main.sh`

**Which issue(s) this PR fixes**:

N/A