### PR TITLE
fix(gpu): pull the GPU driver image from the cloud's own MCR endpoint

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1234,7 +1234,14 @@ pullGPUDriverImage() {
     # Cache-miss path only. Retry to ride out a transient blip, but stay tight: a truly missing image
     # should fail fast rather than eat the shared CSE window the driver install needs next. retrycmd
     # also self-caps to the CSE budget, so this can't overrun provisioning.
-    retrycmd_if_failure 3 5 120 ctr -n k8s.io image pull $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG
+    retrycmd_if_failure 3 5 120 ctr -n k8s.io image pull $NVIDIA_DRIVER_IMAGE_PULL_REF:$NVIDIA_DRIVER_IMAGE_TAG || return 1
+    if [ "$NVIDIA_DRIVER_IMAGE_PULL_REF" != "$NVIDIA_DRIVER_IMAGE" ]; then
+        # Converge onto the canonical ref that install and cleanup use. Removing the pull ref drops
+        # only the name; the canonical tag still holds the manifest, so no blobs are collected.
+        ctr -n k8s.io image tag $NVIDIA_DRIVER_IMAGE_PULL_REF:$NVIDIA_DRIVER_IMAGE_TAG $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG || return 1
+        ctr -n k8s.io image rm $NVIDIA_DRIVER_IMAGE_PULL_REF:$NVIDIA_DRIVER_IMAGE_TAG
+    fi
+    return 0 # the rm above is best effort; don't let it set the caller's exit code
 }
 
 installGPUDriverImage() {

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -199,7 +199,14 @@ export GPU_DEST=/usr/local/nvidia
 export NVIDIA_DRIVER_IMAGE_SHA="${GPU_IMAGE_SHA:=}"
 export NVIDIA_DRIVER_IMAGE_TAG="${GPU_DV}-${NVIDIA_DRIVER_IMAGE_SHA}"
 export NVIDIA_GPU_DRIVER_TYPE="${GPU_DRIVER_TYPE:=}"
+# Canonical ref: the VHD bakes CUDA LTS under this exact name and configGPUDrivers matches it
+# exactly, so it must stay mcr.microsoft.com in every cloud.
 export NVIDIA_DRIVER_IMAGE="mcr.microsoft.com/aks/aks-gpu-${NVIDIA_GPU_DRIVER_TYPE}"
+# GRID is never baked, so it is pulled at provision time from this cloud's own MCR (sovereign clouds
+# cannot reach mcr.microsoft.com). The base may carry a trailing slash and is unset during VHD build,
+# where this file is sourced under `set -o nounset`, hence the default.
+NVIDIA_DRIVER_IMAGE_MCR_BASE="${MCR_REPOSITORY_BASE:-mcr.microsoft.com}"
+export NVIDIA_DRIVER_IMAGE_PULL_REF="${NVIDIA_DRIVER_IMAGE_MCR_BASE%/}/aks/aks-gpu-${NVIDIA_GPU_DRIVER_TYPE}"
 export CTR_GPU_INSTALL_CMD="ctr -n k8s.io run --privileged --rm --net-host --with-ns pid:/proc/1/ns/pid --mount type=bind,src=/opt/gpu,dst=/mnt/gpu,options=rbind --mount type=bind,src=/opt/actions,dst=/mnt/actions,options=rbind"
 export DOCKER_GPU_INSTALL_CMD="docker run --privileged --net=host --pid=host -v /opt/gpu:/mnt/gpu -v /opt/actions:/mnt/actions --rm"
 APT_CACHE_DIR=/var/cache/apt/archives/

--- a/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_helpers_spec.sh
@@ -939,3 +939,51 @@ EOF
         End
     End
 End
+
+Describe 'GPU driver image reference resolution'
+    # Both references are computed when cse_helpers.sh is sourced, so each case re-sources the
+    # script in a clean child shell with the environment the RP would supply.
+    resolve_driver_refs() {
+        env -u NVIDIA_DRIVER_IMAGE -u NVIDIA_DRIVER_IMAGE_PULL_REF -u MCR_REPOSITORY_BASE "$@" bash -c \
+            'source ./parts/linux/cloud-init/artifacts/cse_helpers.sh >/dev/null 2>&1; echo "$NVIDIA_DRIVER_IMAGE $NVIDIA_DRIVER_IMAGE_PULL_REF"'
+    }
+
+    It 'uses public MCR for both references when MCR_REPOSITORY_BASE is unset'
+        When call resolve_driver_refs GPU_DRIVER_TYPE=grid
+        The status should be success
+        The output should eq "mcr.microsoft.com/aks/aks-gpu-grid mcr.microsoft.com/aks/aks-gpu-grid"
+    End
+
+    It 'uses public MCR for both references when MCR_REPOSITORY_BASE is empty'
+        When call resolve_driver_refs MCR_REPOSITORY_BASE= GPU_DRIVER_TYPE=grid
+        The status should be success
+        The output should eq "mcr.microsoft.com/aks/aks-gpu-grid mcr.microsoft.com/aks/aks-gpu-grid"
+    End
+
+    It 'pulls from the sovereign MCR endpoint and strips the trailing slash'
+        When call resolve_driver_refs MCR_REPOSITORY_BASE=mcr.microsoft.scloud/ GPU_DRIVER_TYPE=grid
+        The status should be success
+        The output should eq "mcr.microsoft.com/aks/aks-gpu-grid mcr.microsoft.scloud/aks/aks-gpu-grid"
+    End
+
+    It 'pulls from the sovereign MCR endpoint supplied without a trailing slash'
+        When call resolve_driver_refs MCR_REPOSITORY_BASE=mcr.microsoft.eaglex.ic.gov GPU_DRIVER_TYPE=grid
+        The status should be success
+        The output should eq "mcr.microsoft.com/aks/aks-gpu-grid mcr.microsoft.eaglex.ic.gov/aks/aks-gpu-grid"
+    End
+
+    It 'applies the cloud-aware base to every driver type'
+        When call resolve_driver_refs MCR_REPOSITORY_BASE=mcr.azure.cn/ GPU_DRIVER_TYPE=cuda-lts
+        The status should be success
+        The output should eq "mcr.microsoft.com/aks/aks-gpu-cuda-lts mcr.azure.cn/aks/aks-gpu-cuda-lts"
+    End
+
+    # Regression guard: the VHD bakes aks-gpu-cuda-lts under its mcr.microsoft.com name and
+    # configGPUDrivers matches it exactly, so a cloud-specific value here would break every
+    # sovereign CUDA node's cache hit.
+    It 'keeps the cache-facing reference on public MCR regardless of cloud'
+        When call resolve_driver_refs MCR_REPOSITORY_BASE=mcr.microsoft.scloud/ GPU_DRIVER_TYPE=cuda-lts
+        The status should be success
+        The output should start with "mcr.microsoft.com/aks/aks-gpu-cuda-lts "
+    End
+End


### PR DESCRIPTION
**What this PR does / why we need it**:

The GPU driver image reference is hardcoded to `mcr.microsoft.com`. Sovereign and air-gapped clouds cannot reach that host, so a node that has to pull a driver image at provision time fails CSE with `ERR_GPU_DRIVERS_START_FAIL` / `cseExitCode 84`.

**Why only GRID nodes hit this**

Every other AKS image — including `aks-gpu-cuda-lts` — is baked into the VHD under its `mcr.microsoft.com` name and resolves out of the local content store without touching the network, which is why sovereign CUDA pools (A100/H100) have always worked. `aks-gpu-grid` appears only under `GPUContainerImages` in `parts/common/components.json` and is never added to the VHD image cache (`install-dependencies.sh` uses that entry solely to extract a version string for release notes; only `aks-gpu-cuda-lts` goes through `/opt/azure/containers/image-fetcher`). So `configGPUDrivers` must do a real `ctr -n k8s.io image pull` for GRID, and that is the one GPU code path that needs a reachable registry.

This is a latent defect, not a regression — the `mcr.microsoft.com` literal has been there since 2023. It surfaces on NV-series (GRID) pools in sovereign clouds, e.g. `Standard_NV18ads_A10_v5`, which maps to `grid` via `ConvergedGPUDriverSizes`.

**Why two references instead of just rewriting the one**

The obvious fix — making `NVIDIA_DRIVER_IMAGE` itself cloud-specific — is actively dangerous, so this PR deliberately does not do that. `cacheGPUContainerImageComponents` bakes the CUDA image under its literal `mcr.microsoft.com/aks/aks-gpu-cuda-lts` name, and `configGPUDrivers` probes the cache with an **exact** match:

```sh
if [ -z "$(ctr -n k8s.io images ls -q "name==${NVIDIA_DRIVER_IMAGE}:${NVIDIA_DRIVER_IMAGE_TAG}")" ]; then
```

Rewriting `NVIDIA_DRIVER_IMAGE` to `mcr.microsoft.scloud/...` would miss that cache on every sovereign CUDA node and send a **currently working** A100/H100 pool out to a registry that may not carry the image — a strictly worse failure than the one being fixed. (China is a useful proof of the invariant: `retagMCRImagesForChina` only *adds* `mcr.azure.cn` aliases and leaves the canonical name in place, which is exactly why the cache lookup still hits there today.)

So:

| Variable | Value | Used for |
|---|---|---|
| `NVIDIA_DRIVER_IMAGE` | always `mcr.microsoft.com/aks/aks-gpu-<type>` | VHD cache lookup, install, cleanup |
| `NVIDIA_DRIVER_IMAGE_PULL_REF` | `${MCR_REPOSITORY_BASE%/}/aks/aks-gpu-<type>` | the cache-miss pull only |

`pullGPUDriverImage` pulls the cloud-specific ref and then retags it onto the canonical one, so the install and cleanup steps are untouched. In public cloud the two are identical and behavior is byte-for-byte unchanged.

| Cloud | `MCR_REPOSITORY_BASE` | Pull ref |
|---|---|---|
| Public | `mcr.microsoft.com` (default) | `mcr.microsoft.com/aks/aks-gpu-grid` |
| USSec | `mcr.microsoft.scloud/` | `mcr.microsoft.scloud/aks/aks-gpu-grid` |
| USNat | `mcr.microsoft.eaglex.ic.gov` | `mcr.microsoft.eaglex.ic.gov/aks/aks-gpu-grid` |
| Mooncake | `mcr.azure.cn/` | `mcr.azure.cn/aks/aks-gpu-grid` |

`MCR_REPOSITORY_BASE` is already passed to CSE by the RP (`cse_cmd.sh`) and read at runtime by `cse_main.sh`, `cse_config.sh` and `acl/cse_install_acl.sh`; the trailing-slash strip and `mcr.microsoft.com` default here match those existing call sites exactly. The default also matters for VHD build, where the variable is unset and `cse_helpers.sh` is sourced under `set -o nounset`.

**Testing**

Added a `Describe 'GPU driver image reference resolution'` block that re-sources `cse_helpers.sh` in a clean child shell and asserts **both** references for: unset base, empty base, sovereign base with a trailing slash, sovereign base without one, and a non-`grid` driver type — plus an explicit regression guard that the cache-facing reference stays on public MCR regardless of cloud. Spec file goes 85 → 91 examples with the same 17 pre-existing environment-related failures. `shellcheck` findings are identical to baseline, and regenerating both `pkg/agent` and `aks-node-controller` testdata produces no changes.

The `pullGPUDriverImage` exit-code paths were also exercised against a stubbed `ctr`: public-cloud success returns 0 (the `if` is not taken), pull failure returns 1, sovereign success retags then returns 0, and a failed best-effort cleanup does not fail provisioning. `${VAR%/}` was verified identical under `dash`, `sh` and `bash`.

**Known gap / follow-up**

`aks-node-controller` (scriptless) does not plumb `MCR_REPOSITORY_BASE` — it is listed in `app.go`'s `isExpectedDiffCSEVar` and there is no corresponding `AKSNodeConfig` field. There the two references collapse to today's `mcr.microsoft.com` value, so there is no regression, but sovereign scriptless nodes will still need a proto field plus RP wiring. Tracking separately.

Separately, this code fix is necessary but not sufficient on its own: the `aks-gpu-*` tags also have to be syndicated to the sovereign MCR endpoints. If a given tag was never published there, the pull will still fail — with `404 / manifest unknown` rather than a transport error.

**Note on the July revert**

`f6e2f8e32b` briefly introduced an `NVIDIA_DRIVER_IMAGE_REGISTRY` variable and `7bce4bac1f` reverted it 49 minutes later. That was unrelated to this problem: it keyed off `AZURE_PRIVATE_REGISTRY_SERVER` (defaulting to `mcr.microsoft.com/aks`) purely as scaffolding to E2E-test an Ubuntu 26.04 CUDA driver image that had not yet been published, and was reverted once the real image landed on MCR — hence the revert's title, "use published MCR CUDA driver image". It also rewrote the reference in place, which is the cache-miss hazard described above.

**Which issue(s) this PR fixes**:

N/A
