### PR TITLE
[DO NOT REVIEW] Example: enable ENABLE_0803_TEST_FEATURE via enabled-agentbaker-features (brownbag demo)

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -69,7 +69,7 @@ func Test_Ubuntu2204_Enable0803TestFeature(t *testing.T) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateFileHasContent(ctx, s, "/opt/azure/containers/enabled_features.sh", "ENABLE_0803_TEST_FEATURE=true")
-				ValidateFileHasContent(ctx, s, "/etc/enable-0803-test-feature.example.conf", "test_key=test_value")
+				ValidateFileHasContent(ctx, s, "/etc/enable-0803-test-feature.conf", "test_key=test_value")
 			},
 		},
 	})
@@ -91,7 +91,7 @@ func Test_Ubuntu2204_AzureCNI(t *testing.T) {
 				// ENABLE_0803_TEST_FEATURE default-off assertion (illustrative). This scenario does
 				// not enable the feature, so we piggyback the "absent == off" check here instead of
 				// spinning up a dedicated absent scenario (which would consume an extra VM/VMSS).
-				ValidateFileDoesNotExist(ctx, s, "/etc/enable-0803-test-feature.example.conf")
+				ValidateFileDoesNotExist(ctx, s, "/etc/enable-0803-test-feature.conf")
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -69,7 +69,7 @@ func Test_Ubuntu2204_Enable0803TestFeature(t *testing.T) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateFileHasContent(ctx, s, "/opt/azure/containers/enabled_features.sh", "ENABLE_0803_TEST_FEATURE=true")
-				ValidateFileHasContent(ctx, s, "/etc/enable-0803-test-feature.example.conf", "example_test_key = example_test_value")
+				ValidateFileHasContent(ctx, s, "/etc/enable-0803-test-feature.example.conf", "test_key=test_value")
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -55,6 +55,27 @@ func Test_AzureLinuxV3_ARM64(t *testing.T) {
 	})
 }
 
+func Test_Ubuntu2204_Enable0803TestFeature(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "ENABLE_0803_TEST_FEATURE renders to enabled_features.sh and nodePrep applies the example config",
+		Config: Config{
+			Cluster: ClusterKubenet,
+			VHD:     config.VHDUbuntu2204Gen2Containerd,
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				if nbc.EnabledFeatures == nil {
+					nbc.EnabledFeatures = map[string]string{}
+				}
+				nbc.EnabledFeatures["ENABLE_0803_TEST_FEATURE"] = "true"
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateFileHasContent(ctx, s, "/opt/azure/containers/enabled_features.sh", "ENABLE_0803_TEST_FEATURE=true")
+				ValidateFileHasContent(ctx, s, "/etc/sysctl.d/99-enable-0803-test-feature.conf", "net.core.somaxconn = 32768")
+				ValidateSysctlConfig(ctx, s, map[string]string{"net.core.somaxconn": "32768"})
+			},
+		},
+	})
+}
+
 func Test_Ubuntu2204_AzureCNI(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Ubuntu 22.04 scenario on a cluster configured with Azure CNI",
@@ -68,6 +89,10 @@ func Test_Ubuntu2204_AzureCNI(t *testing.T) {
 				nbc.AgentPoolProfile.CustomNodeLabels["kubernetes.azure.com/nodenetwork-vnetguid"] = c.VNetResourceGUID
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
+				// ENABLE_0803_TEST_FEATURE default-off assertion (illustrative). This scenario does
+				// not enable the feature, so we piggyback the "absent == off" check here instead of
+				// spinning up a dedicated absent scenario (which would consume an extra VM/VMSS).
+				ValidateFileDoesNotExist(ctx, s, "/etc/sysctl.d/99-enable-0803-test-feature.conf")
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -69,8 +69,7 @@ func Test_Ubuntu2204_Enable0803TestFeature(t *testing.T) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateFileHasContent(ctx, s, "/opt/azure/containers/enabled_features.sh", "ENABLE_0803_TEST_FEATURE=true")
-				ValidateFileHasContent(ctx, s, "/etc/sysctl.d/99-enable-0803-test-feature.conf", "net.core.somaxconn = 32768")
-				ValidateSysctlConfig(ctx, s, map[string]string{"net.core.somaxconn": "32768"})
+				ValidateFileHasContent(ctx, s, "/etc/enable-0803-test-feature.example.conf", "example_test_key = example_test_value")
 			},
 		},
 	})
