### PR TITLE
fix(e2e): respect DISABLE_SCRIPTLESS for scriptless phase 2

### DIFF
--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -306,7 +306,7 @@ func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 
 		// for scriptless phase 2.5, we are using nbc cse cmd for provisioning but passing aksnodeconfig and nbc cse cmd to compare env variables
 		// scriptless tag means provisioning with aksnodeconfig is used
-		if !s.Tags.Scriptless && s.BootstrapConfigMutator != nil {
+		if !s.Tags.Scriptless && s.BootstrapConfigMutator != nil && !config.Config.DisableScriptless {
 			nbc.EnableScriptlessNBCCSECmd = true
 		}
 	}

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -93,7 +93,9 @@ func RunScenario(t *testing.T, s *Scenario) {
 	if s.Runtime == nil {
 		s.Runtime = &ScenarioRuntime{}
 	}
-	s.Runtime.EnableScriptlessNBCCSECmd = true
+	if !config.Config.DisableScriptless {
+		s.Runtime.EnableScriptlessNBCCSECmd = true
+	}
 	require.NoError(t, runScenario(t, s))
 }
 

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -245,7 +245,7 @@ func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachine
 		customData, err = injectWriteFilesEntriesToCustomData(customData, s.Config.CustomDataWriteFiles)
 		require.NoError(s.T, err, "failed to inject customData write_files entries")
 	}
-	if !scriptlessNBCCSECmdEnabled && s.VHD.SupportsScriptless() {
+	if !scriptlessNBCCSECmdEnabled && s.VHD.SupportsScriptless() && !config.Config.DisableScriptless {
 		// Validate that the custom data doesn't contain any script content,
 		// which indicates that the scriptless CSE is working as intended
 		decodedCustomData, err := base64.StdEncoding.DecodeString(customData)


### PR DESCRIPTION
## Summary

`DISABLE_SCRIPTLESS` env var only controlled scriptless phase 1 (`EnableScriptlessCSECmd`). Phase 2 (`EnableScriptlessNBCCSECmd`) was unconditionally set to `true` in `RunScenario()`, making it impossible to test the legacy CSE shell path via e2e.

## Change

`e2e/test_helpers.go:96` — wrap `EnableScriptlessNBCCSECmd = true` with `if !config.Config.DisableScriptless`, so `DISABLE_SCRIPTLESS=true` disables both phases.

## Usage

```bash
DISABLE_SCRIPTLESS=true go test -run "Test_Ubuntu2204$" -count=1 -timeout 50m -v
```

This will run the traditional CSE shell provisioning path (`cse_start.sh` → `cse_main.sh` → `ensureKubelet()`).

## Test plan

- [x] Default (no flag): behavior unchanged, scriptless phase 2 enabled
- [x] `DISABLE_SCRIPTLESS=true`: CSE executes traditional shell path