### PR TITLE
fix: with SSH access disabled on the node pool, ACL node has port 22 closed at first boot but listening after reboot

### DIFF
--- a/e2e/scenario/provision.go
+++ b/e2e/scenario/provision.go
@@ -746,6 +746,25 @@ func RunCommand(ctx context.Context, s *Scenario, command string) (armcompute.Vi
 	return view, runCommandScriptError(view)
 }
 
+func RestartVMSSVM(ctx context.Context, s *Scenario) error {
+	if s.Runtime == nil || s.Runtime.Cluster == nil || s.Runtime.Cluster.Model == nil ||
+		s.Runtime.Cluster.Model.Properties == nil || s.Runtime.Cluster.Model.Properties.NodeResourceGroup == nil ||
+		s.Runtime.VM == nil || s.Runtime.VM.VM == nil || s.Runtime.VM.VM.InstanceID == nil {
+		return fmt.Errorf("scenario runtime is incomplete for VMSS VM restart")
+	}
+
+	rg := *s.Runtime.Cluster.Model.Properties.NodeResourceGroup
+	instanceID := *s.Runtime.VM.VM.InstanceID
+	poller, err := config.Azure.VMSSVM.BeginRestart(ctx, rg, s.Runtime.VMSSName, instanceID, nil)
+	if err != nil {
+		return fmt.Errorf("begin VMSS VM restart: %w", err)
+	}
+	if _, err = poller.PollUntilDone(ctx, config.PollUntilDoneOptions()); err != nil {
+		return fmt.Errorf("restart VMSS VM: %w", err)
+	}
+	return nil
+}
+
 // runCommandScriptError converts a RunCommand instance view into an error if the
 // script itself failed. The ARM CreateOrUpdate operation reports success as long as
 // the extension was able to run the script — a non-zero exit, throw, or timeout

