### PR TITLE
fix: harden Windows VHD: disable automatic CTL root cert updates

### DIFF
--- a/vhdbuilder/packer/windows/windows_settings.json
+++ b/vhdbuilder/packer/windows/windows_settings.json
@@ -68,6 +68,14 @@
       "Type": "DWORD"
     },
     {
+      "Comment": "Hardening: disable automatic Certificate Trust List (root certificate) updates. Separate auto-update mechanism from WindowsUpdate\\AU (see Disable-WindowsUpdates), not covered by NoAutoUpdate. https://learn.microsoft.com/en-us/windows-server/identity/ad-cs/certificate-trust",
+      "WindowsSkuMatch": "*",
+      "Path": "HKLM:\\Software\\Policies\\Microsoft\\SystemCertificates\\AuthRoot",
+      "Name": "DisableRootAutoUpdate",
+      "Value": "1",
+      "Type": "DWORD"
+    },
+    {
       "Comment": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2013-3900",
       "WindowsSkuMatch": "2022*",
       "Path": "HKLM:\\Software\\Microsoft\\Cryptography\\Wintrust\\Config",


### PR DESCRIPTION
Add DisableRootAutoUpdate=1 under
HKLM:Software\Policies\Microsoft\SystemCertificates\AuthRoot to windows_settings.json so it is applied via the standard WindowsRegistryKeys mechanism on every Windows VHD build.

This is a separate auto-update path from WindowsUpdate\AU (already disabled by Disable-WindowsUpdates) and is not covered by NoAutoUpdate. Defense-in-depth hardening.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
