### PR TITLE
fix: match k8s RP versions and cache latest and latest-1 everywhere for kubelet and kubectl

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1416,8 +1416,8 @@
               {
                 "k8sVersion": "1.36",
                 "renovateTag": "name=kubelet, repository=production, os=ubuntu, release=26.04",
-                "latestVersion": "1.36.2-ubuntu26.04u2",
-                "previousLatestVersion": "1.36.1-ubuntu26.04u3"
+                "latestVersion": "1.36.3-ubuntu26.04u1",
+                "previousLatestVersion": "1.36.2-ubuntu26.04u2"
               }
             ]
           },
@@ -1426,8 +1426,8 @@
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=kubelet, repository=production, os=ubuntu, release=24.04",
-                "latestVersion": "1.34.9-ubuntu24.04u2",
-                "previousLatestVersion": "1.34.8-ubuntu24.04u2"
+                "latestVersion": "1.34.10-ubuntu24.04u1",
+                "previousLatestVersion": "1.34.9-ubuntu24.04u2"
               },
               {
                 "k8sVersion": "1.35",
@@ -1448,18 +1448,20 @@
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=kubelet, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "1.34.9-ubuntu22.04u1",
-                "previousLatestVersion": "1.34.8-ubuntu22.04u1"
+                "latestVersion": "1.34.10-ubuntu22.04u1",
+                "previousLatestVersion": "1.34.9-ubuntu22.04u2"
               },
               {
                 "k8sVersion": "1.35",
                 "renovateTag": "name=kubelet, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "1.35.6-ubuntu22.04u1"
+                "latestVersion": "1.35.7-ubuntu22.04u2",
+                "previousLatestVersion": "1.35.6-ubuntu22.04u2"
               },
               {
                 "k8sVersion": "1.36",
                 "renovateTag": "name=kubelet, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "1.36.3-ubuntu22.04u1"
+                "latestVersion": "1.36.3-ubuntu22.04u1",
+                "previousLatestVersion": "1.36.2-ubuntu22.04u2"
               }
             ]
           },
@@ -1468,7 +1470,8 @@
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=kubelet, repository=production, os=ubuntu, release=20.04",
-                "latestVersion": "1.34.10-ubuntu20.04u1"
+                "latestVersion": "1.34.10-ubuntu20.04u1",
+                "previousLatestVersion": "1.34.9-ubuntu20.04u2"
               }
             ]
           }
@@ -1479,17 +1482,20 @@
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "RPM_registry=https://packages.microsoft.com/azurelinux/3.0/prod/cloud-native/x86_64/repodata, name=kubelet, os=azurelinux, release=3.0",
-                "latestVersion": "1.34.10-1.azl3"
+                "latestVersion": "1.34.10-1.azl3",
+                "previousLatestVersion": "1.34.9-2.azl3"
               },
               {
                 "k8sVersion": "1.35",
                 "renovateTag": "RPM_registry=https://packages.microsoft.com/azurelinux/3.0/prod/cloud-native/x86_64/repodata, name=kubelet, os=azurelinux, release=3.0",
-                "latestVersion": "1.35.7-2.azl3"
+                "latestVersion": "1.35.7-2.azl3",
+                "previousLatestVersion": "1.35.6-2.azl3"
               },
               {
                 "k8sVersion": "1.36",
                 "renovateTag": "RPM_registry=https://packages.microsoft.com/azurelinux/3.0/prod/cloud-native/x86_64/repodata, name=kubelet, os=azurelinux, release=3.0",
-                "latestVersion": "1.36.3-1.azl3"
+                "latestVersion": "1.36.3-1.azl3",
+                "previousLatestVersion": "1.36.2-2.azl3"
               }
             ]
           }
