### PR TITLE
fix(e2e): restore dropped RCV1P storage/firewall fixes for cross-subscription runs 

### DIFF
--- a/e2e/config/azure.go
+++ b/e2e/config/azure.go
@@ -4,6 +4,8 @@ import (
 	"cmp"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -412,6 +414,9 @@ func (a *AzureClient) CreateVMManagedIdentity(ctx context.Context, identityLocat
 	if err := a.assignRolesToVMIdentity(ctx, identity.Properties.PrincipalID); err != nil {
 		return "", err
 	}
+	if err := a.assignBlobContributorToCurrentPrincipal(ctx); err != nil {
+		return "", err
+	}
 	return *identity.Properties.ClientID, nil
 }
 
@@ -480,6 +485,73 @@ func (a *AzureClient) assignRolesToVMIdentity(ctx context.Context, principalID *
 		return fmt.Errorf("assign Storage Blob Data Contributor role: %w", err)
 	}
 	return nil
+}
+
+// assignBlobContributorToCurrentPrincipal grants "Storage Blob Data Contributor" on the
+// e2e blob storage account to the principal currently authenticated against ARM (the
+// test runner: ADO service-connection SP in pipelines, or the developer's user
+// identity locally). Required because the per-subscription storage account naming scheme
+// produces a fresh account per E2E_SUBSCRIPTION_ID, and that fresh account inherits no
+// data-plane RBAC even though the runner has management-plane Contributor.
+// Idempotent: a pre-existing role assignment returns 409 Conflict which is swallowed.
+func (a *AzureClient) assignBlobContributorToCurrentPrincipal(ctx context.Context) error {
+	principalID, principalType, err := getCurrentPrincipalIDAndType(ctx, a.Credential)
+	if err != nil {
+		return fmt.Errorf("resolve current principal: %w", err)
+	}
+	scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s",
+		Config.SubscriptionID, ResourceGroupName(Config.DefaultLocation), Config.BlobStorageAccount())
+	uid := uuid.New().String()
+	_, err = a.RoleAssignments.Create(ctx, scope, uid, armauthorization.RoleAssignmentCreateParameters{
+		Properties: &armauthorization.RoleAssignmentProperties{
+			PrincipalID:      to.Ptr(principalID),
+			RoleDefinitionID: to.Ptr("/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe"),
+			PrincipalType:    to.Ptr(principalType),
+		},
+	}, nil)
+	var respError *azcore.ResponseError
+	if err != nil {
+		if errors.As(err, &respError) && respError.StatusCode == http.StatusConflict {
+			return nil
+		}
+		return fmt.Errorf("assign Storage Blob Data Contributor role to current principal %s: %w", principalID, err)
+	}
+	return nil
+}
+
+// getCurrentPrincipalIDAndType extracts the object ID and principal type of the identity
+// behind the provided credential by acquiring an ARM access token and decoding the JWT.
+// Uses the "oid" claim (stable object ID) and "idtyp" to distinguish app vs user.
+func getCurrentPrincipalIDAndType(ctx context.Context, cred azcore.TokenCredential) (string, armauthorization.PrincipalType, error) {
+	tok, err := cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{"https://management.azure.com/.default"},
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("get ARM token: %w", err)
+	}
+	parts := strings.Split(tok.Token, ".")
+	if len(parts) < 2 {
+		return "", "", fmt.Errorf("malformed JWT: expected 3 segments, got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", "", fmt.Errorf("decode JWT payload: %w", err)
+	}
+	var claims struct {
+		Oid   string `json:"oid"`
+		Idtyp string `json:"idtyp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", "", fmt.Errorf("parse JWT claims: %w", err)
+	}
+	if claims.Oid == "" {
+		return "", "", fmt.Errorf("JWT has no oid claim")
+	}
+	pt := armauthorization.PrincipalTypeUser
+	if claims.Idtyp == "app" {
+		pt = armauthorization.PrincipalTypeServicePrincipal
+	}
+	return claims.Oid, pt, nil
 }
 
 func (a *AzureClient) LatestSIGImageVersionByTag(ctx context.Context, image *Image, tagName, tagValue, location string) (VHDResourceID, error) {

--- a/e2e/config/azure.go
+++ b/e2e/config/azure.go
@@ -493,20 +493,30 @@ func (a *AzureClient) assignRolesToVMIdentity(ctx context.Context, principalID *
 // identity locally). Required because the per-subscription storage account naming scheme
 // produces a fresh account per E2E_SUBSCRIPTION_ID, and that fresh account inherits no
 // data-plane RBAC even though the runner has management-plane Contributor.
-// Idempotent: a pre-existing role assignment returns 409 Conflict which is swallowed.
+// Idempotent: uses a deterministic role-assignment name derived from
+// (scope, principalID, roleDefinitionID) so re-runs recreate the same assignment ID
+// instead of accumulating duplicate assignments (Azure caps at ~2000/sub); a pre-existing
+// role assignment returns 409 Conflict which is swallowed.
 func (a *AzureClient) assignBlobContributorToCurrentPrincipal(ctx context.Context) error {
-	principalID, principalType, err := getCurrentPrincipalIDAndType(ctx, a.Credential)
+	principalID, err := getCurrentPrincipalID(ctx, a.Credential)
 	if err != nil {
 		return fmt.Errorf("resolve current principal: %w", err)
 	}
 	scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s",
 		Config.SubscriptionID, ResourceGroupName(Config.DefaultLocation), Config.BlobStorageAccount())
-	uid := uuid.New().String()
+	// Storage Blob Data Contributor built-in role.
+	roleDefID := "/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe"
+	// Deterministic assignment name so re-runs produce the same GUID and hit the 409
+	// swallow-path below instead of creating a new assignment each run.
+	uid := uuid.NewSHA1(uuid.NameSpaceOID, []byte(scope+"|"+principalID+"|"+roleDefID)).String()
 	_, err = a.RoleAssignments.Create(ctx, scope, uid, armauthorization.RoleAssignmentCreateParameters{
 		Properties: &armauthorization.RoleAssignmentProperties{
 			PrincipalID:      to.Ptr(principalID),
-			RoleDefinitionID: to.Ptr("/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe"),
-			PrincipalType:    to.Ptr(principalType),
+			RoleDefinitionID: to.Ptr(roleDefID),
+			// PrincipalType is intentionally omitted: ARM infers it from PrincipalID.
+			// Deriving it from the "idtyp" JWT claim is brittle — the claim is not present
+			// in all auth flows (e.g. some MSI / federated tokens), and passing the wrong
+			// type causes PrincipalNotFound/PrincipalTypeMismatch failures.
 		},
 	}, nil)
 	var respError *azcore.ResponseError
@@ -519,39 +529,33 @@ func (a *AzureClient) assignBlobContributorToCurrentPrincipal(ctx context.Contex
 	return nil
 }
 
-// getCurrentPrincipalIDAndType extracts the object ID and principal type of the identity
-// behind the provided credential by acquiring an ARM access token and decoding the JWT.
-// Uses the "oid" claim (stable object ID) and "idtyp" to distinguish app vs user.
-func getCurrentPrincipalIDAndType(ctx context.Context, cred azcore.TokenCredential) (string, armauthorization.PrincipalType, error) {
+// getCurrentPrincipalID extracts the object ID of the identity behind the provided
+// credential by acquiring an ARM access token and decoding the "oid" JWT claim.
+func getCurrentPrincipalID(ctx context.Context, cred azcore.TokenCredential) (string, error) {
 	tok, err := cred.GetToken(ctx, policy.TokenRequestOptions{
 		Scopes: []string{"https://management.azure.com/.default"},
 	})
 	if err != nil {
-		return "", "", fmt.Errorf("get ARM token: %w", err)
+		return "", fmt.Errorf("get ARM token: %w", err)
 	}
 	parts := strings.Split(tok.Token, ".")
-	if len(parts) < 2 {
-		return "", "", fmt.Errorf("malformed JWT: expected 3 segments, got %d", len(parts))
+	if len(parts) != 3 {
+		return "", fmt.Errorf("malformed JWT: expected 3 segments, got %d", len(parts))
 	}
 	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
-		return "", "", fmt.Errorf("decode JWT payload: %w", err)
+		return "", fmt.Errorf("decode JWT payload: %w", err)
 	}
 	var claims struct {
-		Oid   string `json:"oid"`
-		Idtyp string `json:"idtyp"`
+		Oid string `json:"oid"`
 	}
 	if err := json.Unmarshal(payload, &claims); err != nil {
-		return "", "", fmt.Errorf("parse JWT claims: %w", err)
+		return "", fmt.Errorf("parse JWT claims: %w", err)
 	}
 	if claims.Oid == "" {
-		return "", "", fmt.Errorf("JWT has no oid claim")
+		return "", fmt.Errorf("JWT has no oid claim")
 	}
-	pt := armauthorization.PrincipalTypeUser
-	if claims.Idtyp == "app" {
-		pt = armauthorization.PrincipalTypeServicePrincipal
-	}
-	return claims.Oid, pt, nil
+	return claims.Oid, nil
 }
 
 func (a *AzureClient) LatestSIGImageVersionByTag(ctx context.Context, image *Image, tagName, tagValue, location string) (VHDResourceID, error) {

--- a/e2e/config/azure.go
+++ b/e2e/config/azure.go
@@ -488,11 +488,17 @@ func (a *AzureClient) assignRolesToVMIdentity(ctx context.Context, principalID *
 }
 
 // assignBlobContributorToCurrentPrincipal grants "Storage Blob Data Contributor" on the
-// e2e blob storage account to the principal currently authenticated against ARM (the
-// test runner: ADO service-connection SP in pipelines, or the developer's user
-// identity locally). Required because the per-subscription storage account naming scheme
+// e2e blob container to the principal currently authenticated against ARM (the test
+// runner: ADO service-connection SP in pipelines, or the developer's user identity
+// locally). Required because the per-subscription storage account naming scheme
 // produces a fresh account per E2E_SUBSCRIPTION_ID, and that fresh account inherits no
 // data-plane RBAC even though the runner has management-plane Contributor.
+//
+// Scoped to the container (not the storage account) to minimise blast radius: the runner
+// only needs to upload/download blobs within the fixed "abe2e" container, so a wider
+// account-scope grant would be excess privilege (matters in TME where the runner SP is
+// long-lived).
+//
 // Idempotent: uses a deterministic role-assignment name derived from
 // (scope, principalID, roleDefinitionID) so re-runs recreate the same assignment ID
 // instead of accumulating duplicate assignments (Azure caps at ~2000/sub); a pre-existing
@@ -502,8 +508,13 @@ func (a *AzureClient) assignBlobContributorToCurrentPrincipal(ctx context.Contex
 	if err != nil {
 		return fmt.Errorf("resolve current principal: %w", err)
 	}
-	scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s",
-		Config.SubscriptionID, ResourceGroupName(Config.DefaultLocation), Config.BlobStorageAccount())
+	// Container-scoped RBAC: /…/storageAccounts/{acct}/blobServices/default/containers/{name}.
+	// Container-scoped Storage Blob Data Contributor is sufficient for UploadFile/DownloadFile
+	// against blobs in that container, without granting rights over sibling containers.
+	scope := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/default/containers/%s",
+		Config.SubscriptionID, ResourceGroupName(Config.DefaultLocation), Config.BlobStorageAccount(), Config.BlobContainer,
+	)
 	// Storage Blob Data Contributor built-in role.
 	roleDefID := "/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe"
 	// Deterministic assignment name so re-runs produce the same GUID and hit the 409

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -100,12 +100,54 @@ type Configuration struct {
 }
 
 func (c *Configuration) BlobStorageAccount() string {
+	// Storage account names are GLOBALLY unique in Azure (not per-subscription).
+	// Two subscriptions cannot own an account with the same name; the second
+	// one to call BeginCreate fails with StorageAccountAlreadyTaken even
+	// though BeginCreate is otherwise idempotent within a single sub.
+	//
+	// This bites whenever a pipeline that normally targets subscription A
+	// (with BLOB_STORAGE_ACCOUNT_PREFIX baked into a variable group) is
+	// redirected at runtime to subscription B — for example when the aks-rp
+	// orchestrator routes the RCV1P phase to its dedicated testing sub via
+	// --subscription-id. The prefix was chosen for sub A, the account
+	// "<prefix><location>" already exists in sub A, and creation in sub B
+	// fails before any test can run.
+	//
+	// Embedding a deterministic subscription-derived suffix in the account
+	// name guarantees a globally-unique name per subscription with zero
+	// per-environment configuration: every new sub gets its own account
+	// the first time it runs and reuses it thereafter. The framework stays
+	// completely agnostic to which subscription is "special" — there is no
+	// subscription identity check anywhere in this repo.
+	//
+	// DefaultLocation is included for the historical reason captured below
+	// (the blob client is keyed off the storage account URL, which is per
+	// location, even though tests run across multiple locations).
+	//
 	// Here DefaultLocation is used because the azure blob client requires the
 	// full URL to the storage account, which means creating a new client per
 	// location. While everything else for running AB tests is sharded per
 	// location, but we continue to use the same storage account for all
 	// locations.
-	return c.BlobStorageAccountPrefix + c.DefaultLocation
+	return c.BlobStorageAccountPrefix + c.DefaultLocation + subscriptionSuffix(c.SubscriptionID)
+}
+
+// subscriptionSuffix returns a short, deterministic suffix derived from the
+// subscription ID, suitable for embedding in resource names that have
+// global-uniqueness constraints (e.g. storage accounts). It takes the first
+// 6 hex characters of the subscription UUID after stripping hyphens, which
+// keeps the resulting name within the Azure storage account length limit
+// (3-24 chars) while giving ~16M-way collision resistance — sufficient for
+// the handful of subscriptions this test framework will ever run against.
+//
+// Lowercase hex is also valid for storage account names (lowercase
+// alphanumeric only), so no further sanitization is required.
+func subscriptionSuffix(subscriptionID string) string {
+	cleaned := strings.ToLower(strings.ReplaceAll(subscriptionID, "-", ""))
+	if len(cleaned) < 6 {
+		return cleaned
+	}
+	return cleaned[:6]
 }
 
 func (c *Configuration) IsLocalBuild() bool {

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -129,7 +129,20 @@ func (c *Configuration) BlobStorageAccount() string {
 	// location. While everything else for running AB tests is sharded per
 	// location, but we continue to use the same storage account for all
 	// locations.
-	return c.BlobStorageAccountPrefix + c.DefaultLocation + subscriptionSuffix(c.SubscriptionID)
+	suffix := subscriptionSuffix(c.SubscriptionID)
+	base := c.BlobStorageAccountPrefix + c.DefaultLocation
+	// Azure storage account names are limited to 24 chars (lowercase alphanumeric).
+	// Truncate the base portion if a long region name + prefix would otherwise
+	// overflow once the deterministic suffix is appended. The suffix is kept whole
+	// so two subscriptions never collide; truncation is deterministic too, so the
+	// same (prefix, location, sub) always resolves to the same account name.
+	if maxBase := 24 - len(suffix); len(base) > maxBase {
+		if maxBase < 0 {
+			maxBase = 0
+		}
+		base = base[:maxBase]
+	}
+	return base + suffix
 }
 
 // subscriptionSuffix returns a short, deterministic suffix derived from the

--- a/e2e/scenario_rcv1p_test.go
+++ b/e2e/scenario_rcv1p_test.go
@@ -172,8 +172,18 @@ var (
 func getOrBuildBranchCSEPackageURL(t *testing.T) string {
 	t.Helper()
 	branchCSEZipOnce.Do(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		// 5m covers a cold-start storage account create (~30-90s) plus the zip build/upload.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
+		// Windows scenarios construct this mutator at scenario-struct-init time, which runs
+		// BEFORE RunScenario -> CachedCreateVMManagedIdentity (which creates the per-sub blob
+		// storage account on first use). On a brand-new region/subscription combo the storage
+		// account does not exist yet, so the upload below fails with NXDOMAIN. Ensure storage
+		// exists first by piggybacking on the same cached identity-creation path Linux tests use.
+		if _, err := CachedCreateVMManagedIdentity(ctx, config.Config.DefaultLocation); err != nil {
+			branchCSEZipErr = fmt.Errorf("ensure shared storage account: %w", err)
+			return
+		}
 		branchCSEZipURL, branchCSEZipErr = buildAndUploadCSEZip(ctx)
 	})
 	if branchCSEZipErr != nil {

--- a/e2e/scenario_rcv1p_test.go
+++ b/e2e/scenario_rcv1p_test.go
@@ -180,6 +180,14 @@ func getOrBuildBranchCSEPackageURL(t *testing.T) string {
 		// storage account on first use). On a brand-new region/subscription combo the storage
 		// account does not exist yet, so the upload below fails with NXDOMAIN. Ensure storage
 		// exists first by piggybacking on the same cached identity-creation path Linux tests use.
+		//
+		// CachedCreateVMManagedIdentity depends on the per-location resource group already
+		// existing (runScenario ensures it later, too late for this init-time path). Ensure
+		// the RG first so the identity/storage-account creation succeeds on a fresh sub/region.
+		if _, err := CachedEnsureResourceGroup(ctx, config.Config.DefaultLocation); err != nil {
+			branchCSEZipErr = fmt.Errorf("ensure shared resource group: %w", err)
+			return
+		}
 		if _, err := CachedCreateVMManagedIdentity(ctx, config.Config.DefaultLocation); err != nil {
 			branchCSEZipErr = fmt.Errorf("ensure shared storage account: %w", err)
 			return

--- a/e2e/shared_infra.go
+++ b/e2e/shared_infra.go
@@ -362,10 +362,45 @@ const (
 )
 
 // ensureSharedFirewall creates or retrieves the shared Azure Firewall and returns its private IP.
+// The firewall is shared across all clusters in the RG, so its application rules persist beyond
+// the lifetime of any single cluster. We reconcile rules on every call so that changes to allowed
+// FQDNs (notably the per-sub blob storage account FQDN, which now embeds a sub-suffix) are picked
+// up. Without this, a firewall created against an older BlobStorageAccount() name silently blocks
+// CSE zip downloads from the new per-sub storage account, causing Windows CSE to fail with
+// NO_CSE_RESULT_LOG and Linux CSE to hang on artifact downloads.
 func ensureSharedFirewall(ctx context.Context, rg, location string) (string, error) {
 	existing, err := config.Azure.AzureFirewall.Get(ctx, rg, SharedFirewallName, nil)
 	if err == nil {
-		return getFirewallPrivateIP(existing.AzureFirewall)
+		// Fast path: rules already match current config.
+		if firewallAppRulesUpToDate(existing.AzureFirewall) {
+			return getFirewallPrivateIP(existing.AzureFirewall)
+		}
+		toolkit.Logf(ctx, "shared firewall %s exists but app rules are stale; updating", SharedFirewallName)
+		firewallSubnetID := fmt.Sprintf(
+			"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/AzureFirewallSubnet",
+			config.Config.SubscriptionID, rg, SharedVNetName,
+		)
+		// Reuse the existing PIP — recreating it would reassign the firewall's public IP and
+		// break any external dependency pinned to it.
+		var publicIPID string
+		if existing.Properties != nil && len(existing.Properties.IPConfigurations) > 0 &&
+			existing.Properties.IPConfigurations[0].Properties != nil &&
+			existing.Properties.IPConfigurations[0].Properties.PublicIPAddress != nil &&
+			existing.Properties.IPConfigurations[0].Properties.PublicIPAddress.ID != nil {
+			publicIPID = *existing.Properties.IPConfigurations[0].Properties.PublicIPAddress.ID
+		} else {
+			return "", fmt.Errorf("existing firewall %s has no public IP configuration", SharedFirewallName)
+		}
+		updated := getFirewall(ctx, location, firewallSubnetID, publicIPID)
+		fwPoller, err := config.Azure.AzureFirewall.BeginCreateOrUpdate(ctx, rg, SharedFirewallName, *updated, nil)
+		if err != nil {
+			return "", fmt.Errorf("updating shared firewall app rules: %w", err)
+		}
+		fwResp, err := fwPoller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+		if err != nil {
+			return "", fmt.Errorf("waiting for shared firewall update: %w", err)
+		}
+		return getFirewallPrivateIP(fwResp.AzureFirewall)
 	}
 	if !isNotFoundError(err) {
 		return "", fmt.Errorf("checking shared firewall: %w", err)
@@ -422,6 +457,36 @@ func getFirewallPrivateIP(fw armnetwork.AzureFirewall) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("firewall has no private IP address")
+}
+
+// firewallAppRulesUpToDate returns true when the existing firewall already allows the current
+// per-sub blob storage FQDN. We only check the blob-storage-fqdn rule because that's the only
+// rule whose target depends on dynamic config — the rest (aks-fqdn, mooncake-mar, dmc) use
+// static values. If the storage FQDN changed (e.g. sub-suffix added), the rule is stale.
+func firewallAppRulesUpToDate(fw armnetwork.AzureFirewall) bool {
+	if fw.Properties == nil {
+		return false
+	}
+	expectedFqdn := config.Config.BlobStorageAccount() + ".blob.core.windows.net"
+	for _, coll := range fw.Properties.ApplicationRuleCollections {
+		if coll == nil || coll.Properties == nil {
+			continue
+		}
+		for _, rule := range coll.Properties.Rules {
+			if rule == nil || rule.Name == nil || *rule.Name != "blob-storage-fqdn" {
+				continue
+			}
+			// Found the dynamic rule; match means firewall is current.
+			for _, fqdn := range rule.TargetFqdns {
+				if fqdn != nil && *fqdn == expectedFqdn {
+					return true
+				}
+			}
+			return false
+		}
+	}
+	// Rule not found at all → firewall predates this rule, treat as stale.
+	return false
 }
 
 // ensureClusterIdentity creates a user-assigned managed identity for AKS clusters


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:

Restores 5 dropped e2e-harness fixes needed for RCV1P runs against sub  38d77129-fc18-4f21-9ce1-79dd1fe50fc6  (or any sub other than the default TME sub). All 5 originally lived on  rchinchani/rcv1p-2  but were dropped during serial rebases before PR #8096 squash-merged.

Currently every RCV1P orchestrator run (e.g. build 173995596) fails within 10s per test on:

create storage account: PUT .../storageAccounts/abe2etmesouthcentralus
RESPONSE 409: StorageAccountAlreadyTaken

because  abe2etme<location>  is globally unique and already owned by the default TME sub.

Cherry-picked commits (in order)

1.  3f1c640a   fix(e2e): make blob storage account name subscription-unique 
Appends a deterministic 6-hex suffix derived from  SubscriptionID  so each sub gets its own globally-unique storage account. Zero per-env config; framework stays subscription-agnostic.
2.  18ddf06c   fix(e2e): truncate BlobStorageAccount base to fit Azure 24-char limit 
Guards long region names (e.g.  germanywestcentral ) — deterministic truncation so identical inputs still resolve to identical account name.
3.  99068ceb   fix(e2e): self-grant Storage Blob Data Contributor on per-sub storage account 
Fresh per-sub account means the runner has only management-plane Contributor. Grants data-plane role (Storage Blob Data Contributor) by decoding the JWT  oid / idtyp  claims from an ARM token, so it works for both ServicePrincipal (pipelines) and User (local dev). Prevents  403 AuthorizationPermissionMismatch  on Windows CSE zip upload.
4.  ad7e2d1c   fix(e2e): reconcile shared firewall app rules when blob storage FQDN drifts 
 ensureSharedFirewall  returned early on any existing firewall without reconciling. Detects blob-storage-FQDN drift and re-issues  CreateOrUpdate , reusing the public IP. Prevents  NO_CSE_RESULT_LOG  on Windows and Linux artifact-download hangs.
5.  eac11709  (from  b5b33ee4 )  fix(e2e): ensure shared storage account exists before Windows CSE zip upload 
Windows RCV1P mutator runs at struct-init time, before  CachedCreateVMManagedIdentity  — the call that actually creates the per-sub account. On a fresh region (like  southcentralus ) this produces  NXDOMAIN  on the blob PUT. Piggybacks on the same identity cache to guarantee the account exists first; bumps ctx timeout 2m→5m for cold create.

Skipped (already applied via different route on main)

•  85a91bfc31  (bump RCV1P cluster names v1→v2 to refresh firewall) —  e2e/cache.go  on main already carries  abe2e-rcv1p-kubenet-v2  /  abe2e-rcv1p-azure-v2 , so this was a no-op cherry-pick.

Intentionally NOT included

•  97f0aca325  ( revert(e2e): remove branch-CSE override once RCV1P ships in published package ) — must wait until  aks-windows-cse-scripts-v0.0.53+  is published to  packages.aks.azure.com  and wired via  parts/common/components.json . Merging prematurely will regress all 5  Test_RCV1P_Windows*  scenarios.

Verification

•  go build ./...  and  go vet ./...  clean in  e2e/  module.
• Conflict in  .pipelines/scripts/e2e_run.sh  on the first pick was resolved by keeping main's version — the RCV1P override block was already removed from main by an earlier separate merge.

Context

• Failing run without these: 173995596 (all 4 Linux RCV1P scenarios failed on  StorageAccountAlreadyTaken )
• Last known-green RCV1P run (with these fixes applied): 170492144 (all 10 RCV1P scenarios passed with real durations, e.g. ACL 705s, Ubuntu 2404 770s)
• Companion fix in-flight:  cameissner/fix-e2e-template-vars  (subscription propagation from orchestrator to child pipeline) — necessary but not sufficient without this PR.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

• Failing run without these: 173995596 (all 4 Linux RCV1P scenarios failed on  StorageAccountAlreadyTaken )
• Last known-green RCV1P run (with these fixes applied): 170492144 (all 10 RCV1P scenarios passed with real durations, e.g. ACL 705s, Ubuntu 2404 770s)
• Companion fix in-flight:  cameissner/fix-e2e-template-vars  (subscription propagation from orchestrator to child pipeline) — necessary but not sufficient without this PR.
