### PR TITLE
fix: start ask node controller within boothook instead of service for non flatcar/acl

### DIFF
--- a/aks-node-controller/hotfix_test.go
+++ b/aks-node-controller/hotfix_test.go
@@ -614,6 +614,7 @@ func TestShouldUpgradeToHotfix(t *testing.T) {
 		{"base .0 -> hotfix .1", "202604.01.0", "202604.01.1", true, false},
 		{"base .0 -> hotfix .2", "202604.01.0", "202604.01.2", true, false},
 		{"hotfix .1 -> hotfix .2", "202604.01.1", "202604.01.2", true, false},
+		{"hotfix .0 -> hotfix .1-1", "202604.01.0", "202604.01.1-1", true, false},
 
 		// Negative: same version
 		{"same version .0", "202604.01.0", "202604.01.0", false, false},

--- a/aks-node-controller/parser/helper_test.go
+++ b/aks-node-controller/parser/helper_test.go
@@ -1266,7 +1266,7 @@ func Test_getTargetEnvironment(t *testing.T) {
 					},
 				},
 			},
-			want: "AzureChinaCloud",
+			want: helpers.AzureChinaCloud,
 		},
 		{
 			name: "Germany location cluster config",
@@ -1278,7 +1278,7 @@ func Test_getTargetEnvironment(t *testing.T) {
 					},
 				},
 			},
-			want: "AzureGermanCloud",
+			want: helpers.AzureGermanCloud,
 		},
 		{
 			name: "usgov location cluster config",
@@ -1290,7 +1290,7 @@ func Test_getTargetEnvironment(t *testing.T) {
 					},
 				},
 			},
-			want: "AzureUSGovernmentCloud",
+			want: helpers.AzureUSGovernmentCloud,
 		},
 	}
 	for _, tt := range tests {

--- a/aks-node-controller/parser/parser_test.go
+++ b/aks-node-controller/parser/parser_test.go
@@ -124,12 +124,12 @@ oom_score = -999
 			k8sVersion: "1.24.2",
 			aksNodeConfigUpdator: func(aksNodeConfig *aksnodeconfigv1.Configuration) {
 				aksNodeConfig.ClusterConfig.Location = "chinaeast2"
-				aksNodeConfig.CustomCloudConfig.CustomCloudEnvName = "AzureChinaCloud"
+				aksNodeConfig.CustomCloudConfig.CustomCloudEnvName = helpers.AzureChinaCloud
 			},
 			validator: func(cmd *exec.Cmd) {
 				vars := environToMap(cmd.Env)
-				assert.Equal(t, "AzureChinaCloud", vars["TARGET_ENVIRONMENT"])
-				assert.Equal(t, "AzureChinaCloud", vars["TARGET_CLOUD"])
+				assert.Equal(t, helpers.AzureChinaCloud, vars["TARGET_ENVIRONMENT"])
+				assert.Equal(t, helpers.AzureChinaCloud, vars["TARGET_CLOUD"])
 				assert.Equal(t, "false", vars["IS_CUSTOM_CLOUD"])
 				assert.Equal(t, "https://management.chinacloudapi.cn/", vars["ARM_RESOURCE_ENDPOINT"])
 			},

--- a/aks-node-controller/pkg/nodeconfigutils/utils.go
+++ b/aks-node-controller/pkg/nodeconfigutils/utils.go
@@ -28,7 +28,7 @@ set -euo pipefail
 
 logger -t aks-boothook "boothook start $(date -Ins)"
 
-mkdir -p /opt/azure/containers
+mkdir -p /opt/azure/containers /var/log/azure
 
 nohup /bin/bash /opt/azure/containers/provision_preload.sh >/dev/null 2>&1 &
 
@@ -37,8 +37,12 @@ cat <<'EOF' | base64 -d >%[1]s
 EOF
 chmod 0600 %[1]s
 %[3]s
-logger -t aks-boothook "launching aks-node-controller service $(date -Ins)"
-systemctl start --no-block aks-node-controller.service
+logger -t aks-boothook "launching aks-node-controller $(date -Ins)"
+if [ -f /opt/azure/containers/aks-node-controller-launcher.sh ]; then
+	nohup /bin/bash /opt/azure/containers/aks-node-controller-launcher.sh > /var/log/azure/aks-node-controller.output 2>&1 &
+else
+	systemctl start --no-block aks-node-controller.service
+fi
 `
 
 	cloudConfigTemplate = `#cloud-config

--- a/aks-node-controller/pkg/nodeconfigutils/utils_test.go
+++ b/aks-node-controller/pkg/nodeconfigutils/utils_test.go
@@ -256,8 +256,9 @@ func TestCustomDataUsesMultipartBoothookAndCloudConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(string(boothook), "#cloud-boothook\n"))
 	require.Contains(t, string(boothook), "/opt/azure/containers/aks-node-controller-config.json")
-	require.Contains(t, string(boothook), "launching aks-node-controller service")
-	require.Contains(t, string(boothook), "systemctl start --no-block aks-node-controller.service")
+	require.Contains(t, string(boothook), "launching aks-node-controller")
+	require.Contains(t, string(boothook), "aks-node-controller.service")
+	require.Contains(t, string(boothook), "/opt/azure/containers/aks-node-controller-launcher.sh")
 
 	part, err = reader.NextPart()
 	require.NoError(t, err)

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -597,54 +597,6 @@ func Test_Ubuntu2204_ScriptlessCSECmd_Hotfix(t *testing.T) {
 	})
 }
 
