### PR TITLE
chore: assign GPU Renovate updates to GPU SIG

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -460,14 +460,38 @@
       ],
       "groupName": "nvidia-device-plugin",
       "assignees": [
-        "djsly",
         "ganeshkumarashok",
-        "surajssd"
+        "sulixu",
+        "xuexu6666",
+        "runzhen",
+        "karenychen"
       ],
       "reviewers": [
-        "djsly",
         "ganeshkumarashok",
-        "surajssd"
+        "sulixu",
+        "xuexu6666",
+        "runzhen",
+        "karenychen"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "dra-driver-nvidia-gpu"
+      ],
+      "groupName": "dra-driver-nvidia-gpu",
+      "assignees": [
+        "ganeshkumarashok",
+        "sulixu",
+        "xuexu6666",
+        "runzhen",
+        "karenychen"
+      ],
+      "reviewers": [
+        "ganeshkumarashok",
+        "sulixu",
+        "xuexu6666",
+        "runzhen",
+        "karenychen"
       ]
     },
     {
@@ -491,14 +515,18 @@
       ],
       "groupName": "nvidia-dcgm",
       "assignees": [
-        "djsly",
         "ganeshkumarashok",
-        "surajssd"
+        "sulixu",
+        "xuexu6666",
+        "runzhen",
+        "karenychen"
       ],
       "reviewers": [
-        "djsly",
         "ganeshkumarashok",
-        "surajssd"
+        "sulixu",
+        "xuexu6666",
+        "runzhen",
+        "karenychen"
       ]
     },
     {
@@ -610,7 +638,21 @@
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<prerelease>\\d{14})$",
       "automerge": false,
       "enabled": true,
-      "ignoreUnstable": false
+      "ignoreUnstable": false,
+      "assignees": [
+        "ganeshkumarashok",
+        "sulixu",
+        "xuexu6666",
+        "runzhen",
+        "karenychen"
+      ],
+      "reviewers": [
+        "ganeshkumarashok",
+        "sulixu",
+        "xuexu6666",
+        "runzhen",
+        "karenychen"
+      ]
     },
     {
       "matchPackageNames": [
@@ -621,7 +663,21 @@
       "allowedVersions": "/^580\\./",
       "automerge": false,
       "enabled": true,
-      "ignoreUnstable": false
+      "ignoreUnstable": false,
+      "assignees": [
+        "ganeshkumarashok",
+        "sulixu",
+        "xuexu6666",
+        "runzhen",
+        "karenychen"
+      ],
+      "reviewers": [
+        "ganeshkumarashok",
+        "sulixu",
+        "xuexu6666",
+        "runzhen",
+        "karenychen"
+      ]
     },
     {
       "matchPackageNames": [
@@ -631,7 +687,21 @@
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<prerelease>\\d{14})$",
       "automerge": false,
       "enabled": true,
-      "ignoreUnstable": false
+      "ignoreUnstable": false,
+      "assignees": [
+        "ganeshkumarashok",
+        "sulixu",
+        "xuexu6666",
+        "runzhen",
+        "karenychen"
+      ],
+      "reviewers": [
+        "ganeshkumarashok",
+        "sulixu",
+        "xuexu6666",
+        "runzhen",
+        "karenychen"
+      ]
     },
     {
       "matchPackageNames": [
@@ -641,7 +711,21 @@
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<prerelease>\\d{14})$",
       "automerge": false,
       "enabled": true,
-      "ignoreUnstable": false
+      "ignoreUnstable": false,
+      "assignees": [
+        "ganeshkumarashok",
+        "sulixu",
+        "xuexu6666",
+        "runzhen",
+        "karenychen"
+      ],
+      "reviewers": [
+        "ganeshkumarashok",
+        "sulixu",
+        "xuexu6666",
+        "runzhen",
+        "karenychen"
+      ]
     },
     {
       "matchPackageNames": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 2026-07-23
+
+- Goal: Assign Renovate-managed GPU and NVIDIA package updates to GPU SIG members.
+- Findings: Seven ownership rules cover the managed GPU packages; `nvidia-container-toolkit` is excluded with `<DO_NOT_UPDATE>`.
+- Failed attempts: Exact-name GitHub searches missed some members, so their logins were resolved from AgentBaker commit metadata.
+- Files changed: `.github/renovate.json`, `CHANGELOG.md`.
+- Next step: Open a PR from a branch in `Azure/AgentBaker`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog
-
-## 2026-07-23
-
-- Goal: Assign Renovate-managed GPU and NVIDIA package updates to GPU SIG members.
-- Findings: Seven ownership rules cover the managed GPU packages; `nvidia-container-toolkit` is excluded with `<DO_NOT_UPDATE>`.
-- Failed attempts: Exact-name GitHub searches missed some members, so their logins were resolved from AgentBaker commit metadata.
-- Files changed: `.github/renovate.json`, `CHANGELOG.md`.
-- Next step: Open a PR from a branch in `Azure/AgentBaker`.


### PR DESCRIPTION
## Summary
- assign all Renovate-managed NVIDIA and GPU packages to the GPU SIG
- add a dedicated ownership rule for `dra-driver-nvidia-gpu`
- use the verified GitHub IDs `ganeshkumarashok`, `sulixu`, `xuexu6666`, `runzhen`, and `karenychen` for assignees and reviewers

## Validation
- parsed `.github/renovate.json` with `jq`
- verified all seven GPU ownership rules have identical assignee and reviewer lists