@@ -1500,12 +1506,20 @@
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/kubelet-sysext",
-                "latestVersion": "v1.34.8-1-azlinux3"
+                "latestVersion": "v1.34.10-1-azlinux3",
+                "previousLatestVersion": "v1.34.9-2-azlinux3"
               },
               {
                 "k8sVersion": "1.35",
                 "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/kubelet-sysext",
-                "latestVersion": "v1.35.5-1-azlinux3"
+                "latestVersion": "v1.35.7-2-azlinux3",
+                "previousLatestVersion": "v1.35.6-2-azlinux3"
+              },
+              {
+                "k8sVersion": "1.36",
+                "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/kubelet-sysext",
+                "latestVersion": "v1.36.3-1-azlinux3",
+                "previousLatestVersion": "v1.36.2-2-azlinux3"
               }
             ],
             "downloadURL": "mcr.microsoft.com/oss/v2/kubernetes/kubelet-sysext:${version}-${SYSTEMD_ARCH}"
@@ -1556,13 +1570,20 @@
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=kubectl, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "1.34.9-ubuntu22.04u5",
-                "previousLatestVersion": "1.34.8-ubuntu22.04u9"
+                "latestVersion": "1.34.10-ubuntu22.04u1",
+                "previousLatestVersion": "1.34.9-ubuntu22.04u5"
               },
               {
                 "k8sVersion": "1.35",
                 "renovateTag": "name=kubectl, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "1.35.7-ubuntu22.04u1"
+                "latestVersion": "1.35.7-ubuntu22.04u1",
+                "previousLatestVersion": "1.35.6-ubuntu22.04u5"
+              },
+              {
+                "k8sVersion": "1.36",
+                "renovateTag": "name=kubectl, repository=production, os=ubuntu, release=22.04",
+                "latestVersion": "1.36.3-ubuntu22.04u1",
+                "previousLatestVersion": "1.36.2-ubuntu22.04u6"
               }
             ]
           },
@@ -1571,7 +1592,8 @@
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=kubectl, repository=production, os=ubuntu, release=20.04",
-                "latestVersion": "1.34.10-ubuntu20.04u1"
+                "latestVersion": "1.34.10-ubuntu20.04u1",
+                "previousLatestVersion": "1.34.9-ubuntu20.04u5"
               }
             ]
           }
@@ -1582,7 +1604,8 @@
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "RPM_registry=https://packages.microsoft.com/azurelinux/3.0/prod/cloud-native/x86_64/repodata, name=kubectl, os=azurelinux, release=3.0",
-                "latestVersion": "1.34.10-1.azl3"
+                "latestVersion": "1.34.10-1.azl3",
+                "previousLatestVersion": "1.34.9-5.azl3"
               },
               {
                 "k8sVersion": "1.35",
@@ -1593,7 +1616,8 @@
               {
                 "k8sVersion": "1.36",
                 "renovateTag": "RPM_registry=https://packages.microsoft.com/azurelinux/3.0/prod/cloud-native/x86_64/repodata, name=kubectl, os=azurelinux, release=3.0",
-                "latestVersion": "1.36.3-1.azl3"
+                "latestVersion": "1.36.3-1.azl3",
+                "previousLatestVersion": "1.36.2-6.azl3"
               }
             ]
           }
@@ -1604,12 +1628,20 @@
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/kubectl-sysext",
-                "latestVersion": "v1.34.8-1-azlinux3"
+                "latestVersion": "v1.34.10-1-azlinux3",
+                "previousLatestVersion": "v1.34.9-5-azlinux3"
               },
               {
                 "k8sVersion": "1.35",
                 "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/kubectl-sysext",
-                "latestVersion": "v1.35.5-1-azlinux3"
+                "latestVersion": "v1.35.7-1-azlinux3",
+                "previousLatestVersion": "v1.35.6-5-azlinux3"
+              },
+              {
+                "k8sVersion": "1.36",
+                "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/kubectl-sysext",
+                "latestVersion": "v1.36.3-1-azlinux3",
+                "previousLatestVersion": "v1.36.2-6-azlinux3"
               }
             ],
             "downloadURL": "mcr.microsoft.com/oss/v2/kubernetes/kubectl-sysext:${version}-${SYSTEMD_ARCH}"


### PR DESCRIPTION
Match k8s versions to RP