### PR TITLE
fix: add stricter regex for pkg version matching

### DIFF
--- a/parts/linux/cloud-init/artifacts/azlosguard/cse_install_osguard.sh
+++ b/parts/linux/cloud-init/artifacts/azlosguard/cse_install_osguard.sh
@@ -26,7 +26,7 @@ installRPMPackageFromFile() {
     fi
     echo "installing ${packageName} version ${desiredVersion}"
 
-    rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep "${desiredVersion}" | sort -V | tail -n 1) || rpmFile=""
+    rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9.]|$)" | sort -V | tail -n 1) || rpmFile=""
     if [ -z "${rpmFile}" ] && { [ "${packageName}" = "kubelet" ] || [ "${packageName}" = "kubectl" ]; } && fallbackToKubeBinaryInstall "${packageName}" "${desiredVersion}"; then
         echo "Successfully installed ${packageName} version ${desiredVersion} from binary fallback"
         rm -rf "${downloadDir}"
@@ -34,14 +34,14 @@ installRPMPackageFromFile() {
     fi
     if [ -z "${rpmFile}" ]; then
         # query all package versions and get the latest version for matching k8s version
-        fullPackageVersion=$(tdnf list ${packageName} | grep ${desiredVersion} | awk '{print $2}' | sort -V | tail -n 1)
+        fullPackageVersion=$(tdnf list ${packageName} | grep -E "${desiredVersion}([^0-9.]|$)" | awk '{print $2}' | sort -V | tail -n 1)
         if [ -z "${fullPackageVersion}" ]; then
             echo "Failed to find valid ${packageName} version for ${desiredVersion}"
             return 1
         fi
         echo "Did not find cached rpm file, downloading ${packageName} version ${fullPackageVersion}"
         downloadPkgFromVersion "${packageName}" "${fullPackageVersion}" "${downloadDir}"
-        rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep "${desiredVersion}" | sort -V | tail -n 1) || rpmFile=""
+        rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9.]|$)" | sort -V | tail -n 1) || rpmFile=""
     fi
     if [ -z "${rpmFile}" ]; then
         echo "Failed to locate ${packageName} rpm"

--- a/parts/linux/cloud-init/artifacts/azlosguard/cse_install_osguard.sh
+++ b/parts/linux/cloud-init/artifacts/azlosguard/cse_install_osguard.sh
@@ -26,7 +26,7 @@ installRPMPackageFromFile() {
     fi
     echo "installing ${packageName} version ${desiredVersion}"
 
-    rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9.]|$)" | sort -V | tail -n 1) || rpmFile=""
+    rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9]|$)" | sort -V | tail -n 1) || rpmFile=""
     if [ -z "${rpmFile}" ] && { [ "${packageName}" = "kubelet" ] || [ "${packageName}" = "kubectl" ]; } && fallbackToKubeBinaryInstall "${packageName}" "${desiredVersion}"; then
         echo "Successfully installed ${packageName} version ${desiredVersion} from binary fallback"
         rm -rf "${downloadDir}"
@@ -34,14 +34,14 @@ installRPMPackageFromFile() {
     fi
     if [ -z "${rpmFile}" ]; then
         # query all package versions and get the latest version for matching k8s version
-        fullPackageVersion=$(tdnf list ${packageName} | grep -E "${desiredVersion}([^0-9.]|$)" | awk '{print $2}' | sort -V | tail -n 1)
+        fullPackageVersion=$(tdnf list ${packageName} | grep -E "${desiredVersion}([^0-9]|$)" | awk '{print $2}' | sort -V | tail -n 1)
         if [ -z "${fullPackageVersion}" ]; then
             echo "Failed to find valid ${packageName} version for ${desiredVersion}"
             return 1
         fi
         echo "Did not find cached rpm file, downloading ${packageName} version ${fullPackageVersion}"
         downloadPkgFromVersion "${packageName}" "${fullPackageVersion}" "${downloadDir}"
-        rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9.]|$)" | sort -V | tail -n 1) || rpmFile=""
+        rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9]|$)" | sort -V | tail -n 1) || rpmFile=""
     fi
     if [ -z "${rpmFile}" ]; then
         echo "Failed to locate ${packageName} rpm"

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -517,7 +517,7 @@ installRPMPackageFromFile() {
     fi
 
     # check cached rpms for matching filename
-    rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep "${desiredVersion}" | sort -V | tail -n 1) || rpmFile=""
+    rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9.]|$)" | sort -V | tail -n 1) || rpmFile=""
     if [ -z "${rpmFile}" ]; then
         # query all package versions and get the latest version for matching k8s version
         # e.g. 1.34.0-5.azl3
