### PR TITLE
test: enable testPackagesInstalled for ARM64 VHDs

### DIFF
--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -263,14 +263,11 @@ testPackagesInstalled() {
         testAcrCredentialProviderInstalled "$PACKAGE_DOWNLOAD_URL" "${PACKAGE_VERSIONS[@]}"
         continue
         ;;
+      "azure-acr-credential-provider-pmc"|\
       "nvidia-device-plugin"|\
       "datacenter-gpu-manager-4-core"|\
       "datacenter-gpu-manager-4-proprietary"|\
       "dcgm-exporter")
-        testPkgDownloaded "${name}" "${downloadLocation}" "${PACKAGE_VERSIONS[@]}"
-        continue
-        ;;
-      "azure-acr-credential-provider-pmc")
         testPkgDownloaded "${name%-pmc}" "${downloadLocation}" "${PACKAGE_VERSIONS[@]}"
         continue
         ;;

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -267,12 +267,6 @@ testPackagesInstalled() {
       "datacenter-gpu-manager-4-core"|\
       "datacenter-gpu-manager-4-proprietary"|\
       "dcgm-exporter")
-        # No ARM64 SKU with GPU now (see install-dependencies.sh).
-        # Remove this skip when ARM64 GPU SKUs become available and GPU packages are cached on ARM64 VHDs.
-        if [ "$(isARM64)" -eq 1 ]; then
-          echo "Skipping ${name} on ARM64 (no GPU SKU)"
-          continue
-        fi
         testPkgDownloaded "${name}" "${downloadLocation}" "${PACKAGE_VERSIONS[@]}"
         continue
         ;;

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -235,10 +235,7 @@ testAcrCredentialProviderInstalled() {
 
 testPackagesInstalled() {
   local test="testPackagesInstalled"
-  if [ "$(isARM64)" -eq 1 ]; then
-    return
-  fi
-  CPU_ARCH="amd64"
+  CPU_ARCH=$(getCPUArch) # "arm64" or "amd64"
   echo "$test:Start"
   packages=$(jq ".Packages" $COMPONENTS_FILEPATH | jq .[] --monochrome-output --compact-output)
 
@@ -266,11 +263,20 @@ testPackagesInstalled() {
         testAcrCredentialProviderInstalled "$PACKAGE_DOWNLOAD_URL" "${PACKAGE_VERSIONS[@]}"
         continue
         ;;
-      "azure-acr-credential-provider-pmc"|\
       "nvidia-device-plugin"|\
       "datacenter-gpu-manager-4-core"|\
       "datacenter-gpu-manager-4-proprietary"|\
       "dcgm-exporter")
+        # No ARM64 SKU with GPU now (see install-dependencies.sh).
+        # Remove this skip when ARM64 GPU SKUs become available and GPU packages are cached on ARM64 VHDs.
+        if [ "$(isARM64)" -eq 1 ]; then
+          echo "Skipping ${name} on ARM64 (no GPU SKU)"
+          continue
+        fi
+        testPkgDownloaded "${name}" "${downloadLocation}" "${PACKAGE_VERSIONS[@]}"
+        continue
+        ;;
+      "azure-acr-credential-provider-pmc")
         testPkgDownloaded "${name%-pmc}" "${downloadLocation}" "${PACKAGE_VERSIONS[@]}"
         continue
         ;;


### PR DESCRIPTION
## Summary
- Remove the ARM64 early-return in `testPackagesInstalled` that skipped all package validation on ARM64 VHDs
- Set `CPU_ARCH` dynamically via `getCPUArch()` instead of hardcoding `"amd64"`
- Skip only GPU packages on ARM64 (no ARM64 GPU SKU exists today), with comments for future maintainers
- Separate `azure-acr-credential-provider-pmc` into its own case branch so it's validated on ARM64

## Test plan
- [ ] Verify ARM64 VHD build passes the `testPackagesInstalled` checks (kubelet, kubectl, containerd, cni-plugins, acr-credential-provider)
- [ ] Verify amd64 VHD build behavior is unchanged
- [ ] Confirm GPU packages are correctly skipped on ARM64 without errors