### PR TITLE
fix: prevent ACL kubelet sysext from starting before CSE

### DIFF
--- a/parts/linux/cloud-init/artifacts/acl/cse_install_acl.sh
+++ b/parts/linux/cloud-init/artifacts/acl/cse_install_acl.sh
@@ -97,6 +97,8 @@ installCriCtlPackage() {
 }
 
 installKubeletKubectlFromPkg() {
+    maskKubeletSysextUpholds || exit $ERR_K8S_INSTALL_ERR
+
     if mergeSysexts kubelet "${2:-mcr.microsoft.com}"/oss/v2/kubernetes/kubelet-sysext "$1" \
                     kubectl "${2:-mcr.microsoft.com}"/oss/v2/kubernetes/kubectl-sysext "$1"; then
         ln -snf /usr/bin/{kubelet,kubectl} /opt/bin/

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -803,6 +803,21 @@ getSystemdArch() {
     esac
 }
 
+maskKubeletSysextUpholds() {
+    local dropinDir="/etc/systemd/system/multi-user.target.d"
+    local dropinPath="${dropinDir}/10-kubelet-kubelet.conf"
+
+    # AgentBaker owns kubelet activation, so suppress the sysext policy that starts it before CSE writes its configuration.
+    if ! mkdir -p "${dropinDir}"; then
+        echo "Failed to create kubelet sysext systemd drop-in directory ${dropinDir}" >&2
+        return 1
+    fi
+    if ! ln -sfn /dev/null "${dropinPath}"; then
+        echo "Failed to mask kubelet sysext systemd drop-in ${dropinPath}" >&2
+        return 1
+    fi
+}
+
 isARM64() {
     if [ "$(getCPUArch)" = "arm64" ]; then
         echo 1

--- a/spec/parts/linux/cloud-init/artifacts/cse_install_acl_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_install_acl_spec.sh
@@ -44,6 +44,49 @@ Describe 'cse_install_acl.sh'
     Include "./parts/linux/cloud-init/artifacts/acl/cse_install_acl.sh"
     Include "./parts/linux/cloud-init/artifacts/cse_helpers.sh"
 
+    Describe 'installKubeletKubectlFromPkg'
+        It 'masks the kubelet sysext Upholds drop-in before activating the sysext'
+            MASK_CREATED=false
+            ln() {
+                if [ "$1" = "-sfn" ] && [ "$2" = "/dev/null" ] && [ "$3" = "/etc/systemd/system/multi-user.target.d/10-kubelet-kubelet.conf" ]; then
+                    MASK_CREATED=true
+                fi
+                echo "mock ln $*" >&2
+            }
+            mergeSysexts() {
+                if [ "$MASK_CREATED" != "true" ]; then
+                    echo "mergeSysexts called before the kubelet sysext Upholds drop-in was masked" >&2
+                    return 1
+                fi
+                echo "mock mergeSysexts $*" >&2
+            }
+            When call installKubeletKubectlFromPkg "1.33"
+            The error should include "mock mkdir -p /etc/systemd/system/multi-user.target.d"
+            The error should include "mock ln -sfn /dev/null /etc/systemd/system/multi-user.target.d/10-kubelet-kubelet.conf"
+            The error should include "mock mergeSysexts kubelet mcr.microsoft.com/oss/v2/kubernetes/kubelet-sysext 1.33 kubectl mcr.microsoft.com/oss/v2/kubernetes/kubectl-sysext 1.33"
+            The error should include "mock ln -snf /usr/bin/kubelet /usr/bin/kubectl /opt/bin/"
+            The error should not include "mergeSysexts called before"
+            The status should be success
+        End
+
+        It 'fails installation when the sysext Upholds drop-in cannot be masked'
+            mkdir() {
+                return 1
+            }
+            mergeSysexts() {
+                echo "unexpected mergeSysexts" >&2
+            }
+            installKubeletKubectlFromURL() {
+                echo "unexpected installKubeletKubectlFromURL" >&2
+            }
+            When run installKubeletKubectlFromPkg "1.33"
+            The error should include "Failed to create kubelet sysext systemd drop-in directory /etc/systemd/system/multi-user.target.d"
+            The error should not include "unexpected mergeSysexts"
+            The error should not include "unexpected installKubeletKubectlFromURL"
+            The status should equal "$ERR_K8S_INSTALL_ERR"
+        End
+    End
+
     Describe 'installSecureTLSBootstrapClientSysext'
         It 'calls mergeSysexts with correct URL and creates symlink on success'
             mergeSysexts() {


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
ACL has a kubelet startup race between sysext activation and CSE configuration. The sysext's `Upholds=kubelet.service` starts kubelet before CSE creates `/etc/default/kubelet`; longer GPU setup allows the retries to hit systemd's start limit.

Mask the vendor `Upholds=` drop-in before activating the ACL kubelet sysext, ensuring CSE owns the initial kubelet start after configuration is complete.

Add regression coverage verifying that the mask is installed before sysext activation.

[TEST All VHDs] AKS Linux VHD Build - Msft Tenant runs to make sure the ACL GPU tests pass consistently:
- https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=174605218&view=results - pass
- https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=174607541&view=results - pass
- https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=174610759&view=results - pass
- https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=174612512&view=results - pass
- https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=174613833&view=results - pass


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
