### PR TITLE
fix: remove az cli pinning

### DIFF
--- a/packer.mk
+++ b/packer.mk
@@ -1,7 +1,5 @@
 SHELL=/bin/bash -o pipefail
 
-export AZCLI_VERSION_OVERRIDE ?= 2.77.0
-
 GOARCH=amd64
 ifeq (${ARCHITECTURE},ARM64)
 	GOARCH=arm64
@@ -92,7 +90,7 @@ az-login:
 	@az account set -s ${SUBSCRIPTION_ID}
 
 init-packer:
-	@./vhdbuilder/packer/produce-packer-settings.sh ${AZCLI_VERSION_OVERRIDE}
+	@./vhdbuilder/packer/produce-packer-settings.sh
 
 run-packer: az-login
 	@packer init ./vhdbuilder/packer/packer-plugin.pkr.hcl && packer version && ($(MAKE) -f packer.mk init-packer | tee packer-output) && ($(MAKE) -f packer.mk build-packer | tee -a packer-output)

--- a/vhdbuilder/packer/produce-packer-settings-functions.sh
+++ b/vhdbuilder/packer/produce-packer-settings-functions.sh
@@ -1,20 +1,5 @@
 #!/bin/bash
 
-function enforce_azcli_version() {
-	AZ_VER_REQUIRED=$1
-	AZ_DIST=$(lsb_release -cs)
-	echo "Enforcing az cli version to ${AZ_VER_REQUIRED} for ${AZ_DIST}"
-	sudo DEBIAN_FRONTEND=noninteractive dpkg --configure -a
-	sudo DEBIAN_FRONTEND=noninteractive apt-get install azure-cli=${AZ_VER_REQUIRED}-1~${AZ_DIST} -y --no-install-recommends --allow-downgrades
-	AZ_VER_INSTALLED=$(az version --query "[\"azure-cli\"]" -o tsv)
-	if [ "${AZ_VER_INSTALLED}" != "${AZ_VER_REQUIRED}" ]; then
-		echo "Failed to install required az cli version ${AZ_VER_REQUIRED}, installed version is ${AZ_VER_INSTALLED}"
-		exit 1
-	else
-		echo "Successfully installed az cli version ${AZ_VER_INSTALLED}"
-	fi
-}
-
 function produce_ua_token() {
 	set +x
 	UA_TOKEN="${UA_TOKEN:-}" # used to attach UA when building ESM-enabled Ubuntu SKUs

--- a/vhdbuilder/packer/produce-packer-settings.sh
+++ b/vhdbuilder/packer/produce-packer-settings.sh
@@ -1,16 +1,8 @@
 #!/bin/bash
 set -e
 
-echo "Installing previous version of azcli in order to mitigate az compute bug"
-source parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
-
 SCRIPT_DIR=$(dirname "$0")
 source "$SCRIPT_DIR/produce-packer-settings-functions.sh"
-
-if [ -n "${AZCLI_VERSION_OVERRIDE}" ]; then
-  echo "Overriding azcli version to ${AZCLI_VERSION_OVERRIDE}"
-  enforce_azcli_version "${AZCLI_VERSION_OVERRIDE}"
-fi
 
 CDIR=$(dirname "${BASH_SOURCE}")
 SETTINGS_JSON="${SETTINGS_JSON:-./packer/settings.json}"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the AZ CLI pinning for the VHD build step.

**Which issue(s) this PR fixes**:

AZ CLI may be unnecessarily pinned.

Fixes #