@@ -528,7 +528,7 @@ installRPMPackageFromFile() {
         fi
         echo "Did not find cached rpm file, downloading ${packageName} version ${fullPackageVersion}"
         downloadPkgFromVersion "${packageName}" "${fullPackageVersion}" "${downloadDir}"
-        rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep "${desiredVersion}" | sort -V | tail -n 1) || rpmFile=""
+        rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9.]|$)" | sort -V | tail -n 1) || rpmFile=""
     fi
     if [ -z "${rpmFile}" ]; then
         echo "Failed to locate ${packageName} rpm"
@@ -559,7 +559,7 @@ installPackageFromCache() {
     fi
 
     # check cached rpms for matching filename
-    rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep "${desiredVersion}" | sort -V | tail -n 1) || rpmFile=""
+    rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9.]|$)" | sort -V | tail -n 1) || rpmFile=""
     if [ -z "${rpmFile}" ]; then
         echo "Failed to find cached rpm file for ${packageName} version ${desiredVersion}"
         return 1

--- a/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
+++ b/parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh
@@ -517,7 +517,7 @@ installRPMPackageFromFile() {
     fi
 
     # check cached rpms for matching filename
-    rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9.]|$)" | sort -V | tail -n 1) || rpmFile=""
+    rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9]|$)" | sort -V | tail -n 1) || rpmFile=""
     if [ -z "${rpmFile}" ]; then
         # query all package versions and get the latest version for matching k8s version
         # e.g. 1.34.0-5.azl3
@@ -528,7 +528,7 @@ installRPMPackageFromFile() {
         fi
         echo "Did not find cached rpm file, downloading ${packageName} version ${fullPackageVersion}"
         downloadPkgFromVersion "${packageName}" "${fullPackageVersion}" "${downloadDir}"
-        rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9.]|$)" | sort -V | tail -n 1) || rpmFile=""
+        rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9]|$)" | sort -V | tail -n 1) || rpmFile=""
     fi
     if [ -z "${rpmFile}" ]; then
         echo "Failed to locate ${packageName} rpm"
@@ -559,7 +559,7 @@ installPackageFromCache() {
     fi
 
     # check cached rpms for matching filename
-    rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9.]|$)" | sort -V | tail -n 1) || rpmFile=""
+    rpmFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${desiredVersion}([^0-9]|$)" | sort -V | tail -n 1) || rpmFile=""
     if [ -z "${rpmFile}" ]; then
         echo "Failed to find cached rpm file for ${packageName} version ${desiredVersion}"
         return 1

--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
@@ -532,13 +532,13 @@ installPkgWithAptGet() {
         return 0
     fi
 
-    debFile=$(ls "${downloadDir}" | grep "${packageName}" | grep "${packageVersion}" | sort -V | tail -n 1) || debFile=""
+    debFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9.]|$)" | sort -V | tail -n 1) || debFile=""
     if [ -z "${debFile}" ]; then
 
         # update pmc repo to get latest versions
         updatePMCRepository "${packageVersion}"
         # query all package versions and get the latest version for matching k8s version and cpu architecture
