### PR TITLE
fix: disable phase 3 for acl customca

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -107,11 +107,6 @@ func Test_ACL_CustomCA(t *testing.T) {
 					},
 				}
 			},
-			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
-				config.CustomCaCerts = []string{
-					encodedTestCert,
-				}
-			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				vmss.Properties = addTrustedLaunchToVMSS(vmss.Properties)
 			},


### PR DESCRIPTION
Customca in ACL seems to tip over 138kb cmd line limit, disable it for now.