-// Test_Ubuntu2204_ANCHotfix_BinarySelection tests that the wrapper script correctly
-// selects a pre-existing hotfix binary over the VHD-baked binary. This validates the
-// wrapper's binary selection logic without requiring an actual PMC download.
-// A stub script at the hotfix binary path delegates to the real ANC binary.
-//
-// Note: In the EnableScriptlessCSECmd (non-NBC) path, the wrapper runs at boot and
-// performs binary selection, but exits before provisioning because no config/nbc-cmd
-// file exists at that point. Provisioning happens later via CSE → provision.sh.
-// This test validates the wrapper's selection logic; node readiness (implicit in
-// RunScenario) confirms provisioning succeeded via the CSE path.
-func Test_Ubuntu2204_ANCHotfix_BinarySelection(t *testing.T) {
-	RunScenario(t, &Scenario{
-		Description: "tests that the wrapper selects a pre-seeded hotfix binary",
-		Config: Config{
-			Cluster: ClusterKubenet,
-			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			CustomDataWriteFiles: []CustomDataWriteFile{
-				{
-					// Hotfix JSON — triggers download-hotfix, but a real hotfix install
-					// should be skipped because this intentionally old version will not
-					// target the VHD base version. The pre-seeded binary below will still
-					// be found and selected by the wrapper.
-					Path:    "/opt/azure/containers/aks-node-controller-hotfix.json",
-					Content: `{"version":"200001.01.1"}`,
-				},
-				{
-					// Pre-seed the hotfix binary path with a stub script that delegates
-					// to the real VHD-baked ANC binary. This simulates a successful
-					// hotfix download without needing PMC.
-					Path:        "/opt/azure/containers/aks-node-controller-hotfix",
-					Permissions: "0755",
-					Content:     "#!/bin/bash\nexec /opt/azure/containers/aks-node-controller \"$@\"",
-				},
-			},
-			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.EnableScriptlessNBCCSECmd = true
-			},
-			Validator: func(ctx context.Context, s *Scenario) {
-				// Wrapper found the pre-seeded hotfix binary and selected it
-				ValidateJournalctlOutput(ctx, s, "aks-node-controller.service", "Using hotfix binary")
-				// download-hotfix was triggered by the hotfix JSON
-				ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log",
-					"aks-node-controller hotfix download finished")
-			},
-		},
-	})
-}
-
 func Test_Ubuntu2204FIPS(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that a node using the Ubuntu 2204 FIPS Gen1 VHD can be properly bootstrapped",
@@ -2711,9 +2663,6 @@ func Test_Ubuntu2204_NodeHardening_KubeReservedSlice_ConfigFile(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			// Force the "default" (non-scriptless) subtest path so that fresh CSE scripts
-			// with the Slice= drop-ins are uploaded via custom data.
-			CustomDataWriteFiles: []CustomDataWriteFile{{Path: "/etc/aks-node-hardening-test", Content: "sentinel"}},
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				// AgentBaker (not the RP) now owns --kube-reserved-cgroup/--system-reserved-cgroup;
 				// it derives them from --enforce-node-allocatable (see setNodeHardeningCgroupFlags).
@@ -2731,9 +2680,6 @@ func Test_Ubuntu2204_NodeHardening_KubeReservedSlice_ConfigFile(t *testing.T) {
 				// Non-nil (even empty) CustomKubeletConfig switches AgentBaker to the
 				// config-file (kubeletconfig.json) path instead of CLI flags.
 				nbc.AgentPoolProfile.CustomKubeletConfig = &datamodel.CustomKubeletConfig{}
-				// Disable scriptless CSE so that the current cse_helpers.sh (with kubereserved.slice drop-in)
-				// is uploaded via custom data instead of relying on potentially stale VHD scripts.
-				nbc.EnableScriptlessCSECmd = false
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateFileExists(ctx, s, "/etc/systemd/system/kubereserved.slice")
@@ -2757,9 +2703,6 @@ func Test_Ubuntu2204_NodeHardening_KubeReservedSlice_CLIFlags(t *testing.T) {
 		Config: Config{
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDUbuntu2204Gen2Containerd,
-			// Force the "default" (non-scriptless) subtest path so that fresh CSE scripts
-			// with the Slice= drop-ins are uploaded via custom data.
-			CustomDataWriteFiles: []CustomDataWriteFile{{Path: "/etc/aks-node-hardening-test", Content: "sentinel"}},
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
 				// AgentBaker (not the RP) now owns --kube-reserved-cgroup/--system-reserved-cgroup;
 				// it derives them from --enforce-node-allocatable (see setNodeHardeningCgroupFlags).
@@ -2774,12 +2717,6 @@ func Test_Ubuntu2204_NodeHardening_KubeReservedSlice_CLIFlags(t *testing.T) {
 				// owns rather than trusting them, or the node would end up in the wrong slice.
 				nbc.KubeletConfig["--kube-reserved-cgroup"] = "/kubelet.slice"
 				nbc.KubeletConfig["--system-reserved-cgroup"] = "/kubelet.slice"
-				// CustomKubeletConfig/CustomLinuxOSConfig left nil so kubelet reads its
-				// flags from the CLI (KUBELET_FLAGS in /etc/default/kubelet) instead of
-				// the config-file path.
-				// Disable scriptless CSE so that the current cse_helpers.sh (with kubereserved.slice drop-in)
-				// is uploaded via custom data instead of relying on potentially stale VHD scripts.
-				nbc.EnableScriptlessCSECmd = false
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateFileExists(ctx, s, "/etc/systemd/system/kubereserved.slice")

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2227,6 +2227,22 @@ echo "  2. Hosts file populated later: CoreDNS picks it up via reload"
 		"localdns should work after cold start with empty hosts file and pick up populated file")
 }
 
+// ValidateANCLauncherOutput checks that the aks-node-controller-launcher.sh output contains
+// expectedContent, regardless of how the VHD launches it:
+//   - ACL/Flatcar VHDs still launch the launcher via the aks-node-controller.service systemd unit
+//     (ignition doesn't support cloud-boothooks), so its stdout/stderr only lands in the journal.
+//   - All other VHDs launch the launcher as a direct fork from the cloud-boothook (not a systemd
+//     unit, for faster dispatch - see baker.go boothookTemplate), with stdout/stderr redirected to
+//     /var/log/azure/aks-node-controller.output.
+func ValidateANCLauncherOutput(ctx context.Context, s *Scenario, expectedContent string) {
+	s.T.Helper()
+	if s.VHD.Flatcar {
+		ValidateJournalctlOutput(ctx, s, "aks-node-controller.service", expectedContent)
+		return
+	}
+	ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.output", expectedContent)
+}
+
 // ValidateJournalctlOutput checks if specific content exists in the systemd service logs
 func ValidateJournalctlOutput(ctx context.Context, s *Scenario, serviceName string, expectedContent string) {
 	s.T.Helper()
@@ -2758,11 +2774,12 @@ func ValidateScriptlessCSECmd(ctx context.Context, s *Scenario) {
 func ValidateScriptlessNBCCSECmd(ctx context.Context, s *Scenario) {
 	if usesScriptlessNBCCSECmd(s) {
 		fileNameToCheck := "/opt/azure/containers/aks-node-controller-nbc-cmd.sh"
-		if enableScriptlessCompilation(s) {
-			fileNameToCheck = "/opt/azure/containers/aks-node-controller-nbc-cmd-hack.sh"
-		}
 		ValidateFileExists(ctx, s, fileNameToCheck)
 		ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log", "Using NBC command for scriptless phase 2")
+		if enableScriptlessCompilation(s) {
+			ValidateFileExists(ctx, s, "/opt/azure/containers/aks-node-controller-hotfix")
+			ValidateFileHasContent(ctx, s, "/var/log/azure/aks-node-controller.log", "Using hotfix binary")
+		}
 	}
 }
 

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -199,108 +199,6 @@ func deleteVMSSAndWait(ctx context.Context, s *Scenario) {
 	}
 }
 
-// CustomDataWithHack is similar to nodeconfigutils.CustomData, but it uses a hack to run new aks-node-controller binary.
-// Original aks-node-controller isn't run because it fails systemd check validating aks-node-controller-config.json exists
-// (check aks-node-controller.service for details).
-//
-// Uses a cloud-boothook to write the config file and create a systemd service unit early in boot (during cloud-init init).
-// The systemd service waits for network-online.target before downloading the binary and running provisioning,
-// avoiding the race condition where runcmd or boothook scripts execute before networking is available.
-// Flatcar cannot use boothooks (coreos-cloudinit doesn't support MIME multipart), so it uses cloud-config
-// with a coreos.units block to define and start the service instead.
-func CustomDataWithHack(s *Scenario, binaryURL string) (string, error) {
-	cloudConfigTemplate := `#cloud-boothook
-#!/bin/bash
-set -euo pipefail
-
-mkdir -p /opt/azure/containers /opt/azure/bin
-
-nohup /bin/bash /opt/azure/containers/provision_preload.sh >/dev/null 2>&1 &
-
-cat <<'EOF' | base64 -d > %[1]s
-%[2]s
-EOF
-chmod 0600 %[1]s
-
-cat <<'SCRIPT' > /opt/azure/bin/run-aks-node-controller-hack.sh
-#!/bin/bash
-set -euo pipefail
-mkdir -p /opt/azure/bin
-curl -fSL --retry 10 --retry-delay 2 --retry-connrefused "%[3]s" -o /opt/azure/bin/aks-node-controller-hack
-chmod +x /opt/azure/bin/aks-node-controller-hack
-
-/opt/azure/bin/aks-node-controller-hack provision --provision-config=%[1]s
-
-SCRIPT
-chmod +x /opt/azure/bin/run-aks-node-controller-hack.sh
-
-cat <<'UNIT' > /etc/systemd/system/aks-node-controller-hack.service
-[Unit]
-Description=Downloads and runs the AKS node controller hack
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/opt/azure/bin/run-aks-node-controller-hack.sh
-
-[Install]
-WantedBy=basic.target
-UNIT
-
-systemctl daemon-reload
-systemctl start --no-block aks-node-controller-hack.service
-`
-	if s.VHD.Flatcar {
-		// Flatcar uses coreos-cloudinit which only supports a subset of cloud-config features
-		// and does not handle MIME multipart or boothooks. Use coreos.units to define the service instead.
-		// https://github.com/flatcar/coreos-cloudinit/blob/main/Documentation/cloud-config.md#coreos-parameters
-		cloudConfigTemplate = `#cloud-config
-write_files:
-- path: %[1]s
-  permissions: "0600"
-  owner: root
-  content: !!binary |
-   %[2]s
-- path: /opt/azure/bin/run-aks-node-controller-hack.sh
-  permissions: "0755"
-  owner: root
-  content: |
-    #!/bin/bash
-    set -euo pipefail
-    mkdir -p /opt/azure/bin
-    curl -fSL --retry 10 --retry-delay 2 --retry-connrefused "%[3]s" -o /opt/azure/bin/aks-node-controller-hack
-    chmod +x /opt/azure/bin/aks-node-controller-hack
-    /opt/azure/bin/aks-node-controller-hack provision --provision-config=%[1]s
-# Flatcar specific configuration. It supports only a subset of cloud-init features https://github.com/flatcar/coreos-cloudinit/blob/main/Documentation/cloud-config.md#coreos-parameters
-coreos:
-  units:
-    - name: aks-node-controller-hack.service
-      command: start
-      content: |
-        [Unit]
-        Description=Downloads and runs the AKS node controller hack
-        After=network-online.target
-        Wants=network-online.target
-        [Service]
-        Type=oneshot
-        ExecStart=/opt/azure/bin/run-aks-node-controller-hack.sh
-        [Install]
-        WantedBy=multi-user.target
-`
-	}
-
-	aksNodeConfigJSON, err := nodeconfigutils.MarshalConfigurationV1(s.Runtime.AKSNodeConfig)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal nbc, error: %w", err)
-	}
-	encodedAksNodeConfigJSON := base64.StdEncoding.EncodeToString(aksNodeConfigJSON)
-	configPath := "/opt/azure/containers/aks-node-controller-config-hack.json"
-
-	customDataYAML := fmt.Sprintf(cloudConfigTemplate, configPath, encodedAksNodeConfigJSON, binaryURL)
-	return base64.StdEncoding.EncodeToString([]byte(customDataYAML)), nil
-}
-
 // CustomDataWithNBCCmdHack is similar to baker.boothooktemplate, but it uses a hack to run new aks-node-controller binary.
 // Original aks-node-controller isn't run because it fails systemd check validating aks-node-controller-config.json exists
 // (check aks-node-controller.service for details).
@@ -309,168 +207,9 @@ func CustomDataWithNBCCmdHack(s *Scenario, customData, binaryURL string) (string
 	decoded, err := base64.StdEncoding.DecodeString(customData)
 	require.NoError(s.T, err)
 
-	customData = strings.Replace(string(decoded), "aks-node-controller-nbc-cmd.sh", "aks-node-controller-nbc-cmd-hack.sh", -1)
-	customData = strings.Replace(customData, "aks-node-controller-config.json", "aks-node-controller-config-hack.json", -1)
-
-	if s.VHD.Flatcar {
-		// For Flatcar, customData is an ignition JSON config from baker.go's flatcarTemplate.
-		// Ignition's "enabled: true" only creates enable symlinks but does NOT start services,
-		// so we can't use ignition JSON to start the hack service reliably.
-		// Instead, convert to #cloud-config format with coreos.units "command: start",
-		// which coreos-cloudinit processes and explicitly starts the service.
-		var ignitionConfig map[string]interface{}
-		if err := json.Unmarshal([]byte(customData), &ignitionConfig); err != nil {
-			return "", fmt.Errorf("failed to parse ignition config: %w", err)
-		}
-
-		// Extract the nbc-cmd-hack.sh content from the ignition storage.files
-		var nbcCmdContent string
-		if storage, ok := ignitionConfig["storage"].(map[string]interface{}); ok {
-			if files, ok := storage["files"].([]interface{}); ok {
-				for _, f := range files {
-					file, _ := f.(map[string]interface{})
-					if file["path"] == "/opt/azure/containers/aks-node-controller-nbc-cmd-hack.sh" {
-						if contents, ok := file["contents"].(map[string]interface{}); ok {
-							source, _ := contents["source"].(string)
-							// source is "data:;base64,<base64data>"
-							nbcCmdContent, _ = strings.CutPrefix(source, "data:;base64,")
-							// As of PR #8357, baker.go's flatcarTemplate marks the file with
-							// `compression: gzip`, so the base64 payload decodes to gzip bytes
-							// rather than plaintext shell. Ignition would normally gunzip it,
-							// but here we re-emit via cloud-config `!!binary`, which only
-							// base64-decodes. We must gunzip ourselves and re-base64 the
-							// plaintext, otherwise the resulting nbc-cmd-hack.sh contains raw
-							// gzip bytes and CSE exec fails with "cannot execute binary file"
-							// (exit 126).
-							if compression, _ := contents["compression"].(string); compression == "gzip" {
-								gzBytes, err := base64.StdEncoding.DecodeString(nbcCmdContent)
-								if err != nil {
-									return "", fmt.Errorf("failed to base64-decode gzipped nbc-cmd source: %w", err)
-								}
-								gzReader, err := gzip.NewReader(bytes.NewReader(gzBytes))
-								if err != nil {
-									return "", fmt.Errorf("failed to create gzip reader for nbc-cmd source: %w", err)
-								}
-								plain, err := io.ReadAll(gzReader)
-								_ = gzReader.Close()
-								if err != nil {
-									return "", fmt.Errorf("failed to gunzip nbc-cmd source: %w", err)
-								}
-								nbcCmdContent = base64.StdEncoding.EncodeToString(plain)
-							}
-						}
-					}
-				}
-			}
-		}
-		if nbcCmdContent == "" {
-			return "", fmt.Errorf("failed to extract nbc-cmd-hack.sh content from ignition config")
-		}
-
-		// Build a #cloud-config that writes both the nbc-cmd script and hack runner,
-		// then starts the hack service via coreos.units command: start
-		var aksNodeConfigEntry string
-		provisionFlags := "--nbc-cmd=/opt/azure/containers/aks-node-controller-nbc-cmd-hack.sh"
-		if s.Runtime.AKSNodeConfig != nil {
-			aksNodeConfigJSON, err := nodeconfigutils.MarshalConfigurationV1(s.Runtime.AKSNodeConfig)
-			if err != nil {
-				return "", fmt.Errorf("failed to marshal AKSNodeConfig: %w", err)
-			}
-			encodedConfig := base64.StdEncoding.EncodeToString(aksNodeConfigJSON)
-			aksNodeConfigEntry = fmt.Sprintf(`- path: /opt/azure/containers/aks-node-controller-config-hack.json
-  permissions: "0600"
-  owner: root
-  content: !!binary |
-   %s
-`, encodedConfig)
-			provisionFlags += " --provision-config=/opt/azure/containers/aks-node-controller-config-hack.json"
-		}
-
-		cloudConfig := fmt.Sprintf(`#cloud-config
-write_files:
-- path: /opt/azure/containers/aks-node-controller-nbc-cmd-hack.sh
-  permissions: "0600"
-  owner: root
-  content: !!binary |
-   %[1]s
-%[4]s- path: /opt/azure/bin/run-aks-node-controller-hack.sh
-  permissions: "0755"
-  owner: root
-  content: |
-    #!/bin/bash
-    set -euo pipefail
-    mkdir -p /opt/azure/bin
-    curl -fSL --retry 10 --retry-delay 2 --retry-connrefused "%[2]s" -o /opt/azure/bin/aks-node-controller-hack
-    chmod +x /opt/azure/bin/aks-node-controller-hack
-    /opt/azure/bin/aks-node-controller-hack provision %[3]s
-coreos:
-  units:
-    - name: aks-node-controller-hack.service
-      command: start
-      content: |
-        [Unit]
-        Description=Downloads and runs the AKS node controller hack
-        After=network-online.target
-        Wants=network-online.target
-        [Service]
-        Type=oneshot
-        ExecStart=/opt/azure/bin/run-aks-node-controller-hack.sh
-        [Install]
-        WantedBy=multi-user.target
-`, nbcCmdContent, binaryURL, provisionFlags, aksNodeConfigEntry)
-
-		return base64.StdEncoding.EncodeToString([]byte(cloudConfig)), nil
-	}
-
-	provisionFlags := "--nbc-cmd=/opt/azure/containers/aks-node-controller-nbc-cmd-hack.sh"
-	var aksNodeConfigBlock string
-	if s.Runtime.AKSNodeConfig != nil {
-		aksNodeConfigJSON, err := nodeconfigutils.MarshalConfigurationV1(s.Runtime.AKSNodeConfig)
-		if err != nil {
-			return "", fmt.Errorf("failed to marshal AKSNodeConfig: %w", err)
-		}
-		encodedConfig := base64.StdEncoding.EncodeToString(aksNodeConfigJSON)
-		configPath := "/opt/azure/containers/aks-node-controller-config-hack.json"
-		aksNodeConfigBlock = fmt.Sprintf("\ncat <<'EOF' | base64 -d > %s\n%s\nEOF\nchmod 0600 %s\n", configPath, encodedConfig, configPath)
-		provisionFlags += " --provision-config=" + configPath
-	}
-
-	cloudConfigTemplate := `%s
-
-mkdir -p /opt/azure/bin
-%s
-cat <<'SCRIPT' > /opt/azure/bin/run-aks-node-controller-hack.sh
-#!/bin/bash
-set -euo pipefail
-mkdir -p /opt/azure/bin
-curl -fSL --retry 10 --retry-delay 2 --retry-connrefused "%s" -o /opt/azure/bin/aks-node-controller-hack
-chmod +x /opt/azure/bin/aks-node-controller-hack
-
-/opt/azure/bin/aks-node-controller-hack provision %s
-
-SCRIPT
-chmod +x /opt/azure/bin/run-aks-node-controller-hack.sh
-
-cat <<'UNIT' > /etc/systemd/system/aks-node-controller-hack.service
-[Unit]
-Description=Downloads and runs the AKS node controller hack
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/opt/azure/bin/run-aks-node-controller-hack.sh
-
-[Install]
-WantedBy=basic.target
-UNIT
-
-systemctl daemon-reload
-systemctl start --no-block aks-node-controller-hack.service
-`
-
-	customDataYAML := fmt.Sprintf(cloudConfigTemplate, customData, aksNodeConfigBlock, binaryURL, provisionFlags)
-	return base64.StdEncoding.EncodeToString([]byte(customDataYAML)), nil
+	binaryDownloadCmd := fmt.Sprintf("curl -fSL --retry 10 --retry-delay 2 --retry-connrefused \"%s\" -o /opt/azure/containers/aks-node-controller-hotfix && chmod +x /opt/azure/containers/aks-node-controller-hotfix", binaryURL)
+	customData = strings.Replace(string(decoded), "#hotfix-marker", binaryDownloadCmd, -1)
+	return base64.StdEncoding.EncodeToString([]byte(customData)), nil
 }
 
 func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachineScaleSet {
@@ -478,7 +217,14 @@ func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachine
 	var nodeBootstrapping *datamodel.NodeBootstrapping
 	ab, err := agent.NewAgentBaker()
 	require.NoError(s.T, err)
-	var cse, customData string
+	var cse, customData, aksNodeConfig string
+
+	if s.Runtime.AKSNodeConfig != nil {
+		aksNodeConfigBytes, err := nodeconfigutils.MarshalConfigurationV1(s.Runtime.AKSNodeConfig)
+		require.NoError(s.T, err)
+		aksNodeConfig = string(aksNodeConfigBytes)
+		s.Runtime.NBC.AKSNodeConfigJSON = aksNodeConfig
+	}
 
 	if s.Runtime.NBC != nil {
 		nodeBootstrapping, err = ab.GetNodeBootstrapping(ctx, s.Runtime.NBC)
@@ -486,67 +232,30 @@ func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachine
 	}
 
 	scriptlessNBCCSECmdEnabled := usesScriptlessNBCCSECmd(s)
-	if s.Runtime.AKSNodeConfig != nil && scriptlessNBCCSECmdEnabled {
-		cse = nodeconfigutils.CSE
-		aksNodeConfig := s.Runtime.AKSNodeConfig
 
-		if scriptlessNBCCSECmdEnabled {
-			cse = nodeBootstrapping.CSE
-		}
-
-		customData = func() string {
-			if config.Config.DisableScriptLessCompilation {
-				var data string
-				var err error
-				if scriptlessNBCCSECmdEnabled {
-					return nodeBootstrapping.CustomData
-				}
-				if s.VHD.Flatcar {
-					data, err = nodeconfigutils.CustomDataFlatcar(aksNodeConfig)
-				} else {
-					data, err = nodeconfigutils.CustomData(aksNodeConfig)
-				}
-				require.NoError(s.T, err, "failed to generate custom data from AKSNodeConfig")
-				return data
-			}
-			binaryURL, err := CachedCompileAndUploadAKSNodeController(ctx, s.VHD.Arch)
-			require.NoError(s.T, err, "failed to compile and upload aks-node-controller binary")
-			if scriptlessNBCCSECmdEnabled {
-				customData := nodeBootstrapping.CustomData
-				customData, err = CustomDataWithNBCCmdHack(s, customData, binaryURL)
-				require.NoError(s.T, err, "failed to generate custom data with NBC cmd hack")
-				return customData
-			}
-			data, err := CustomDataWithHack(s, binaryURL)
-			require.NoError(s.T, err, "failed to generate custom data from AKSNodeConfig with hack")
-			return data
-		}()
-
-	} else {
-		cse = nodeBootstrapping.CSE
-		customData = nodeBootstrapping.CustomData
-		if enableScriptlessCompilation(s) {
-			binaryURL, err := CachedCompileAndUploadAKSNodeController(ctx, s.VHD.Arch)
-			require.NoError(s.T, err, "failed to compile and upload aks-node-controller binary")
-			customData, err = CustomDataWithNBCCmdHack(s, customData, binaryURL)
-			require.NoError(s.T, err, "failed to generate custom data with NBC cmd hack")
-		}
-		if len(s.Config.CustomDataWriteFiles) > 0 {
-			customData, err = injectWriteFilesEntriesToCustomData(customData, s.Config.CustomDataWriteFiles)
-			require.NoError(s.T, err, "failed to inject customData write_files entries")
-		}
-		if s.Runtime.NBC.EnableScriptlessCSECmd && !scriptlessNBCCSECmdEnabled && s.VHD.SupportsScriptless() {
-			// Validate that the custom data indicates scriptless CSE is enabled by checking
-			// for the scriptless overrides sentinel file path.
-			decodedCustomData, err := base64.StdEncoding.DecodeString(customData)
-			require.NoError(s.T, err, "failed to decode custom data")
-			reader, err := gzip.NewReader(bytes.NewReader(decodedCustomData))
-			require.NoError(s.T, err, "failed to create gzip reader")
-			result, err := io.ReadAll(reader)
-			require.NoError(s.T, err, "failed to read gzip data")
-			reader.Close()
-			require.Contains(s.T, string(result), "/opt/azure/containers/scriptless-cse-overrides.txt", "custom data contains other script content, but scriptless CSE CMD is enabled")
-		}
+	cse = nodeBootstrapping.CSE
+	customData = nodeBootstrapping.CustomData
+	if enableScriptlessCompilation(s) {
+		binaryURL, err := CachedCompileAndUploadAKSNodeController(ctx, s.VHD.Arch)
+		require.NoError(s.T, err, "failed to compile and upload aks-node-controller binary")
+		customData, err = CustomDataWithNBCCmdHack(s, customData, binaryURL)
+		require.NoError(s.T, err, "failed to generate custom data with NBC cmd hack")
+	}
+	if len(s.Config.CustomDataWriteFiles) > 0 {
+		customData, err = injectWriteFilesEntriesToCustomData(customData, s.Config.CustomDataWriteFiles)
+		require.NoError(s.T, err, "failed to inject customData write_files entries")
+	}
+	if !scriptlessNBCCSECmdEnabled && s.VHD.SupportsScriptless() {
+		// Validate that the custom data doesn't contain any script content,
+		// which indicates that the scriptless CSE is working as intended
+		decodedCustomData, err := base64.StdEncoding.DecodeString(customData)
+		require.NoError(s.T, err, "failed to decode custom data")
+		reader, err := gzip.NewReader(bytes.NewReader(decodedCustomData))
+		require.NoError(s.T, err, "failed to create gzip reader")
+		result, err := io.ReadAll(reader)
+		require.NoError(s.T, err, "failed to read gzip data")
+		reader.Close()
+		require.Contains(s.T, string(result), "/opt/azure/containers/scriptless-cse-overrides.txt", "custom data contains other script content, but scriptless CSE CMD is enabled")
 	}
 
 	// These two links are really for local development
@@ -603,7 +312,7 @@ func usesScriptlessNBCCSECmd(s *Scenario) bool {
 }
 
 func enableScriptlessCompilation(s *Scenario) bool {
-	return s.Runtime.NBC.EnableScriptlessNBCCSECmd && len(s.Config.CustomDataWriteFiles) <= 0 && !config.Config.DisableScriptLessCompilation && !s.Tags.NetworkIsolated && !s.Runtime.NBC.PreProvisionOnly
+	return usesScriptlessNBCCSECmd(s) && len(s.Config.CustomDataWriteFiles) <= 0 && !config.Config.DisableScriptLessCompilation && !s.Tags.NetworkIsolated && !s.VHD.Flatcar
 }
 
 func CreateVMSSWithRetry(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
@@ -1022,13 +731,12 @@ func extractLogsFromVMLinux(ctx context.Context, s *Scenario, vm *ScenarioVM) er
 		"waagent.log":                      "sudo cat /var/log/waagent.log",
 		"aks-node-controller.log":          "sudo cat /var/log/azure/aks-node-controller.log",
 		"aks-node-controller-config.json":  "sudo cat /opt/azure/containers/aks-node-controller-config.json", // Only available in Scriptless.
-
-		// Only available in Scriptless. By default, e2e enables aks-node-controller-hack, so this is the actual config used. Only in e2e. Not used in production.
-		"aks-node-controller-config-hack.json": "sudo cat /opt/azure/containers/aks-node-controller-config-hack.json",
-		"syslog":                               "sudo cat /var/log/" + syslogHandle,
-		"journalctl":                           "sudo journalctl --boot=0 --no-pager",
-		"azure.json":                           "sudo cat /etc/kubernetes/azure.json",
-		"provision.json":                       "sudo cat /var/log/azure/aks/provision.json",
+		"syslog":                           "sudo cat /var/log/" + syslogHandle,
+		"journalctl":                       "sudo journalctl --boot=0 --no-pager",
+		"azure.json":                       "sudo cat /etc/kubernetes/azure.json",
+		"provision.json":                   "sudo cat /var/log/azure/aks/provision.json",
+		"cloud-init.log":                   "sudo cat /var/log/cloud-init.log",
+		"cloud-init-output.log":            "sudo cat /var/log/cloud-init-output.log",
 	}
 	if s.SecureTLSBootstrappingEnabled() {
 		commandList["secure-tls-bootstrap.log"] = "sudo cat /var/log/azure/aks/secure-tls-bootstrap.log"
@@ -1485,9 +1193,9 @@ func injectWriteFilesEntriesToBoothookCustomData(decoded []byte, entries []Custo
 		return "", err
 	}
 
-	insertPos := strings.Index(boothookStr, "systemctl start --no-block aks-node-controller.service")
+	insertPos := strings.Index(boothookStr, "/bin/bash /opt/azure/containers/aks-node-controller-launcher.sh")
 	if insertPos == -1 {
-		insertPos = strings.Index(boothookStr, "systemctl start --no-block aks-node-controller-hack.service")
+		insertPos = strings.Index(boothookStr, "systemctl start --no-block aks-node-controller.service")
 	}
 	if insertPos == -1 {
 		return "", fmt.Errorf("cloud-boothook customData missing aks-node-controller service start")

--- a/parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh
@@ -22,7 +22,7 @@ NBC_CMD_PATH="${NBC_CMD_PATH:-/opt/azure/containers/aks-node-controller-nbc-cmd.
 # producer is the sole trusted writer. Parsed below at wrapper runtime; absent file (default-off,
 # or an older VHD without the producer) is a no-op.
 FEATURES_PATH="${FEATURES_PATH:-/opt/azure/containers/enabled_features.sh}"
-LOGGER_TAG="aks-node-controller-wrapper"
+LOGGER_TAG="aks-node-controller-launcher"
 
 log() {
     local message="$1"

--- a/parts/linux/cloud-init/artifacts/aks-node-controller.service
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller.service
@@ -1,11 +1,18 @@
 [Unit]
 Description=Parse contract and run csecmd
+# DefaultDependencies=no avoids the implicit After=sysinit.target/basic.target
+# systemd adds by default, which otherwise forces this unit to wait for the
+# whole basic.target transaction (including cloud-init.service's remaining
+# modules such as growpart/resizefs/ssh-keygen) to resolve before it can
+# start, even though the boothook already requested "systemctl start
+# --no-block" on it much earlier.
+DefaultDependencies=no
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/opt/azure/containers/aks-node-controller-wrapper.sh
+ExecStart=/opt/azure/containers/aks-node-controller-launcher.sh
 RemainAfterExit=yes
 
 [Install]

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -56,13 +56,18 @@ set -euo pipefail
 
 logger -t aks-boothook "boothook start $(date -Ins)"
 
-mkdir -p /opt/azure/containers
+mkdir -p /opt/azure/containers /var/log/azure
 
 nohup /bin/bash /opt/azure/containers/provision_preload.sh >/dev/null 2>&1 &
 
+#hotfix-marker
 %s
-logger -t aks-boothook "launching aks-node-controller service $(date -Ins)"
-systemctl start --no-block aks-node-controller.service
+logger -t aks-boothook "launching aks-node-controller $(date -Ins)"
+if [ -f /opt/azure/containers/aks-node-controller-launcher.sh ]; then
+	nohup /bin/bash /opt/azure/containers/aks-node-controller-launcher.sh > /var/log/azure/aks-node-controller.output 2>&1 &
+else
+	systemctl start --no-block aks-node-controller.service
+fi
 `
 	// boothookFileEntry is appended to the boothook for each additional file.
 	// It writes gzipped+base64-encoded content to disk before starting aks-node-controller.
@@ -74,8 +79,19 @@ chmod 0600 %[1]s
 `
 	flatcarTemplate = `{
      "ignition": { "version": "3.4.0" },
+     "systemd": {
+       "units": [{
+         "name": "aks-node-controller.service",
+         "enabled": true
+       }]
+     },
      "storage": {
-       "files": [%s]
+       "files": [%s],
+       "links": [{
+         "path": "/etc/systemd/system/basic.target.wants/aks-node-controller.service",
+         "target": "/etc/systemd/system/aks-node-controller.service",
+         "overwrite": true
+       }]
       }
      }`
 	// flatcarFileEntry is an Ignition file entry appended to the files array

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -1712,8 +1712,25 @@ var _ = Describe("getLinuxNodeBootstrappingPayload", func() {
 		var ignition map[string]interface{}
 		Expect(json.Unmarshal(decodedPayload, &ignition)).To(Succeed())
 
+		systemd, ok := ignition["systemd"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		units, ok := systemd["units"].([]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(units).To(ConsistOf(map[string]interface{}{
+			"name":    "aks-node-controller.service",
+			"enabled": true,
+		}))
+
 		storage, ok := ignition["storage"].(map[string]interface{})
 		Expect(ok).To(BeTrue())
+		links, ok := storage["links"].([]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(links).To(ConsistOf(map[string]interface{}{
+			"path":      "/etc/systemd/system/basic.target.wants/aks-node-controller.service",
+			"target":    "/etc/systemd/system/aks-node-controller.service",
+			"overwrite": true,
+		}))
+
 		files, ok := storage["files"].([]interface{})
 		Expect(ok).To(BeTrue())
 		Expect(len(files)).To(Equal(3)) // nbc-cmd, nodecustomdata, aks-node-config (no hotfix file present)

--- a/spec/parts/linux/cloud-init/artifacts/aks_node_controller_launcher_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/aks_node_controller_launcher_spec.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env shellspec
 
-Describe 'aks-node-controller-wrapper.sh'
-    SCRIPT="./parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh"
+Describe 'aks-node-controller-launcher.sh'
+    SCRIPT="./parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh"
 
     setup_wrapper_test() {
-        TEST_DIR="${SHELLSPEC_WORKDIR}/aks-node-controller-wrapper"
+        TEST_DIR="${SHELLSPEC_WORKDIR}/aks-node-controller-launcher"
         BIN_DIR="${TEST_DIR}/bin"
         mkdir -p "$BIN_DIR"
 

--- a/vhdbuilder/packer/imagecustomizer/azlosguard/azlosguard.yml
+++ b/vhdbuilder/packer/imagecustomizer/azlosguard/azlosguard.yml
@@ -70,8 +70,8 @@ os:
     - source: /AgentBaker/parts/linux/cloud-init/artifacts/aks-node-controller.service
       destination: /etc/systemd/system/aks-node-controller.service
       permissions: 600
-    - source: /AgentBaker/parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh
-      destination: /opt/azure/containers/aks-node-controller-wrapper.sh
+    - source: /AgentBaker/parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh
+      destination: /opt/azure/containers/aks-node-controller-launcher.sh
       permissions: 755
     # Fix systemd resolved caching
     - source: /AgentBaker/parts/linux/cloud-init/artifacts/resolv-uplink-override.service
@@ -338,7 +338,6 @@ os:
     - measure-tls-bootstrapping-latency
     - systemd-sysext
     - ipv6_nftables
-    - aks-node-controller
     - update_certs.path
     - disk_queue
     - ci-syslog-watcher.path
@@ -349,6 +348,7 @@ os:
     # Disable Azure Linux iptables service so k8s has control
     - iptables
     - auditd
+    - aks-node-controller
 
 previewFeatures:
   - uki

--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -113,8 +113,8 @@ copyPackerFiles() {
   AKS_CHECK_NETWORK_SCRIPT_DEST=/opt/azure/containers/aks-check-network.sh
   AKS_CHECK_NETWORK_SERVICE_SRC=/home/packer/aks-check-network.service
   AKS_CHECK_NETWORK_SERVICE_DEST=/etc/systemd/system/aks-check-network.service
-  AKS_NODE_CONTROLLER_WRAPPER_SRC=/home/packer/aks-node-controller-wrapper.sh
-  AKS_NODE_CONTROLLER_WRAPPER_DEST=/opt/azure/containers/aks-node-controller-wrapper.sh
+  AKS_NODE_CONTROLLER_LAUNCHER_SRC=/home/packer/aks-node-controller-launcher.sh
+  AKS_NODE_CONTROLLER_LAUNCHER_DEST=/opt/azure/containers/aks-node-controller-launcher.sh
   BLOCK_WIRESERVER_SRC=/home/packer/block_wireserver.sh
   BLOCK_WIRESERVER_DEST=/opt/azure/containers/kubelet.sh
   ENSURE_IMDS_RESTRICTION_SRC=/home/packer/ensure_imds_restriction.sh
@@ -276,7 +276,7 @@ copyPackerFiles() {
   AKS_NODE_CONTROLLER_SRC=/home/packer/aks-node-controller
   AKS_NODE_CONTROLLER_DEST=/opt/azure/containers/aks-node-controller
   cpAndMode $AKS_NODE_CONTROLLER_SRC $AKS_NODE_CONTROLLER_DEST 755
-  cpAndMode $AKS_NODE_CONTROLLER_WRAPPER_SRC $AKS_NODE_CONTROLLER_WRAPPER_DEST 755
+  cpAndMode $AKS_NODE_CONTROLLER_LAUNCHER_SRC $AKS_NODE_CONTROLLER_LAUNCHER_DEST 0755
 
   AKS_NODE_CONTROLLER_SERVICE_SRC=/home/packer/aks-node-controller.service
   AKS_NODE_CONTROLLER_SERVICE_DEST=/etc/systemd/system/aks-node-controller.service

--- a/vhdbuilder/packer/pre-install-dependencies.sh
+++ b/vhdbuilder/packer/pre-install-dependencies.sh
@@ -78,8 +78,17 @@ rm -f /etc/cron.daily/logrotate
 systemctlEnableAndStart sync-container-logs.service 30 || exit 1
 capture_benchmark "${SCRIPT_NAME}_enable_and_configure_logging_services"
 
-# enable aks-node-controller.service
-systemctl enable aks-node-controller.service
+# Keep aks-node-controller.service disabled in the VHD image. The unit now has
+# DefaultDependencies=no (see aks-node-controller.service), so if it were enabled
+# via WantedBy=basic.target it could be auto-started by systemd before the
+# boothook has written the provision config/nbc-cmd files, causing the wrapper's
+# graceful no-op exit to mark the oneshot unit "active (exited)" - after which
+# the boothook's own explicit "systemctl start" would be a no-op and ANC would
+# never actually run with the real config. The boothook's explicit
+# "systemctl start --no-block aks-node-controller.service" call (issued only
+# after those files exist) remains the sole trigger for this unit.
+# Sometimes its also started diretly in boothook
+systemctl disable aks-node-controller.service
 
 # First handle Mariner + FIPS
 if isMarinerOrAzureLinux "$OS"; then
@@ -128,6 +137,25 @@ if [[ ${OS} == ${MARINER_OS_NAME} ]] && [[ "${ENABLE_CGROUPV2,,}" == "true" ]]; 
   enableCgroupV2forAzureLinux
 fi
 capture_benchmark "${SCRIPT_NAME}_enable_cgroupv2_for_azurelinux"
+
+if { isUbuntu "$OS" || isAzureLinux "$OS"; }; then
+  echo "nodelay" | tee -a /etc/dhcpcd.conf
+  tee /etc/systemd/system/cache-warmup.service > /dev/null << 'EOF'
+[Unit]
+Description=Preload Critical Binaries into Page Cache
+DefaultDependencies=no
+
+[Service]
+Type=simple
+ExecStart=/bin/bash /opt/azure/containers/provision_preload.sh
+
+[Install]
+WantedBy=sysinit.target
+EOF
+
+  systemctl daemon-reload
+  systemctl enable cache-warmup.service
+fi
 
 # Remove lockdown=integrity from kernel cmdline for Azure Linux 3.0
 # The kernel has an OOT patch that auto-enables lockdown when secure boot is detected
@@ -247,7 +275,7 @@ if [[ ${UBUNTU_RELEASE//./} -ge 2204 && "${ENABLE_FIPS,,}" != "true" ]]; then
       if apt-cache show "${NVIDIA_KERNEL_PACKAGE}" &> /dev/null; then
         echo "ARM64 image. Installing NVIDIA kernel and its packages alongside LTS kernel"
         wait_for_apt_locks
-        sudo apt install --no-install-recommends -y "${NVIDIA_KERNEL_PACKAGE}"
+        apt install --no-install-recommends -y "${NVIDIA_KERNEL_PACKAGE}"
         echo "after installation:"
         dpkg -l | grep "linux-.*-azure-nvidia" || true
       else

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1990,16 +1990,24 @@ testAKSNodeControllerService() {
   echo "$test:Start"
 
   # is-enabled returns:
-  # 'enabled' if the service is enabled.
+  # 'disabled' if the service is disabled.
   # empty string if the service is not installed.
   # 'not-found' if the unit files are not present. Encountered with Ubuntu 24.04
-  echo "$test: Checking that $service_name is enabled"
+  #
+  # The unit is kept disabled in the VHD image on purpose: it must only ever be
+  # started by the boothook's explicit "systemctl start --no-block" call, issued
+  # after the provision config/nbc-cmd files exist. If it were enabled (pulled in
+  # via WantedBy=basic.target), systemd could auto-start it before those files
+  # exist; the wrapper's graceful no-op exit would then mark this oneshot unit
+  # "active (exited)", making the boothook's later start call a no-op and
+  # preventing ANC from ever running with the real config.
+  echo "$test: Checking that $service_name is disabled"
   is_enabled=$(systemctl is-enabled $service_name 2>/dev/null)
   echo "$test: logging ${is_enabled} here"
-  if [ "${is_enabled}" = "enabled" ]; then
-    echo "$test: $service_name is correctly enabled"
+  if [ "${is_enabled}" = "disabled" ]; then
+    echo "$test: $service_name is correctly disabled"
   else
-    err $test "$service_name is not enabled, instead in state $is_enabled"
+    err $test "$service_name is not disabled, instead in state $is_enabled"
   fi
 
   echo "$test:Finish"

--- a/vhdbuilder/packer/vhd-image-builder-acl-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-acl-arm64.json
@@ -104,8 +104,8 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh",
-      "destination": "/home/packer/aks-node-controller-wrapper.sh"
+      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh",
+      "destination": "/home/packer/aks-node-controller-launcher.sh"
     },
     {
       "type": "file",

--- a/vhdbuilder/packer/vhd-image-builder-acl.json
+++ b/vhdbuilder/packer/vhd-image-builder-acl.json
@@ -104,8 +104,8 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh",
-      "destination": "/home/packer/aks-node-controller-wrapper.sh"
+      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh",
+      "destination": "/home/packer/aks-node-controller-launcher.sh"
     },
     {
       "type": "file",

--- a/vhdbuilder/packer/vhd-image-builder-arm64-gb.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gb.json
@@ -104,8 +104,8 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh",
-      "destination": "/home/packer/aks-node-controller-wrapper.sh"
+      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh",
+      "destination": "/home/packer/aks-node-controller-launcher.sh"
     },
     {
       "type": "file",

--- a/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
+++ b/vhdbuilder/packer/vhd-image-builder-arm64-gen2.json
@@ -104,8 +104,8 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh",
-      "destination": "/home/packer/aks-node-controller-wrapper.sh"
+      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh",
+      "destination": "/home/packer/aks-node-controller-launcher.sh"
     },
     {
       "type": "file",

--- a/vhdbuilder/packer/vhd-image-builder-base.json
+++ b/vhdbuilder/packer/vhd-image-builder-base.json
@@ -107,8 +107,8 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh",
-      "destination": "/home/packer/aks-node-controller-wrapper.sh"
+      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh",
+      "destination": "/home/packer/aks-node-controller-launcher.sh"
     },
     {
       "type": "file",

--- a/vhdbuilder/packer/vhd-image-builder-cvm.json
+++ b/vhdbuilder/packer/vhd-image-builder-cvm.json
@@ -111,8 +111,8 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh",
-      "destination": "/home/packer/aks-node-controller-wrapper.sh"
+      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh",
+      "destination": "/home/packer/aks-node-controller-launcher.sh"
     },
     {
       "type": "file",

--- a/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-arm64.json
@@ -103,8 +103,8 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh",
-      "destination": "/home/packer/aks-node-controller-wrapper.sh"
+      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh",
+      "destination": "/home/packer/aks-node-controller-launcher.sh"
     },
     {
       "type": "file",

--- a/vhdbuilder/packer/vhd-image-builder-mariner-cvm.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner-cvm.json
@@ -114,8 +114,8 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh",
-      "destination": "/home/packer/aks-node-controller-wrapper.sh"
+      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh",
+      "destination": "/home/packer/aks-node-controller-launcher.sh"
     },
     {
       "type": "file",

--- a/vhdbuilder/packer/vhd-image-builder-mariner.json
+++ b/vhdbuilder/packer/vhd-image-builder-mariner.json
@@ -105,8 +105,8 @@
     },
     {
       "type": "file",
-      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-wrapper.sh",
-      "destination": "/home/packer/aks-node-controller-wrapper.sh"
+      "source": "parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh",
+      "destination": "/home/packer/aks-node-controller-launcher.sh"
     },
     {
       "type": "file",


### PR DESCRIPTION
1. Start aks node controller immediately instad of queueing the service start which is about 3-4s slower
2. Add no delay to dhcpd temporary call made during cloud init which gets DHCP lease, there is an artifical 1.9s jitter for no reason
3. Disable aks node controller service from auto starting.
4. Flatcar/ACL uses service still since there is no easy way to start scripts in boot

After all these changes we gain about 5-6s improvement in boot times.

Network online happens during cloud init local phase so when boothook runs which is part of cloud init phase network is definitely online so no check is required.


**Before:**

- Kernel boot -> CSE start: 15.000s
- Boot -> CSE start (journalctl hostname): 8.000s
- CloudInit -> CSE start: 6.000s

**After:**

- Kernel boot -> CSE start: 10.000s
- Boot -> CSE start (journalctl hostname): 4.000s
- CloudInit -> CSE start: 1.000s