### PR TITLE
fix: revert "feat: add erofs snapshotter configuration for new kata-preview runtime class (#9085)

### DIFF
--- a/aks-node-controller/parser/templates/containerd.toml.gtpl
+++ b/aks-node-controller/parser/templates/containerd.toml.gtpl
@@ -1,27 +1,12 @@
 version = 2
 oom_score = -999{{if getHasDataDir .KubeletConfig}}
 root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
-{{- if .GetIsKata }}
-[plugins."io.containerd.snapshotter.v1.erofs"]
-  default_size = "10G"
-  enable_fsverity = false
-  ovl_mount_options = []
-  max_unmerged_layers = 1
-
-[plugins."io.containerd.service.v1.diff-service"]
-  default = ["erofs", "walking"]
-
-[plugins."io.containerd.differ.v1.erofs"]
-  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
-  enable_tar_index = false
-{{- end}}
 [plugins."io.containerd.grpc.v1.cri"]
   sandbox_image = "{{ .KubeBinaryConfig.GetPodInfraContainerImageUrl }}"
   enable_cdi = true
   [plugins."io.containerd.grpc.v1.cri".containerd]
     {{- if .GetIsKata }}
     disable_snapshot_annotations = false
-    snapshotter = "overlayfs"
     {{- end}}
     {{- if .GetEnableArtifactStreaming }}
     snapshotter = "overlaybd"
@@ -77,7 +62,6 @@ root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
 {{- if .GetIsKata }}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
-  snapshotter = "overlayfs"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.katacli]
   runtime_type = "io.containerd.runc.v1"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.katacli.options]
@@ -90,12 +74,6 @@ root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
   Root = ""
   CriuPath = ""
   SystemdCgroup = false
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
-  runtime_type = "io.containerd.kata.v2"
-  privileged_without_host_devices = true
-  snapshotter = "erofs"
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
-    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-templating.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"

--- a/aks-node-controller/parser/templates/containerd_no_GPU.toml.gtpl
+++ b/aks-node-controller/parser/templates/containerd_no_GPU.toml.gtpl
@@ -1,26 +1,11 @@
 version = 2
 oom_score = -999{{if getHasDataDir .KubeletConfig}}
 root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
-{{- if .GetIsKata }}
-[plugins."io.containerd.snapshotter.v1.erofs"]
-  default_size = "10G"
-  enable_fsverity = false
-  ovl_mount_options = []
-  max_unmerged_layers = 1
-
-[plugins."io.containerd.service.v1.diff-service"]
-  default = ["erofs", "walking"]
-
-[plugins."io.containerd.differ.v1.erofs"]
-  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
-  enable_tar_index = false
-{{- end}}
 [plugins."io.containerd.grpc.v1.cri"]
   sandbox_image = "{{ .KubeBinaryConfig.GetPodInfraContainerImageUrl }}"
   [plugins."io.containerd.grpc.v1.cri".containerd]
     {{- if .GetIsKata }}
     disable_snapshot_annotations = false
-    snapshotter = "overlayfs"
     {{- end}}
     {{- if .GetEnableArtifactStreaming }}
     snapshotter = "overlaybd"
@@ -61,7 +46,6 @@ root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
 {{- if .GetIsKata }}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
-  snapshotter = "overlayfs"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.katacli]
   runtime_type = "io.containerd.runc.v1"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.katacli.options]
@@ -74,12 +58,6 @@ root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
   Root = ""
   CriuPath = ""
   SystemdCgroup = false
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
-  runtime_type = "io.containerd.kata.v2"
-  privileged_without_host_devices = true
-  snapshotter = "erofs"
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
-    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-templating.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"

--- a/aks-node-controller/parser/templates/containerd_v2.toml.gtpl
+++ b/aks-node-controller/parser/templates/containerd_v2.toml.gtpl
@@ -1,20 +1,6 @@
 version = 2
 oom_score = -999{{if getHasDataDir .KubeletConfig}}
 root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
-{{- if .GetIsKata }}
-[plugins."io.containerd.snapshotter.v1.erofs"]
-  default_size = "10G"
-  enable_fsverity = false
-  ovl_mount_options = []
-  max_unmerged_layers = 1
-
-[plugins."io.containerd.service.v1.diff-service"]
-  default = ["erofs", "walking"]
-
-[plugins."io.containerd.differ.v1.erofs"]
-  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
-  enable_tar_index = false
-{{- end}}
 [plugins."io.containerd.cri.v1.images"]
 {{- if .GetEnableArtifactStreaming }}
   snapshotter = "overlaybd"
@@ -70,15 +56,8 @@ root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
   privileged_without_host_devices = true
-  snapshotter = "overlayfs"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
     ConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
-  runtime_type = "io.containerd.kata.v2"
-  privileged_without_host_devices = true
-  snapshotter = "erofs"
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
-    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-templating.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"

--- a/aks-node-controller/parser/templates/containerd_v2_no_GPU.toml.gtpl
+++ b/aks-node-controller/parser/templates/containerd_v2_no_GPU.toml.gtpl
@@ -1,20 +1,6 @@
 version = 2
 oom_score = -999{{if getHasDataDir .KubeletConfig}}
 root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
