### PR TITLE
chore: upgrade Blob CSI driver and sidecar image versions

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -580,13 +580,13 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/blob-csi",
-          "latestVersion": "v1.26.14",
-          "previousLatestVersion": "v1.26.12"
+          "latestVersion": "v1.26.15",
+          "previousLatestVersion": "v1.26.14"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/blob-csi",
-          "latestVersion": "v1.27.7",
-          "previousLatestVersion": "v1.27.5"
+          "latestVersion": "v1.27.8",
+          "previousLatestVersion": "v1.27.7"
         }
       ],
       "windowsVersions": []
@@ -597,6 +597,10 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
+          "latestVersion": "v2.19.0"
+        },
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
           "latestVersion": "v2.18.0"
         },
         {
@@ -605,6 +609,10 @@
         }
       ],
       "windowsVersions": [
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
+          "latestVersion": "v2.19.0"
+        },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
           "latestVersion": "v2.18.0"
@@ -621,6 +629,10 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/csi-node-driver-registrar",
+          "latestVersion": "v2.17.0"
+        },
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/csi-node-driver-registrar",
           "latestVersion": "v2.16.0"
         },
         {
@@ -629,6 +641,10 @@
         }
       ],
       "windowsVersions": [
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/csi-node-driver-registrar",
+          "latestVersion": "v2.17.0"
+        },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/csi-node-driver-registrar",
           "latestVersion": "v2.16.0"


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade Blob CSI driver and its sidecar images bundled in the VHD to their latest versions.

Changes in `parts/common/components.json`:

| Component | Prev | New |
|---|---|---|
| `oss/v2/kubernetes-csi/blob-csi` (master track) | v1.26.14 | **v1.26.15** |
| `oss/v2/kubernetes-csi/blob-csi` (release-1.27 track) | v1.27.7 | **v1.27.8** |
| `oss/v2/kubernetes-csi/livenessprobe` (linux + windows) | v2.18.0 | **+ v2.19.0** |
| `oss/v2/kubernetes-csi/csi-node-driver-registrar` (linux + windows) | v2.16.0 | **+ v2.17.0** |

Sidecar entries are added alongside the existing ones so both versions are cached in the VHD during the transition.

**Which issue(s) this PR fixes**:
Fixes #