### PR TITLE
fix: harden kubelet.service restart semantics after a watchdog abort

### DIFF
--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -40,6 +40,7 @@ func ValidateCommonLinux(ctx context.Context, s *Scenario) {
 	ValidateTLSBootstrapping(ctx, s)
 	ValidateKubeletServingCertificateRotation(ctx, s)
 	ValidateSystemdWatchdogForKubernetes132Plus(ctx, s)
+	ValidateKubeletWatchdogRecovery(ctx, s)
 	ValidateAKSLogCollector(ctx, s)
 	ValidateDiskQueueService(ctx, s)
 	ValidateLeakedSecrets(ctx, s)

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -196,6 +196,37 @@ func ValidateAKSLogCollector(ctx context.Context, s *Scenario) {
 	ValidateSystemdUnitIsNotFailed(ctx, s, "aks-log-collector")
 }
 
+// ValidateKubeletWatchdogRecovery asserts the effective systemd settings that let kubelet come
+// back after a watchdog timeout. WatchdogSec turns a stalled kubelet into a SIGABRT, which the Go
+// runtime reports as "Main process exited, code=exited, status=2". Recovery then depends on
+// systemd not blocking on the unit cgroup draining and on the start rate limit being disabled,
+// since a tripped limiter makes systemd ignore Restart=always until reset-failed or a reboot.
+//
+// This reads the merged unit (base unit plus every drop-in) so a drop-in that regresses these
+// settings is caught too. It only runs when kubelet.service is delivered through CustomData;
+// scriptless nodes take the unit from the VHD, which lags the current branch.
+func ValidateKubeletWatchdogRecovery(ctx context.Context, s *Scenario) {
+	nbc := s.Runtime.NBC
+	if nbc == nil || nbc.EnableScriptlessCSECmd {
+		return
+	}
+	for _, property := range []struct {
+		name string
+		want string
+	}{
+		{"Restart", "always"},
+		{"StartLimitIntervalUSec", "0"},
+		{"KillMode", "mixed"},
+		{"TimeoutStopUSec", "30s"},
+		// An exit status listed here would exclude the code a watchdog SIGABRT produces.
+		{"RestartPreventExitStatus", ""},
+	} {
+		cmd := fmt.Sprintf("systemctl show kubelet.service --property=%s --value", property.name)
+		execResult := execScriptOnVMForScenarioValidateExitCode(ctx, s, cmd, 0, "could not read effective kubelet.service systemd properties")
+		require.Equal(s.T, property.want, strings.TrimSpace(execResult.stdout), "unexpected effective kubelet.service %s", property.name)
+	}
+}
+
 func ValidateDiskQueueService(ctx context.Context, s *Scenario) {
 	ValidateSystemdUnitIsRunning(ctx, s, "disk_queue.service")
 }

--- a/parts/linux/cloud-init/artifacts/kubelet.service
+++ b/parts/linux/cloud-init/artifacts/kubelet.service
@@ -3,10 +3,23 @@ Description=Kubelet
 ConditionPathExists=/opt/bin/kubelet
 Wants=network-online.target containerd.service
 After=network-online.target containerd.service
+# Restart=always is ignored once systemd's default start rate limit (StartLimitBurst=5 within
+# StartLimitIntervalSec=10s) trips: the unit result becomes start-limit-hit, systemd stops
+# scheduling restart jobs, and the node has no kubelet until reset-failed or a reboot. Upstream
+# Kubernetes ships the same override in its packaged kubelet.service.
+StartLimitIntervalSec=0
 
 [Service]
 Restart=always
 RestartSec=2
+# The systemd watchdog (10-watchdog.conf, k8s >= 1.32) aborts a stalled kubelet. Under the default
+# KillMode=control-group systemd sends that SIGABRT to every process in the cgroup and then holds
+# the unit in "deactivating" until the cgroup drains, so one wedged child - a hung CRI or CSI mount
+# helper - blocks the restart with no restart job logged. mixed signals kubelet alone; the final
+# SIGKILL still covers the whole cgroup.
+KillMode=mixed
+# Bound each stop step instead of inheriting DefaultTimeoutStopSec.
+TimeoutStopSec=30
 EnvironmentFile=/etc/default/kubelet
 # Graceful termination (SIGTERM)
 SuccessExitStatus=143

--- a/pkg/agent/kubelet_service_test.go
+++ b/pkg/agent/kubelet_service_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Azure/agentbaker/parts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseSystemdUnit returns a section -> directive -> values map for a systemd unit file.
+// Directives may legitimately repeat (ExecStartPre), so values are collected in order.
+func parseSystemdUnit(t *testing.T, content string) map[string]map[string][]string {
+	t.Helper()
+	unit := map[string]map[string][]string{}
+	section := ""
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.Trim(line, "[]")
+			if _, ok := unit[section]; !ok {
+				unit[section] = map[string][]string{}
+			}
+			continue
+		}
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		require.NotEmpty(t, section, "directive %q appears before any section header", line)
+		key = strings.TrimSpace(key)
+		unit[section][key] = append(unit[section][key], strings.TrimSpace(value))
+	}
+	return unit
+}
+
+func firstValue(unit map[string]map[string][]string, section, key string) (string, bool) {
+	values := unit[section][key]
+	if len(values) == 0 {
+		return "", false
+	}
+	return values[0], true
+}
+
+// TestKubeletServiceWatchdogRecovery locks in the systemd settings that let kubelet recover
+// from a watchdog timeout.
+//
+// WatchdogSec=60s is written to /etc/systemd/system/kubelet.service.d/10-watchdog.conf by
+// ensureKubelet() for Kubernetes >= 1.32, which turns a stalled kubelet into a SIGABRT. The Go
+// runtime handles SIGABRT by dumping goroutines and calling exit(2), so systemd observes
+// "Main process exited, code=exited, status=2". Recovery from that state depends on:
+//
+//   - KillMode=mixed: under the default control-group mode systemd sends the watchdog SIGABRT to
+//     every process in the cgroup and then holds the unit in "deactivating" until the cgroup
+//     drains. A single wedged child blocks the restart, and no restart job is logged while the
+//     unit deactivates. mixed signals kubelet alone; the final SIGKILL still covers the cgroup.
+//   - TimeoutStopSec: bounds each stop step (stop-watchdog, final-SIGTERM, final-SIGKILL) instead
+//     of inheriting DefaultTimeoutStopSec.
+//   - StartLimitIntervalSec=0: systemd's default limiter (StartLimitBurst=5 within
+//     StartLimitIntervalSec=10s) sets the unit result to start-limit-hit, and
+//     service_shall_restart() returns false for Restart=always in that state. The unit then
+//     stays failed with no further restart jobs until reset-failed or a reboot. Upstream
+//     Kubernetes ships the same override.
+//   - No RestartPreventExitStatus: it would exclude the exit code the watchdog abort produces.
+func TestKubeletServiceWatchdogRecovery(t *testing.T) {
+	raw, err := parts.Templates.ReadFile(kubeletSystemdService)
+	require.NoError(t, err)
+	unit := parseSystemdUnit(t, string(raw))
+
+	restart, ok := firstValue(unit, "Service", "Restart")
+	require.True(t, ok, "kubelet.service must set Restart")
+	assert.Equal(t, "always", restart)
+
+	startLimit, ok := firstValue(unit, "Unit", "StartLimitIntervalSec")
+	require.True(t, ok, "kubelet.service must disable the systemd start rate limit, otherwise a "+
+		"burst of fast failures permanently disables Restart=always and leaves the node without a kubelet")
+	assert.Equal(t, "0", startLimit)
+
+	assert.Empty(t, unit["Service"]["RestartPreventExitStatus"],
+		"RestartPreventExitStatus must stay unset so the exit code produced by a watchdog SIGABRT still restarts kubelet")
+
+	assert.NotEmpty(t, unit["Service"]["TimeoutStopSec"],
+		"kubelet.service must bound the stop path so a wedged child process cannot hold the unit in 'deactivating'")
+
+	killMode, ok := firstValue(unit, "Service", "KillMode")
+	require.True(t, ok, "kubelet.service must set KillMode")
+	assert.Equal(t, "mixed", killMode)
+
+	// Preserved from before the watchdog recovery fix: SIGTERM is a graceful stop, not a failure.
+	assert.Equal(t, []string{"143"}, unit["Service"]["SuccessExitStatus"])
+}
+
+// TestKubeletServiceSurvivesCommentStripping guards the CustomData delivery path. The unit is
+// piped through removeComments() before it is gzipped into CustomData, so a directive that only
+// survives in the VHD-baked copy would silently not apply to nodes provisioned from CustomData.
+func TestKubeletServiceSurvivesCommentStripping(t *testing.T) {
+	raw, err := parts.Templates.ReadFile(kubeletSystemdService)
+	require.NoError(t, err)
+
+	delivered := parseSystemdUnit(t, string(removeComments(raw)))
+
+	for _, tc := range []struct {
+		section string
+		key     string
+		want    string
+	}{
+		{"Unit", "StartLimitIntervalSec", "0"},
+		{"Service", "Restart", "always"},
+		{"Service", "RestartSec", "2"},
+		{"Service", "KillMode", "mixed"},
+		{"Service", "TimeoutStopSec", "30"},
+		{"Service", "SuccessExitStatus", "143"},
+	} {
+		got, ok := firstValue(delivered, tc.section, tc.key)
+		require.Truef(t, ok, "[%s] %s missing from the comment-stripped unit delivered via CustomData", tc.section, tc.key)
+		assert.Equalf(t, tc.want, got, "[%s] %s", tc.section, tc.key)
+	}
+}


