### PR TITLE
fix: persist Azure Linux THP settings after reboot

### DIFF
--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	scp "github.com/bramvdbogaerde/go-scp"
@@ -18,12 +17,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 )
-
-var bufferPool = sync.Pool{
-	New: func() any {
-		return new(bytes.Buffer)
-	},
-}
 
 type podExecResult struct {
 	exitCode       string
@@ -111,17 +104,26 @@ func runSSHCommandWithPrivateKeyFile(
 	}
 	defer session.Close()
 
-	stdout := bufferPool.Get().(*bytes.Buffer)
-	stderr := bufferPool.Get().(*bytes.Buffer)
-	stdout.Reset()
-	stderr.Reset()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	session.Stdout = &stdout
+	session.Stderr = &stderr
 
-	defer bufferPool.Put(stdout)
-	defer bufferPool.Put(stderr)
-	session.Stdout = stdout
-	session.Stderr = stderr
-
-	err = session.Run(command)
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- session.Run(command)
+	}()
+	select {
+	case err = <-runErr:
+	case <-ctx.Done():
+		_ = session.Close()
+		_ = client.Close()
+		select {
+		case <-runErr:
+		case <-time.After(5 * time.Second):
+		}
+		return nil, fmt.Errorf("SSH command canceled or timed out: %w", ctx.Err())
+	}
 
 	exitCode := 0
 	if err != nil {

--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -142,9 +142,11 @@ func getBaseNBC(ctx context.Context, t testing.TB, cluster *Cluster, vhd *config
 
 // is a temporary workaround
 // eventually we want to phase out usage of nbc
-func nbcToAKSNodeConfigV1(nbc *datamodel.NodeBootstrappingConfiguration) *aksnodeconfigv1.Configuration {
+func nbcToAKSNodeConfigV1(nbc *datamodel.NodeBootstrappingConfiguration) (*aksnodeconfigv1.Configuration, error) {
 	cs := nbc.ContainerService
-	agent.ValidateAndSetLinuxNodeBootstrappingConfiguration(nbc)
+	if err := agent.ValidateAndSetLinuxNodeBootstrappingConfiguration(nbc); err != nil {
+		return nil, err
+	}
 
 	bootstrappingConfig := &aksnodeconfigv1.BootstrappingConfig{
 		TlsBootstrappingToken:                           nbc.KubeletClientTLSBootstrapToken,
@@ -377,7 +379,7 @@ func nbcToAKSNodeConfigV1(nbc *datamodel.NodeBootstrappingConfiguration) *aksnod
 		cfg.KubeletConfig.KubeletFlags = kubeletFlags
 	}
 
-	return cfg
+	return cfg, nil
 }
 
 // this is huge, but accurate, so leave it here.

--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -144,7 +144,7 @@ func getBaseNBC(ctx context.Context, t testing.TB, cluster *Cluster, vhd *config
 // eventually we want to phase out usage of nbc
 func nbcToAKSNodeConfigV1(nbc *datamodel.NodeBootstrappingConfiguration) (*aksnodeconfigv1.Configuration, error) {
 	cs := nbc.ContainerService
-	if err := agent.ValidateAndSetLinuxNodeBootstrappingConfiguration(nbc); err != nil {
+	if err := agent.ValidateAndSetLinuxNodeBootstrappingConfigurationWithError(nbc); err != nil {
 		return nil, err
 	}
 

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1631,6 +1631,76 @@ func Test_AzureLinuxV3_CustomSysctls(t *testing.T) {
 	})
 }
 
+func Test_AzureLinuxV3_CustomLinuxOSConfigPersistsAfterReboot(t *testing.T) {
+	customSysctls := map[string]string{
+		"net.ipv4.ip_local_port_range":       "32768 62535",
+		"net.netfilter.nf_conntrack_max":     "2097152",
+		"net.netfilter.nf_conntrack_buckets": "524288",
+		"net.ipv4.tcp_keepalive_intvl":       "90",
+	}
+	customContainerdUlimits := map[string]string{
+		"LimitMEMLOCK": "75000",
+		"LimitNOFILE":  "1048",
+	}
+	const (
+		swapFileSizeMB int32 = 64
+		thpEnabled           = "never"
+		thpDefrag            = "never"
+	)
+
+	RunScenario(t, &Scenario{
+		Description: "tests that AzureLinuxV3 custom Linux OS config persists after a node reboot",
+		Config: Config{
+			Cluster: ClusterKubenet,
+			VHD:     config.VHDAzureLinuxV3Gen2,
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.AgentPoolProfile.CustomLinuxOSConfig = &datamodel.CustomLinuxOSConfig{
+					Sysctls: &datamodel.SysctlConfig{
+						NetNetfilterNfConntrackMax:     to.Ptr(toolkit.StrToInt32(customSysctls["net.netfilter.nf_conntrack_max"])),
+						NetNetfilterNfConntrackBuckets: to.Ptr(toolkit.StrToInt32(customSysctls["net.netfilter.nf_conntrack_buckets"])),
+						NetIpv4IpLocalPortRange:        customSysctls["net.ipv4.ip_local_port_range"],
+						NetIpv4TcpkeepaliveIntvl:       to.Ptr(toolkit.StrToInt32(customSysctls["net.ipv4.tcp_keepalive_intvl"])),
+					},
+					UlimitConfig: &datamodel.UlimitConfig{
+						MaxLockedMemory: customContainerdUlimits["LimitMEMLOCK"],
+						NoFile:          customContainerdUlimits["LimitNOFILE"],
+					},
+					SwapFileSizeMB:             to.Ptr(swapFileSizeMB),
+					TransparentHugePageEnabled: thpEnabled,
+					TransparentHugePageDefrag:  thpDefrag,
+				}
+				nbc.AgentPoolProfile.CustomKubeletConfig = &datamodel.CustomKubeletConfig{
+					FailSwapOn: to.Ptr(false),
+				}
+			},
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
+				config.CustomLinuxOsConfig = &aksnodeconfigv1.CustomLinuxOsConfig{
+					SysctlConfig: &aksnodeconfigv1.SysctlConfig{
+						NetNetfilterNfConntrackMax:     to.Ptr(toolkit.StrToInt32(customSysctls["net.netfilter.nf_conntrack_max"])),
+						NetNetfilterNfConntrackBuckets: to.Ptr(toolkit.StrToInt32(customSysctls["net.netfilter.nf_conntrack_buckets"])),
+						NetIpv4IpLocalPortRange:        to.Ptr(customSysctls["net.ipv4.ip_local_port_range"]),
+						NetIpv4TcpkeepaliveIntvl:       to.Ptr(toolkit.StrToInt32(customSysctls["net.ipv4.tcp_keepalive_intvl"])),
+					},
+					UlimitConfig: &aksnodeconfigv1.UlimitConfig{
+						MaxLockedMemory: to.Ptr(customContainerdUlimits["LimitMEMLOCK"]),
+						NoFile:          to.Ptr(customContainerdUlimits["LimitNOFILE"]),
+					},
+					EnableSwapConfig:           true,
+					SwapFileSize:               swapFileSizeMB,
+					TransparentHugepageSupport: thpEnabled,
+					TransparentDefrag:          thpDefrag,
+				}
+				config.KubeletConfig.EnableKubeletConfigFile = true
+				config.KubeletConfig.KubeletConfigFileConfig.FailSwapOn = to.Ptr(false)
+			},
+			WaitForSSHAfterReboot: 10 * time.Minute,
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateCustomLinuxOSConfigPersistsAfterReboot(ctx, s, customSysctls, customContainerdUlimits, swapFileSizeMB, thpEnabled, thpDefrag)
+			},
+		},
+	})
+}
+
 func Test_Ubuntu2204_KubeletCustomConfig(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Tags: Tags{

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -85,7 +85,7 @@ func RunScenario(t *testing.T, s *Scenario) {
 		})
 		return
 	}
-	if scriptlessUnsupported(s) {
+	if config.Config.DisableScriptless || scriptlessUnsupported(s) {
 		require.NoError(t, runScenario(t, s))
 		return
 	}
@@ -304,7 +304,7 @@ func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 
 		// for scriptless phase 2.5, we are using nbc cse cmd for provisioning but passing aksnodeconfig and nbc cse cmd to compare env variables
 		// scriptless tag means provisioning with aksnodeconfig is used
-		if !s.Tags.Scriptless && s.BootstrapConfigMutator != nil {
+		if !config.Config.DisableScriptless && !s.Tags.Scriptless && s.BootstrapConfigMutator != nil {
 			nbc.EnableScriptlessNBCCSECmd = true
 		}
 	}

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -292,7 +292,8 @@ func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 		s.BootstrapConfigMutator(s.Runtime.Cluster, nbc)
 	}
 	if s.AKSNodeConfigMutator != nil {
-		nodeconfig := nbcToAKSNodeConfigV1(nbc)
+		nodeconfig, err := nbcToAKSNodeConfigV1(nbc)
+		require.NoError(s.T, err)
 		s.AKSNodeConfigMutator(s.Runtime.Cluster, nodeconfig)
 		s.Runtime.AKSNodeConfig = nodeconfig
 

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -336,7 +336,9 @@ func RebootVMAndWaitForSSH(ctx context.Context, s *Scenario) {
 			return false, nil
 		}
 
-		execResult, err := runSSHCommand(ctx, sshClient, "cat /proc/sys/kernel/random/boot_id", s.IsWindows())
+		bootIDCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		execResult, err := runSSHCommand(bootIDCtx, sshClient, "cat /proc/sys/kernel/random/boot_id", s.IsWindows())
+		cancel()
 		if err != nil {
 			cleanupBastionTunnel(sshClient)
 			s.T.Logf("waiting for boot ID after reboot: %v", err)

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -250,7 +250,7 @@ func ValidateDirectoryContent(ctx context.Context, s *Scenario, path string, fil
 
 func ValidateSysctlConfig(ctx context.Context, s *Scenario, customSysctls map[string]string) {
 	s.T.Helper()
-	keysToCheck := make([]string, len(customSysctls))
+	keysToCheck := make([]string, 0, len(customSysctls))
 	for k := range customSysctls {
 		keysToCheck = append(keysToCheck, k)
 	}
@@ -258,10 +258,102 @@ func ValidateSysctlConfig(ctx context.Context, s *Scenario, customSysctls map[st
 		"set -ex",
 		fmt.Sprintf("sudo sysctl %s | sed -E 's/([0-9])\\s+([0-9])/\\1 \\2/g'", strings.Join(keysToCheck, " ")),
 	}
-	execResult := execScriptOnVMForScenarioValidateExitCode(ctx, s, strings.Join(command, "\n"), 0, "systmctl command failed")
+	execResult := execScriptOnVMForScenarioValidateExitCode(ctx, s, strings.Join(command, "\n"), 0, "sysctl command failed")
 	for name, value := range customSysctls {
 		require.Contains(s.T, execResult.stdout, fmt.Sprintf("%s = %v", name, value), "expected to find %s set to %v, but was not.\nStdout:\n%s", name, value, execResult.stdout)
 	}
+}
+
+func ValidateCustomLinuxOSConfigPersistsAfterReboot(ctx context.Context, s *Scenario, customSysctls map[string]string, customContainerdUlimits map[string]string, swapFileSizeMB int32, thpEnabled, thpDefrag string) {
+	s.T.Helper()
+	validateCustomLinuxOSConfig(ctx, s, customSysctls, customContainerdUlimits, swapFileSizeMB, thpEnabled, thpDefrag)
+	RebootVMAndWaitForSSH(ctx, s)
+	validateCustomLinuxOSConfig(ctx, s, customSysctls, customContainerdUlimits, swapFileSizeMB, thpEnabled, thpDefrag)
+}
+
+func validateCustomLinuxOSConfig(ctx context.Context, s *Scenario, customSysctls map[string]string, customContainerdUlimits map[string]string, swapFileSizeMB int32, thpEnabled, thpDefrag string) {
+	s.T.Helper()
+	ValidateSysctlConfig(ctx, s, customSysctls)
+	ValidateUlimitSettings(ctx, s, customContainerdUlimits)
+	ValidateSwapFileConfig(ctx, s, swapFileSizeMB)
+	ValidateTransparentHugePageConfig(ctx, s, thpEnabled, thpDefrag)
+}
+
+func ValidateTransparentHugePageConfig(ctx context.Context, s *Scenario, thpEnabled, thpDefrag string) {
+	s.T.Helper()
+	command := []string{"set -ex"}
+	if thpEnabled != "" {
+		command = append(command,
+			"cat /sys/kernel/mm/transparent_hugepage/enabled",
+			fmt.Sprintf("grep -Fq '[%s]' /sys/kernel/mm/transparent_hugepage/enabled", thpEnabled),
+		)
+	}
+	if thpDefrag != "" {
+		command = append(command,
+			"cat /sys/kernel/mm/transparent_hugepage/defrag",
+			fmt.Sprintf("grep -Fq '[%s]' /sys/kernel/mm/transparent_hugepage/defrag", thpDefrag),
+		)
+	}
+
+	execScriptOnVMForScenarioValidateExitCode(ctx, s, strings.Join(command, "\n"), 0, "transparent huge page configuration did not match expected values")
+}
+
+func ValidateSwapFileConfig(ctx context.Context, s *Scenario, swapFileSizeMB int32) {
+	s.T.Helper()
+	if swapFileSizeMB <= 0 {
+		return
+	}
+
+	command := []string{
+		"set -ex",
+		"swapon --show --bytes",
+		"swap_file=$(awk '$3 == \"swap\" {print $1; exit}' /etc/fstab)",
+		"test -n \"${swap_file}\"",
+		"swapon --show --bytes | grep -F \"${swap_file}\"",
+		fmt.Sprintf("expected_bytes=$((%d * 1000 * 1000))", swapFileSizeMB),
+		"actual_bytes=$(stat -c %s \"${swap_file}\")",
+		"test \"${actual_bytes}\" -ge \"${expected_bytes}\"",
+	}
+	execScriptOnVMForScenarioValidateExitCode(ctx, s, strings.Join(command, "\n"), 0, "swap file configuration did not match expected values")
+}
+
+func RebootVMAndWaitForSSH(ctx context.Context, s *Scenario) {
+	s.T.Helper()
+	beforeRebootBootID := strings.TrimSpace(execScriptOnVMForScenarioValidateExitCode(ctx, s, "cat /proc/sys/kernel/random/boot_id", 0, "could not read boot ID before reboot").stdout)
+	execScriptOnVMForScenarioValidateExitCode(ctx, s, "sudo nohup sh -c 'sleep 1; systemctl reboot' >/dev/null 2>&1 &", 0, "failed to trigger VM reboot")
+	cleanupBastionTunnel(s.Runtime.VM.SSHClient)
+	s.Runtime.VM.SSHClient = nil
+
+	waitTimeout := s.Config.WaitForSSHAfterReboot
+	if waitTimeout == 0 {
+		waitTimeout = 10 * time.Minute
+	}
+
+	err := wait.PollUntilContextTimeout(ctx, 15*time.Second, waitTimeout, true, func(ctx context.Context) (bool, error) {
+		sshClient, err := DialSSHOverBastion(ctx, s.Runtime.Cluster.Bastion, s.Runtime.VM.PrivateIP, config.VMSSHPrivateKey)
+		if err != nil {
+			s.T.Logf("waiting for SSH after reboot: %v", err)
+			return false, nil
+		}
+
+		execResult, err := runSSHCommand(ctx, sshClient, "cat /proc/sys/kernel/random/boot_id", s.IsWindows())
+		if err != nil {
+			cleanupBastionTunnel(sshClient)
+			s.T.Logf("waiting for boot ID after reboot: %v", err)
+			return false, nil
+		}
+
+		afterRebootBootID := strings.TrimSpace(execResult.stdout)
+		if afterRebootBootID == "" || afterRebootBootID == beforeRebootBootID {
+			cleanupBastionTunnel(sshClient)
+			s.T.Logf("waiting for VM reboot to complete: boot ID is still %q", afterRebootBootID)
+			return false, nil
+		}
+
+		s.Runtime.VM.SSHClient = sshClient
+		return true, nil
+	})
+	require.NoError(s.T, err, "timed out waiting for VM to reboot and accept SSH")
 }
 
 // ValidateNetworkInterfaceConfig validates network interface configuration settings using ethtool.

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -245,7 +245,7 @@ func createVMSSModel(ctx context.Context, s *Scenario) armcompute.VirtualMachine
 		customData, err = injectWriteFilesEntriesToCustomData(customData, s.Config.CustomDataWriteFiles)
 		require.NoError(s.T, err, "failed to inject customData write_files entries")
 	}
-	if !scriptlessNBCCSECmdEnabled && s.VHD.SupportsScriptless() {
+	if !config.Config.DisableScriptless && !scriptlessNBCCSECmdEnabled && s.VHD.SupportsScriptless() {
 		// Validate that the custom data doesn't contain any script content,
 		// which indicates that the scriptless CSE is working as intended
 		decodedCustomData, err := base64.StdEncoding.DecodeString(customData)

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -24,12 +24,12 @@ configureTransparentHugePage() {
     local thp_defrag_path="/sys/kernel/mm/transparent_hugepage/defrag"
 
     if [ -n "${THP_ENABLED}" ]; then
-        printf '%s\n' "${THP_ENABLED}" > "${thp_enabled_path}"
-        printf 'kernel/mm/transparent_hugepage/enabled=%s\n' "${THP_ENABLED}" >> "${etc_sysfs_conf}"
+        printf '%s\n' "${THP_ENABLED}" > "${thp_enabled_path}" || exit "$ERR_SYSCTL_RELOAD"
+        printf 'kernel/mm/transparent_hugepage/enabled=%s\n' "${THP_ENABLED}" >> "${etc_sysfs_conf}" || exit "$ERR_SYSCTL_RELOAD"
     fi
     if [ -n "${THP_DEFRAG}" ]; then
-        printf '%s\n' "${THP_DEFRAG}" > "${thp_defrag_path}"
-        printf 'kernel/mm/transparent_hugepage/defrag=%s\n' "${THP_DEFRAG}" >> "${etc_sysfs_conf}"
+        printf '%s\n' "${THP_DEFRAG}" > "${thp_defrag_path}" || exit "$ERR_SYSCTL_RELOAD"
+        printf 'kernel/mm/transparent_hugepage/defrag=%s\n' "${THP_DEFRAG}" >> "${etc_sysfs_conf}" || exit "$ERR_SYSCTL_RELOAD"
     fi
     reconcileTransparentHugePagePersistence
 }
@@ -43,17 +43,33 @@ reconcileTransparentHugePagePersistence() {
 configureTransparentHugePageSystemdService() {
     local service_name="aks-transparent-hugepage"
     local script_path="/opt/azure/containers/aks-transparent-hugepage.sh"
+    local config_dir="/opt/azure/containers/aks-transparent-hugepage"
     local service_path="/etc/systemd/system/${service_name}.service"
 
-    mkdir -p "$(dirname "${script_path}")" || exit "$ERR_SYSCTL_RELOAD"
-    if ! tee "${script_path}" > /dev/null <<EOF
+    mkdir -p "$(dirname "${script_path}")" "${config_dir}" || exit "$ERR_SYSCTL_RELOAD"
+    if [ -n "${THP_ENABLED}" ]; then
+        printf '%s\n' "${THP_ENABLED}" | tee "${config_dir}/enabled" > /dev/null || exit "$ERR_SYSCTL_RELOAD"
+    else
+        rm -f "${config_dir}/enabled" || exit "$ERR_SYSCTL_RELOAD"
+    fi
+    if [ -n "${THP_DEFRAG}" ]; then
+        printf '%s\n' "${THP_DEFRAG}" | tee "${config_dir}/defrag" > /dev/null || exit "$ERR_SYSCTL_RELOAD"
+    else
+        rm -f "${config_dir}/defrag" || exit "$ERR_SYSCTL_RELOAD"
+    fi
+
+    if ! tee "${script_path}" > /dev/null <<'EOF'
 #!/bin/bash
 set -e
-if [ -n "${THP_ENABLED}" ]; then
-    printf '%s\n' "${THP_ENABLED}" > /sys/kernel/mm/transparent_hugepage/enabled
+config_dir="/opt/azure/containers/aks-transparent-hugepage"
+thp_enabled_config="${config_dir}/enabled"
+thp_defrag_config="${config_dir}/defrag"
+
+if [ -s "${thp_enabled_config}" ]; then
+    cat "${thp_enabled_config}" > /sys/kernel/mm/transparent_hugepage/enabled
 fi
-if [ -n "${THP_DEFRAG}" ]; then
-    printf '%s\n' "${THP_DEFRAG}" > /sys/kernel/mm/transparent_hugepage/defrag
+if [ -s "${thp_defrag_config}" ]; then
+    cat "${thp_defrag_config}" > /sys/kernel/mm/transparent_hugepage/defrag
 fi
 EOF
     then

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -17,15 +17,49 @@ Environment="KUBE_API_SERVER_NAME=${API_SERVER_NAME}"
 EOF
   systemctlEnableAndStart reconcile-private-hosts 30 || exit $ERR_SYSTEMCTL_START_FAIL
 }
+
+validateTransparentHugePageValue() {
+    local setting_name="$1"
+    local value="$2"
+    local supported_values_path="$3"
+
+    if [ -z "${value}" ]; then
+        return 0
+    fi
+
+    case "${value}" in
+        *[!abcdefghijklmnopqrstuvwxyz+]*)
+            echo "Invalid transparent huge page ${setting_name} value '${value}': only lowercase THP tokens are supported" >&2
+            return 1
+            ;;
+    esac
+
+    if [ ! -r "${supported_values_path}" ]; then
+        echo "Cannot validate transparent huge page ${setting_name}; ${supported_values_path} is not readable" >&2
+        return 1
+    fi
+
+    if ! tr ' ' '\n' < "${supported_values_path}" | tr -d '[]' | grep -Fx "${value}" > /dev/null; then
+        echo "Unsupported transparent huge page ${setting_name} value '${value}'. Supported values: $(tr -d '[]' < "${supported_values_path}")" >&2
+        return 1
+    fi
+}
+
 configureTransparentHugePage() {
-    ETC_SYSFS_CONF="/etc/sysfs.conf"
+    local etc_sysfs_conf="/etc/sysfs.conf"
+    local thp_enabled_path="/sys/kernel/mm/transparent_hugepage/enabled"
+    local thp_defrag_path="/sys/kernel/mm/transparent_hugepage/defrag"
+
+    validateTransparentHugePageValue "enabled" "${THP_ENABLED}" "${thp_enabled_path}" || exit "$ERR_SYSCTL_RELOAD"
+    validateTransparentHugePageValue "defrag" "${THP_DEFRAG}" "${thp_defrag_path}" || exit "$ERR_SYSCTL_RELOAD"
+
     if [ -n "${THP_ENABLED}" ]; then
-        echo "${THP_ENABLED}" > /sys/kernel/mm/transparent_hugepage/enabled
-        echo "kernel/mm/transparent_hugepage/enabled=${THP_ENABLED}" >> "${ETC_SYSFS_CONF}"
+        printf '%s\n' "${THP_ENABLED}" > "${thp_enabled_path}"
+        printf 'kernel/mm/transparent_hugepage/enabled=%s\n' "${THP_ENABLED}" >> "${etc_sysfs_conf}"
     fi
     if [ -n "${THP_DEFRAG}" ]; then
-        echo "${THP_DEFRAG}" > /sys/kernel/mm/transparent_hugepage/defrag
-        echo "kernel/mm/transparent_hugepage/defrag=${THP_DEFRAG}" >> "${ETC_SYSFS_CONF}"
+        printf '%s\n' "${THP_DEFRAG}" > "${thp_defrag_path}"
+        printf 'kernel/mm/transparent_hugepage/defrag=%s\n' "${THP_DEFRAG}" >> "${etc_sysfs_conf}"
     fi
     if { [ -n "${THP_ENABLED}" ] || [ -n "${THP_DEFRAG}" ]; } && isMarinerOrAzureLinux "$OS" "$OS_VARIANT"; then
         configureTransparentHugePageSystemdService
@@ -42,10 +76,10 @@ configureTransparentHugePageSystemdService() {
 #!/bin/bash
 set -e
 if [ -n "${THP_ENABLED}" ]; then
-    echo "${THP_ENABLED}" > /sys/kernel/mm/transparent_hugepage/enabled
+    printf '%s\n' "${THP_ENABLED}" > /sys/kernel/mm/transparent_hugepage/enabled
 fi
 if [ -n "${THP_DEFRAG}" ]; then
-    echo "${THP_DEFRAG}" > /sys/kernel/mm/transparent_hugepage/defrag
+    printf '%s\n' "${THP_DEFRAG}" > /sys/kernel/mm/transparent_hugepage/defrag
 fi
 EOF
     chmod 0755 "${script_path}"

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -142,7 +142,7 @@ configureSystemdUseDomains() {
 swapFileIsActive() {
     local swap_location="$1"
 
-    swapon --show=NAME --noheadings | awk '{print $1}' | grep -Fxq "${swap_location}"
+    swapon --show --noheadings | awk '{print $1}' | grep -Fxq "${swap_location}"
 }
 
 ensureSwapFileFstabEntry() {
@@ -269,7 +269,7 @@ configureSwapFileSystemdService() {
     if ! tee "${script_path}" > /dev/null <<EOF
 #!/bin/bash
 set -e
-if ! swapon --show=NAME --noheadings | awk '{print \$1}' | grep -Fxq "${swap_location}"; then
+if ! swapon --show --noheadings | awk '{print \$1}' | grep -Fxq "${swap_location}"; then
     swapon "${swap_location}"
 fi
 EOF

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -81,8 +81,8 @@ configureTransparentHugePageSystemdService() {
     local script_path="/opt/azure/containers/aks-transparent-hugepage.sh"
     local service_path="/etc/systemd/system/${service_name}.service"
 
-    mkdir -p "$(dirname "${script_path}")"
-    tee "${script_path}" > /dev/null <<EOF
+    mkdir -p "$(dirname "${script_path}")" || exit "$ERR_SYSCTL_RELOAD"
+    if ! tee "${script_path}" > /dev/null <<EOF
 #!/bin/bash
 set -e
 if [ -n "${THP_ENABLED}" ]; then
@@ -92,9 +92,12 @@ if [ -n "${THP_DEFRAG}" ]; then
     printf '%s\n' "${THP_DEFRAG}" > /sys/kernel/mm/transparent_hugepage/defrag
 fi
 EOF
-    chmod 0755 "${script_path}"
+    then
+        exit "$ERR_SYSCTL_RELOAD"
+    fi
+    chmod 0755 "${script_path}" || exit "$ERR_SYSCTL_RELOAD"
 
-    tee "${service_path}" > /dev/null <<EOF
+    if ! tee "${service_path}" > /dev/null <<EOF
 [Unit]
 Description=Apply AKS transparent huge page settings
 After=systemd-sysctl.service
@@ -108,9 +111,12 @@ ExecStart=${script_path}
 [Install]
 WantedBy=multi-user.target
 EOF
+    then
+        exit "$ERR_SYSCTL_RELOAD"
+    fi
 
-    systemctl daemon-reload
-    systemctlEnableAndStart "${service_name}" 30 || exit $ERR_SYSTEMCTL_START_FAIL
+    systemctl daemon-reload || exit "$ERR_SYSTEMCTL_START_FAIL"
+    systemctlEnableAndStart "${service_name}" 30 || exit "$ERR_SYSTEMCTL_START_FAIL"
 }
 
 configureSystemdUseDomains() {

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -177,7 +177,8 @@ reconcileSwapFilePersistence() {
     fi
 
     if [ -z "${swap_location}" ]; then
-        echo "No existing AKS swap file found; skipping swap file persistence reconciliation"
+        echo "No existing AKS swap file found; creating swap file for persistence reconciliation"
+        configureSwapFile
         return 0
     fi
 

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -18,44 +18,10 @@ EOF
   systemctlEnableAndStart reconcile-private-hosts 30 || exit $ERR_SYSTEMCTL_START_FAIL
 }
 
-validateTransparentHugePageValue() {
-    local setting_name="$1"
-    local value="$2"
-    local supported_values_path="$3"
-
-    if [ -z "${value}" ]; then
-        return 0
-    fi
-
-    case "${value}" in
-        *[!abcdefghijklmnopqrstuvwxyz+]*)
-            echo "Invalid transparent huge page ${setting_name} value '${value}': only lowercase THP tokens are supported" >&2
-            return 1
-            ;;
-    esac
-
-    if [ ! -r "${supported_values_path}" ]; then
-        echo "Cannot validate transparent huge page ${setting_name}; ${supported_values_path} is not readable" >&2
-        return 1
-    fi
-
-    if ! tr ' ' '\n' < "${supported_values_path}" | tr -d '[]' | grep -Fx "${value}" > /dev/null; then
-        echo "Unsupported transparent huge page ${setting_name} value '${value}'. Supported values: $(tr -d '[]' < "${supported_values_path}")" >&2
-        return 1
-    fi
-}
-
-validateTransparentHugePageConfig() {
-    validateTransparentHugePageValue "enabled" "${THP_ENABLED}" "/sys/kernel/mm/transparent_hugepage/enabled" || exit "$ERR_SYSCTL_RELOAD"
-    validateTransparentHugePageValue "defrag" "${THP_DEFRAG}" "/sys/kernel/mm/transparent_hugepage/defrag" || exit "$ERR_SYSCTL_RELOAD"
-}
-
 configureTransparentHugePage() {
     local etc_sysfs_conf="/etc/sysfs.conf"
     local thp_enabled_path="/sys/kernel/mm/transparent_hugepage/enabled"
     local thp_defrag_path="/sys/kernel/mm/transparent_hugepage/defrag"
-
-    validateTransparentHugePageConfig
 
     if [ -n "${THP_ENABLED}" ]; then
         printf '%s\n' "${THP_ENABLED}" > "${thp_enabled_path}"
@@ -69,8 +35,6 @@ configureTransparentHugePage() {
 }
 
 reconcileTransparentHugePagePersistence() {
-    validateTransparentHugePageConfig
-
     if { [ -n "${THP_ENABLED}" ] || [ -n "${THP_DEFRAG}" ]; } && isMarinerOrAzureLinux "$OS" "$OS_VARIANT"; then
         configureTransparentHugePageSystemdService
     fi

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -113,9 +113,11 @@ ensureSwapFileFstabEntry() {
     local swap_location="$1"
     local fstab_entry="${swap_location} none swap noauto,nofail 0 0"
     local fstab_file="${2:-/etc/fstab}"
+    local fstab_dir
     local temp_fstab
 
-    temp_fstab="$(mktemp)"
+    fstab_dir="$(dirname "${fstab_file}")"
+    temp_fstab="$(mktemp "${fstab_dir}/fstab.XXXXXX")" || return 1
     awk -v swap_location="${swap_location}" '$1 != swap_location { print }' "${fstab_file}" > "${temp_fstab}" || {
         rm -f "${temp_fstab}"
         return 1
@@ -124,11 +126,10 @@ ensureSwapFileFstabEntry() {
         rm -f "${temp_fstab}"
         return 1
     }
-    cat "${temp_fstab}" > "${fstab_file}" || {
+    mv "${temp_fstab}" "${fstab_file}" || {
         rm -f "${temp_fstab}"
         return 1
     }
-    rm -f "${temp_fstab}"
 }
 
 findExistingSwapFileLocation() {

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -142,10 +142,23 @@ swapFileIsActive() {
 ensureSwapFileFstabEntry() {
     local swap_location="$1"
     local fstab_entry="${swap_location} none swap noauto,nofail 0 0"
+    local fstab_file="${2:-/etc/fstab}"
+    local temp_fstab
 
-    if ! grep -Fxq "${fstab_entry}" /etc/fstab; then
-        echo "${fstab_entry}" >> /etc/fstab
-    fi
+    temp_fstab="$(mktemp)"
+    awk -v swap_location="${swap_location}" '$1 != swap_location { print }' "${fstab_file}" > "${temp_fstab}" || {
+        rm -f "${temp_fstab}"
+        return 1
+    }
+    echo "${fstab_entry}" >> "${temp_fstab}" || {
+        rm -f "${temp_fstab}"
+        return 1
+    }
+    cat "${temp_fstab}" > "${fstab_file}" || {
+        rm -f "${temp_fstab}"
+        return 1
+    }
+    rm -f "${temp_fstab}"
 }
 
 findExistingSwapFileLocation() {
@@ -193,13 +206,24 @@ configureSwapFile() {
 
     # Attempt to use the resource disk
     if [ -L /dev/disk/azure/resource-part1 ]; then
-        resource_disk_path=$(findmnt -nr -o target -S "$(readlink -f /dev/disk/azure/resource-part1)")
-        disk_free_kb=$(df "${resource_disk_path}" | sed 1d | awk '{print $4}')
-        if [ "${disk_free_kb}" -gt "${swap_size_kb}" ]; then
-            echo "Will use resource disk for swap file"
-            swap_location=${resource_disk_path}/swapfile
+        resource_disk_path=$(findmnt -nr -o target -S "$(readlink -f /dev/disk/azure/resource-part1)" || true)
+        if [ -n "${resource_disk_path}" ]; then
+            disk_free_kb=$(df -P "${resource_disk_path}" | sed 1d | awk '{print $4}')
+            case "${disk_free_kb}" in
+                ''|*[!0-9]*)
+                    echo "Could not determine free space on resource disk, attempting to fall back to OS disk..."
+                    ;;
+                *)
+                    if [ "${disk_free_kb}" -gt "${swap_size_kb}" ]; then
+                        echo "Will use resource disk for swap file"
+                        swap_location=${resource_disk_path}/swapfile
+                    else
+                        echo "Insufficient disk space on resource disk to create swap file: request ${swap_size_kb} free ${disk_free_kb}, attempting to fall back to OS disk..."
+                    fi
+                    ;;
+            esac
         else
-            echo "Insufficient disk space on resource disk to create swap file: request ${swap_size_kb} free ${disk_free_kb}, attempting to fall back to OS disk..."
+            echo "Could not determine resource disk mountpoint, attempting to fall back to OS disk..."
         fi
     fi
 

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -195,8 +195,8 @@ reconcileSwapFilePersistence() {
         return 0
     fi
 
-    ensureSwapFileFstabEntry "${swap_location}"
-    configureSwapFileSystemdService "${swap_location}"
+    ensureSwapFileFstabEntry "${swap_location}" || exit "$ERR_SWAP_CREATE_FAIL"
+    configureSwapFileSystemdService "${swap_location}" || exit "$ERR_SWAP_CREATE_FAIL"
 }
 
 configureSwapFile() {
@@ -247,7 +247,7 @@ configureSwapFile() {
     retrycmd_if_failure 24 5 25 mkswap "${swap_location}" || exit "$ERR_SWAP_CREATE_FAIL"
     retrycmd_if_failure 24 5 25 swapon "${swap_location}" || exit "$ERR_SWAP_CREATE_FAIL"
     swapFileIsActive "${swap_location}" || exit "$ERR_SWAP_CREATE_FAIL"
-    reconcileSwapFilePersistence "${swap_location}"
+    reconcileSwapFilePersistence "${swap_location}" || exit "$ERR_SWAP_CREATE_FAIL"
 }
 
 configureSwapFileSystemdService() {
@@ -259,17 +259,20 @@ configureSwapFileSystemdService() {
 
     swap_mount_path="$(dirname "${swap_location}")"
 
-    mkdir -p "$(dirname "${script_path}")"
-    tee "${script_path}" > /dev/null <<EOF
+    mkdir -p "$(dirname "${script_path}")" || exit "$ERR_SWAP_CREATE_FAIL"
+    if ! tee "${script_path}" > /dev/null <<EOF
 #!/bin/bash
 set -e
 if ! swapon --show=NAME --noheadings | awk '{print \$1}' | grep -Fxq "${swap_location}"; then
     swapon "${swap_location}"
 fi
 EOF
-    chmod 0755 "${script_path}"
+    then
+        exit "$ERR_SWAP_CREATE_FAIL"
+    fi
+    chmod 0755 "${script_path}" || exit "$ERR_SWAP_CREATE_FAIL"
 
-    tee "${service_path}" > /dev/null <<EOF
+    if ! tee "${service_path}" > /dev/null <<EOF
 [Unit]
 Description=Activate AKS swap file
 After=local-fs.target
@@ -285,9 +288,12 @@ RemainAfterExit=yes
 [Install]
 WantedBy=multi-user.target
 EOF
+    then
+        exit "$ERR_SWAP_CREATE_FAIL"
+    fi
 
-    systemctl daemon-reload
-    systemctlEnableAndStart "${service_name}" 30 || exit $ERR_SYSTEMCTL_START_FAIL
+    systemctl daemon-reload || exit "$ERR_SYSTEMCTL_START_FAIL"
+    systemctlEnableAndStart "${service_name}" 30 || exit "$ERR_SYSTEMCTL_START_FAIL"
 }
 
 configureEtcEnvironment() {

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -20,18 +20,28 @@ EOF
 
 configureTransparentHugePage() {
     local etc_sysfs_conf="/etc/sysfs.conf"
+
+    applyTransparentHugePageValues
+
+    if [ -n "${THP_ENABLED}" ]; then
+        printf 'kernel/mm/transparent_hugepage/enabled=%s\n' "${THP_ENABLED}" >> "${etc_sysfs_conf}" || exit "$ERR_SYSCTL_RELOAD"
+    fi
+    if [ -n "${THP_DEFRAG}" ]; then
+        printf 'kernel/mm/transparent_hugepage/defrag=%s\n' "${THP_DEFRAG}" >> "${etc_sysfs_conf}" || exit "$ERR_SYSCTL_RELOAD"
+    fi
+    reconcileTransparentHugePagePersistence
+}
+
+applyTransparentHugePageValues() {
     local thp_enabled_path="/sys/kernel/mm/transparent_hugepage/enabled"
     local thp_defrag_path="/sys/kernel/mm/transparent_hugepage/defrag"
 
     if [ -n "${THP_ENABLED}" ]; then
         printf '%s\n' "${THP_ENABLED}" > "${thp_enabled_path}" || exit "$ERR_SYSCTL_RELOAD"
-        printf 'kernel/mm/transparent_hugepage/enabled=%s\n' "${THP_ENABLED}" >> "${etc_sysfs_conf}" || exit "$ERR_SYSCTL_RELOAD"
     fi
     if [ -n "${THP_DEFRAG}" ]; then
         printf '%s\n' "${THP_DEFRAG}" > "${thp_defrag_path}" || exit "$ERR_SYSCTL_RELOAD"
-        printf 'kernel/mm/transparent_hugepage/defrag=%s\n' "${THP_DEFRAG}" >> "${etc_sysfs_conf}" || exit "$ERR_SYSCTL_RELOAD"
     fi
-    reconcileTransparentHugePagePersistence
 }
 
 reconcileTransparentHugePagePersistence() {
@@ -125,15 +135,30 @@ swapFileIsActive() {
     swapon --show --noheadings | awk '{print $1}' | grep -Fxq "${swap_location}"
 }
 
+getFileMode() {
+    local file="$1"
+
+    stat -c "%a" "${file}" 2>/dev/null || stat -f "%Lp" "${file}" 2>/dev/null
+}
+
 ensureSwapFileFstabEntry() {
     local swap_location="$1"
     local fstab_entry="${swap_location} none swap noauto,nofail 0 0"
     local fstab_file="${2:-/etc/fstab}"
     local fstab_dir
+    local fstab_mode
     local temp_fstab
 
     fstab_dir="$(dirname "${fstab_file}")"
     temp_fstab="$(mktemp "${fstab_dir}/fstab.XXXXXX")" || return 1
+    fstab_mode="$(getFileMode "${fstab_file}")" || {
+        rm -f "${temp_fstab}"
+        return 1
+    }
+    chmod "${fstab_mode}" "${temp_fstab}" || {
+        rm -f "${temp_fstab}"
+        return 1
+    }
     awk -v swap_location="${swap_location}" '$1 != swap_location { print }' "${fstab_file}" > "${temp_fstab}" || {
         rm -f "${temp_fstab}"
         return 1

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -45,13 +45,17 @@ validateTransparentHugePageValue() {
     fi
 }
 
+validateTransparentHugePageConfig() {
+    validateTransparentHugePageValue "enabled" "${THP_ENABLED}" "/sys/kernel/mm/transparent_hugepage/enabled" || exit "$ERR_SYSCTL_RELOAD"
+    validateTransparentHugePageValue "defrag" "${THP_DEFRAG}" "/sys/kernel/mm/transparent_hugepage/defrag" || exit "$ERR_SYSCTL_RELOAD"
+}
+
 configureTransparentHugePage() {
     local etc_sysfs_conf="/etc/sysfs.conf"
     local thp_enabled_path="/sys/kernel/mm/transparent_hugepage/enabled"
     local thp_defrag_path="/sys/kernel/mm/transparent_hugepage/defrag"
 
-    validateTransparentHugePageValue "enabled" "${THP_ENABLED}" "${thp_enabled_path}" || exit "$ERR_SYSCTL_RELOAD"
-    validateTransparentHugePageValue "defrag" "${THP_DEFRAG}" "${thp_defrag_path}" || exit "$ERR_SYSCTL_RELOAD"
+    validateTransparentHugePageConfig
 
     if [ -n "${THP_ENABLED}" ]; then
         printf '%s\n' "${THP_ENABLED}" > "${thp_enabled_path}"
@@ -61,6 +65,12 @@ configureTransparentHugePage() {
         printf '%s\n' "${THP_DEFRAG}" > "${thp_defrag_path}"
         printf 'kernel/mm/transparent_hugepage/defrag=%s\n' "${THP_DEFRAG}" >> "${etc_sysfs_conf}"
     fi
+    reconcileTransparentHugePagePersistence
+}
+
+reconcileTransparentHugePagePersistence() {
+    validateTransparentHugePageConfig
+
     if { [ -n "${THP_ENABLED}" ] || [ -n "${THP_DEFRAG}" ]; } && isMarinerOrAzureLinux "$OS" "$OS_VARIANT"; then
         configureTransparentHugePageSystemdService
     fi
@@ -123,15 +133,67 @@ configureSystemdUseDomains() {
     systemctl restart rsyslog
 }
 
+swapFileIsActive() {
+    local swap_location="$1"
+
+    swapon --show=NAME --noheadings | awk '{print $1}' | grep -Fxq "${swap_location}"
+}
+
+ensureSwapFileFstabEntry() {
+    local swap_location="$1"
+    local fstab_entry="${swap_location} none swap noauto,nofail 0 0"
+
+    if ! grep -Fxq "${fstab_entry}" /etc/fstab; then
+        echo "${fstab_entry}" >> /etc/fstab
+    fi
+}
+
+findExistingSwapFileLocation() {
+    local resource_disk_path
+    local swap_location
+
+    if [ -L /dev/disk/azure/resource-part1 ]; then
+        resource_disk_path=$(findmnt -nr -o target -S "$(readlink -f /dev/disk/azure/resource-part1)" || true)
+        swap_location="${resource_disk_path}/swapfile"
+        if [ -n "${resource_disk_path}" ] && [ -f "${swap_location}" ]; then
+            echo "${swap_location}"
+            return 0
+        fi
+    fi
+
+    if [ -f /swapfile ]; then
+        echo "/swapfile"
+        return 0
+    fi
+
+    return 1
+}
+
+reconcileSwapFilePersistence() {
+    local swap_location="${1:-}"
+
+    if [ -z "${swap_location}" ]; then
+        swap_location="$(findExistingSwapFileLocation || true)"
+    fi
+
+    if [ -z "${swap_location}" ]; then
+        echo "No existing AKS swap file found; skipping swap file persistence reconciliation"
+        return 0
+    fi
+
+    ensureSwapFileFstabEntry "${swap_location}"
+    configureSwapFileSystemdService "${swap_location}"
+}
+
 configureSwapFile() {
     # https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/troubleshoot-device-names-problems#identify-disk-luns
-    swap_size_kb=$(expr ${SWAP_FILE_SIZE_MB} \* 1000)
+    swap_size_kb=$(expr "${SWAP_FILE_SIZE_MB}" \* 1000)
     swap_location=""
 
     # Attempt to use the resource disk
     if [ -L /dev/disk/azure/resource-part1 ]; then
-        resource_disk_path=$(findmnt -nr -o target -S $(readlink -f /dev/disk/azure/resource-part1))
-        disk_free_kb=$(df ${resource_disk_path} | sed 1d | awk '{print $4}')
+        resource_disk_path=$(findmnt -nr -o target -S "$(readlink -f /dev/disk/azure/resource-part1)")
+        disk_free_kb=$(df "${resource_disk_path}" | sed 1d | awk '{print $4}')
         if [ "${disk_free_kb}" -gt "${swap_size_kb}" ]; then
             echo "Will use resource disk for swap file"
             swap_location=${resource_disk_path}/swapfile
@@ -155,13 +217,12 @@ configureSwapFile() {
     fi
 
     echo "Swap file will be saved to: ${swap_location}"
-    retrycmd_if_failure 24 5 25 fallocate -l ${swap_size_kb}K ${swap_location} || exit $ERR_SWAP_CREATE_FAIL
-    chmod 600 ${swap_location}
-    retrycmd_if_failure 24 5 25 mkswap ${swap_location} || exit $ERR_SWAP_CREATE_FAIL
-    retrycmd_if_failure 24 5 25 swapon ${swap_location} || exit $ERR_SWAP_CREATE_FAIL
-    retrycmd_if_failure 24 5 25 swapon --show | grep ${swap_location} || exit $ERR_SWAP_CREATE_FAIL
-    echo "${swap_location} none swap noauto,nofail 0 0" >> /etc/fstab
-    configureSwapFileSystemdService "${swap_location}"
+    retrycmd_if_failure 24 5 25 fallocate -l "${swap_size_kb}K" "${swap_location}" || exit "$ERR_SWAP_CREATE_FAIL"
+    chmod 600 "${swap_location}"
+    retrycmd_if_failure 24 5 25 mkswap "${swap_location}" || exit "$ERR_SWAP_CREATE_FAIL"
+    retrycmd_if_failure 24 5 25 swapon "${swap_location}" || exit "$ERR_SWAP_CREATE_FAIL"
+    swapFileIsActive "${swap_location}" || exit "$ERR_SWAP_CREATE_FAIL"
+    reconcileSwapFilePersistence "${swap_location}"
 }
 
 configureSwapFileSystemdService() {
@@ -177,7 +238,7 @@ configureSwapFileSystemdService() {
     tee "${script_path}" > /dev/null <<EOF
 #!/bin/bash
 set -e
-if ! swapon --show=NAME --noheadings | grep -Fxq "${swap_location}"; then
+if ! swapon --show=NAME --noheadings | awk '{print \$1}' | grep -Fxq "${swap_location}"; then
     swapon "${swap_location}"
 fi
 EOF

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -21,12 +21,52 @@ configureTransparentHugePage() {
     ETC_SYSFS_CONF="/etc/sysfs.conf"
     if [ -n "${THP_ENABLED}" ]; then
         echo "${THP_ENABLED}" > /sys/kernel/mm/transparent_hugepage/enabled
-        echo "kernel/mm/transparent_hugepage/enabled=${THP_ENABLED}" >> ${ETC_SYSFS_CONF}
+        echo "kernel/mm/transparent_hugepage/enabled=${THP_ENABLED}" >> "${ETC_SYSFS_CONF}"
     fi
     if [ -n "${THP_DEFRAG}" ]; then
         echo "${THP_DEFRAG}" > /sys/kernel/mm/transparent_hugepage/defrag
-        echo "kernel/mm/transparent_hugepage/defrag=${THP_DEFRAG}" >> ${ETC_SYSFS_CONF}
+        echo "kernel/mm/transparent_hugepage/defrag=${THP_DEFRAG}" >> "${ETC_SYSFS_CONF}"
     fi
+    if { [ -n "${THP_ENABLED}" ] || [ -n "${THP_DEFRAG}" ]; } && isMarinerOrAzureLinux "$OS" "$OS_VARIANT"; then
+        configureTransparentHugePageSystemdService
+    fi
+}
+
+configureTransparentHugePageSystemdService() {
+    local service_name="aks-transparent-hugepage"
+    local script_path="/opt/azure/containers/aks-transparent-hugepage.sh"
+    local service_path="/etc/systemd/system/${service_name}.service"
+
+    mkdir -p "$(dirname "${script_path}")"
+    tee "${script_path}" > /dev/null <<EOF
+#!/bin/bash
+set -e
+if [ -n "${THP_ENABLED}" ]; then
+    echo "${THP_ENABLED}" > /sys/kernel/mm/transparent_hugepage/enabled
+fi
+if [ -n "${THP_DEFRAG}" ]; then
+    echo "${THP_DEFRAG}" > /sys/kernel/mm/transparent_hugepage/defrag
+fi
+EOF
+    chmod 0755 "${script_path}"
+
+    tee "${service_path}" > /dev/null <<EOF
+[Unit]
+Description=Apply AKS transparent huge page settings
+After=systemd-sysctl.service
+Before=kubelet.service
+ConditionPathExists=/sys/kernel/mm/transparent_hugepage
+
+[Service]
+Type=oneshot
+ExecStart=${script_path}
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    systemctl daemon-reload
+    systemctlEnableAndStart "${service_name}" 30 || exit $ERR_SYSTEMCTL_START_FAIL
 }
 
 configureSystemdUseDomains() {
@@ -86,7 +126,48 @@ configureSwapFile() {
     retrycmd_if_failure 24 5 25 mkswap ${swap_location} || exit $ERR_SWAP_CREATE_FAIL
     retrycmd_if_failure 24 5 25 swapon ${swap_location} || exit $ERR_SWAP_CREATE_FAIL
     retrycmd_if_failure 24 5 25 swapon --show | grep ${swap_location} || exit $ERR_SWAP_CREATE_FAIL
-    echo "${swap_location} none swap sw 0 0" >> /etc/fstab
+    echo "${swap_location} none swap noauto,nofail 0 0" >> /etc/fstab
+    configureSwapFileSystemdService "${swap_location}"
+}
+
+configureSwapFileSystemdService() {
+    local swap_location="$1"
+    local service_name="aks-swapfile"
+    local script_path="/opt/azure/containers/aks-swapfile.sh"
+    local service_path="/etc/systemd/system/${service_name}.service"
+    local swap_mount_path
+
+    swap_mount_path="$(dirname "${swap_location}")"
+
+    mkdir -p "$(dirname "${script_path}")"
+    tee "${script_path}" > /dev/null <<EOF
+#!/bin/bash
+set -e
+if ! swapon --show=NAME --noheadings | grep -Fxq "${swap_location}"; then
+    swapon "${swap_location}"
+fi
+EOF
+    chmod 0755 "${script_path}"
+
+    tee "${service_path}" > /dev/null <<EOF
+[Unit]
+Description=Activate AKS swap file
+After=local-fs.target
+Before=kubelet.service
+RequiresMountsFor=${swap_mount_path}
+ConditionPathExists=${swap_location}
+
+[Service]
+Type=oneshot
+ExecStart=${script_path}
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    systemctl daemon-reload
+    systemctlEnableAndStart "${service_name}" 30 || exit $ERR_SYSTEMCTL_START_FAIL
 }
 
 configureEtcEnvironment() {

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -426,6 +426,7 @@ function nodePrep {
     reconcileVulnerableKernelModuleMitigation
 
     if [ "${SHOULD_CONFIG_TRANSPARENT_HUGE_PAGE}" = "true" ]; then
+        logs_to_events "AKS.CSE.applyTransparentHugePageValues" applyTransparentHugePageValues
         logs_to_events "AKS.CSE.reconcileTransparentHugePagePersistence" reconcileTransparentHugePagePersistence
     fi
 

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -425,6 +425,14 @@ function nodePrep {
     logs_to_events "AKS.CSE.fetch_and_cache_imds_instance_metadata" fetch_and_cache_imds_instance_metadata
     reconcileVulnerableKernelModuleMitigation
 
+    if [ "${SHOULD_CONFIG_TRANSPARENT_HUGE_PAGE}" = "true" ]; then
+        logs_to_events "AKS.CSE.reconcileTransparentHugePagePersistence" reconcileTransparentHugePagePersistence
+    fi
+
+    if [ "${SHOULD_CONFIG_SWAP_FILE}" = "true" ]; then
+        logs_to_events "AKS.CSE.reconcileSwapFilePersistence" reconcileSwapFilePersistence
+    fi
+
     # IMPORTANT NOTE: We do this here since this function can mutate kubelet flags and node labels,
     # which is used by configureK8s and other functions. Thus, we need to make sure flag and label content is correct beforehand.
     logs_to_events "AKS.CSE.configureKubeletServing" configureKubeletServing

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -722,9 +722,13 @@ func normalizeResourceGroupNameForLabel(resourceGroupName string) string {
 }
 
 // ValidateAndSetLinuxNodeBootstrappingConfiguration is exported only for temporary usage in e2e testing of new config.
-func ValidateAndSetLinuxNodeBootstrappingConfiguration(config *datamodel.NodeBootstrappingConfiguration) {
+func ValidateAndSetLinuxNodeBootstrappingConfiguration(config *datamodel.NodeBootstrappingConfiguration) error {
+	if err := validateCustomLinuxOSConfig(config.AgentPoolProfile.GetCustomLinuxOSConfig()); err != nil {
+		return err
+	}
+
 	if config.KubeletConfig == nil {
-		return
+		return nil
 	}
 	kubeletFlags := config.KubeletConfig
 
@@ -785,6 +789,46 @@ func ValidateAndSetLinuxNodeBootstrappingConfiguration(config *datamodel.NodeBoo
 	if IsKubernetesVersionGe(config.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion, "1.34.0") {
 		delete(kubeletFlags, "--streaming-connection-idle-timeout")
 	}
+	return nil
+}
+
+func validateCustomLinuxOSConfig(config *datamodel.CustomLinuxOSConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	if err := validateTransparentHugePageConfigValue("transparentHugePageEnabled", config.TransparentHugePageEnabled, map[string]struct{}{
+		"always":  {},
+		"madvise": {},
+		"never":   {},
+	}); err != nil {
+		return err
+	}
+
+	return validateTransparentHugePageConfigValue("transparentHugePageDefrag", config.TransparentHugePageDefrag, map[string]struct{}{
+		"always":        {},
+		"defer":         {},
+		"defer+madvise": {},
+		"madvise":       {},
+		"never":         {},
+	})
+}
+
+func validateTransparentHugePageConfigValue(fieldName, value string, allowedValues map[string]struct{}) error {
+	if value == "" {
+		return nil
+	}
+
+	if _, ok := allowedValues[value]; ok {
+		return nil
+	}
+
+	allowed := make([]string, 0, len(allowedValues))
+	for allowedValue := range allowedValues {
+		allowed = append(allowed, allowedValue)
+	}
+	sort.Strings(allowed)
+	return fmt.Errorf("customLinuxOSConfig.%s value %q is invalid; allowed values are: %s", fieldName, value, strings.Join(allowed, ", "))
 }
 
 func validateAndSetWindowsNodeBootstrappingConfiguration(config *datamodel.NodeBootstrappingConfiguration) {

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -28,6 +29,11 @@ import (
 
 const (
 	MaxCustomDataLength = 87380
+)
+
+var (
+	allowedTransparentHugePageEnabledOptions = []string{"always", "madvise", "never"}
+	allowedTransparentHugePageDefragOptions  = []string{"always", "defer", "defer+madvise", "madvise", "never"}
 )
 
 // TemplateGenerator represents the object that performs the template generation.
@@ -797,38 +803,31 @@ func validateCustomLinuxOSConfig(config *datamodel.CustomLinuxOSConfig) error {
 		return nil
 	}
 
-	if err := validateTransparentHugePageConfigValue("transparentHugePageEnabled", config.TransparentHugePageEnabled, map[string]struct{}{
-		"always":  {},
-		"madvise": {},
-		"never":   {},
-	}); err != nil {
+	if err := validateTransparentHugePageConfigValue(
+		"transparentHugePageEnabled",
+		config.TransparentHugePageEnabled,
+		allowedTransparentHugePageEnabledOptions,
+	); err != nil {
 		return err
 	}
 
-	return validateTransparentHugePageConfigValue("transparentHugePageDefrag", config.TransparentHugePageDefrag, map[string]struct{}{
-		"always":        {},
-		"defer":         {},
-		"defer+madvise": {},
-		"madvise":       {},
-		"never":         {},
-	})
+	return validateTransparentHugePageConfigValue(
+		"transparentHugePageDefrag",
+		config.TransparentHugePageDefrag,
+		allowedTransparentHugePageDefragOptions,
+	)
 }
 
-func validateTransparentHugePageConfigValue(fieldName, value string, allowedValues map[string]struct{}) error {
+func validateTransparentHugePageConfigValue(fieldName, value string, allowedValues []string) error {
 	if value == "" {
 		return nil
 	}
 
-	if _, ok := allowedValues[value]; ok {
+	if slices.Contains(allowedValues, value) {
 		return nil
 	}
 
-	allowed := make([]string, 0, len(allowedValues))
-	for allowedValue := range allowedValues {
-		allowed = append(allowed, allowedValue)
-	}
-	sort.Strings(allowed)
-	return fmt.Errorf("customLinuxOSConfig.%s value %q is invalid; allowed values are: %s", fieldName, value, strings.Join(allowed, ", "))
+	return fmt.Errorf("customLinuxOSConfig.%s value %q is invalid; allowed values are: %s", fieldName, value, strings.Join(allowedValues, ", "))
 }
 
 func validateAndSetWindowsNodeBootstrappingConfiguration(config *datamodel.NodeBootstrappingConfiguration) {

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -728,7 +728,12 @@ func normalizeResourceGroupNameForLabel(resourceGroupName string) string {
 }
 
 // ValidateAndSetLinuxNodeBootstrappingConfiguration is exported only for temporary usage in e2e testing of new config.
-func ValidateAndSetLinuxNodeBootstrappingConfiguration(config *datamodel.NodeBootstrappingConfiguration) error {
+func ValidateAndSetLinuxNodeBootstrappingConfiguration(config *datamodel.NodeBootstrappingConfiguration) {
+	_ = ValidateAndSetLinuxNodeBootstrappingConfigurationWithError(config)
+}
+
+// ValidateAndSetLinuxNodeBootstrappingConfigurationWithError validates and updates Linux node bootstrapping configuration.
+func ValidateAndSetLinuxNodeBootstrappingConfigurationWithError(config *datamodel.NodeBootstrappingConfiguration) error {
 	if err := validateCustomLinuxOSConfig(config.AgentPoolProfile.GetCustomLinuxOSConfig()); err != nil {
 		return err
 	}

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -31,11 +31,6 @@ const (
 	MaxCustomDataLength = 87380
 )
 
-var (
-	allowedTransparentHugePageEnabledOptions = []string{"always", "madvise", "never"}
-	allowedTransparentHugePageDefragOptions  = []string{"always", "defer", "defer+madvise", "madvise", "never"}
-)
-
 // TemplateGenerator represents the object that performs the template generation.
 type TemplateGenerator struct{}
 
@@ -811,7 +806,7 @@ func validateCustomLinuxOSConfig(config *datamodel.CustomLinuxOSConfig) error {
 	if err := validateTransparentHugePageConfigValue(
 		"transparentHugePageEnabled",
 		config.TransparentHugePageEnabled,
-		allowedTransparentHugePageEnabledOptions,
+		[]string{"always", "madvise", "never"},
 	); err != nil {
 		return err
 	}
@@ -819,7 +814,7 @@ func validateCustomLinuxOSConfig(config *datamodel.CustomLinuxOSConfig) error {
 	return validateTransparentHugePageConfigValue(
 		"transparentHugePageDefrag",
 		config.TransparentHugePageDefrag,
-		allowedTransparentHugePageDefragOptions,
+		[]string{"always", "defer", "defer+madvise", "madvise", "never"},
 	)
 }
 

--- a/pkg/agent/bakerapi.go
+++ b/pkg/agent/bakerapi.go
@@ -40,7 +40,9 @@ func (agentBaker *agentBakerImpl) GetNodeBootstrapping(ctx context.Context, conf
 	if config.AgentPoolProfile.IsWindows() {
 		validateAndSetWindowsNodeBootstrappingConfiguration(config)
 	} else {
-		ValidateAndSetLinuxNodeBootstrappingConfiguration(config)
+		if err := ValidateAndSetLinuxNodeBootstrappingConfiguration(config); err != nil {
+			return nil, err
+		}
 	}
 
 	templateGenerator := InitializeTemplateGenerator()

--- a/pkg/agent/bakerapi.go
+++ b/pkg/agent/bakerapi.go
@@ -40,7 +40,7 @@ func (agentBaker *agentBakerImpl) GetNodeBootstrapping(ctx context.Context, conf
 	if config.AgentPoolProfile.IsWindows() {
 		validateAndSetWindowsNodeBootstrappingConfiguration(config)
 	} else {
-		if err := ValidateAndSetLinuxNodeBootstrappingConfiguration(config); err != nil {
+		if err := ValidateAndSetLinuxNodeBootstrappingConfigurationWithError(config); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/agent/bakerapi_test.go
+++ b/pkg/agent/bakerapi_test.go
@@ -179,6 +179,54 @@ var _ = Describe("AgentBaker API implementation tests", func() {
 			Expect(nodeBootStrapping.SigImageConfig.Definition).To(Equal("2204gen2containerd"))
 		})
 
+		It("should accept supported custom Linux transparent huge page values", func() {
+			config.AgentPoolProfile.CustomLinuxOSConfig = &datamodel.CustomLinuxOSConfig{
+				TransparentHugePageEnabled: "never",
+				TransparentHugePageDefrag:  "defer+madvise",
+			}
+			agentBaker, err := NewAgentBaker()
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = agentBaker.GetNodeBootstrapping(context.Background(), config)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should reject unsupported custom Linux transparent huge page values", func() {
+			testCases := []struct {
+				name        string
+				enabled     string
+				defrag      string
+				expectedErr string
+			}{
+				{
+					name:        "enabled",
+					enabled:     "within_size",
+					expectedErr: "customLinuxOSConfig.transparentHugePageEnabled",
+				},
+				{
+					name:        "defrag",
+					defrag:      "within_size",
+					expectedErr: "customLinuxOSConfig.transparentHugePageDefrag",
+				},
+			}
+			agentBaker, err := NewAgentBaker()
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, tc := range testCases {
+				configCopy, err := deepcopy.Anything(config)
+				Expect(err).To(BeNil())
+				testConfig, ok := configCopy.(*datamodel.NodeBootstrappingConfiguration)
+				Expect(ok).To(BeTrue())
+				testConfig.AgentPoolProfile.CustomLinuxOSConfig = &datamodel.CustomLinuxOSConfig{
+					TransparentHugePageEnabled: tc.enabled,
+					TransparentHugePageDefrag:  tc.defrag,
+				}
+
+				_, err = agentBaker.GetNodeBootstrapping(context.Background(), testConfig)
+				Expect(err).To(MatchError(ContainSubstring(tc.expectedErr)), tc.name)
+			}
+		})
+
 		It("should return the correct bootstrapping data when linux node image version override is present", func() {
 			nodeImageVersionOverride := "202402.27.0"
 			toggles := &testToggles{

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -1476,7 +1476,7 @@ func TestValidateAndSetNodeBootstrappingConfiguration_StreamingConnectionIdleTim
 			if tc.isWindows {
 				validateAndSetWindowsNodeBootstrappingConfiguration(config)
 			} else {
-				if err := ValidateAndSetLinuxNodeBootstrappingConfiguration(config); err != nil {
+				if err := ValidateAndSetLinuxNodeBootstrappingConfigurationWithError(config); err != nil {
 					t.Fatalf("unexpected validation error: %v", err)
 				}
 			}
@@ -1508,7 +1508,7 @@ func TestValidateAndSetNodeBootstrappingConfiguration_StreamingConnectionIdleTim
 			},
 		}
 
-		if err := ValidateAndSetLinuxNodeBootstrappingConfiguration(config); err != nil {
+		if err := ValidateAndSetLinuxNodeBootstrappingConfigurationWithError(config); err != nil {
 			t.Fatalf("unexpected validation error: %v", err)
 		}
 
@@ -1563,7 +1563,7 @@ func TestValidateAndSetNodeBootstrappingConfiguration_StreamingConnectionIdleTim
 			},
 		}
 
-		if err := ValidateAndSetLinuxNodeBootstrappingConfiguration(config); err != nil {
+		if err := ValidateAndSetLinuxNodeBootstrappingConfigurationWithError(config); err != nil {
 			t.Fatalf("unexpected validation error: %v", err)
 		}
 
@@ -1603,7 +1603,7 @@ func TestValidateAndSetNodeBootstrappingConfiguration_StreamingConnectionIdleTim
 			},
 		}
 
-		if err := ValidateAndSetLinuxNodeBootstrappingConfiguration(config); err != nil {
+		if err := ValidateAndSetLinuxNodeBootstrappingConfigurationWithError(config); err != nil {
 			t.Fatalf("unexpected validation error: %v", err)
 		}
 
@@ -1655,7 +1655,7 @@ func TestValidateAndSetLinuxNodeBootstrappingConfiguration_TransparentHugePageVa
 				},
 			}
 
-			err := ValidateAndSetLinuxNodeBootstrappingConfiguration(config)
+			err := ValidateAndSetLinuxNodeBootstrappingConfigurationWithError(config)
 			if tc.expectedErr == "" {
 				if err != nil {
 					t.Fatalf("unexpected validation error: %v", err)

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -1476,7 +1476,9 @@ func TestValidateAndSetNodeBootstrappingConfiguration_StreamingConnectionIdleTim
 			if tc.isWindows {
 				validateAndSetWindowsNodeBootstrappingConfiguration(config)
 			} else {
-				ValidateAndSetLinuxNodeBootstrappingConfiguration(config)
+				if err := ValidateAndSetLinuxNodeBootstrappingConfiguration(config); err != nil {
+					t.Fatalf("unexpected validation error: %v", err)
+				}
 			}
 
 			_, exists := config.KubeletConfig["--streaming-connection-idle-timeout"]
@@ -1506,7 +1508,9 @@ func TestValidateAndSetNodeBootstrappingConfiguration_StreamingConnectionIdleTim
 			},
 		}
 
-		ValidateAndSetLinuxNodeBootstrappingConfiguration(config)
+		if err := ValidateAndSetLinuxNodeBootstrappingConfiguration(config); err != nil {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
 
 		_, exists := config.KubeletConfig["--streaming-connection-idle-timeout"]
 		if exists {
@@ -1559,7 +1563,9 @@ func TestValidateAndSetNodeBootstrappingConfiguration_StreamingConnectionIdleTim
 			},
 		}
 
-		ValidateAndSetLinuxNodeBootstrappingConfiguration(config)
+		if err := ValidateAndSetLinuxNodeBootstrappingConfiguration(config); err != nil {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
 
 		cmdLine := GetOrderedKubeletConfigFlagString(config)
 		if strings.Contains(cmdLine, "streaming-connection-idle-timeout") {
@@ -1597,11 +1603,71 @@ func TestValidateAndSetNodeBootstrappingConfiguration_StreamingConnectionIdleTim
 			},
 		}
 
-		ValidateAndSetLinuxNodeBootstrappingConfiguration(config)
+		if err := ValidateAndSetLinuxNodeBootstrappingConfiguration(config); err != nil {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
 
 		cmdLine := GetOrderedKubeletConfigFlagString(config)
 		if strings.Contains(cmdLine, "streaming-connection-idle-timeout") {
 			t.Fatalf("streaming-connection-idle-timeout must not appear in final kubelet command line via custom configuration for k8s >= 1.34, got: %s", cmdLine)
 		}
 	})
+}
+
+func TestValidateAndSetLinuxNodeBootstrappingConfiguration_TransparentHugePageValues(t *testing.T) {
+	testCases := []struct {
+		name        string
+		enabled     string
+		defrag      string
+		expectedErr string
+	}{
+		{
+			name: "accepts empty values",
+		},
+		{
+			name:    "accepts supported enabled values",
+			enabled: "always",
+		},
+		{
+			name:   "accepts supported defrag values",
+			defrag: "defer+madvise",
+		},
+		{
+			name:        "rejects unsupported enabled values",
+			enabled:     "within_size",
+			expectedErr: "customLinuxOSConfig.transparentHugePageEnabled",
+		},
+		{
+			name:        "rejects unsupported defrag values",
+			defrag:      "within_size",
+			expectedErr: "customLinuxOSConfig.transparentHugePageDefrag",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &datamodel.NodeBootstrappingConfiguration{
+				AgentPoolProfile: &datamodel.AgentPoolProfile{
+					CustomLinuxOSConfig: &datamodel.CustomLinuxOSConfig{
+						TransparentHugePageEnabled: tc.enabled,
+						TransparentHugePageDefrag:  tc.defrag,
+					},
+				},
+			}
+
+			err := ValidateAndSetLinuxNodeBootstrappingConfiguration(config)
+			if tc.expectedErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected validation error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected validation error containing %q", tc.expectedErr)
+			}
+			if !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected validation error containing %q, got %q", tc.expectedErr, err.Error())
+			}
+		})
+	}
 }

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -18,6 +18,50 @@ Describe 'cse_config.sh'
     Include "./parts/linux/cloud-init/artifacts/cse_config.sh"
     Include "./parts/linux/cloud-init/artifacts/cse_helpers.sh"
 
+    Describe 'validateTransparentHugePageValue'
+        setup() {
+            THP_SUPPORTED_VALUES_FILE="$(mktemp)"
+            printf 'always [madvise] never\n' > "${THP_SUPPORTED_VALUES_FILE}"
+        }
+
+        cleanup() {
+            rm -f "${THP_SUPPORTED_VALUES_FILE}"
+            unset THP_SUPPORTED_VALUES_FILE
+        }
+
+        BeforeEach 'setup'
+        AfterEach 'cleanup'
+
+        It 'accepts an empty value'
+            When call validateTransparentHugePageValue "enabled" "" "${THP_SUPPORTED_VALUES_FILE}"
+            The status should be success
+        End
+
+        It 'accepts a kernel-supported value'
+            When call validateTransparentHugePageValue "enabled" "never" "${THP_SUPPORTED_VALUES_FILE}"
+            The status should be success
+        End
+
+        It 'accepts a supported value with a plus token'
+            printf 'always defer defer+madvise [madvise] never\n' > "${THP_SUPPORTED_VALUES_FILE}"
+
+            When call validateTransparentHugePageValue "defrag" "defer+madvise" "${THP_SUPPORTED_VALUES_FILE}"
+            The status should be success
+        End
+
+        It 'rejects values that are not kernel-supported'
+            When call validateTransparentHugePageValue "enabled" "defer" "${THP_SUPPORTED_VALUES_FILE}"
+            The status should be failure
+            The stderr should include "Unsupported transparent huge page enabled value 'defer'"
+        End
+
+        It 'rejects values with shell metacharacters before script generation'
+            When call validateTransparentHugePageValue "enabled" 'never"; touch /tmp/pwn #' "${THP_SUPPORTED_VALUES_FILE}"
+            The status should be failure
+            The stderr should include "Invalid transparent huge page enabled value"
+        End
+    End
+
     Describe 'logGPUDriverPrebakeReadiness'
         It 'reports marker_present=false when no prebake marker exists'
             GPU_DKMS_MARKER_FILE="$(mktemp)"; rm -f "${GPU_DKMS_MARKER_FILE}"

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -26,7 +26,7 @@ Describe 'cse_config.sh'
         }
 
         cleanup_thp_service() {
-            unset THP_ENABLED THP_DEFRAG FAIL_MKDIR FAIL_TEE_PATH FAIL_CHMOD FAIL_DAEMON_RELOAD FAIL_SYSTEMCTL_ENABLE
+            unset THP_ENABLED THP_DEFRAG FAIL_MKDIR FAIL_TEE_PATH CAPTURE_TEE_PATH FAIL_CHMOD FAIL_DAEMON_RELOAD FAIL_SYSTEMCTL_ENABLE
         }
 
         mkdir() {
@@ -38,6 +38,10 @@ Describe 'cse_config.sh'
         tee() {
             if [ "${1:-}" = "${FAIL_TEE_PATH:-__none__}" ]; then
                 return 1
+            fi
+            if [ "${1:-}" = "${CAPTURE_TEE_PATH:-__none__}" ]; then
+                cat >&2
+                return 0
             fi
             cat > /dev/null
         }
@@ -113,6 +117,18 @@ Describe 'cse_config.sh'
             The status should equal "$ERR_SYSTEMCTL_START_FAIL"
             The output should include "systemctl daemon-reload"
             The output should not include "systemctlEnableAndStart"
+        End
+
+        It 'does not embed raw THP values in the generated helper script'
+            THP_ENABLED='never"; touch /tmp/aks-thp-injection #'
+            CAPTURE_TEE_PATH="/opt/azure/containers/aks-transparent-hugepage.sh"
+
+            When run configureTransparentHugePageSystemdService
+
+            The status should be success
+            The output should include "systemctlEnableAndStart aks-transparent-hugepage 30"
+            The error should include 'cat "${thp_enabled_config}" > /sys/kernel/mm/transparent_hugepage/enabled'
+            The error should not include "touch /tmp/aks-thp-injection"
         End
     End
 

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -2889,7 +2889,13 @@ EOF
             if test "$1" = "-L" && test "$2" = "/dev/disk/azure/resource-part1"; then
                 return 0
             fi
-            command [ "$@"
+            local last_arg=""
+            for last_arg in "$@"; do :; done
+            if test "${last_arg}" = "]"; then
+                command [ "$@"
+            else
+                command [ "$@" ]
+            fi
         }
 
         readlink() {

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -82,6 +82,42 @@ Describe 'cse_config.sh'
         End
     End
 
+    Describe 'ensureSwapFileFstabEntry'
+        setup() {
+            TEST_FSTAB_FILE="$(mktemp)"
+        }
+
+        cleanup() {
+            rm -f "${TEST_FSTAB_FILE}"
+            unset TEST_FSTAB_FILE
+        }
+
+        BeforeEach 'setup'
+        AfterEach 'cleanup'
+
+        It 'replaces existing fstab entries for the same swap file'
+            printf '/swapfile none swap sw 0 0\n/other none swap sw 0 0\n/swapfile none swap defaults 0 0\n' > "${TEST_FSTAB_FILE}"
+            expected_fstab='/other none swap sw 0 0
+/swapfile none swap noauto,nofail 0 0'
+
+            When call ensureSwapFileFstabEntry "/swapfile" "${TEST_FSTAB_FILE}"
+
+            The status should be success
+            The contents of file "${TEST_FSTAB_FILE}" should equal "${expected_fstab}"
+        End
+
+        It 'keeps one canonical fstab entry when it already exists'
+            printf '/other none swap sw 0 0\n/swapfile none swap noauto,nofail 0 0\n' > "${TEST_FSTAB_FILE}"
+            expected_fstab='/other none swap sw 0 0
+/swapfile none swap noauto,nofail 0 0'
+
+            When call ensureSwapFileFstabEntry "/swapfile" "${TEST_FSTAB_FILE}"
+
+            The status should be success
+            The contents of file "${TEST_FSTAB_FILE}" should equal "${expected_fstab}"
+        End
+    End
+
     Describe 'logGPUDriverPrebakeReadiness'
         It 'reports marker_present=false when no prebake marker exists'
             GPU_DKMS_MARKER_FILE="$(mktemp)"; rm -f "${GPU_DKMS_MARKER_FILE}"
@@ -2745,6 +2781,81 @@ EOF
             The output should include 'dcgm-exporter'
             The output should include 'dra-driver-nvidia-gpu'
             The output should not include 'nvidia-device-plugin'
+        End
+    End
+
+    Describe 'configureSwapFile'
+        SWAP_FILE_SIZE_MB=1
+
+        function [ {
+            if test "$1" = "-L" && test "$2" = "/dev/disk/azure/resource-part1"; then
+                return 0
+            fi
+            command [ "$@"
+        }
+
+        readlink() {
+            case "$2" in
+                /dev/disk/azure/resource-part1) echo "/dev/sdb1" ;;
+                /dev/disk/azure/root) echo "/dev/sda1" ;;
+            esac
+        }
+
+        retrycmd_if_failure() {
+            echo "retrycmd_if_failure $*"
+        }
+
+        chmod() {
+            echo "chmod $*"
+        }
+
+        swapFileIsActive() {
+            echo "swapFileIsActive $1"
+        }
+
+        reconcileSwapFilePersistence() {
+            echo "reconcileSwapFilePersistence $1"
+        }
+
+        It 'falls back to OS disk when resource disk mountpoint cannot be determined'
+            findmnt() {
+                return 1
+            }
+            df() {
+                printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/sda1 1000000 0 1000000 0%% /\n'
+            }
+
+            When call configureSwapFile
+
+            The status should be success
+            The output should include "Could not determine resource disk mountpoint, attempting to fall back to OS disk..."
+            The output should include "Will use OS disk for swap file"
+            The output should include "Swap file will be saved to: /swapfile"
+            The output should include "reconcileSwapFilePersistence /swapfile"
+        End
+
+        It 'falls back to OS disk when resource disk free space cannot be determined'
+            findmnt() {
+                echo "/mnt/resource"
+            }
+            df() {
+                case "$2" in
+                    /mnt/resource)
+                        printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+                        ;;
+                    /)
+                        printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/sda1 1000000 0 1000000 0%% /\n'
+                        ;;
+                esac
+            }
+
+            When call configureSwapFile
+
+            The status should be success
+            The output should include "Could not determine free space on resource disk, attempting to fall back to OS disk..."
+            The output should include "Will use OS disk for swap file"
+            The output should include "Swap file will be saved to: /swapfile"
+            The output should include "reconcileSwapFilePersistence /swapfile"
         End
     End
 

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -14,6 +14,10 @@ check_hosts_file_permissions() {
     stat -c '%a' "$AKS_LOCALDNS_HOSTS_FILE"
 }
 
+check_test_fstab_permissions() {
+    printf "0%s" "$(getFileMode "$TEST_FSTAB_FILE")"
+}
+
 Describe 'cse_config.sh'
     Include "./parts/linux/cloud-init/artifacts/cse_config.sh"
     Include "./parts/linux/cloud-init/artifacts/cse_helpers.sh"
@@ -191,6 +195,7 @@ Describe 'cse_config.sh'
         }
 
         It 'replaces existing fstab entries for the same swap file'
+            chmod 0644 "${TEST_FSTAB_FILE}"
             printf '/swapfile none swap sw 0 0\n/other none swap sw 0 0\n/swapfile none swap defaults 0 0\n' > "${TEST_FSTAB_FILE}"
             expected_fstab='/other none swap sw 0 0
 /swapfile none swap noauto,nofail 0 0'
@@ -199,6 +204,17 @@ Describe 'cse_config.sh'
 
             The status should be success
             The contents of file "${TEST_FSTAB_FILE}" should equal "${expected_fstab}"
+        End
+
+        It 'preserves the fstab file mode when replacing entries'
+            chmod 0640 "${TEST_FSTAB_FILE}"
+            printf '/other none swap sw 0 0\n' > "${TEST_FSTAB_FILE}"
+
+            When call ensureSwapFileFstabEntry "/swapfile" "${TEST_FSTAB_FILE}"
+
+            The status should be success
+            The path "${TEST_FSTAB_FILE}" should be file
+            The result of function check_test_fstab_permissions should equal "0640"
         End
 
         It 'keeps one canonical fstab entry when it already exists'

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -62,6 +62,26 @@ Describe 'cse_config.sh'
         End
     End
 
+    Describe 'swapFileIsActive'
+        swapon() {
+            printf '%b' "${SWAPON_OUTPUT}"
+        }
+
+        It 'matches an active swap file when swapon output has leading whitespace'
+            SWAPON_OUTPUT='    /swapfile\n'
+
+            When call swapFileIsActive "/swapfile"
+            The status should be success
+        End
+
+        It 'matches only the exact swap file path'
+            SWAPON_OUTPUT='    /swapfile-extra\n'
+
+            When call swapFileIsActive "/swapfile"
+            The status should be failure
+        End
+    End
+
     Describe 'logGPUDriverPrebakeReadiness'
         It 'reports marker_present=false when no prebake marker exists'
             GPU_DKMS_MARKER_FILE="$(mktemp)"; rm -f "${GPU_DKMS_MARKER_FILE}"

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -2747,4 +2747,41 @@ EOF
             The output should not include 'nvidia-device-plugin'
         End
     End
+
+    Describe 'reconcileSwapFilePersistence'
+        findExistingSwapFileLocation() {
+            return 1
+        }
+
+        configureSwapFile() {
+            echo "createSwapFile"
+        }
+
+        ensureSwapFileFstabEntry() {
+            echo "ensureSwapFileFstabEntry $1"
+        }
+
+        configureSwapFileSystemdService() {
+            echo "configureSwapFileSystemdService $1"
+        }
+
+        It 'creates the requested swap file when no existing swap file is present'
+            When call reconcileSwapFilePersistence
+
+            The status should be success
+            The output should include "No existing AKS swap file found; creating swap file for persistence reconciliation"
+            The output should include "createSwapFile"
+            The output should not include "ensureSwapFileFstabEntry"
+            The output should not include "configureSwapFileSystemdService"
+        End
+
+        It 'reconciles persistence for an existing swap file without recreating it'
+            When call reconcileSwapFilePersistence "/swapfile"
+
+            The status should be success
+            The output should include "ensureSwapFileFstabEntry /swapfile"
+            The output should include "configureSwapFileSystemdService /swapfile"
+            The output should not include "createSwapFile"
+        End
+    End
 End

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -162,6 +162,9 @@ Describe 'cse_config.sh'
 
     Describe 'swapFileIsActive'
         swapon() {
+            if [ "$*" != "--show --noheadings" ]; then
+                return 1
+            fi
             printf '%b' "${SWAPON_OUTPUT}"
         }
 

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -67,6 +67,16 @@ Describe 'cse_config.sh'
         BeforeEach 'setup_thp_service'
         AfterEach 'cleanup_thp_service'
 
+        It 'writes helper files, reloads systemd, and enables the service'
+            When run configureTransparentHugePageSystemdService
+
+            The status should be success
+            The output should include "mkdir -p /opt/azure/containers /opt/azure/containers/aks-transparent-hugepage"
+            The output should include "chmod 0755 /opt/azure/containers/aks-transparent-hugepage.sh"
+            The output should include "systemctl daemon-reload"
+            The output should include "systemctlEnableAndStart aks-transparent-hugepage 30"
+        End
+
         It 'exits when helper directory creation fails'
             FAIL_MKDIR="true"
 

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -2894,5 +2894,27 @@ EOF
             The output should include "configureSwapFileSystemdService /swapfile"
             The output should not include "createSwapFile"
         End
+
+        It 'exits when fstab reconciliation fails'
+            ensureSwapFileFstabEntry() {
+                return 1
+            }
+
+            When run reconcileSwapFilePersistence "/swapfile"
+
+            The status should equal "$ERR_SWAP_CREATE_FAIL"
+            The output should not include "configureSwapFileSystemdService"
+        End
+
+        It 'exits when swap systemd service reconciliation fails'
+            configureSwapFileSystemdService() {
+                return 1
+            }
+
+            When run reconcileSwapFilePersistence "/swapfile"
+
+            The status should equal "$ERR_SWAP_CREATE_FAIL"
+            The output should include "ensureSwapFileFstabEntry /swapfile"
+        End
     End
 End

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -141,16 +141,28 @@ Describe 'cse_config.sh'
 
     Describe 'ensureSwapFileFstabEntry'
         setup() {
-            TEST_FSTAB_FILE="$(mktemp)"
+            TEST_FSTAB_DIR="$(mktemp -d)"
+            TEST_FSTAB_FILE="${TEST_FSTAB_DIR}/fstab"
+            : > "${TEST_FSTAB_FILE}"
         }
 
         cleanup() {
-            rm -f "${TEST_FSTAB_FILE}"
+            rm -rf "${TEST_FSTAB_DIR}"
             unset TEST_FSTAB_FILE
+            unset TEST_FSTAB_DIR
+            unset FAIL_MV
         }
 
         BeforeEach 'setup'
         AfterEach 'cleanup'
+
+        mv() {
+            if [ "${FAIL_MV:-false}" = "true" ]; then
+                return 1
+            fi
+
+            command mv "$@"
+        }
 
         It 'replaces existing fstab entries for the same swap file'
             printf '/swapfile none swap sw 0 0\n/other none swap sw 0 0\n/swapfile none swap defaults 0 0\n' > "${TEST_FSTAB_FILE}"
@@ -172,6 +184,16 @@ Describe 'cse_config.sh'
 
             The status should be success
             The contents of file "${TEST_FSTAB_FILE}" should equal "${expected_fstab}"
+        End
+
+        It 'leaves the existing fstab untouched when atomic replace fails'
+            printf '/other none swap sw 0 0\n' > "${TEST_FSTAB_FILE}"
+            FAIL_MV=true
+
+            When call ensureSwapFileFstabEntry "/swapfile" "${TEST_FSTAB_FILE}"
+
+            The status should be failure
+            The contents of file "${TEST_FSTAB_FILE}" should equal '/other none swap sw 0 0'
         End
     End
 

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -18,50 +18,6 @@ Describe 'cse_config.sh'
     Include "./parts/linux/cloud-init/artifacts/cse_config.sh"
     Include "./parts/linux/cloud-init/artifacts/cse_helpers.sh"
 
-    Describe 'validateTransparentHugePageValue'
-        setup() {
-            THP_SUPPORTED_VALUES_FILE="$(mktemp)"
-            printf 'always [madvise] never\n' > "${THP_SUPPORTED_VALUES_FILE}"
-        }
-
-        cleanup() {
-            rm -f "${THP_SUPPORTED_VALUES_FILE}"
-            unset THP_SUPPORTED_VALUES_FILE
-        }
-
-        BeforeEach 'setup'
-        AfterEach 'cleanup'
-
-        It 'accepts an empty value'
-            When call validateTransparentHugePageValue "enabled" "" "${THP_SUPPORTED_VALUES_FILE}"
-            The status should be success
-        End
-
-        It 'accepts a kernel-supported value'
-            When call validateTransparentHugePageValue "enabled" "never" "${THP_SUPPORTED_VALUES_FILE}"
-            The status should be success
-        End
-
-        It 'accepts a supported value with a plus token'
-            printf 'always defer defer+madvise [madvise] never\n' > "${THP_SUPPORTED_VALUES_FILE}"
-
-            When call validateTransparentHugePageValue "defrag" "defer+madvise" "${THP_SUPPORTED_VALUES_FILE}"
-            The status should be success
-        End
-
-        It 'rejects values that are not kernel-supported'
-            When call validateTransparentHugePageValue "enabled" "defer" "${THP_SUPPORTED_VALUES_FILE}"
-            The status should be failure
-            The stderr should include "Unsupported transparent huge page enabled value 'defer'"
-        End
-
-        It 'rejects values with shell metacharacters before script generation'
-            When call validateTransparentHugePageValue "enabled" 'never"; touch /tmp/pwn #' "${THP_SUPPORTED_VALUES_FILE}"
-            The status should be failure
-            The stderr should include "Invalid transparent huge page enabled value"
-        End
-    End
-
     Describe 'configureTransparentHugePageSystemdService'
         setup_thp_service() {
             THP_ENABLED="never"

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -62,6 +62,104 @@ Describe 'cse_config.sh'
         End
     End
 
+    Describe 'configureTransparentHugePageSystemdService'
+        setup_thp_service() {
+            THP_ENABLED="never"
+            THP_DEFRAG="madvise"
+            unset FAIL_MKDIR FAIL_TEE_PATH FAIL_CHMOD FAIL_DAEMON_RELOAD FAIL_SYSTEMCTL_ENABLE
+        }
+
+        cleanup_thp_service() {
+            unset THP_ENABLED THP_DEFRAG FAIL_MKDIR FAIL_TEE_PATH FAIL_CHMOD FAIL_DAEMON_RELOAD FAIL_SYSTEMCTL_ENABLE
+        }
+
+        mkdir() {
+            echo "mkdir $*"
+            [ "${FAIL_MKDIR:-}" = "true" ] && return 1
+            return 0
+        }
+
+        tee() {
+            if [ "${1:-}" = "${FAIL_TEE_PATH:-__none__}" ]; then
+                return 1
+            fi
+            cat > /dev/null
+        }
+
+        chmod() {
+            echo "chmod $*"
+            [ "${FAIL_CHMOD:-}" = "true" ] && return 1
+            return 0
+        }
+
+        systemctl() {
+            echo "systemctl $*"
+            [ "${1:-}" = "daemon-reload" ] && [ "${FAIL_DAEMON_RELOAD:-}" = "true" ] && return 1
+            return 0
+        }
+
+        systemctlEnableAndStart() {
+            echo "systemctlEnableAndStart $*"
+            [ "${FAIL_SYSTEMCTL_ENABLE:-}" = "true" ] && return 1
+            return 0
+        }
+
+        BeforeEach 'setup_thp_service'
+        AfterEach 'cleanup_thp_service'
+
+        It 'exits when helper directory creation fails'
+            FAIL_MKDIR="true"
+
+            When run configureTransparentHugePageSystemdService
+
+            The status should equal "$ERR_SYSCTL_RELOAD"
+            The output should include "mkdir -p /opt/azure/containers"
+            The output should not include "chmod"
+            The output should not include "systemctl daemon-reload"
+        End
+
+        It 'exits when helper script write fails'
+            FAIL_TEE_PATH="/opt/azure/containers/aks-transparent-hugepage.sh"
+
+            When run configureTransparentHugePageSystemdService
+
+            The status should equal "$ERR_SYSCTL_RELOAD"
+            The output should include "mkdir -p /opt/azure/containers"
+            The output should not include "chmod"
+            The output should not include "systemctl daemon-reload"
+        End
+
+        It 'exits when helper script chmod fails'
+            FAIL_CHMOD="true"
+
+            When run configureTransparentHugePageSystemdService
+
+            The status should equal "$ERR_SYSCTL_RELOAD"
+            The output should include "chmod 0755 /opt/azure/containers/aks-transparent-hugepage.sh"
+            The output should not include "systemctl daemon-reload"
+        End
+
+        It 'exits when service unit write fails'
+            FAIL_TEE_PATH="/etc/systemd/system/aks-transparent-hugepage.service"
+
+            When run configureTransparentHugePageSystemdService
+
+            The status should equal "$ERR_SYSCTL_RELOAD"
+            The output should include "chmod 0755 /opt/azure/containers/aks-transparent-hugepage.sh"
+            The output should not include "systemctl daemon-reload"
+        End
+
+        It 'exits when systemd daemon reload fails'
+            FAIL_DAEMON_RELOAD="true"
+
+            When run configureTransparentHugePageSystemdService
+
+            The status should equal "$ERR_SYSTEMCTL_START_FAIL"
+            The output should include "systemctl daemon-reload"
+            The output should not include "systemctlEnableAndStart"
+        End
+    End
+
     Describe 'swapFileIsActive'
         swapon() {
             printf '%b' "${SWAPON_OUTPUT}"

--- a/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
@@ -461,4 +461,15 @@ Describe 'CVE kernel module mitigation phase coverage'
         When call phase_body "nodePrep"
         The output should include "reconcileVulnerableKernelModuleMitigation"
     End
+
+    It 'configures transparent huge page from basePrep so VHD bakes keep the intended state'
+        When call phase_body "basePrep"
+        The output should include "configureTransparentHugePage"
+    End
+
+    It 'applies and reconciles transparent huge page from nodePrep for PIS and already-released VHDs'
+        When call phase_body "nodePrep"
+        The output should include "applyTransparentHugePageValues"
+        The output should include "reconcileTransparentHugePagePersistence"
+    End
 End


### PR DESCRIPTION
## Summary

Fix Azure Linux custom Linux OS config persistence after node reboot for support case 2608050010000389. AgentBaker was writing transparent huge page settings to `/etc/sysfs.conf`, but Azure Linux does not reliably apply that file at boot, so THP reverted to the distro default after reboot.

## Changes

- Add an AKS-owned Azure Linux/Mariner systemd oneshot service to reapply custom THP enabled/defrag settings on boot before kubelet starts.
- Keep the existing `/etc/sysfs.conf` behavior for compatibility with distros that apply it.
- Persist custom swap activation through an AKS systemd service with `noauto,nofail` fstab entries to avoid Azure Linux `/mnt` swap ordering cycles after reboot.
- Add an Azure Linux V3 E2E regression test that validates custom Linux OS config values before and after reboot.
- Fix E2E helpers so `DISABLE_SCRIPTLESS=true` fully exercises local CSE script changes during local validation.

## Testing

- `cd e2e && go test . -run '^Test_AzureLinuxV3_CustomLinuxOSConfigPersistsAfterReboot$' -count=0`
- `DISABLE_SCRIPTLESS=true TAGS_TO_RUN='name=Test_AzureLinuxV3_CustomLinuxOSConfigPersistsAfterReboot' ./e2e-local.sh` — passed
- `GENERATE_TEST_DATA=true go test ./pkg/agent...`
- `make generate` attempted, but blocked while installing ginkgo by internal Go proxy `401 Unauthorized`; fallback snapshot generation above passed.

## Related

- AB#39130468
- Support case: 2608050010000389

🤖 *Generated by GitHub Copilot*