@@ -92,7 +91,7 @@ func Test_Ubuntu2204_AzureCNI(t *testing.T) {
 				// ENABLE_0803_TEST_FEATURE default-off assertion (illustrative). This scenario does
 				// not enable the feature, so we piggyback the "absent == off" check here instead of
 				// spinning up a dedicated absent scenario (which would consume an extra VM/VMSS).
-				ValidateFileDoesNotExist(ctx, s, "/etc/sysctl.d/99-enable-0803-test-feature.conf")
+				ValidateFileDoesNotExist(ctx, s, "/etc/enable-0803-test-feature.example.conf")
 			},
 		},
 	})

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -437,7 +437,7 @@ function nodePrep {
     # placeholder names (not a real kernel tunable or subsystem) to keep this purely illustrative.
     if [ "${ENABLE_0803_TEST_FEATURE:-}" = "true" ]; then
         ENABLE_0803_TEST_FEATURE_CONF="/etc/enable-0803-test-feature.example.conf"
-        echo "example_test_key = example_test_value" > "$ENABLE_0803_TEST_FEATURE_CONF"
+        echo "test_key=test_value" > "$ENABLE_0803_TEST_FEATURE_CONF"
         echo "ENABLE_0803_TEST_FEATURE enabled; wrote example config to $ENABLE_0803_TEST_FEATURE_CONF"
     fi
 

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -425,6 +425,21 @@ function nodePrep {
     logs_to_events "AKS.CSE.fetch_and_cache_imds_instance_metadata" fetch_and_cache_imds_instance_metadata
     reconcileVulnerableKernelModuleMitigation
 
+    # ENABLE_0803_TEST_FEATURE: illustrative aks-rp-delivered toggle. Delivered generically via
+    # enabled_features.sh, which the aks-node-controller launcher parses and exports; the ANC
+    # binary then runs this CSE script inheriting that environment, so the flag arrives here as a
+    # plain env var (same delivery path as ENABLE_PROVISIONING_HOTFIX). Consumed in nodePrep so it
+    # applies to every real node - including nodes booted from a PIS-cached VHD where basePrep is
+    # skipped. Default-off: only the literal "true" enables it; an absent var is a no-op.
+    # Kept intentionally simple (inline, no helper) for this teaching example; a real feature would
+    # factor non-trivial work into an idempotent configure<Feature>() helper. Idempotent: re-running
+    # overwrites the drop-in with identical content.
+    if [ "${ENABLE_0803_TEST_FEATURE:-}" = "true" ]; then
+        ENABLE_0803_TEST_FEATURE_CONF="/etc/sysctl.d/99-enable-0803-test-feature.conf"
+        echo "net.core.somaxconn = 32768" > "$ENABLE_0803_TEST_FEATURE_CONF"
+        sysctl -p "$ENABLE_0803_TEST_FEATURE_CONF"
+    fi
+
     # IMPORTANT NOTE: We do this here since this function can mutate kubelet flags and node labels,
     # which is used by configureK8s and other functions. Thus, we need to make sure flag and label content is correct beforehand.
     logs_to_events "AKS.CSE.configureKubeletServing" configureKubeletServing

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -433,11 +433,12 @@ function nodePrep {
     # skipped. Default-off: only the literal "true" enables it; an absent var is a no-op.
     # Kept intentionally simple (inline, no helper) for this teaching example; a real feature would
     # factor non-trivial work into an idempotent configure<Feature>() helper. Idempotent: re-running
-    # overwrites the drop-in with identical content.
+    # overwrites the example file with identical content. The key/value below are deliberately
+    # placeholder names (not a real kernel tunable or subsystem) to keep this purely illustrative.
     if [ "${ENABLE_0803_TEST_FEATURE:-}" = "true" ]; then
-        ENABLE_0803_TEST_FEATURE_CONF="/etc/sysctl.d/99-enable-0803-test-feature.conf"
-        echo "net.core.somaxconn = 32768" > "$ENABLE_0803_TEST_FEATURE_CONF"
-        sysctl -p "$ENABLE_0803_TEST_FEATURE_CONF"
+        ENABLE_0803_TEST_FEATURE_CONF="/etc/enable-0803-test-feature.example.conf"
+        echo "example_test_key = example_test_value" > "$ENABLE_0803_TEST_FEATURE_CONF"
+        echo "ENABLE_0803_TEST_FEATURE enabled; wrote example config to $ENABLE_0803_TEST_FEATURE_CONF"
     fi
 
     # IMPORTANT NOTE: We do this here since this function can mutate kubelet flags and node labels,

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -436,7 +436,7 @@ function nodePrep {
     # overwrites the example file with identical content. The key/value below are deliberately
     # placeholder names (not a real kernel tunable or subsystem) to keep this purely illustrative.
     if [ "${ENABLE_0803_TEST_FEATURE:-}" = "true" ]; then
-        ENABLE_0803_TEST_FEATURE_CONF="/etc/enable-0803-test-feature.example.conf"
+        ENABLE_0803_TEST_FEATURE_CONF="/etc/enable-0803-test-feature.conf"
         echo "test_key=test_value" > "$ENABLE_0803_TEST_FEATURE_CONF"
         echo "ENABLE_0803_TEST_FEATURE enabled; wrote example config to $ENABLE_0803_TEST_FEATURE_CONF"
     fi


### PR DESCRIPTION
> ⚠️ **DO NOT REVIEW / DO NOT MERGE.** This is a teaching **EXAMPLE** for a brownbag demo, not a real change. `ENABLE_0803_TEST_FEATURE` is a **throwaway demo key** and must never ship.

## What this demonstrates

The canonical AgentBaker consumer pattern for an `enabled-agentbaker-features` toggle key, end to end:

- **Generic delivery (no Go change):** aks-rp sets `NodeBootstrappingConfiguration.EnabledFeatures["ENABLE_0803_TEST_FEATURE"]="true"`. `renderEnabledFeatures` serializes it into `/opt/azure/containers/enabled_features.sh` as a sorted `KEY=VALUE` line.
- **Launcher export:** `aks-node-controller-launcher.sh` parses `enabled_features.sh` and `export`s every valid key. The aks-node-controller binary then runs the CSE bootstrap script with `cmd.Env = append(os.Environ(), env...)` (`parser.go`), so the flag arrives in the CSE script as a plain inherited env var — the same delivery path as `ENABLE_PROVISIONING_HOTFIX`.
- **CSE consumption:** `cse_main.sh` `nodePrep` gates directly on `[ "${ENABLE_0803_TEST_FEATURE:-}" = "true" ]` and, kept intentionally simple for this teaching example, does the work **inline** (writes + applies a sysctl drop-in) rather than a separate `cse_config.sh` helper. Placed in `nodePrep` (not `basePrep`) so it applies to every real node, including nodes booted from a PIS-cached VHD where `basePrep` is skipped. Default-off: an absent key is a no-op.

> A real feature would typically factor non-trivial work into an idempotent `configure<Feature>()` helper (e.g. in `cse_config.sh`) and add a ShellSpec unit test; both are omitted here to keep the example minimal.

## Tests

- **Enabled path** — a dedicated scenario `Test_Ubuntu2204_Enable0803TestFeature` sets the key and asserts the rendered `enabled_features.sh` line, the sysctl drop-in, and the applied sysctl value.
- **Default-off path** — rather than a dedicated absent scenario (which would consume an extra VM/VMSS), the "absent == off" assertion is folded into the existing `Test_Ubuntu2204_AzureCNI` scenario as one extra validator (`ValidateFileDoesNotExist`). Prefer reusing a suitable existing scenario for negative checks.

## Files

- `parts/linux/cloud-init/artifacts/cse_main.sh` — `nodePrep` gate on the inherited env var, work done inline.
- `e2e/scenario_test.go` — enabled scenario + default-off validator folded into an existing scenario.

The companion aks-rp toggle PR enables the delivery side (setting the `EnabledFeatures` key).
