### PR TITLE
fix: detect secure TLS bootstrap sysext updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -472,7 +472,8 @@
     },
     {
       "matchPackageNames": [
-        "aks-secure-tls-bootstrap-client"
+        "aks-secure-tls-bootstrap-client",
+        "aks-secure-tls-bootstrap/v2/aks-secure-tls-bootstrap-client-sysext"
       ],
       "groupName": "aks-secure-tls-bootstrap-client",
       "assignees": [
@@ -594,7 +595,8 @@
         "docker"
       ],
       "matchPackageNames": [
-        "oss/v2/kubernetes/*-sysext"
+        "oss/v2/kubernetes/*-sysext",
+        "aks-secure-tls-bootstrap/v2/aks-secure-tls-bootstrap-client-sysext"
       ],
       "matchCurrentVersion": "/-azlinux3$/",
       "extractVersion": "^(?<version>.+-azlinux3)-x86-64$",


### PR DESCRIPTION
## Summary
- include the Flatcar secure TLS bootstrap sysext OCI package in the existing sysext normalization rule
- group its updates with the secure TLS bootstrap client package and ownership

MCR publishes architecture-suffixed tags such as `v1.1.4-2-azlinux3-x86-64`; the existing extraction rule now applies to this package so Renovate stores `v1.1.4-2-azlinux3` in `components.json`.