-{{- if .GetIsKata }}
-[plugins."io.containerd.snapshotter.v1.erofs"]
-  default_size = "10G"
-  enable_fsverity = false
-  ovl_mount_options = []
-  max_unmerged_layers = 1
-
-[plugins."io.containerd.service.v1.diff-service"]
-  default = ["erofs", "walking"]
-
-[plugins."io.containerd.differ.v1.erofs"]
-  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
-  enable_tar_index = false
-{{- end}}
 [plugins."io.containerd.cri.v1.images"]
 {{- if .GetEnableArtifactStreaming }}
   snapshotter = "overlaybd"
@@ -57,15 +43,8 @@ root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
   privileged_without_host_devices = true
-  snapshotter = "overlayfs"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
     ConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
-  runtime_type = "io.containerd.kata.v2"
-  privileged_without_host_devices = true
-  snapshotter = "erofs"
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
-    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-templating.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -1890,27 +1890,12 @@ const (
 	containerdV1ConfigTemplate ContainerdConfigTemplate = `version = 2
 oom_score = -999{{if HasDataDir }}
 root = "{{GetDataDir}}"{{- end}}
-{{- if IsKata }}
-[plugins."io.containerd.snapshotter.v1.erofs"]
-  default_size = "10G"
-  enable_fsverity = false
-  ovl_mount_options = []
-  max_unmerged_layers = 1
-
-[plugins."io.containerd.service.v1.diff-service"]
-  default = ["erofs", "walking"]
-
-[plugins."io.containerd.differ.v1.erofs"]
-  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
-  enable_tar_index = false
-{{- end}}
 [plugins."io.containerd.grpc.v1.cri"]
   sandbox_image = "{{GetPodInfraContainerSpec}}"
   enable_cdi = true
   [plugins."io.containerd.grpc.v1.cri".containerd]
     {{- if IsKata }}
     disable_snapshot_annotations = false
-    snapshotter = "overlayfs"
     {{- end}}
     {{- if IsArtifactStreamingEnabled }}
     snapshotter = "overlaybd"
@@ -1967,15 +1952,8 @@ root = "{{GetDataDir}}"{{- end}}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
   privileged_without_host_devices = true
-  snapshotter = "overlayfs"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
     ConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
-  runtime_type = "io.containerd.kata.v2"
-  privileged_without_host_devices = true
-  snapshotter = "erofs"
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
-    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-templating.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"
@@ -1992,20 +1970,6 @@ root = "{{GetDataDir}}"{{- end}}
 	containerdV2ConfigTemplate ContainerdConfigTemplate = `version = 2
 oom_score = -999{{if HasDataDir }}
 root = "{{GetDataDir}}"{{- end}}
-{{- if IsKata }}
-[plugins."io.containerd.snapshotter.v1.erofs"]
-  default_size = "10G"
-  enable_fsverity = false
-  ovl_mount_options = []
-  max_unmerged_layers = 1
-
-[plugins."io.containerd.service.v1.diff-service"]
-  default = ["erofs", "walking"]
-
-[plugins."io.containerd.differ.v1.erofs"]
-  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
-  enable_tar_index = false
-{{- end}}
 [plugins."io.containerd.cri.v1.images"]
 {{- if IsArtifactStreamingEnabled }}
   snapshotter = "overlaybd"
@@ -2061,15 +2025,8 @@ root = "{{GetDataDir}}"{{- end}}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
   privileged_without_host_devices = true
-  snapshotter = "overlayfs"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
     ConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
-  runtime_type = "io.containerd.kata.v2"
-  privileged_without_host_devices = true
-  snapshotter = "erofs"
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
-    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-templating.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"
@@ -2086,20 +2043,6 @@ root = "{{GetDataDir}}"{{- end}}
 	containerdV2NoGPUConfigTemplate ContainerdConfigTemplate = `version = 2
 oom_score = -999{{if HasDataDir }}
 root = "{{GetDataDir}}"{{- end}}
-{{- if IsKata }}
-[plugins."io.containerd.snapshotter.v1.erofs"]
-  default_size = "10G"
-  enable_fsverity = false
-  ovl_mount_options = []
-  max_unmerged_layers = 1
-
-[plugins."io.containerd.service.v1.diff-service"]
-  default = ["erofs", "walking"]
-
-[plugins."io.containerd.differ.v1.erofs"]
-  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
-  enable_tar_index = false
-{{- end}}
 [plugins."io.containerd.cri.v1.images"]
 {{- if IsArtifactStreamingEnabled }}
   snapshotter = "overlaybd"
@@ -2142,15 +2085,8 @@ root = "{{GetDataDir}}"{{- end}}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
   privileged_without_host_devices = true
-  snapshotter = "overlayfs"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
     ConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
-  runtime_type = "io.containerd.kata.v2"
-  privileged_without_host_devices = true
-  snapshotter = "erofs"
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
-    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-templating.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"
@@ -2160,26 +2096,11 @@ root = "{{GetDataDir}}"{{- end}}
 	containerdV1NoGPUConfigTemplate ContainerdConfigTemplate = `version = 2
 oom_score = -999{{if HasDataDir }}
 root = "{{GetDataDir}}"{{- end}}
-{{- if IsKata }}
-[plugins."io.containerd.snapshotter.v1.erofs"]
-  default_size = "10G"
-  enable_fsverity = false
-  ovl_mount_options = []
-  max_unmerged_layers = 1
-
-[plugins."io.containerd.service.v1.diff-service"]
-  default = ["erofs", "walking"]
-
-[plugins."io.containerd.differ.v1.erofs"]
-  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
-  enable_tar_index = false
-{{- end}}
 [plugins."io.containerd.grpc.v1.cri"]
   sandbox_image = "{{GetPodInfraContainerSpec}}"
   [plugins."io.containerd.grpc.v1.cri".containerd]
     {{- if IsKata }}
     disable_snapshot_annotations = false
-    snapshotter = "overlayfs"
     {{- end}}
     {{- if IsArtifactStreamingEnabled }}
     snapshotter = "overlaybd"
@@ -2221,15 +2142,8 @@ root = "{{GetDataDir}}"{{- end}}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
   privileged_without_host_devices = true
-  snapshotter = "overlayfs"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
     ConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
-  runtime_type = "io.containerd.kata.v2"
-  privileged_without_host_devices = true
-  snapshotter = "erofs"
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
-    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-templating.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"


### PR DESCRIPTION
This reverts commit f1581afd02d317f7d65f2b3a5de3ff0fbca6596b.

```
containerd.log — CRI plugin never loads

containerd 2.2.4 starts, but the erofs differ can't initialize:

level=info  msg="skip loading plugin"
  error="failed to check mkfs.erofs availability: failed to run mkfs.erofs --help:
         exec: \"mkfs.erofs\": executable file not found in $PATH: skip plugin"
  id=io.containerd.differ.v1.erofs

That cascades through every dependent plugin —  needed differ not loaded: erofs :

┌─────────────────────────────────────┬──────────────────────────┐
│ Failed plugin                       │ Consequence              │
├─────────────────────────────────────┼──────────────────────────┤
│ service.v1.diff-service             │ diff unavailable         │
├─────────────────────────────────────┼──────────────────────────┤
│ grpc.v1.diff                        │ —                        │
├─────────────────────────────────────┼──────────────────────────┤
│ cri.v1.images                       │ CRI image service dead   │
├─────────────────────────────────────┼──────────────────────────┤
│ podsandbox.controller.v1.podsandbox │ no pod sandboxes         │
├─────────────────────────────────────┼──────────────────────────┤
│ grpc.v1.sandbox-controllers         │ —                        │
├─────────────────────────────────────┼──────────────────────────┤
│ monitor.container.v1.restart        │ —                        │
├─────────────────────────────────────┼──────────────────────────┤
│ grpc.v1.cri                         │ CRI API never registered │
└─────────────────────────────────────┴──────────────────────────┘

level=warning msg="failed to load plugin"
  error="unable to load CRI image service plugin dependency: unable to init client
         for cri image service: failed to get service plugin: needed differ not loaded: erofs"
  id=io.containerd.grpc.v1.cri

Crucially, containerd then reports  containerd successfully booted in 0.079117s  and systemd marks it  Started . It serves the socket — just without CRI. This is why CSE exits 0 and the failure is invisible to node bootstrap.

The trigger is in the CRI config: the  kata-preview  runtime is configured with  "snapshotter":"erofs" , but the VHD never installs  erofs-utils  (which provides  mkfs.erofs ). The erofs snapshotter loads fine; the differ is what needs the binary.

kubelet.log — 298 crash loops

Every kubelet start dies instantly:

E0806 01:38:19.492121 run.go:72] "command failed"
  err="failed to run Kubelet: validate service connection:
       validate CRI v1 runtime API for endpoint \"unix:///run/containerd/containerd.sock\":
       rpc error: code = Unimplemented desc = unknown service runtime.v1.RuntimeService"
systemd[1]: kubelet.service: Main process exited, code=exited, status=1/FAILURE

298 restarts between  01:38:19  and  01:49:27 , identical error each time.

This closes the loop on build 175410680

mkfs.erofs missing  →  erofs differ skipped  →  containerd CRI plugin fails
   →  containerd still "boots successfully" (CSE exit 0 ✓)
   →  kubelet: Unimplemented runtime.v1.RuntimeService  →  crash-loops 298×
   →  node never registers  →  RP: "Expected: 2, registered: 0"
   →  CreateManagedCluster times out at 30:00  →  all 16 Kata sessions fail

It also explains the earlier telemetry precisely:  ExitCode 0 ,  KubeletStartTime  set,  KubeletReadyTime  never set.

Actions

2. Fix in AgentBaker: add  erofs-utils  to the AzureLinux V3 Kata VHD package list, or drop the  erofs  snapshotter from the  kata-preview  runtime config until the dependency ships.
```