### PR TITLE
test(e2e): add Kata Containers E2E scenario for AzureLinux V3

### DIFF
--- a/e2e/config/vhd.go
+++ b/e2e/config/vhd.go
@@ -128,6 +128,18 @@ var (
 		Gallery: imageGalleryLinux,
 	}
 
+	// VHDAzureLinuxV3Gen2Kata is the AzureLinux V3 Gen2 VHD built with FEATURE_FLAGS=kata.
+	// The image definition name mirrors the SIG_IMAGE_NAME produced by the VHD builder for
+	// OS_VERSION=V3kata + HYPERV_GENERATION=V2 (SKU_NAME=V3katagen2, prefixed with "AzureLinux").
+	// See .pipelines/.vsts-vhd-builder-release.yaml (buildAzureLinuxV3gen2kata) and
+	// vhdbuilder/packer/produce-packer-settings-functions.sh (ensure_sig_image_name_linux).
+	VHDAzureLinuxV3Gen2Kata = &Image{
+		Name:    "AzureLinuxV3katagen2",
+		OS:      OSAzureLinux,
+		Arch:    "amd64",
+		Distro:  datamodel.AKSAzureLinuxV3Gen2Kata,
+		Gallery: imageGalleryLinux,
+	}
 	VHDAzureLinux3OSGuard = &Image{
 		Name:                "AzureLinuxOSGuardOSGuardV3gen2fipsTL",
 		OS:                  OSAzureLinux,

--- a/e2e/node_config.go
+++ b/e2e/node_config.go
@@ -210,6 +210,12 @@ func nbcToAKSNodeConfigV1(nbc *datamodel.NodeBootstrappingConfiguration) *aksnod
 		DisableCustomData:   true,
 		LinuxAdminUsername:  "azureuser",
 		VmSize:              config.Config.DefaultVMSKU,
+		// The scriptless/aks-node-controller path gates its Kata containerd config blocks on
+		// this field alone, whereas the NBC/baker path derives Kata from the agent pool distro
+		// (see Distro.IsKataDistro and the IsKata template func in pkg/agent/baker.go). Without
+		// this mapping a scriptless scenario running on a Kata VHD would silently get a Kata
+		// image with a non-Kata containerd config.
+		IsKata: nbc.AgentPoolProfile.Distro.IsKataDistro(),
 		ClusterConfig: &aksnodeconfigv1.ClusterConfig{
 			Location:            nbc.ContainerService.Location,
 			ResourceGroup:       nbc.ResourceGroupName,

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -414,7 +414,7 @@ func Test_AzureLinuxV3(t *testing.T) {
 // Test_AzureLinuxV3Gen2Kata verifies that AgentBaker correctly bootstraps a Kata-enabled node.
 //
 // Kata Containers is a runtime, so the thing that can silently break is the containerd
-// configuration: pkg/agent/baker.go only emits the `kata` and `kata-cc` runtime handler blocks
+// configuration: pkg/agent/baker.go only emits the `kata` runtime handler blocks
 // when the agent pool's Distro satisfies Distro.IsKataDistro(). Selecting a Kata VHD here flows
 // through e2e/node_config.go -> AgentPoolProfile.Distro -> the IsKata template func, so this
 // scenario exercises that whole path against a real node.
@@ -425,7 +425,7 @@ func Test_AzureLinuxV3(t *testing.T) {
 //  3. a pod scheduled via a Kata RuntimeClass runs and is genuinely VM-isolated.
 func Test_AzureLinuxV3Gen2Kata(t *testing.T) {
 	RunScenario(t, &Scenario{
-		Description: "Tests that an AzureLinuxV3 Gen2 Kata node is bootstrapped with working kata and kata-cc containerd runtime handlers, and can run a VM-isolated pod via a Kata RuntimeClass",
+		Description: "Tests that an AzureLinuxV3 Gen2 Kata node is bootstrapped with a working kata containerd runtime handler, and can run a VM-isolated pod via a Kata RuntimeClass",
 		Tags: Tags{
 			Kata: true,
 		},

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -422,11 +422,11 @@ func Test_AzureLinuxV3(t *testing.T) {
 // The scenario asserts three increasingly strong properties:
 //  1. the rendered /etc/containerd/config.toml contains the Kata runtime handlers,
 //  2. containerd actually parsed and loaded them (no warnings, handlers in `config dump`),
-//  3. a pod scheduled via a Kata RuntimeClass runs and is genuinely VM-isolated, for both the
-//     `kata` and `kata-preview` runtime handlers.
+//  3. for every handler in kataRuntimeHandlers, a pod scheduled via a Kata RuntimeClass runs
+//     and is genuinely VM-isolated.
 func Test_AzureLinuxV3Gen2Kata(t *testing.T) {
 	RunScenario(t, &Scenario{
-		Description: "Tests that an AzureLinuxV3 Gen2 Kata node is bootstrapped with working kata and kata-preview containerd runtime handlers, and can run VM-isolated pods via Kata RuntimeClasses",
+		Description: "Tests that an AzureLinuxV3 Gen2 Kata node is bootstrapped with working kata containerd runtime handlers, and can run VM-isolated pods via Kata RuntimeClasses",
 		Tags: Tags{
 			Kata: true,
 		},
@@ -449,8 +449,9 @@ func Test_AzureLinuxV3Gen2Kata(t *testing.T) {
 				ValidateKataContainerdConfig(ctx, s)
 				ValidateKataContainerdConfigDump(ctx, s)
 				ValidateKataHostReadiness(ctx, s)
-				ValidateKataPodIsIsolated(ctx, s, "kata")
-				ValidateKataPodIsIsolated(ctx, s, "kata-preview")
+				for _, handler := range kataRuntimeHandlers {
+					ValidateKataPodIsIsolated(ctx, s, handler)
+				}
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -422,10 +422,11 @@ func Test_AzureLinuxV3(t *testing.T) {
 // The scenario asserts three increasingly strong properties:
 //  1. the rendered /etc/containerd/config.toml contains the Kata runtime handlers,
 //  2. containerd actually parsed and loaded them (no warnings, handlers in `config dump`),
-//  3. a pod scheduled via a Kata RuntimeClass runs and is genuinely VM-isolated.
+//  3. a pod scheduled via a Kata RuntimeClass runs and is genuinely VM-isolated, for both the
+//     `kata` and `kata-preview` runtime handlers.
 func Test_AzureLinuxV3Gen2Kata(t *testing.T) {
 	RunScenario(t, &Scenario{
-		Description: "Tests that an AzureLinuxV3 Gen2 Kata node is bootstrapped with a working kata containerd runtime handler, and can run a VM-isolated pod via a Kata RuntimeClass",
+		Description: "Tests that an AzureLinuxV3 Gen2 Kata node is bootstrapped with working kata and kata-preview containerd runtime handlers, and can run VM-isolated pods via Kata RuntimeClasses",
 		Tags: Tags{
 			Kata: true,
 		},
@@ -448,7 +449,8 @@ func Test_AzureLinuxV3Gen2Kata(t *testing.T) {
 				ValidateKataContainerdConfig(ctx, s)
 				ValidateKataContainerdConfigDump(ctx, s)
 				ValidateKataHostReadiness(ctx, s)
-				ValidateKataPodIsIsolated(ctx, s)
+				ValidateKataPodIsIsolated(ctx, s, "kata")
+				ValidateKataPodIsIsolated(ctx, s, "kata-preview")
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -411,6 +411,52 @@ func Test_AzureLinuxV3(t *testing.T) {
 	})
 }
 
+// Test_AzureLinuxV3Gen2Kata verifies that AgentBaker correctly bootstraps a Kata-enabled node.
+//
+// Kata Containers is a runtime, so the thing that can silently break is the containerd
+// configuration: pkg/agent/baker.go only emits the `kata` and `kata-cc` runtime handler blocks
+// when the agent pool's Distro satisfies Distro.IsKataDistro(). Selecting a Kata VHD here flows
+// through e2e/node_config.go -> AgentPoolProfile.Distro -> the IsKata template func, so this
+// scenario exercises that whole path against a real node.
+//
+// The scenario asserts three increasingly strong properties:
+//  1. the rendered /etc/containerd/config.toml contains the Kata runtime handlers,
+//  2. containerd actually parsed and loaded them (no warnings, handlers in `config dump`),
+//  3. a pod scheduled via a Kata RuntimeClass runs and is genuinely VM-isolated.
+func Test_AzureLinuxV3Gen2Kata(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "Tests that an AzureLinuxV3 Gen2 Kata node is bootstrapped with working kata and kata-cc containerd runtime handlers, and can run a VM-isolated pod via a Kata RuntimeClass",
+		Tags: Tags{
+			Kata: true,
+		},
+		Config: Config{
+			Cluster: ClusterKubenet,
+			VHD:     config.VHDAzureLinuxV3Gen2Kata,
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				// Kata launches each pod inside its own VM, which requires nested virtualization
+				// and more headroom than the 2-vCPU e2e default (config.Config.DefaultVMSKU).
+				nbc.ContainerService.Properties.AgentPoolProfiles[0].VMSize = kataVMSize
+				nbc.AgentPoolProfile.VMSize = kataVMSize
+				// Leave unattended upgrades on so that CSE's kata-specific opt-out branch is
+				// actually exercised, which ValidateKataHostReadiness asserts.
+				nbc.DisableUnattendedUpgrades = false
+			},
+			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
+				vmss.SKU.Name = to.Ptr(kataVMSize)
+			},
+			Validator: func(ctx context.Context, s *Scenario) {
+				ValidateKataContainerdConfig(ctx, s)
+				ValidateKataContainerdConfigDump(ctx, s)
+				ValidateKataHostReadiness(ctx, s)
+				ValidateKataPodIsIsolated(ctx, s)
+			},
+		},
+	})
+}
+
+// kataVMSize is a nested-virtualization capable SKU with enough capacity to host a Kata guest VM.
+const kataVMSize = "Standard_D4ds_v5"
+
 func Test_AzureLinuxV3_CustomCA(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "Tests that an AzureLinuxV3 node can be properly bootstrapped with custom ca",

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -30,6 +30,7 @@ type Tags struct {
 	NonAnonymousACR        bool
 	GPU                    bool
 	WASM                   bool
+	Kata                   bool
 	BootstrapTokenFallback bool
 	KubeletCustomConfig    bool
 	Scriptless             bool

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -1170,6 +1170,21 @@ func ValidateContainerd2Properties(ctx context.Context, s *Scenario, versions []
 
 	ValidateInstalledPackageVersion(ctx, s, "moby-containerd", versions[0])
 
+	// TODO: this assertion never actually runs and always passes vacuously.
+	//
+	// execOnVMForScenarioOnUnprivilegedPod executes inside the "debugnonhost" daemonset pod,
+	// which runs a bare mcr.microsoft.com/cbl-mariner/base/core:2.0 image with no volume mounts
+	// (see daemonsetDebug in e2e/kube.go). The host filesystem is not mounted into it, so the
+	// containerd binary is unreachable and the command exits 127 with an empty stdout and
+	// "command not found" on stderr. attemptExecOnPod treats a non-zero exit as a successful
+	// exec, so no error surfaces, and the NotContains check below then trivially passes against
+	// an empty string.
+	//
+	// Two changes are needed: run this on the node via execScriptOnVMForScenarioValidateExitCode
+	// (as ValidateKataContainerdConfigDump in validators_kata.go now does), and check stderr as
+	// well as stdout, since containerd logs its warnings to stderr. Fixing it is likely to
+	// surface real warnings at the 11 call sites that use this validator, so it is left as a
+	// follow-up rather than folded into an unrelated change.
 	execResult := execOnVMForScenarioOnUnprivilegedPod(ctx, s, "containerd config dump ")
 	// validate containerd config dump has no warnings
 	require.NotContains(s.T, execResult.stdout, "level=warning", "do not expect warning message when converting config file %", execResult.stdout)

--- a/e2e/validators_kata.go
+++ b/e2e/validators_kata.go
@@ -84,8 +84,10 @@ func ValidateKataContainerdConfigDump(ctx context.Context, s *Scenario) {
 
 	dump := execResult.stdout
 
-	// The effective config must expose the kata runtime handler.
-	assert.Contains(s.T, dump, `runtimes.`+kataRuntimeHandler,
+	// The effective config must expose the kata runtime handler. Note the trailing "]": without
+	// it this would also match "runtimes.kata-preview" and pass even if the "kata" handler
+	// itself were missing.
+	assert.Contains(s.T, dump, `runtimes.`+kataRuntimeHandler+`]`,
 		"expected the %q runtime handler in the effective containerd config.\nDump:\n%s", kataRuntimeHandler, dump)
 	assert.Contains(s.T, dump, `runtime_type = "io.containerd.kata.v2"`,
 		"expected the kata v2 shim runtime_type in the effective containerd config.\nDump:\n%s", dump)

--- a/e2e/validators_kata.go
+++ b/e2e/validators_kata.go
@@ -1,0 +1,258 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	nodev1 "k8s.io/api/node/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// kataRuntimeHandler is the containerd runtime handler name for standard Kata Containers,
+	// emitted by the IsKata block of the containerd config templates in pkg/agent/baker.go.
+	kataRuntimeHandler = "kata"
+	// kataCCRuntimeHandler is the containerd runtime handler name for Kata Confidential Containers.
+	kataCCRuntimeHandler = "kata-cc"
+
+	// kataConfigPath is the Kata configuration file referenced by the "kata" runtime handler's
+	// options.ConfigPath in the rendered containerd config.
+	kataConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
+	// kataCCConfigPath is the config referenced by the "kata-cc" runtime handler.
+	kataCCConfigPath = "/opt/confidential-containers/share/defaults/kata-containers/configuration-clh-snp.toml"
+	// kataPreviewConfigPath is the config referenced by the "kata-preview" runtime handler.
+	kataPreviewConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-templating.toml"
+
+	// containerdConfigPath is where CSE / aks-node-controller writes the rendered containerd config.
+	containerdConfigPath = "/etc/containerd/config.toml"
+)
+
+// ValidateKataContainerdConfig asserts that AgentBaker rendered a containerd configuration
+// containing the Kata runtime handlers on a Kata-enabled VHD.
+//
+// This is the core regression check for the IsKata blocks of the containerd config templates in
+// pkg/agent/baker.go. Note that AgentPoolProfile.IsContainerdV2Distro() returns false for every
+// Kata distro (pkg/agent/datamodel/types.go), so Kata nodes are always rendered from
+// containerdV1ConfigTemplate / containerdV1NoGPUConfigTemplate regardless of the underlying OS.
+// The assertions below therefore target the containerd 1.x plugin paths that those templates
+// emit. If Kata is ever promoted to the V2 templates, this validator should fail loudly rather
+// than silently pass, which is why the plugin paths are asserted explicitly.
+func ValidateKataContainerdConfig(ctx context.Context, s *Scenario) {
+	s.T.Helper()
+
+	require.True(s.T, s.VHD.Distro.IsKataDistro(),
+		"ValidateKataContainerdConfig requires a Kata distro, got %q", s.VHD.Distro)
+
+	// The standard "kata" runtime handler, backed by the kata v2 shim.
+	ValidateFileHasContent(ctx, s, containerdConfigPath, `[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]`)
+	ValidateFileHasContent(ctx, s, containerdConfigPath, `runtime_type = "io.containerd.kata.v2"`)
+	ValidateFileHasContent(ctx, s, containerdConfigPath, kataConfigPath)
+
+	// Kata relies on snapshot annotations being forwarded to the snapshotter; the template sets
+	// this explicitly under IsKata and disabling it breaks image pulling for Kata pods.
+	ValidateFileHasContent(ctx, s, containerdConfigPath, "disable_snapshot_annotations = false")
+
+	// The "kata-preview" handler shares the kata v2 shim but uses the erofs snapshotter and the
+	// cloud-hypervisor templating config.
+	ValidateFileHasContent(ctx, s, containerdConfigPath, `[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]`)
+	ValidateFileHasContent(ctx, s, containerdConfigPath, kataPreviewConfigPath)
+	ValidateFileHasContent(ctx, s, containerdConfigPath, `[plugins."io.containerd.snapshotter.v1.erofs"]`)
+	ValidateFileHasContent(ctx, s, containerdConfigPath, `[plugins."io.containerd.differ.v1.erofs"]`)
+
+	// kata-cc (confidential containers) handler and its tardev proxy snapshotter.
+	ValidateFileHasContent(ctx, s, containerdConfigPath, `[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-cc]`)
+	ValidateFileHasContent(ctx, s, containerdConfigPath, `runtime_type = "io.containerd.kata-cc.v2"`)
+	ValidateFileHasContent(ctx, s, containerdConfigPath, kataCCConfigPath)
+	ValidateFileHasContent(ctx, s, containerdConfigPath, "[proxy_plugins.tardev]")
+	ValidateFileHasContent(ctx, s, containerdConfigPath, "/run/containerd/tardev-snapshotter.sock")
+}
+
+// ValidateKataContainerdConfigDump asserts that containerd itself accepted the rendered
+// configuration and actually loaded the Kata runtime handlers.
+//
+// Checking the file alone is not enough. Kata VHDs ship their own containerd build - CSE skips
+// installing one (see the "azurelinuxkata" entries in parts/common/components.json) - so the
+// containerd major version on the node is decided by the image, not by AgentBaker. containerd
+// 1.x and 2.x use different plugin paths ("io.containerd.grpc.v1.cri" vs
+// "io.containerd.cri.v1.runtime"), and containerd silently ignores config under a path it does
+// not recognise. The result would be a node whose config.toml looks correct but where `kata` is
+// not a usable runtime handler.
+//
+// `containerd config dump` reflects the effective, parsed configuration and emits `level=warning`
+// lines for unknown or deprecated config, so it catches exactly that class of bug.
+func ValidateKataContainerdConfigDump(ctx context.Context, s *Scenario) {
+	s.T.Helper()
+
+	execResult := execOnVMForScenarioOnUnprivilegedPod(ctx, s, "containerd config dump")
+	require.Equal(s.T, "0", execResult.exitCode,
+		"containerd config dump failed.\nstdout:\n%s\nstderr:\n%s", execResult.stdout, execResult.stderr)
+
+	dump := execResult.stdout
+
+	// The effective config must expose both kata runtime handlers.
+	assert.Contains(s.T, dump, `runtimes.`+kataRuntimeHandler,
+		"expected the %q runtime handler in the effective containerd config.\nDump:\n%s", kataRuntimeHandler, dump)
+	assert.Contains(s.T, dump, `runtime_type = "io.containerd.kata.v2"`,
+		"expected the kata v2 shim runtime_type in the effective containerd config.\nDump:\n%s", dump)
+	assert.Contains(s.T, dump, `runtimes.`+kataCCRuntimeHandler,
+		"expected the %q runtime handler in the effective containerd config.\nDump:\n%s", kataCCRuntimeHandler, dump)
+
+	// A warning here means containerd did not understand part of the config we generated -
+	// most commonly because the kata blocks use containerd 1.x plugin paths in a 2.x config.
+	assert.NotContains(s.T, dump, "level=warning",
+		"containerd reported warnings while parsing the AgentBaker-generated config.\nDump:\n%s", dump)
+}
+
+// ValidateKataHostReadiness asserts the host-side prerequisites that the Kata VHD is expected to
+// ship and that the containerd config references. Without these, the containerd config would be
+// syntactically valid but the kata shim would fail at pod sandbox creation time.
+func ValidateKataHostReadiness(ctx context.Context, s *Scenario) {
+	s.T.Helper()
+
+	// The kata shim binary that runtime_type = "io.containerd.kata.v2" resolves to.
+	execScriptOnVMForScenarioValidateExitCode(ctx, s,
+		"command -v containerd-shim-kata-v2", 0, "containerd-shim-kata-v2 is not present on the Kata VHD")
+
+	// The Kata configuration file referenced by options.ConfigPath in the containerd config.
+	ValidateFileExists(ctx, s, kataConfigPath)
+
+	// Kata VHDs deliberately opt out of automatic package updates even when unattended upgrades
+	// are enabled, because kata packages must be updated as a unit (including the kernel, which
+	// requires a reboot). See the IS_KATA branch in parts/linux/cloud-init/artifacts/cse_main.sh.
+	// The scenario leaves unattended upgrades enabled so this branch is genuinely exercised.
+	execScriptOnVMForScenarioValidateExitCode(ctx, s,
+		"systemctl is-enabled dnf-automatic-install.timer", 1,
+		"dnf-automatic-install.timer must not be enabled on Kata VHDs: kata packages have to be updated as a unit via image updates")
+}
+
+// ValidateKataPodIsIsolated creates a RuntimeClass bound to the "kata" handler, schedules a pod
+// against it on the node under test, and asserts the pod is genuinely running inside a Kata VM.
+//
+// This is the end-to-end proof that the containerd config AgentBaker generated is not merely
+// syntactically present but actually usable: if the kata runtime handler were missing or
+// misconfigured, the kubelet would reject the pod with "RuntimeHandler not supported" and the
+// pod would never reach Running.
+//
+// Isolation itself is asserted by comparing kernel releases. A Kata pod boots its own guest
+// kernel, so it must report a different `uname -r` than the host; a matching value would mean
+// the pod silently fell back to the shared-kernel runc runtime.
+//
+// The RuntimeClass is pinned to this scenario's node via Scheduling.NodeSelector so it cannot
+// interfere with other scenarios running in parallel against the same cluster.
+func ValidateKataPodIsIsolated(ctx context.Context, s *Scenario) {
+	s.T.Helper()
+
+	hostKernel := strings.TrimSpace(
+		execScriptOnVMForScenarioValidateExitCode(ctx, s, "uname -r", 0, "unable to read host kernel release").stdout)
+	require.NotEmpty(s.T, hostKernel, "host kernel release was empty")
+
+	runtimeClassName := createKataRuntimeClass(ctx, s)
+	pod := createKataPod(ctx, s, runtimeClassName)
+
+	execResult, err := execOnPod(ctx, s.Runtime.Kube, pod.Namespace, pod.Name, []string{"uname", "-r"})
+	require.NoErrorf(s.T, err, "failed to exec in kata pod %q", pod.Name)
+	guestKernel := strings.TrimSpace(execResult.stdout)
+	require.NotEmpty(s.T, guestKernel, "kata guest kernel release was empty")
+
+	s.T.Logf("host kernel: %q, kata guest kernel: %q", hostKernel, guestKernel)
+	assert.NotEqual(s.T, hostKernel, guestKernel,
+		"pod running under the %q RuntimeClass reported the same kernel release as the host, "+
+			"which means it was not launched inside a Kata VM", kataRuntimeHandler)
+}
+
+// createKataRuntimeClass creates a RuntimeClass for the "kata" handler scoped to the scenario's
+// node and registers its cleanup. It returns the RuntimeClass name.
+func createKataRuntimeClass(ctx context.Context, s *Scenario) string {
+	s.T.Helper()
+
+	kube := s.Runtime.Kube
+	name := truncateKataResourceName(fmt.Sprintf("kata-%s", s.Runtime.VM.KubeName))
+
+	runtimeClass := &nodev1.RuntimeClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Handler:    kataRuntimeHandler,
+		Scheduling: &nodev1.Scheduling{
+			NodeSelector: map[string]string{"kubernetes.io/hostname": s.Runtime.VM.KubeName},
+		},
+	}
+
+	_, err := kube.Typed.NodeV1().RuntimeClasses().Create(ctx, runtimeClass, metav1.CreateOptions{})
+	require.NoErrorf(s.T, err, "failed to create RuntimeClass %q for handler %q", name, kataRuntimeHandler)
+
+	s.T.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		if err := kube.Typed.NodeV1().RuntimeClasses().Delete(cleanupCtx, name, metav1.DeleteOptions{}); err != nil {
+			s.T.Logf("could not delete RuntimeClass %s: %v", name, err)
+		}
+	})
+
+	return name
+}
+
+// createKataPod creates a long-lived pod bound to the given Kata RuntimeClass on the scenario's
+// node, waits for it to reach Running, and registers its cleanup. Unlike ValidatePodRunning the
+// pod is kept alive after this returns so callers can exec into it.
+func createKataPod(ctx context.Context, s *Scenario, runtimeClassName string) *corev1.Pod {
+	s.T.Helper()
+
+	kube := s.Runtime.Kube
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      truncateKataResourceName(fmt.Sprintf("%s-kata-pod", s.Runtime.VM.KubeName)),
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			RuntimeClassName: to.Ptr(runtimeClassName),
+			Containers: []corev1.Container{
+				{
+					Name:    "kata",
+					Image:   "mcr.microsoft.com/cbl-mariner/busybox:2.0",
+					Command: []string{"sh", "-c"},
+					Args:    []string{"sleep 3600"},
+				},
+			},
+			NodeSelector: map[string]string{
+				"kubernetes.io/hostname": s.Runtime.VM.KubeName,
+			},
+		},
+	}
+
+	s.T.Logf("creating pod %q under RuntimeClass %q", pod.Name, runtimeClassName)
+	_, err := kube.Typed.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+	require.NoErrorf(s.T, err, "failed to create kata pod %q", pod.Name)
+
+	s.T.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		err := kube.Typed.CoreV1().Pods(pod.Namespace).Delete(cleanupCtx, pod.Name, metav1.DeleteOptions{
+			GracePeriodSeconds: to.Ptr(int64(0)),
+		})
+		if err != nil {
+			s.T.Logf("could not delete pod %s: %v", pod.Name, err)
+		}
+	})
+
+	running, err := kube.WaitUntilPodRunning(ctx, pod.Namespace, "", "metadata.name="+pod.Name)
+	require.NoErrorf(s.T, err,
+		"kata pod %q never reached Running. This usually means containerd did not register the %q "+
+			"runtime handler from the AgentBaker-generated config", pod.Name, kataRuntimeHandler)
+
+	return running
+}
+
+// truncateKataResourceName keeps generated Kubernetes object names within the 63 character
+// DNS-1123 label limit.
+func truncateKataResourceName(name string) string {
+	const maxLen = 63
+	if len(name) <= maxLen {
+		return name
+	}
+	return strings.TrimRight(name[:maxLen], "-")
+}

--- a/e2e/validators_kata.go
+++ b/e2e/validators_kata.go
@@ -18,19 +18,24 @@ const (
 	// kataRuntimeHandler is the containerd runtime handler name for standard Kata Containers,
 	// emitted by the IsKata block of the containerd config templates in pkg/agent/baker.go.
 	kataRuntimeHandler = "kata"
-	// kataPreviewRuntimeHandler shares the kata v2 shim with kataRuntimeHandler but uses the
-	// erofs snapshotter and the cloud-hypervisor templating config.
-	kataPreviewRuntimeHandler = "kata-preview"
 
 	// kataConfigPath is the Kata configuration file referenced by the "kata" runtime handler's
 	// options.ConfigPath in the rendered containerd config.
 	kataConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
-	// kataPreviewConfigPath is the config referenced by the "kata-preview" runtime handler.
-	kataPreviewConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-templating.toml"
 
 	// containerdConfigPath is where CSE / aks-node-controller writes the rendered containerd config.
 	containerdConfigPath = "/etc/containerd/config.toml"
 )
+
+// kataRuntimeHandlers lists every Kata containerd runtime handler that this scenario expects to
+// be configured and usable on the node. Each one is asserted in the effective containerd config
+// and independently exercised by ValidateKataPodIsIsolated, so covering an additional handler is
+// a one-line change here plus a call in the scenario.
+//
+// Note that "kata-cc" (confidential containers) is intentionally absent: its handler block is
+// templated for all Kata VHDs, but it targets a different VHD than regular Kata, so this image
+// cannot actually run it.
+var kataRuntimeHandlers = []string{kataRuntimeHandler}
 
 // ValidateKataContainerdConfig asserts that AgentBaker rendered a containerd configuration
 // containing the Kata runtime handlers on a Kata-enabled VHD.
@@ -56,13 +61,6 @@ func ValidateKataContainerdConfig(ctx context.Context, s *Scenario) {
 	// Kata relies on snapshot annotations being forwarded to the snapshotter; the template sets
 	// this explicitly under IsKata and disabling it breaks image pulling for Kata pods.
 	ValidateFileHasContent(ctx, s, containerdConfigPath, "disable_snapshot_annotations = false")
-
-	// The "kata-preview" handler shares the kata v2 shim but uses the erofs snapshotter and the
-	// cloud-hypervisor templating config.
-	ValidateFileHasContent(ctx, s, containerdConfigPath, `[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]`)
-	ValidateFileHasContent(ctx, s, containerdConfigPath, kataPreviewConfigPath)
-	ValidateFileHasContent(ctx, s, containerdConfigPath, `[plugins."io.containerd.snapshotter.v1.erofs"]`)
-	ValidateFileHasContent(ctx, s, containerdConfigPath, `[plugins."io.containerd.differ.v1.erofs"]`)
 }
 
 // ValidateKataContainerdConfigDump asserts that containerd itself accepted the rendered
@@ -81,16 +79,23 @@ func ValidateKataContainerdConfig(ctx context.Context, s *Scenario) {
 func ValidateKataContainerdConfigDump(ctx context.Context, s *Scenario) {
 	s.T.Helper()
 
-	execResult := execOnVMForScenarioOnUnprivilegedPod(ctx, s, "containerd config dump")
-	require.Equal(s.T, "0", execResult.exitCode,
-		"containerd config dump failed.\nstdout:\n%s\nstderr:\n%s", execResult.stdout, execResult.stderr)
+	// This must run on the node itself, not in a debug pod. The "debugnonhost" daemonset pods
+	// used by execOnVMForScenarioOnUnprivilegedPod run a bare CBL-Mariner base image with no
+	// volume mounts, so the host's containerd binary is not reachable from them and the command
+	// would simply exit 127.
+	execResult := execScriptOnVMForScenarioValidateExitCode(ctx, s, "sudo containerd config dump", 0,
+		"unable to dump the effective containerd config on the node")
 
+	// The effective config is printed on stdout, but containerd logs diagnostics (including the
+	// "level=warning" lines we care about) on stderr, so both streams have to be inspected.
 	dump := execResult.stdout
+	diagnostics := execResult.stdout + "\n" + execResult.stderr
 
-	// The effective config must expose both kata runtime handlers. Note the trailing "]": without
-	// it, "runtimes.kata" would also match "runtimes.kata-preview" and pass even if the "kata"
-	// handler itself were missing.
-	for _, handler := range []string{kataRuntimeHandler, kataPreviewRuntimeHandler} {
+	// The effective config must expose every Kata runtime handler we expect. Note the trailing
+	// "]": without it a handler name would also match longer handlers sharing its prefix (e.g.
+	// "runtimes.kata" matching "runtimes.kata-preview") and pass even if the handler itself
+	// were missing.
+	for _, handler := range kataRuntimeHandlers {
 		assert.Contains(s.T, dump, `runtimes.`+handler+`]`,
 			"expected the %q runtime handler in the effective containerd config.\nDump:\n%s", handler, dump)
 	}
@@ -99,8 +104,9 @@ func ValidateKataContainerdConfigDump(ctx context.Context, s *Scenario) {
 
 	// A warning here means containerd did not understand part of the config we generated -
 	// most commonly because the kata blocks use containerd 1.x plugin paths in a 2.x config.
-	assert.NotContains(s.T, dump, "level=warning",
-		"containerd reported warnings while parsing the AgentBaker-generated config.\nDump:\n%s", dump)
+	assert.NotContains(s.T, diagnostics, "level=warning",
+		"containerd reported warnings while parsing the AgentBaker-generated config.\nstdout:\n%s\nstderr:\n%s",
+		execResult.stdout, execResult.stderr)
 }
 
 // ValidateKataHostReadiness asserts the host-side prerequisites that the Kata VHD is expected to

--- a/e2e/validators_kata.go
+++ b/e2e/validators_kata.go
@@ -18,6 +18,9 @@ const (
 	// kataRuntimeHandler is the containerd runtime handler name for standard Kata Containers,
 	// emitted by the IsKata block of the containerd config templates in pkg/agent/baker.go.
 	kataRuntimeHandler = "kata"
+	// kataPreviewRuntimeHandler shares the kata v2 shim with kataRuntimeHandler but uses the
+	// erofs snapshotter and the cloud-hypervisor templating config.
+	kataPreviewRuntimeHandler = "kata-preview"
 
 	// kataConfigPath is the Kata configuration file referenced by the "kata" runtime handler's
 	// options.ConfigPath in the rendered containerd config.
@@ -84,11 +87,13 @@ func ValidateKataContainerdConfigDump(ctx context.Context, s *Scenario) {
 
 	dump := execResult.stdout
 
-	// The effective config must expose the kata runtime handler. Note the trailing "]": without
-	// it this would also match "runtimes.kata-preview" and pass even if the "kata" handler
-	// itself were missing.
-	assert.Contains(s.T, dump, `runtimes.`+kataRuntimeHandler+`]`,
-		"expected the %q runtime handler in the effective containerd config.\nDump:\n%s", kataRuntimeHandler, dump)
+	// The effective config must expose both kata runtime handlers. Note the trailing "]": without
+	// it, "runtimes.kata" would also match "runtimes.kata-preview" and pass even if the "kata"
+	// handler itself were missing.
+	for _, handler := range []string{kataRuntimeHandler, kataPreviewRuntimeHandler} {
+		assert.Contains(s.T, dump, `runtimes.`+handler+`]`,
+			"expected the %q runtime handler in the effective containerd config.\nDump:\n%s", handler, dump)
+	}
 	assert.Contains(s.T, dump, `runtime_type = "io.containerd.kata.v2"`,
 		"expected the kata v2 shim runtime_type in the effective containerd config.\nDump:\n%s", dump)
 
@@ -120,11 +125,12 @@ func ValidateKataHostReadiness(ctx context.Context, s *Scenario) {
 		"dnf-automatic-install.timer must not be enabled on Kata VHDs: kata packages have to be updated as a unit via image updates")
 }
 
-// ValidateKataPodIsIsolated creates a RuntimeClass bound to the "kata" handler, schedules a pod
-// against it on the node under test, and asserts the pod is genuinely running inside a Kata VM.
+// ValidateKataPodIsIsolated creates a RuntimeClass bound to the given Kata runtime handler,
+// schedules a pod against it on the node under test, and asserts the pod is genuinely running
+// inside a Kata VM.
 //
 // This is the end-to-end proof that the containerd config AgentBaker generated is not merely
-// syntactically present but actually usable: if the kata runtime handler were missing or
+// syntactically present but actually usable: if the runtime handler were missing or
 // misconfigured, the kubelet would reject the pod with "RuntimeHandler not supported" and the
 // pod would never reach Running.
 //
@@ -133,16 +139,17 @@ func ValidateKataHostReadiness(ctx context.Context, s *Scenario) {
 // the pod silently fell back to the shared-kernel runc runtime.
 //
 // The RuntimeClass is pinned to this scenario's node via Scheduling.NodeSelector so it cannot
-// interfere with other scenarios running in parallel against the same cluster.
-func ValidateKataPodIsIsolated(ctx context.Context, s *Scenario) {
+// interfere with other scenarios running in parallel against the same cluster, and is named
+// after the handler so that several handlers can be validated on one node.
+func ValidateKataPodIsIsolated(ctx context.Context, s *Scenario, handler string) {
 	s.T.Helper()
 
 	hostKernel := strings.TrimSpace(
 		execScriptOnVMForScenarioValidateExitCode(ctx, s, "uname -r", 0, "unable to read host kernel release").stdout)
 	require.NotEmpty(s.T, hostKernel, "host kernel release was empty")
 
-	runtimeClassName := createKataRuntimeClass(ctx, s)
-	pod := createKataPod(ctx, s, runtimeClassName)
+	runtimeClassName := createKataRuntimeClass(ctx, s, handler)
+	pod := createKataPod(ctx, s, runtimeClassName, handler)
 
 	execResult, err := execOnPod(ctx, s.Runtime.Kube, pod.Namespace, pod.Name, []string{"uname", "-r"})
 	require.NoErrorf(s.T, err, "failed to exec in kata pod %q", pod.Name)
@@ -152,27 +159,27 @@ func ValidateKataPodIsIsolated(ctx context.Context, s *Scenario) {
 	s.T.Logf("host kernel: %q, kata guest kernel: %q", hostKernel, guestKernel)
 	assert.NotEqual(s.T, hostKernel, guestKernel,
 		"pod running under the %q RuntimeClass reported the same kernel release as the host, "+
-			"which means it was not launched inside a Kata VM", kataRuntimeHandler)
+			"which means it was not launched inside a Kata VM", handler)
 }
 
-// createKataRuntimeClass creates a RuntimeClass for the "kata" handler scoped to the scenario's
+// createKataRuntimeClass creates a RuntimeClass for the given handler scoped to the scenario's
 // node and registers its cleanup. It returns the RuntimeClass name.
-func createKataRuntimeClass(ctx context.Context, s *Scenario) string {
+func createKataRuntimeClass(ctx context.Context, s *Scenario, handler string) string {
 	s.T.Helper()
 
 	kube := s.Runtime.Kube
-	name := truncateKataResourceName(fmt.Sprintf("kata-%s", s.Runtime.VM.KubeName))
+	name := truncateKataResourceName(fmt.Sprintf("%s-%s", handler, s.Runtime.VM.KubeName))
 
 	runtimeClass := &nodev1.RuntimeClass{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Handler:    kataRuntimeHandler,
+		Handler:    handler,
 		Scheduling: &nodev1.Scheduling{
 			NodeSelector: map[string]string{"kubernetes.io/hostname": s.Runtime.VM.KubeName},
 		},
 	}
 
 	_, err := kube.Typed.NodeV1().RuntimeClasses().Create(ctx, runtimeClass, metav1.CreateOptions{})
-	require.NoErrorf(s.T, err, "failed to create RuntimeClass %q for handler %q", name, kataRuntimeHandler)
+	require.NoErrorf(s.T, err, "failed to create RuntimeClass %q for handler %q", name, handler)
 
 	s.T.Cleanup(func() {
 		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
@@ -188,20 +195,20 @@ func createKataRuntimeClass(ctx context.Context, s *Scenario) string {
 // createKataPod creates a long-lived pod bound to the given Kata RuntimeClass on the scenario's
 // node, waits for it to reach Running, and registers its cleanup. Unlike ValidatePodRunning the
 // pod is kept alive after this returns so callers can exec into it.
-func createKataPod(ctx context.Context, s *Scenario, runtimeClassName string) *corev1.Pod {
+func createKataPod(ctx context.Context, s *Scenario, runtimeClassName, handler string) *corev1.Pod {
 	s.T.Helper()
 
 	kube := s.Runtime.Kube
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      truncateKataResourceName(fmt.Sprintf("%s-kata-pod", s.Runtime.VM.KubeName)),
+			Name:      truncateKataResourceName(fmt.Sprintf("%s-%s-pod", s.Runtime.VM.KubeName, handler)),
 			Namespace: "default",
 		},
 		Spec: corev1.PodSpec{
 			RuntimeClassName: to.Ptr(runtimeClassName),
 			Containers: []corev1.Container{
 				{
-					Name:    "kata",
+					Name:    "workload",
 					Image:   "mcr.microsoft.com/cbl-mariner/busybox:2.0",
 					Command: []string{"sh", "-c"},
 					Args:    []string{"sleep 3600"},
@@ -231,7 +238,7 @@ func createKataPod(ctx context.Context, s *Scenario, runtimeClassName string) *c
 	running, err := kube.WaitUntilPodRunning(ctx, pod.Namespace, "", "metadata.name="+pod.Name)
 	require.NoErrorf(s.T, err,
 		"kata pod %q never reached Running. This usually means containerd did not register the %q "+
-			"runtime handler from the AgentBaker-generated config", pod.Name, kataRuntimeHandler)
+			"runtime handler from the AgentBaker-generated config", pod.Name, handler)
 
 	return running
 }

--- a/e2e/validators_kata.go
+++ b/e2e/validators_kata.go
@@ -68,14 +68,17 @@ func ValidateKataContainerdConfig(ctx context.Context, s *Scenario) {
 //
 // Checking the file alone is not enough. Kata VHDs ship their own containerd build - CSE skips
 // installing one (see the "azurelinuxkata" entries in parts/common/components.json) - so the
-// containerd major version on the node is decided by the image, not by AgentBaker. containerd
-// 1.x and 2.x use different plugin paths ("io.containerd.grpc.v1.cri" vs
-// "io.containerd.cri.v1.runtime"), and containerd silently ignores config under a path it does
-// not recognise. The result would be a node whose config.toml looks correct but where `kata` is
-// not a usable runtime handler.
+// containerd major version on the node is decided by the image, not by AgentBaker, while the
+// template AgentBaker renders is decided by the distro (IsContainerdV2Distro short-circuits to
+// the v1 template for every Kata distro). The two can therefore disagree: AzureLinux V3 Kata
+// currently boots containerd 2.x while being handed a containerd 1.x style config.
 //
-// `containerd config dump` reflects the effective, parsed configuration and emits `level=warning`
-// lines for unknown or deprecated config, so it catches exactly that class of bug.
+// That combination happens to work today because containerd 2.x migrates the legacy
+// "io.containerd.grpc.v1.cri" runtime handlers onto the current
+// "io.containerd.cri.v1.runtime" paths, but nothing guarantees it keeps doing so. This
+// validator pins the property we actually care about: after containerd has parsed the config,
+// the Kata handlers are present in the effective configuration and containerd raised no
+// warnings while getting there.
 func ValidateKataContainerdConfigDump(ctx context.Context, s *Scenario) {
 	s.T.Helper()
 
@@ -91,19 +94,24 @@ func ValidateKataContainerdConfigDump(ctx context.Context, s *Scenario) {
 	dump := execResult.stdout
 	diagnostics := execResult.stdout + "\n" + execResult.stderr
 
+	// "containerd config dump" re-serializes the config and quotes TOML strings with single
+	// quotes, whereas the config file AgentBaker generates uses double quotes. Normalize so the
+	// assertions below can be written the way the config file reads.
+	normalizedDump := strings.ReplaceAll(dump, "'", `"`)
+
 	// The effective config must expose every Kata runtime handler we expect. Note the trailing
 	// "]": without it a handler name would also match longer handlers sharing its prefix (e.g.
 	// "runtimes.kata" matching "runtimes.kata-preview") and pass even if the handler itself
 	// were missing.
 	for _, handler := range kataRuntimeHandlers {
-		assert.Contains(s.T, dump, `runtimes.`+handler+`]`,
+		assert.Contains(s.T, normalizedDump, `runtimes.`+handler+`]`,
 			"expected the %q runtime handler in the effective containerd config.\nDump:\n%s", handler, dump)
 	}
-	assert.Contains(s.T, dump, `runtime_type = "io.containerd.kata.v2"`,
+	assert.Contains(s.T, normalizedDump, `runtime_type = "io.containerd.kata.v2"`,
 		"expected the kata v2 shim runtime_type in the effective containerd config.\nDump:\n%s", dump)
 
-	// A warning here means containerd did not understand part of the config we generated -
-	// most commonly because the kata blocks use containerd 1.x plugin paths in a 2.x config.
+	// A warning here means containerd did not fully understand the config we generated, e.g. it
+	// had to fall back on deprecated handling for the legacy plugin paths the Kata templates use.
 	assert.NotContains(s.T, diagnostics, "level=warning",
 		"containerd reported warnings while parsing the AgentBaker-generated config.\nstdout:\n%s\nstderr:\n%s",
 		execResult.stdout, execResult.stderr)

--- a/e2e/validators_kata.go
+++ b/e2e/validators_kata.go
@@ -18,14 +18,10 @@ const (
 	// kataRuntimeHandler is the containerd runtime handler name for standard Kata Containers,
 	// emitted by the IsKata block of the containerd config templates in pkg/agent/baker.go.
 	kataRuntimeHandler = "kata"
-	// kataCCRuntimeHandler is the containerd runtime handler name for Kata Confidential Containers.
-	kataCCRuntimeHandler = "kata-cc"
 
 	// kataConfigPath is the Kata configuration file referenced by the "kata" runtime handler's
 	// options.ConfigPath in the rendered containerd config.
 	kataConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
-	// kataCCConfigPath is the config referenced by the "kata-cc" runtime handler.
-	kataCCConfigPath = "/opt/confidential-containers/share/defaults/kata-containers/configuration-clh-snp.toml"
 	// kataPreviewConfigPath is the config referenced by the "kata-preview" runtime handler.
 	kataPreviewConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-templating.toml"
 
@@ -64,13 +60,6 @@ func ValidateKataContainerdConfig(ctx context.Context, s *Scenario) {
 	ValidateFileHasContent(ctx, s, containerdConfigPath, kataPreviewConfigPath)
 	ValidateFileHasContent(ctx, s, containerdConfigPath, `[plugins."io.containerd.snapshotter.v1.erofs"]`)
 	ValidateFileHasContent(ctx, s, containerdConfigPath, `[plugins."io.containerd.differ.v1.erofs"]`)
-
-	// kata-cc (confidential containers) handler and its tardev proxy snapshotter.
-	ValidateFileHasContent(ctx, s, containerdConfigPath, `[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-cc]`)
-	ValidateFileHasContent(ctx, s, containerdConfigPath, `runtime_type = "io.containerd.kata-cc.v2"`)
-	ValidateFileHasContent(ctx, s, containerdConfigPath, kataCCConfigPath)
-	ValidateFileHasContent(ctx, s, containerdConfigPath, "[proxy_plugins.tardev]")
-	ValidateFileHasContent(ctx, s, containerdConfigPath, "/run/containerd/tardev-snapshotter.sock")
 }
 
 // ValidateKataContainerdConfigDump asserts that containerd itself accepted the rendered
@@ -95,13 +84,11 @@ func ValidateKataContainerdConfigDump(ctx context.Context, s *Scenario) {
 
 	dump := execResult.stdout
 
-	// The effective config must expose both kata runtime handlers.
+	// The effective config must expose the kata runtime handler.
 	assert.Contains(s.T, dump, `runtimes.`+kataRuntimeHandler,
 		"expected the %q runtime handler in the effective containerd config.\nDump:\n%s", kataRuntimeHandler, dump)
 	assert.Contains(s.T, dump, `runtime_type = "io.containerd.kata.v2"`,
 		"expected the kata v2 shim runtime_type in the effective containerd config.\nDump:\n%s", dump)
-	assert.Contains(s.T, dump, `runtimes.`+kataCCRuntimeHandler,
-		"expected the %q runtime handler in the effective containerd config.\nDump:\n%s", kataCCRuntimeHandler, dump)
 
 	// A warning here means containerd did not understand part of the config we generated -
 	// most commonly because the kata blocks use containerd 1.x plugin paths in a 2.x config.

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -252,6 +252,7 @@ var AKSDistrosAvailableOnVHD = []Distro{
 	AKSAzureLinuxV3Gen2FIPS,
 	AKSCBLMarinerV2Gen2Kata,
 	AKSAzureLinuxV2Gen2Kata,
+	AKSAzureLinuxV3Gen2Kata,
 	AKSCBLMarinerV2Gen2TL,
 	AKSAzureLinuxV2Gen2TL,
 	AKSAzureLinuxV3Gen2TL,

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -252,7 +252,6 @@ var AKSDistrosAvailableOnVHD = []Distro{
 	AKSAzureLinuxV3Gen2FIPS,
 	AKSCBLMarinerV2Gen2Kata,
 	AKSAzureLinuxV2Gen2Kata,
-	AKSAzureLinuxV3Gen2Kata,
 	AKSCBLMarinerV2Gen2TL,
 	AKSAzureLinuxV2Gen2TL,
 	AKSAzureLinuxV3Gen2TL,


### PR DESCRIPTION
**What this PR does / why we need it**:

AgentBaker has no E2E coverage for Kata Containers today (`grep -ri kata e2e/` returns nothing), even though Kata VHDs are built and shipped by this repo.

Because Kata is a *runtime*, the thing that can silently break is the containerd configuration. `pkg/agent/baker.go` only emits the Kata runtime handler block when the agent pool's `Distro` satisfies `Distro.IsKataDistro()`, and nothing verified that the result is actually usable on the node.

This adds `Test_AzureLinuxV3Gen2Kata`, which asserts three increasingly strong properties:

1. **Rendered config** — `/etc/containerd/config.toml` carries the `kata` handler block, the kata v2 shim `runtime_type`, and `disable_snapshot_annotations = false`.
2. **Effective config** — `containerd config dump`, run over SSH on the node, shows the handler in the *parsed* config and emits no `level=warning` on either stdout or stderr.
3. **End-to-end** — for every handler in `kataRuntimeHandlers`, a pod scheduled through a Kata `RuntimeClass` reaches Running and is genuinely VM-isolated (guest `uname -r` differs from the host's). Reaching Running proves the handler is registered with CRI; the kernel comparison proves the pod did not silently fall back to shared-kernel runc.

Verified against a real E2E run (build 175521223): the node bootstrapped, the kata handler was present in the effective config, and the Kata pod ran with guest kernel `6.6.137.mshv1-1.azl3` vs host `6.6.137.mshv2-1.azl3`.

Selecting a Kata VHD flows through `e2e/node_config.go` -> `AgentPoolProfile.Distro` -> the `IsKata` template func, so the scenario exercises that whole path against a real node. The PR is purely additive to `e2e/`.

Additionally, `nbcToAKSNodeConfigV1` now derives `Configuration.IsKata` from the distro. The aks-node-controller path gates its Kata containerd blocks on that proto field alone, while the NBC/baker path uses the distro, and nothing connected the two. This is inert for existing scenarios, since `nbcToAKSNodeConfigV1` only runs when a scenario sets `AKSNodeConfigMutator`.

**Why step 2 exists, and what it does and does not prove**

Kata VHDs ship their own containerd (CSE skips installing one — see the `azurelinuxkata` `<SKIP>` entries in `parts/common/components.json`), so the containerd *version* is decided by the image, while the *template* is decided by the distro (`IsContainerdV2Distro` short-circuits to the v1 template for every Kata distro). These disagree today: AzureLinux V3 Kata boots containerd 2.x while being handed a containerd 1.x style config.

The E2E run shows that combination currently works, because containerd 2.x migrates the legacy `io.containerd.grpc.v1.cri` runtime handlers onto the current `io.containerd.cri.v1.runtime` paths, and raises no warnings doing so. So this is a fragility rather than a live bug. Step 2 pins the property we actually care about — after parsing, the handlers are present and containerd was not unhappy — so that if that migration behaviour ever changes, it is caught here rather than in production.

**Scope and known gaps**

- **`kata-cc`** is intentionally not covered: its handler block is templated for all Kata VHDs, but it targets a different VHD than regular Kata, so this image cannot run it.
- **`kata-preview`** is intentionally not covered, as the change adding it to the containerd config was reverted. The validators and scenario are driven by the `kataRuntimeHandlers` list, so re-adding it is a one-line change. Note that re-adding it will also need VHD-side artifacts (`configuration-clh-templating.toml`, `mkfs.erofs`) present in the Kata VHD that E2E resolves; see the note on VHD/code skew below.
- **The aks-node-controller containerd templates (`aks-node-controller/parser/templates/*.gtpl`) are not exercised.** This scenario renders from `baker.go`'s inline templates. Worth flagging for anyone planning to close that gap: `Tags.Scriptless` is referenced in exactly one place (`test_helpers.go:307`), where it only guards a redundant re-set of `EnableScriptlessNBCCSECmd`, which `RunScenario` already sets for every Linux scenario. Since the aks-node-controller prefers `--nbc-cmd` over `--provision-config` (`aks-node-controller/app.go:636`), simply adding an `AKSNodeConfigMutator` + `Tags.Scriptless` scenario does **not** appear sufficient to reach those templates. The `IsKata` mapping above is the groundwork, but the harness likely needs a way to suppress `EnableScriptlessNBCCSECmd` first.
- **VHD/code skew**: E2E compiles baker and aks-node-controller from the PR (`replace` directives in `e2e/go.mod`), but resolves node images from the SIG. With no `VHD_BUILD_ID` it uses the latest `branch=refs/heads/main` image, so config-template changes are validated immediately while VHD-content changes are not. The Linux VHD PR gate does not build a Kata VHD, and its E2E stage sets `IgnoreScenariosWithMissingVhd: true`, so this scenario skips there rather than failing.

Each `RuntimeClass` is named after its handler and pinned to the scenario's node via `Scheduling.NodeSelector`, since `RuntimeClass` is cluster-scoped and e2e scenarios run in parallel against a shared cluster.

**Notes for reviewers**

- The scenario uses `Standard_D4ds_v5` (nested virtualization plus headroom over the 2-vCPU e2e default) and deliberately leaves unattended upgrades enabled so CSE's Kata-specific opt-out branch (`cse_main.sh`) is genuinely exercised rather than passing vacuously.
- **Related pre-existing bug, documented via TODO rather than fixed here**: `ValidateContainerd2Properties` runs `containerd config dump` through `execOnVMForScenarioOnUnprivilegedPod`, i.e. inside the `debugnonhost` daemonset pod. That pod is a bare CBL-Mariner base image with no volume mounts, so `containerd` is unreachable and the command exits 127. Since that validator never checks the exit code and `attemptExecOnPod` returns no error for non-zero exits, its `level=warning` assertion has been passing vacuously at all 11 call sites.

**Which issue(s) this PR fixes**:

N/A