### PR TITLE
test: extend gpu e2e pipeline jobTimeoutInMinutes to 2 hours

### DIFF
--- a/.pipelines/e2e-gpu.yaml
+++ b/.pipelines/e2e-gpu.yaml
@@ -36,4 +36,5 @@ jobs:
     parameters:
       name: Linux GPU Tests
       IgnoreScenariosWithMissingVhd: false
+      jobTimeoutInMinutes: 120
       failedTestsRetryCount: ${{ variables.E2E_FAILED_TESTS_RETRY_COUNT }}

--- a/.pipelines/templates/e2e-template.yaml
+++ b/.pipelines/templates/e2e-template.yaml
@@ -18,6 +18,10 @@ parameters:
     type: number
     displayName: Number of times to retry failed E2E tests
     default: 0
+  - name: jobTimeoutInMinutes
+    type: number
+    displayName: Maximum duration of the E2E job
+    default: 90
   - name: useVhdMetadataArtifacts
     type: boolean
     displayName: Resolve VHDs from metadata artifacts produced by this pipeline
@@ -45,7 +49,7 @@ jobs:
           value: ${{parameters.subscriptionId}}
     pool:
       name: $(E2E_POOL_NAME)
-    timeoutInMinutes: 90
+    timeoutInMinutes: ${{ parameters.jobTimeoutInMinutes }}
     displayName: Run AgentBaker E2E ${{parameters.name}}
     steps:
       - checkout: self


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
 GPU-only 120-minute timeout.

  - Added jobTimeoutInMinutes, default 90, to .pipelines/templates/e2e-template.yaml:21.
  - Set GPU pipeline to 120 in .pipelines/e2e-gpu.yaml:39.
  - Other E2E pipelines remain at 90 minutes.
  
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
