### PR TITLE
fix: enable ip connect in bastion, something changed recently causing us to need it

### DIFF
--- a/e2e/shared_infra.go
+++ b/e2e/shared_infra.go
@@ -331,6 +331,7 @@ func ensureSharedBastion(ctx context.Context, rg, location string) (string, erro
 		},
 		Properties: &armnetwork.BastionHostPropertiesFormat{
 			EnableTunneling: to.Ptr(true),
+			EnableIPConnect: to.Ptr(true),
 			IPConfigurations: []*armnetwork.BastionHostIPConfiguration{
 				{
 					Name: to.Ptr("bastion-ipcfg"),


### PR DESCRIPTION
Recently we started running into this

`failed to start bastion tunnel: error creating tunnel: 403`

Seems like we need to enable ip connect, may be some policy or bug fix on bastion side