-        fullPackageVersion=$(apt list "${packageName}" --all-versions | grep "${packageVersion}" | grep "$(getCPUArch)" | awk '{print $2}' | sort -V | tail -n 1)
+        fullPackageVersion=$(apt list "${packageName}" --all-versions | grep -E "${packageVersion}([^0-9.]|$)" | grep "$(getCPUArch)" | awk '{print $2}' | sort -V | tail -n 1)
         if [ -z "${fullPackageVersion}" ]; then
             echo "Failed to find valid ${packageName} version for ${packageVersion}"
             return 1
@@ -546,7 +546,7 @@ installPkgWithAptGet() {
         echo "Did not find cached deb file, downloading ${packageName} version ${fullPackageVersion}"
         logs_to_events "AKS.CSE.install${packageName}FromPkg.downloadPkgFromVersion" "downloadPkgFromVersion ${packageName} ${fullPackageVersion} ${downloadDir}"
 
-        debFile=$(ls "${downloadDir}" | grep "${packageName}" | grep "${packageVersion}" | sort -V | tail -n 1) || debFile=""
+        debFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9.]|$)" | sort -V | tail -n 1) || debFile=""
     fi
     if [ -z "${debFile}" ]; then
         echo "Failed to locate ${packageName} deb"
@@ -574,13 +574,9 @@ installPackageFromCache() {
         return 0
     fi
 
-    debFile=$(ls "${downloadDir}" | grep "${packageName}" | grep "${packageVersion}" | sort -V | tail -n 1) || debFile=""
+    debFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9.]|$)" | sort -V | tail -n 1) || debFile=""
     if [ -z "${debFile}" ]; then
         echo "Failed to find cached deb file for ${packageName} version ${packageVersion}"
-        return 1
-    fi
-    if [ -z "${debFile}" ]; then
-        echo "Failed to locate ${packageName} deb"
         return 1
     fi
 

--- a/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
+++ b/parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh
@@ -532,13 +532,13 @@ installPkgWithAptGet() {
         return 0
     fi
 
-    debFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9.]|$)" | sort -V | tail -n 1) || debFile=""
+    debFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9]|$)" | sort -V | tail -n 1) || debFile=""
     if [ -z "${debFile}" ]; then
 
         # update pmc repo to get latest versions
         updatePMCRepository "${packageVersion}"
         # query all package versions and get the latest version for matching k8s version and cpu architecture
-        fullPackageVersion=$(apt list "${packageName}" --all-versions | grep -E "${packageVersion}([^0-9.]|$)" | grep "$(getCPUArch)" | awk '{print $2}' | sort -V | tail -n 1)
+        fullPackageVersion=$(apt list "${packageName}" --all-versions | grep -E "${packageVersion}([^0-9]|$)" | grep "$(getCPUArch)" | awk '{print $2}' | sort -V | tail -n 1)
         if [ -z "${fullPackageVersion}" ]; then
             echo "Failed to find valid ${packageName} version for ${packageVersion}"
             return 1
@@ -546,7 +546,7 @@ installPkgWithAptGet() {
         echo "Did not find cached deb file, downloading ${packageName} version ${fullPackageVersion}"
         logs_to_events "AKS.CSE.install${packageName}FromPkg.downloadPkgFromVersion" "downloadPkgFromVersion ${packageName} ${fullPackageVersion} ${downloadDir}"
 
-        debFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9.]|$)" | sort -V | tail -n 1) || debFile=""
+        debFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9]|$)" | sort -V | tail -n 1) || debFile=""
     fi
     if [ -z "${debFile}" ]; then
         echo "Failed to locate ${packageName} deb"
@@ -574,7 +574,7 @@ installPackageFromCache() {
         return 0
     fi
 
-    debFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9.]|$)" | sort -V | tail -n 1) || debFile=""
+    debFile=$(ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9]|$)" | sort -V | tail -n 1) || debFile=""
     if [ -z "${debFile}" ]; then
         echo "Failed to find cached deb file for ${packageName} version ${packageVersion}"
         return 1

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_mariner_spec.sh
@@ -456,4 +456,52 @@ Describe 'cse_install_mariner.sh'
             The output should not include 'nvidia-device-plugin'
         End
     End