--- a/e2e/scenario/scenario.go
+++ b/e2e/scenario/scenario.go
@@ -262,7 +262,12 @@ var _ = Register(&Scenario{
 		SkipSSHConnectivityValidation: true, // Skip SSH connectivity validation since SSH is down
 		SkipDefaultValidation:         true, // Skip default validation since it requires SSH connectivity
 		Validator: func(ctx context.Context, s *Scenario) error {
-			// Validate SSH daemon is disabled via RunCommand
+			if err := ValidateSSHServiceDisabled(ctx, s); err != nil {
+				return err
+			}
+			if err := RestartVMSSVM(ctx, s); err != nil {
+				return err
+			}
 			return ValidateSSHServiceDisabled(ctx, s)
 		},
 	},

--- a/e2e/scenario/ssh_validation.go
+++ b/e2e/scenario/ssh_validation.go
@@ -1,0 +1,40 @@
+package scenario
+
+const validateSSHServiceDisabledScript = `#!/bin/bash
+set -euo pipefail
+. /etc/os-release
+
+if [[ "$ID" == "ubuntu" ]]; then
+    units=(ssh.service)
+elif [[ "$ID" == "azurecontainerlinux" || ( "$ID" == "azurelinux" && "${VARIANT_ID:-}" == "azurecontainerlinux" ) ]]; then
+    units=(sshd.socket sshd.service)
+else
+    units=(sshd.service)
+fi
+
+for unit in "${units[@]}"; do
+    active_state=$(systemctl is-active "$unit" || true)
+    enabled_state=$(systemctl is-enabled "$unit" || true)
+    echo "$unit: active=$active_state enabled=$enabled_state"
+
+    if [[ "$active_state" != "inactive" ]]; then
+        echo "FAILED: $unit is not inactive"
+        exit 1
+    fi
+    if [[ "$enabled_state" != "disabled" ]]; then
+        echo "FAILED: $unit is not disabled"
+        exit 1
+    fi
+done
+
+listeners=$(ss -H -ltn 'sport = :22') || {
+    echo "FAILED: unable to inspect TCP port 22"
+    exit 1
+}
+if [[ -n "$listeners" ]]; then
+    echo "FAILED: TCP port 22 is listening"
+    exit 1
+fi
+
+echo "SUCCESS: SSH units are disabled and stopped"
+`

--- a/e2e/scenario/ssh_validation_test.go
+++ b/e2e/scenario/ssh_validation_test.go
@@ -1,0 +1,99 @@
+package scenario
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSSHServiceDisabledScript(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is required for Linux SSH validation tests")
+	}
+
+	tests := []struct {
+		name      string
+		osID      string
+		variant   string
+		active    string
+		enabled   string
+		stateUnit string
+		listeners string
+		ssStatus  string
+		want      string
+		wantError bool
+	}{
+		{name: "ACL", osID: "azurelinux", variant: "azurecontainerlinux", want: "sshd.socket: active=inactive enabled=disabled"},
+		{name: "legacy ACL", osID: "azurecontainerlinux", want: "sshd.socket: active=inactive enabled=disabled"},
+		{name: "Ubuntu", osID: "ubuntu", want: "ssh.service: active=inactive enabled=disabled"},
+		{name: "Azure Linux", osID: "azurelinux", want: "sshd.service: active=inactive enabled=disabled"},
+		{name: "Mariner", osID: "mariner", want: "sshd.service: active=inactive enabled=disabled"},
+		{name: "active socket", active: "active", want: "sshd.socket is not inactive", wantError: true},
+		{name: "enabled socket", enabled: "enabled", want: "sshd.socket is not disabled", wantError: true},
+		{name: "masked socket", enabled: "masked", want: "sshd.socket is not disabled", wantError: true},
+		{name: "active service", active: "active", stateUnit: "sshd.service", want: "sshd.service is not inactive", wantError: true},
+		{name: "enabled service", enabled: "enabled", stateUnit: "sshd.service", want: "sshd.service is not disabled", wantError: true},
+		{name: "missing unit", enabled: "not-found", want: "sshd.socket is not disabled", wantError: true},
+		{name: "inspection error", active: "unknown", want: "sshd.socket is not inactive", wantError: true},
+		{name: "IPv4 listener", listeners: "LISTEN 0 128 0.0.0.0:22 0.0.0.0:*", want: "TCP port 22 is listening", wantError: true},
+		{name: "IPv6 listener", listeners: "LISTEN 0 128 [::]:22 [::]:*", want: "TCP port 22 is listening", wantError: true},
+		{name: "ss failed", ssStatus: "1", want: "unable to inspect TCP port 22", wantError: true},
+		{name: "ss missing", ssStatus: "127", want: "unable to inspect TCP port 22", wantError: true},
+		{name: "ss failed with output", ssStatus: "1", listeners: "partial output", want: "unable to inspect TCP port 22", wantError: true},
+	}
+
+	const mocks = `
+function .() {
+    ID="${TEST_OS:-azurelinux}"
+    VARIANT_ID="${TEST_VARIANT}"
+    if [[ -z "$TEST_OS" ]]; then VARIANT_ID=azurecontainerlinux; fi
+}
+systemctl() {
+	local active="${TEST_ACTIVE:-inactive}" enabled="${TEST_ENABLED:-disabled}"
+	if [[ -n "$TEST_STATE_UNIT" && "$2" != "$TEST_STATE_UNIT" ]]; then
+		active=inactive
+		enabled=disabled
+	fi
+    if [[ "$ID" == ubuntu ]]; then
+        [[ "$2" == ssh.service ]] || return 1
+    elif [[ "$ID" != azurecontainerlinux && "$VARIANT_ID" != azurecontainerlinux ]]; then
+        [[ "$2" == sshd.service ]] || return 1
+    fi
+    case "$1" in
+		is-active) printf '%s\n' "$active"; [[ "$active" == active ]] && return 0; return 3 ;;
+		is-enabled) printf '%s\n' "$enabled"; [[ "$enabled" == enabled ]] && return 0; return 1 ;;
+        *) return 1 ;;
+    esac
+}
+ss() {
+    [[ "$#" == 3 && "$1" == -H && "$2" == -ltn && "$3" == 'sport = :22' ]] || return 99
+    printf '%s' "$TEST_LISTENERS"
+    return "${TEST_SS_STATUS:-0}"
+}
+`
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			command := exec.CommandContext(ctx, "bash", "-c", mocks+validateSSHServiceDisabledScript)
+			command.Env = append(os.Environ(),
+				"TEST_OS="+test.osID, "TEST_VARIANT="+test.variant,
+				"TEST_ACTIVE="+test.active, "TEST_ENABLED="+test.enabled,
+				"TEST_STATE_UNIT="+test.stateUnit,
+				"TEST_LISTENERS="+test.listeners, "TEST_SS_STATUS="+test.ssStatus)
+			output, err := command.CombinedOutput()
+			if (err != nil) != test.wantError {
+				t.Fatalf("error = %v, wantError = %v; output: %s", err, test.wantError, output)
+			}
+			if !strings.Contains(string(output), test.want) {
+				t.Fatalf("output missing %q: %s", test.want, output)
+			}
+			if strings.Contains(string(output), "SUCCESS:") == test.wantError {
+				t.Fatalf("unexpected success marker: %s", output)
+			}
+		})
+	}
+}

