### PR TITLE
fix: serialize Renovate package index requests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,12 @@
     "renovate"
   ],
   "rebaseWhen": "never",
+  "hostRules": [
+    {
+      "matchHost": "packages.microsoft.com",
+      "concurrentRequestLimit": 1
+    }
+  ],
   "logLevelRemap": [
     {
       "matchMessage": "/^Custom manager fetcher/",


### PR DESCRIPTION
## Summary
- serialize Renovate requests to packages.microsoft.com
- avoid transient connection resets from parallel Ubuntu package index downloads

## Validation
- parsed .github/renovate.json successfully
- confirmed the diff contains only the packages.microsoft.com host rule