### PR DESCRIPTION
> **Reframed after a corrected RCA.** An earlier revision of this PR claimed to fix IcM 51000001068223. **It does not.** That incident's root cause is a deadlocked, end-of-life third-party fanotify permission interceptor (details below). This PR is now scoped as measured systemd hardening only, and is in **draft** pending a decision on whether the team wants it on its own merits. It must not be used to close that IcM.

**What this PR does / why we need it**:

`WatchdogSec=60s` is enabled by `ensureKubelet()` for k8s >= 1.32 (#6343). On timeout systemd sends SIGABRT; the Go runtime treats SIGABRT as `_SigThrow`, dumps goroutines and calls `exit(2)`, so systemd logs `Main process exited, code=exited, status=2/INVALIDARGUMENT`. Exit status 2 is expected here - `RestartPreventExitStatus` is unset and `SuccessExitStatus=143` does not affect restart under `Restart=always`. Two latent properties of `kubelet.service` delay or permanently prevent the restart that should follow.

**1. systemd blocks the restart on the cgroup draining.** Under the default `KillMode=control-group` systemd sends the watchdog SIGABRT to *every* process in kubelet's cgroup, then holds the unit in `deactivating` until the cgroup empties. A child that does not die on SIGABRT or SIGTERM blocks the restart, and **no restart job is logged while the unit deactivates**. With no `TimeoutStopSec` each stop step inherits `DefaultTimeoutStopSec` (90s on Ubuntu).

**2. The start rate limit permanently defeats `Restart=always`.** systemd's `service_shall_restart()` returns false for `Restart=always` when the unit result is `start-limit-hit`. Once `StartLimitBurst=5` within `StartLimitIntervalSec=10s` trips, the unit stays `failed` until `reset-failed` or a reboot - including after the underlying problem clears. Upstream Kubernetes ships `StartLimitInterval=0` in its own packaged `kubelet.service`; AgentBaker never carried it.

### Change

```
[Unit]
StartLimitIntervalSec=0

[Service]
KillMode=mixed
TimeoutStopSec=30
```

No change to `Restart=always`, `RestartSec=2`, or `SuccessExitStatus=143`. Intentional stops and shutdown are unaffected - `Restart=always` already does not restart after `systemctl stop` or during shutdown, and `StartLimitIntervalSec=0` does not change that.

### Measured on systemd 249 (Ubuntu 22.04, the AKS VHD baseline)

Watchdog unit whose main process traps SIGABRT and `exit 2` (mirroring Go) and leaves a child in the cgroup that ignores SIGTERM, over 120s:

| Config | Restarts in 120s | Observed state |
|---|---|---|
| Current | 1 | `deactivating/final-sigterm`, `NRestarts=0` for the first 90s |
| `TimeoutStopSec=30` only | 3 | 30s stall per cycle |
| `KillMode=mixed` + `TimeoutStopSec=30` | 15 | recovers within ~2s each cycle |

Crash loop at `RestartSec=100ms`: without `StartLimitIntervalSec=0` the unit goes permanently `failed` after 5 restarts with `Start request repeated too quickly`; with it, 88 restarts and still recovering. Note that at the shipped `RestartSec=2` a plain crash loop does **not** trip the limiter (20 restarts in 45s observed), so this is a latent lockout, not a routine one.

Checked for child-process leakage under `KillMode=mixed`: after 44 restarts the cgroup held only the current main process and its child - systemd reaps leftovers on restart. `systemd-analyze verify` on systemd 249 reports no directive or syntax errors.

---

### What this does *not* fix

IcM 51000001068223 was **not** a systemd restart-policy problem. On that VM new `open()` and `execve()` calls blocked host-wide:

- At the SIGABRT, 9 kubelet goroutines had been in `openat()` for >= 1 minute - 6 on `/etc/resolv.conf` (DNS/pod sandbox config), 3 on `/etc/os-release` (cadvisor `VersionInfo`/node status). One parent was waiting on an `acr-credential-provider` child that could not finish `exec`.
- kubelet's watchdog goroutine was healthy and *deliberately* withheld `WATCHDOG=1` because `syncNodeStatus` was wedged - the watchdog worked as designed.
- `cgroup-memory-telemetry.service` started afterwards and never finished; both later platform shutdowns hung in `poweroff_work_func -> call_usermodehelper_exec -> wait_for_completion` because `/sbin/poweroff` could not `execve`.
- No disk errors, OOM, or CPU saturation; existing processes kept writing through already-open FDs.

#### Kernel mechanism (verified against Linux v5.15 source)

`FANOTIFY_PERM_EVENTS` = `FAN_OPEN_PERM | FAN_ACCESS_PERM | FAN_OPEN_EXEC_PERM` ([`include/linux/fanotify.h`](https://github.com/torvalds/linux/blob/v5.15/include/linux/fanotify.h#L96)). Any of them routes through [`fanotify_get_response()`](https://github.com/torvalds/linux/blob/v5.15/fs/notify/fanotify/fanotify.c#L193), which is:

```c
ret = wait_event_killable(group->fanotify_data.access_waitq,
                          event->state == FAN_EVENT_ANSWERED);
```

No timeout. `wait_event_killable` is `TASK_KILLABLE`, so it wakes only on a *fatal* signal. A Go child with a SIGABRT handler installed is therefore **not** woken by systemd's watchdog SIGABRT or the follow-up SIGTERM - only SIGKILL. That is precisely why the wedged `acr-credential-provider` sat in kubelet's cgroup and held the unit in `deactivating`.

No timeout has been merged upstream as of July 2026. Miklos Szeredi (Red Hat) has an unmerged RFC, [`fanotify: add watchdog for permission events`](https://lore.kernel.org/linux-fsdevel/20250703130539.1696938-1-mszeredi@redhat.com/) (v2: [Sept 2025](https://lore.kernel.org/linux-fsdevel/20250909143053.112171-1-mszeredi@redhat.com/)), motivated verbatim by:

> "This is to make it easier to debug issues with AV software, which time and again deadlocks with no indication of where the issue comes from, and the kernel being blamed for the deadlock."

Jan Kara (SUSE, fsnotify maintainer) [concurs](https://lore.kernel.org/linux-fsdevel/eybdb3wqnod644u2nmmasd34uxhnjbvte4p2ued6dyy2vzt3sv@tsc4wysiypvr/): "I share the pain. I had to do quite some of these analyses myself." Even if merged, that patch only *warns*; it does not unblock the waiter.

#### The interceptor

The node ran Twistlock/Prisma Cloud Defender image `defender_20_09_365`, digest `sha256:ccf16f63800d43af39cb5c738192bb642722813e1f2a4bad955a8a24fb78d05f`.

- `20.09` is the **September 2020** release. Palo Alto's own documentation metadata marks it end-of-life (`Self-Hosted 20.09 (EoL)`, taxonomy tag `pan:osversion/20-09-eol`).
- Palo Alto's [support lifecycle](https://docs.prismacloud.io/content-collections/runtime-security/rs-support-lifecycle.md) is n-2 (~1 year). The current release is **34.04**, so 20.09 is roughly **14 major versions and ~6 years** out of support - it fell out of the support window by ~Q1 2022.
- Nothing on that node existed when 20.09 shipped: Ubuntu 22.04 (Apr 2022), kernel 5.15 (Oct 2021), containerd 2.x (Nov 2024), Kubernetes 1.34 (2025), cgroup v2. Per the [current system requirements](https://docs.prismacloud.io/content-collections/runtime-security/install/system-requirements), AKS 1.34 was first tested in Prisma **34.03**.
- Defender is documented to run with [`CAP_SYS_ADMIN`](https://docs.prismacloud.io/content-collections/runtime-security/install/deploy-defender/defender-architecture.md), which `fanotify_init(2)` requires for permission-event classes, and its filesystem **Prevent** action [requires kernel >= 4.20](https://docs.prismacloud.io/content-collections/runtime-security/runtime-defense/runtime-defense-hosts.md) (the `FAN_MARK_FILESYSTEM` floor). Palo Alto does not publish the exact event flags, so the specific flag in use is inferred, but blocking permission events are what "Prevent" means.

#### Why AgentBaker cannot fix this

`Restart=always` cannot recover a host where `execve` is globally blocked - the restart's own `ExecStartPre=/bin/bash /opt/azure/containers/kubelet.sh` cannot exec either. Nothing AgentBaker ships on Linux uses fanotify (verified across `parts/`, `vhdbuilder/`, `pkg/`, `aks-node-controller/`), and any AgentBaker-side mitigation or diagnostic capture would itself need `execve`, which is the blocked primitive.

The [AKS support policy](https://learn.microsoft.com/en-us/azure/aks/support-policies) places this outside AKS scope: *"Third-party closed-source software. This software can include security scanning tools and networking devices or software."*

**Operational note for the IcM:** a reboot is not strictly required. [`fanotify_release()`](https://github.com/torvalds/linux/blob/v5.15/fs/notify/fanotify/fanotify_user.c#L766) walks the pending `access_list`, answers every queued permission event with `FAN_ALLOW`, and calls `wake_up()` on the wait queue. So `SIGKILL`ing the wedged Defender process releases every blocked `open()`/`execve()` on the node. The catch is getting a process to issue it - a fresh SSH login or `run-command` needs `execve` and will itself hang, so this only works from an already-live session.

The one setting in this PR still relevant to that scenario is `StartLimitIntervalSec=0`: once the interceptor is cleared, kubelet resumes on its own instead of remaining `failed` from an exhausted start limit.

---

### Test plan

- `pkg/agent/kubelet_service_test.go` (new): asserts the directives on the embedded unit and separately on the copy after `removeComments()` - the CustomData delivery path - so a directive cannot silently survive only in the VHD-baked copy. Verified both tests fail without the unit change.
- `e2e`: `ValidateKubeletWatchdogRecovery` asserts the *effective* merged properties via `systemctl show` (`Restart=always`, `StartLimitIntervalUSec=0`, `KillMode=mixed`, `TimeoutStopUSec=30s`, empty `RestartPreventExitStatus`), so a regressing drop-in is caught too. Expected values confirmed against systemd 249. Gated to CustomData-delivered nodes; scriptless nodes take the unit from the VHD, which lags the branch.
- `go build ./...`, `go test ./pkg/agent/...`, `go vet`, `golangci-lint` (no new findings), `cd e2e && go build ./... && go vet ./...` all pass.

### Compatibility

- Single source of truth: this unit is both baked into the VHD by `packer_source.sh` and written from CustomData by `nodecustomdata.yml`, so one edit covers both delivery paths and all distros (Ubuntu, Azure Linux/Mariner, ACL, OSGuard, Flatcar).
- No AgentBaker-generated drop-in (`10-httpproxy`, `10-componentconfig`, `10-watchdog`, `10-credential-validation`, `10-tlsbootstrap`, `10-ensure-imds-restriction`, `10-containerd-base-flag`, `10-cgroupv2`, `10-container-runtime-flag`, `10-bindmount`, `10-kubereserved-slice`, `11-fmtmount`) sets `Restart`, `StartLimit*`, `KillMode`, or `TimeoutStopSec`.
- `StartLimitIntervalSec` in `[Unit]` has been supported since systemd v229; the oldest systemd in scope is 249.
- No behavior depends on a newer VHD, so old VHDs with new CSE are unaffected.
- No testdata regeneration needed - the unit is not decoded into any snapshot.

**Which issue(s) this PR fixes**:

None. Explicitly **not** a fix for IcM 51000001068223.