--- a/e2e/scenario/validators.go
+++ b/e2e/scenario/validators.go
@@ -3204,53 +3204,16 @@ fi`)
 	return nil
 }
 
-// ValidateSSHServiceDisabled validates that the SSH daemon service is disabled and stopped on the node
+// ValidateSSHServiceDisabled validates that SSH services and sockets are disabled and stopped on the node
 func ValidateSSHServiceDisabled(ctx context.Context, s *Scenario) error {
-	// Use VMSS RunCommand to check SSH service status directly on the node
-	// Ubuntu uses 'ssh' as service name, while AzureLinux and Mariner use 'sshd'
-	resp, err := RunCommand(ctx, s, `#!/bin/bash
-# Determine the correct SSH service name based on the distro
-# Ubuntu uses 'ssh', AzureLinux and Mariner use 'sshd'
-if [ -f /etc/os-release ]; then
-    . /etc/os-release
-    if [[ "$ID" == "ubuntu" ]]; then
-        SSH_SERVICE="ssh"
-    else
-        SSH_SERVICE="sshd"
-    fi
-else
-    # Default to sshd if we can't determine the OS
-    SSH_SERVICE="sshd"
-fi
-
-echo "Detected SSH service name: $SSH_SERVICE"
-
-# Check SSH service status
-status_output=$(systemctl status "$SSH_SERVICE" 2>&1)
-echo "SSH service status output:"
-echo "$status_output"
-
-# Check if the service is inactive (dead) and disabled
-if echo "$status_output" | grep -q "Active: inactive (dead)"; then
-    if echo "$status_output" | grep -q "Loaded:.*disabled"; then
-        echo "SUCCESS: SSH service is disabled and stopped"
-        exit 0
-    else
-        echo "FAILED: SSH service is inactive but not disabled"
-        exit 1
-    fi
-else
-    echo "FAILED: SSH service is not inactive"
-    exit 1
-fi`)
+	resp, err := RunCommand(ctx, s, validateSSHServiceDisabledScript)
 	if err != nil {
 		return fmt.Errorf("run command to check SSH service status: %w", err)
 	}
 	stdout := lo.FromPtr(resp.Output)
 	s.Logger.Logf("Run command stdout: %s\nstderr: %s", stdout, lo.FromPtr(resp.Error))
 
-	// Check if the command execution was successful by looking for our success message in the output
-	if err := assert.Contains(stdout, "SUCCESS: SSH service is disabled and stopped", "SSH service is not properly disabled and stopped"); err != nil {
+	if err := assert.Contains(stdout, "SUCCESS: SSH units are disabled and stopped", "SSH service is not properly disabled and stopped"); err != nil {
 		return err
 	}
 

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1491,6 +1491,8 @@ disableSSH() {
     systemctlDisableAndStop ssh || exit $ERR_DISABLE_SSH
     # On AzureLinux, the ssh service is named "sshd.service"
     systemctlDisableAndStop sshd || exit $ERR_DISABLE_SSH
+    # On ACL, port 22 is owned by sshd.socket (socket activation)
+    systemctlDisableAndStop sshd.socket || exit $ERR_DISABLE_SSH
 }
 
 disableSSHPubkeyAuth() {

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1788,6 +1788,8 @@ disableSSH() {
     systemctlDisableAndStop ssh || exit $ERR_DISABLE_SSH
     # On AzureLinux, the ssh service is named "sshd.service"
     systemctlDisableAndStop sshd || exit $ERR_DISABLE_SSH
+    # On ACL, port 22 is owned by sshd.socket (socket activation)
+    systemctlDisableAndStop sshd.socket || exit $ERR_DISABLE_SSH
 }
 
 disableSSHPubkeyAuth() {

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1784,12 +1784,27 @@ setupAmdAma() {
 }
 
 disableSSH() {
-    # On ubuntu, the ssh service is named "ssh.service"
-    systemctlDisableAndStop ssh || exit $ERR_DISABLE_SSH
-    # On AzureLinux, the ssh service is named "sshd.service"
-    systemctlDisableAndStop sshd || exit $ERR_DISABLE_SSH
-    # On ACL, port 22 is owned by sshd.socket (socket activation)
-    systemctlDisableAndStop sshd.socket || exit $ERR_DISABLE_SSH
+    local units=() unit result=0
+    if isACL "$OS" "$OS_VARIANT"; then
+        units=(sshd.socket sshd.service)
+    elif isUbuntu "$OS"; then
+        units=(ssh.service)
+    elif isMarinerOrAzureLinux "$OS" "$OS_VARIANT" || isFlatcar "$OS"; then
+        units=(sshd.service)
+    else
+        echo "Disabling SSH is not supported on OS $OS"
+        return 1
+    fi
+
+    for unit in "${units[@]}"; do
+        if ! systemctl cat "$unit" >/dev/null 2>&1; then
+            echo "Cannot inspect expected SSH unit $unit"
+            return 1
+        fi
+        systemctl_stop 20 5 25 "$unit" || { echo "$unit could not be stopped"; result=1; }
+        systemctl_disable 20 5 25 "$unit" || { echo "$unit could not be disabled"; result=1; }
+    done
+    return "$result"
 }
 
 disableSSHPubkeyAuth() {

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -446,6 +446,147 @@ Describe 'cse_config.sh'
         End
     End
 
+    Describe 'disableSSH'
+        run_disable_ssh_cse() {
+            disableSSH || exit "$ERR_DISABLE_SSH"
+        }
+
+        systemctl() {
+            case "$1" in
+                daemon-reload) return 0 ;;
+                cat|stop|disable)
+                    echo "$*"
+                    [ "$*" != "${FAIL_COMMAND:-}" ]
+                    ;;
+                *) return 1 ;;
+            esac
+        }
+
+        timeout() {
+            shift
+            "$@"
+        }
+
+        sleep() {
+            :
+        }
+
+        It 'disables ssh.service on Ubuntu'
+            OS="$UBUNTU_OS_NAME"
+            OS_VARIANT=""
+            When call disableSSH
+            The output should equal "stop ssh.service
+disable ssh.service"
+            The status should be success
+        End
+
+        It 'disables sshd.service on Azure Linux'
+            OS="$AZURELINUX_OS_NAME"
+            OS_VARIANT=""
+            When call disableSSH
+            The output should equal "stop sshd.service
+disable sshd.service"
+            The status should be success
+        End
+
+        It 'disables the socket and service on ACL'
+            OS="$ACL_OS_NAME"
+            OS_VARIANT=""
+            When call disableSSH
+            The output should equal "stop sshd.socket
+disable sshd.socket
+stop sshd.service
+disable sshd.service"
+            The status should be success
+        End
+
+        It 'recognizes ACL through the Azure Linux variant'
+            OS="$AZURELINUX_OS_NAME"
+            OS_VARIANT="$ACL_OS_VARIANT"
+            When call disableSSH
+            The output should equal "stop sshd.socket
+disable sshd.socket
+stop sshd.service
+disable sshd.service"
+            The status should be success
+        End
+
+        It 'returns failure when the socket cannot be disabled'
+            OS="$ACL_OS_NAME"
+            OS_VARIANT=""
+            FAIL_COMMAND="disable sshd.socket"
+            When call disableSSH
+            The output should include "sshd.socket could not be disabled"
+            The output should include "disable sshd.service"
+            The status should be failure
+        End
+
+        It 'still disables both units when stopping the socket fails'
+            OS="$ACL_OS_NAME"
+            OS_VARIANT=""
+            FAIL_COMMAND="stop sshd.socket"
+            When call disableSSH
+            The output should include "sshd.socket could not be stopped"
+            The output should include "disable sshd.socket"
+            The output should include "disable sshd.service"
+            The status should be failure
+        End
+
+        It 'returns failure when the service cannot be disabled'
+            OS="$ACL_OS_NAME"
+            OS_VARIANT=""
+            FAIL_COMMAND="disable sshd.service"
+            When call disableSSH
+            The output should include "sshd.service could not be disabled"
+            The status should be failure
+        End
+
+        It 'rejects an absent or uninspectable expected socket'
+            OS="$ACL_OS_NAME"
+            OS_VARIANT=""
+            FAIL_COMMAND="cat sshd.socket"
+            When call disableSSH
+            The output should equal "Cannot inspect expected SSH unit sshd.socket"
+            The status should be failure
+        End
+
+        It 'maps a stop failure to the CSE SSH error code'
+            OS="$ACL_OS_NAME"
+            OS_VARIANT=""
+            FAIL_COMMAND="stop sshd.service"
+            When run run_disable_ssh_cse
+            The output should include "sshd.service could not be stopped"
+            The output should include "disable sshd.service"
+            The status should equal 172
+        End
+
+        It 'disables sshd.service on Mariner'
+            OS="$MARINER_OS_NAME"
+            OS_VARIANT=""
+            When call disableSSH
+            The output should equal "stop sshd.service
+disable sshd.service"
+            The status should be success
+        End
+
+        It 'disables sshd.service on Flatcar'
+            OS="$FLATCAR_OS_NAME"
+            OS_VARIANT=""
+            When call disableSSH
+            The output should equal "stop sshd.service
+disable sshd.service"
+            The status should be success
+        End
+
+        It 'rejects unsupported operating systems'
+            OS="UNKNOWN"
+            OS_VARIANT=""
+            When call disableSSH
+            The output should equal "Disabling SSH is not supported on OS UNKNOWN"
+            The status should be failure
+        End
+    End
+
     Describe 'disableSSHPubkeyAuth'
         setup() {
             SSHD_CONFIG_FILE="$(mktemp)"

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
@@ -17,6 +17,42 @@ readContainerImage() {
 
 Describe 'cse_helpers.sh'
     Include "./parts/linux/cloud-init/artifacts/cse_helpers.sh"
+    Describe 'systemctlDisableAndStop'
+        systemctl() {
+            [ "$1" = "cat" ] && [ "${UNIT_EXISTS:-true}" = "true" ]
+        }
+
+        systemctl_stop() {
+            [ "${STOP_SUCCEEDS:-true}" = "true" ]
+        }
+
+        systemctl_disable() {
+            DISABLE_CALLED="true"
+            [ "${DISABLE_SUCCEEDS:-true}" = "true" ]
+        }
+
+        It 'succeeds when the unit does not exist'
+            UNIT_EXISTS="false"
+            When call systemctlDisableAndStop missing.service
+            The status should be success
+        End
+
+        It 'still disables the unit and succeeds when stopping fails'
+            STOP_SUCCEEDS="false"
+            When call systemctlDisableAndStop sshd.service
+            The output should equal "sshd.service could not be stopped"
+            The variable DISABLE_CALLED should equal "true"
+            The status should be success
+        End
+
+        It 'preserves best-effort success when disabling fails'
+            DISABLE_SUCCEEDS="false"
+            When call systemctlDisableAndStop sshd.service
+            The output should equal "sshd.service could not be disabled"
+            The status should be success
+        End
+    End
+
     Describe 'updatePackageVersions'
         It 'returns downloadURIs.ubuntu.r2204.versionsV2 of package pkgVersionsV2 for UBUNTU 22.04'
             package=$(readPackage "pkgVersionsV2")


### PR DESCRIPTION


<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:

On ACL, SSH uses socket activation, sshd.socket listens on port 22, not sshd.service. When AKS disables SSH, it only disables sshd.service but leaves sshd.socket enabled.
On first boot it looks fine because the socket hasn't started yet. But on reboot, systemd sees sshd.socket is still enabled, starts it, and port 22 comes back up.
The fix disables sshd.socket too, so it stays off across reboots

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://dev.azure.com/mariner-org/ACL/_workitems/edit/22659

pipeline run -> https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=174629723&view=results
