### PR TITLE
ci: extend GPU E2E timeout to three hours

### DIFF
--- a/.pipelines/e2e-gpu.yaml
+++ b/.pipelines/e2e-gpu.yaml
@@ -37,5 +37,5 @@ jobs:
     parameters:
       name: Ubuntu GPU Tests
       IgnoreScenariosWithMissingVhd: false
-      jobTimeoutInMinutes: 120
+      jobTimeoutInMinutes: 180
       failedTestsRetryCount: ${{ variables.E2E_FAILED_TESTS_RETRY_COUNT }}


### PR DESCRIPTION
## What changed

- Increase AgentBaker GPU E2E job timeout from 120 to 180 minutes.
- Keep the change scoped to the GPU pipeline; other E2E jobs retain their configured timeouts.

## Why

Recent GPU E2E runs reached the two-hour job limit while retrying failed GPU scenarios, canceling tests before final results were available.

## Validation

- Parsed .pipelines/e2e-gpu.yaml successfully.
- Ran git diff --check.