+
+    Describe 'installPackageFromCache version matching'
+        rpm_version_cache="/tmp/shellspec-rpm-version-cache-$$"
+
+        setup_version_cache() {
+            RPM_PACKAGE_CACHE_BASE_DIR="$rpm_version_cache"
+            mkdir -p "$RPM_PACKAGE_CACHE_BASE_DIR/kubelet/downloads"
+        }
+
+        cleanup_version_cache() {
+            rm -rf "$rpm_version_cache"
+        }
+
+        BeforeEach 'setup_version_cache'
+        AfterEach 'cleanup_version_cache'
+
+        It 'does not match version 1.34.10 when requesting 1.34.1'
+            desiredVersion="1.34.1"
+            rpmDir="$RPM_PACKAGE_CACHE_BASE_DIR/kubelet/downloads"
+            touch "$rpmDir/kubelet-1.34.1-5.azl3.x86_64.rpm"
+            touch "$rpmDir/kubelet-1.34.10-2.azl3.x86_64.rpm"
+            touch "$rpmDir/kubelet-1.34.11-1.azl3.x86_64.rpm"
+            When call installPackageFromCache kubelet "$desiredVersion"
+            The output should include "extractBinaryFromRPM $rpmDir/kubelet-1.34.1-5.azl3.x86_64.rpm kubelet /opt/bin/kubelet"
+            The output should not include "1.34.10"
+            The output should not include "1.34.11"
+        End
+
+        It 'selects the latest release of the exact version requested'
+            desiredVersion="1.34.1"
+            rpmDir="$RPM_PACKAGE_CACHE_BASE_DIR/kubelet/downloads"
+            touch "$rpmDir/kubelet-1.34.1-1.azl3.x86_64.rpm"
+            touch "$rpmDir/kubelet-1.34.1-3.azl3.x86_64.rpm"
+            touch "$rpmDir/kubelet-1.34.10-2.azl3.x86_64.rpm"
+            When call installPackageFromCache kubelet "$desiredVersion"
+            The output should include "extractBinaryFromRPM $rpmDir/kubelet-1.34.1-3.azl3.x86_64.rpm kubelet /opt/bin/kubelet"
+        End
+
+        It 'returns failure when only a longer version exists in cache'
+            desiredVersion="1.34.1"
+            rpmDir="$RPM_PACKAGE_CACHE_BASE_DIR/kubelet/downloads"
+            touch "$rpmDir/kubelet-1.34.10-2.azl3.x86_64.rpm"
+            touch "$rpmDir/kubelet-1.34.12-1.azl3.x86_64.rpm"
+            When call installPackageFromCache kubelet "$desiredVersion"
+            The output should include "Failed to find cached rpm file for kubelet version 1.34.1"
+            The status should equal 1
+        End
+    End
 End

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
@@ -116,7 +116,7 @@ Describe 'cse_install_ubuntu.sh'
             touch "$downloadDir/kubelet_1.34.12-1ubuntu22.04u1_amd64.deb"
 
             result() {
-                ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9.]|$)" | sort -V | tail -n 1
+                ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9]|$)" | sort -V | tail -n 1
             }
             When call result
             The output should equal "kubelet_1.34.1-1ubuntu22.04u1_amd64.deb"
@@ -130,7 +130,7 @@ Describe 'cse_install_ubuntu.sh'
             touch "$downloadDir/kubelet_1.34.1-2ubuntu22.04u1_amd64.deb"
 
             result() {
-                ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9.]|$)" | sort -V | tail -n 1
+                ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9]|$)" | sort -V | tail -n 1
             }
             When call result
             The output should equal "kubelet_1.34.1-2ubuntu22.04u1_amd64.deb"
@@ -144,7 +144,7 @@ Describe 'cse_install_ubuntu.sh'
             touch "$downloadDir/kubelet_1.34.2-1ubuntu22.04u1_amd64.deb"
 
             result() {
-                ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9.]|$)" | sort -V | tail -n 1
+                ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9]|$)" | sort -V | tail -n 1
             }
             When call result
             The output should equal ""
