### PR TITLE
feat: upgrade azurefile-csi-driver image to v1.35.6 / v1.34.7

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -542,8 +542,8 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.35.5",
-          "previousLatestVersion": "v1.35.4"
+          "latestVersion": "v1.35.6",
+          "previousLatestVersion": "v1.35.5"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
@@ -552,15 +552,15 @@
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.34.6",
-          "previousLatestVersion": "v1.34.5"
+          "latestVersion": "v1.34.7",
+          "previousLatestVersion": "v1.34.6"
         }
       ],
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.35.5-windows-hp",
-          "previousLatestVersion": "v1.35.4-windows-hp"
+          "latestVersion": "v1.35.6-windows-hp",
+          "previousLatestVersion": "v1.35.5-windows-hp"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
@@ -569,8 +569,8 @@
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.34.6-windows-hp",
-          "previousLatestVersion": "v1.34.5-windows-hp"
+          "latestVersion": "v1.34.7-windows-hp",
+          "previousLatestVersion": "v1.34.6-windows-hp"
         }
       ]
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade the azurefile-csi-driver image bundled in AgentBaker to the latest patch releases:
- Linux: `v1.35.5` → `v1.35.6` and `v1.34.6` → `v1.34.7`
- Windows: `v1.35.5-windows-hp` → `v1.35.6-windows-hp` and `v1.34.6-windows-hp` → `v1.34.7-windows-hp`

Release notes:
- v1.35.6: https://github.com/kubernetes-sigs/azurefile-csi-driver/releases/tag/v1.35.6
- v1.34.7: https://github.com/kubernetes-sigs/azurefile-csi-driver/releases/tag/v1.34.7

**Which issue(s) this PR fixes**:
Fixes #
