### PR TITLE
fix: add per-attempt timeout and cse budget guard to _apt_get_update

### DIFF
--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh
@@ -26,23 +26,70 @@ wait_for_apt_locks() {
     done
 }
 # Core update function used by apt_get_update and apt_get_install_from_local_repo
+# returns 0 if successful, 1 if retries are exhausted, 2 if the CSE timeout is approaching
+# and the caller should short-circuit.
 _apt_get_update() {
     local retries=$1
     local apt_opts=$2
     local apt_update_output=/tmp/apt-get-update.out
+    # Per-attempt cap for `apt-get update`. apt applies its own per-connection timeouts, but a run
+    # fetches many index files sequentially, so on broken DNS/NSG a single attempt can hang for many
+    # minutes. Without a cap, retries alone can consume the entire CSE budget and starve later steps.
+    local attemptTimeout=${APT_GET_UPDATE_TIMEOUT_SECONDS:-180}
+    local effectiveTimeout
+    local remainingCseTime
+    local aptStatus
 
     for i in $(seq 1 $retries); do
+        # Only apply *CSE budget* guards when CSE_STARTTIME_SECONDS is set (i.e. in a real CSE run).
+        # Note: the per-attempt `timeout` wrapper still applies in both CSE and VHD build;
+        # only the CSE budget checks are skipped during VHD build to avoid noisy "CSE_STARTTIME_SECONDS is not set" warnings.
+        if [ -n "${CSE_STARTTIME_SECONDS:-}" ] && ! check_cse_timeout; then
+            echo "CSE timeout approaching, exiting apt_get_update early." >&2
+            return 2
+        fi
+
         wait_for_apt_locks
         export DEBIAN_FRONTEND=noninteractive
         dpkg --configure -a --force-confdef
         apt-get ${apt_opts} -f -y install
-        ! (apt-get ${apt_opts} update 2>&1 | tee $apt_update_output | grep -E "^([WE]:.*)|^([Ee][Rr][Rr][Oo][Rr].*)$") && \
-        cat $apt_update_output && break || \
+
+        # Cap the per-attempt timeout to the remaining CSE budget so a single attempt cannot
+        # overrun the global provisioning window.
+        effectiveTimeout=$attemptTimeout
+        if [ -n "${CSE_STARTTIME_SECONDS:-}" ]; then
+            remainingCseTime=$(( ${CSE_MAX_DURATION_SECONDS:-780} - ( $(date +%s) - CSE_STARTTIME_SECONDS ) ))
+            if [ "$remainingCseTime" -lt 1 ]; then
+                echo "No CSE time remaining, exiting apt_get_update early." >&2
+                return 2
+            fi
+            if [ "$effectiveTimeout" -gt "$remainingCseTime" ]; then
+                effectiveTimeout=$remainingCseTime
+            fi
+        fi
+
+        timeout "$effectiveTimeout" apt-get ${apt_opts} update > $apt_update_output 2>&1
+        aptStatus=$?
         cat $apt_update_output
+        # apt-get must both exit 0 and emit no W:/E: lines. Checking the exit status matters now that
+        # attempts are wrapped in timeout: a killed apt-get may flush no diagnostics at all, which the
+        # grep-only check would have misread as success.
+        if [ $aptStatus -eq 0 ] && ! grep -qE "^([WE]:.*)|^([Ee][Rr][Rr][Oo][Rr].*)$" $apt_update_output; then
+            break
+        fi
+        if [ $aptStatus -eq 124 ]; then
+            echo "apt-get update timed out after ${effectiveTimeout}s on attempt $i of $retries" >&2
+        fi
+
         if [ $i -eq $retries ]; then
             return 1
-        else sleep 5
         fi
+        # Re-check after the failure, before sleeping, so we give up as early as possible.
+        if [ -n "${CSE_STARTTIME_SECONDS:-}" ] && ! check_cse_timeout; then
+            echo "CSE timeout approaching, exiting apt_get_update early." >&2
+            return 2
+        fi
+        sleep 5
     done
     echo Executed apt-get update $i times
     wait_for_apt_locks

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_ubuntu_spec.sh
@@ -122,6 +122,75 @@ Describe 'apt_get_install budget timeout'
         End
     End
 
+    Describe '_apt_get_update CSE budget and per-attempt timeout'
+        wait_for_apt_locks() { :; }
+        dpkg() { :; }
+        apt-get() { return 0; }
+        # Report the per-attempt timeout value, then run the command. _apt_get_update redirects both
+        # streams of the timeout invocation into its output file and cats it, so this lands on stdout.
+        timeout() { echo "timeout arg: $1"; shift; "$@"; }
+
+        It "caps each attempt at the default per-attempt timeout when CSE budget is plentiful"
+            CSE_STARTTIME_SECONDS=$(date +%s)
+            When call _apt_get_update 1 ""
+            The status should eq 0
+            The stdout should include "timeout arg: 180"
+            The stdout should include "Executed apt-get update 1 times"
+        End
+
+        It "caps each attempt at the remaining CSE budget when it is smaller"
+            CSE_MAX_DURATION_SECONDS=1000
+            CSE_STARTTIME_SECONDS=$(( $(date +%s) - 900 ))
+            # Allow a few seconds of drift between the setup above and the call.
+            timeout() {
+                if [ "$1" -le 100 ] && [ "$1" -ge 95 ]; then
+                    echo "capped to remaining CSE budget"
+                else
+                    echo "not capped: $1"
+                fi
+                shift
+                "$@"
+            }
+            When call _apt_get_update 1 ""
+            The status should eq 0
+            The stdout should include "capped to remaining CSE budget"
+        End
+
+        It "returns 2 when the CSE timeout is already exceeded before the first attempt"
+            CSE_STARTTIME_SECONDS=$(( $(date +%s) - 800 ))
+            When call _apt_get_update 3 ""
+            The status should eq 2
+            The stderr should include "CSE timeout approaching"
+        End
+
+        It "returns 2 when no CSE time remains"
+            # Stub the guard so this test isolates the remaining-budget check, which would otherwise
+            # only be reachable in the single second where elapsed time exactly equals the max.
+            check_cse_timeout() { return 0; }
+            CSE_MAX_DURATION_SECONDS=100
+            CSE_STARTTIME_SECONDS=$(( $(date +%s) - 200 ))
+            When call _apt_get_update 3 ""
+            The status should eq 2
+            The stderr should include "No CSE time remaining"
+        End
+
+        It "treats a timed-out apt-get as failure even when it emits no diagnostics"
+            timeout() { return 124; }
+            When call _apt_get_update 1 ""
+            The status should eq 1
+            The stderr should include "apt-get update timed out after"
+        End
+
+        It "still applies the per-attempt timeout during VHD build without CSE warnings"
+            unset CSE_STARTTIME_SECONDS
+            When call _apt_get_update 1 ""
+            The status should eq 0
+            The stdout should include "timeout arg: 180"
+            The stderr should not include "CSE timeout approaching"
+            The stdout should include "Executed apt-get update 1 times"
+        End
+    End
+
     Describe 'apt_get_dist_upgrade phased updates'
         wait_for_apt_locks() { :; }
         dpkg() { :; }


### PR DESCRIPTION
## Description:

`_apt_get_update` was the only retry helper without a per-attempt timeout or CSE budget
guard. On broken DNS/NSG, 10 uncapped attempts could burn the entire 780s CSE budget and
starve later provisioning steps, surfacing as exit 99 (`ERR_APT_UPDATE_TIMEOUT`) — a
timeout the function never actually enforced.

## Changes
- Wrap each `apt-get update` attempt in `timeout`, defaulting to 180s (override via
  `APT_GET_UPDATE_TIMEOUT_SECONDS`), capped to the remaining CSE budget.
- Add `check_cse_timeout` before each attempt and before each sleep; return `2` to let
  callers short-circuit, matching `_apt_get_install` and `_retrycmd_internal`.
- Success now requires `apt-get` to exit 0 *and* emit no `W:`/`E:` lines. Required by the
  above: a `timeout`-killed apt-get may flush no diagnostics, which the previous grep-only
  check would have misread as success.

Guards are only active when `CSE_STARTTIME_SECONDS` is set, so VHD build behavior is
unchanged. All callers already use `|| exit $ERR_APT_UPDATE_TIMEOUT`, so return `2` is handled.

180s (not the 90s originally proposed) since `apt-get update` fetches index files from
several repos sequentially; a tighter cap risks failing slow-but-recoverable mirrors.