@@ -158,7 +158,7 @@ Describe 'cse_install_ubuntu.sh'
             touch "$downloadDir/kubelet_1.34.10+azure-1_amd64.deb"
 
             result() {
-                ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9.]|$)" | sort -V | tail -n 1
+                ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9]|$)" | sort -V | tail -n 1
             }
             When call result
             The output should equal "kubelet_1.34.1+azure-1_amd64.deb"

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_ubuntu_spec.sh
@@ -86,4 +86,82 @@ Describe 'cse_install_ubuntu.sh'
             The output should include "status=incomplete"
         End
     End
+
+    Describe 'installPackageFromCache version matching'
+        deb_cache_root="/tmp/shellspec-deb-cache-$$"
+
+        setup_deb_cache() {
+            mkdir -p "$deb_cache_root"
+        }
+
+        cleanup_deb_cache() {
+            rm -rf "$deb_cache_root"
+        }
+
+        BeforeEach 'setup_deb_cache'
+        AfterEach 'cleanup_deb_cache'
+
+        # Mock functions used by installPackageFromCache
+        fallbackToKubeBinaryInstall() { return 1; }
+        logs_to_events() { shift; eval "$@"; }
+        extractDebBinaryFromFile() { echo "extractDebBinaryFromFile $1 $2 $3"; }
+
+        It 'does not match version 1.34.10 when requesting 1.34.1'
+            downloadDir="$deb_cache_root"
+            packageName="kubelet"
+            packageVersion="1.34.1"
+            touch "$downloadDir/kubelet_1.34.1-1ubuntu22.04u1_amd64.deb"
+            touch "$downloadDir/kubelet_1.34.10-1ubuntu22.04u1_amd64.deb"
+            touch "$downloadDir/kubelet_1.34.11-1ubuntu22.04u1_amd64.deb"
+            touch "$downloadDir/kubelet_1.34.12-1ubuntu22.04u1_amd64.deb"
+
+            result() {
+                ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9.]|$)" | sort -V | tail -n 1
+            }
+            When call result
+            The output should equal "kubelet_1.34.1-1ubuntu22.04u1_amd64.deb"
+        End
+
+        It 'matches the latest release of the exact version requested'
+            downloadDir="$deb_cache_root"
+            packageName="kubelet"
+            packageVersion="1.34.1"
+            touch "$downloadDir/kubelet_1.34.1-1ubuntu22.04u1_amd64.deb"
+            touch "$downloadDir/kubelet_1.34.1-2ubuntu22.04u1_amd64.deb"
+
+            result() {
+                ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9.]|$)" | sort -V | tail -n 1
+            }
+            When call result
+            The output should equal "kubelet_1.34.1-2ubuntu22.04u1_amd64.deb"
+        End
+
+        It 'returns empty when no matching version exists'
+            downloadDir="$deb_cache_root"
+            packageName="kubelet"
+            packageVersion="1.34.1"
+            touch "$downloadDir/kubelet_1.34.10-1ubuntu22.04u1_amd64.deb"
+            touch "$downloadDir/kubelet_1.34.2-1ubuntu22.04u1_amd64.deb"
+
+            result() {
+                ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9.]|$)" | sort -V | tail -n 1
+            }
+            When call result
+            The output should equal ""
+        End
+
+        It 'matches version with plus suffix (azure convention)'
+            downloadDir="$deb_cache_root"
+            packageName="kubelet"
+            packageVersion="1.34.1"
+            touch "$downloadDir/kubelet_1.34.1+azure-1_amd64.deb"
+            touch "$downloadDir/kubelet_1.34.10+azure-1_amd64.deb"
+
+            result() {
+                ls "${downloadDir}" | grep "${packageName}" | grep -E "${packageVersion}([^0-9.]|$)" | sort -V | tail -n 1
+            }
+            When call result
+            The output should equal "kubelet_1.34.1+azure-1_amd64.deb"
+        End
+    End
 End


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
Ensure pkg version is followed by non-numeric character when matching to avoid edge cases like matching 1.34.10 when version is 1.34.1

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
