### PR TITLE
fix(gpu): tolerate nvidia-cdi-refresh starting before the driver is ready

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1467,72 +1467,89 @@ installGPUDriverImage() {
     retrycmd_if_failure 5 10 600 bash -c "$CTR_GPU_INSTALL_CMD $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG gpuinstall /entrypoint.sh install"
 }
 
-NVIDIA_CDI_REFRESH_SERVICE_DROP_IN="/etc/systemd/system/nvidia-cdi-refresh.service.d/10-aks-driver-not-ready.conf"
-NVIDIA_CDI_REFRESH_PATH_DROP_IN="/etc/systemd/system/nvidia-cdi-refresh.path.d/10-aks-driver-not-ready.conf"
+NVIDIA_CDI_REFRESH_SERVICE_DROP_IN="/etc/systemd/system/nvidia-cdi-refresh.service.d/10-aks-cdi-refresh.conf"
+NVIDIA_CDI_REFRESH_PATH_DROP_IN="/etc/systemd/system/nvidia-cdi-refresh.path.d/10-aks-cdi-refresh.conf"
 
-# nvidia-container-toolkit's post-install enables and immediately starts
-# nvidia-cdi-refresh.{service,path} from inside the aks-gpu install container, before the
-# AKS-managed driver userspace has been staged onto the host. nvidia-ctk then runs with no
-# nvidia-smi and no libnvidia-ml.so and exits non-zero, systemd burns the unit's start limit
-# retrying, and both units settle into a failed state. Newer aks-gpu images react to that by
-# running "systemctl restart nvidia-cdi-refresh.service" under `set -o errexit`, which turns a
-# cosmetic failed unit into an aborted driver install and CSE exit ERR_GPU_DRIVERS_START_FAIL.
+# $1: "true" to add ExecCondition=/bin/false, which makes systemd skip the unit and report the
+# job as successful without ever running nvidia-ctk. "false" lets the unit run normally.
 #
-# Stage the drop-ins before the install so that premature run is tolerated rather than fatal.
-# systemd resolves drop-ins when the unit is loaded, so writing them before the units exist is
-# the point: the toolkit's very first start already picks them up. finalizeNvidiaCDIRefresh
-# removes them and generates the spec for real once the driver is actually usable, so this
-# defers the verdict on CDI health instead of suppressing it.
-stageNvidiaCDIRefreshDropIns() {
+# Restart=no plus an unlimited start-limit window stop the restart storm that otherwise leaves
+# nvidia-cdi-refresh.path dead with unit-start-limit-hit. SuccessExitStatus covers the nvidia-ctk
+# exits seen on healthy AKS nodes: 1 (spec generation refused), 2 (Go runtime crash against a
+# partially loaded driver) and 127 (nvidia-smi / libnvidia-ml.so not on the host yet).
+writeNvidiaCDIRefreshDropIns() {
+    local skip_run="$1"
+
     mkdir -p "$(dirname "$NVIDIA_CDI_REFRESH_SERVICE_DROP_IN")" "$(dirname "$NVIDIA_CDI_REFRESH_PATH_DROP_IN")" || return 1
 
-    # Restart=no plus an unlimited start-limit window stops the restart storm that leaves the
-    # .path unit dead with unit-start-limit-hit. SuccessExitStatus covers nvidia-ctk missing
-    # entirely (127) and failing to build a spec (1), which are the two driver-not-ready modes.
-    cat > "$NVIDIA_CDI_REFRESH_SERVICE_DROP_IN" <<'EOF' || return 1
-[Unit]
-StartLimitIntervalSec=0
+    {
+        printf '[Unit]\nStartLimitIntervalSec=0\n\n[Service]\nRestart=no\nSuccessExitStatus=1 2 127\n'
+        if [ "$skip_run" = "true" ]; then
+            printf 'ExecCondition=/bin/false\n'
+        fi
+    } > "$NVIDIA_CDI_REFRESH_SERVICE_DROP_IN" || return 1
 
-[Service]
-Restart=no
-SuccessExitStatus=1 127
-EOF
-
-    cat > "$NVIDIA_CDI_REFRESH_PATH_DROP_IN" <<'EOF' || return 1
-[Unit]
-StartLimitIntervalSec=0
-EOF
+    printf '[Unit]\nStartLimitIntervalSec=0\n' > "$NVIDIA_CDI_REFRESH_PATH_DROP_IN" || return 1
 
     systemctl daemon-reload || return 1
     return 0
 }
 
-# Undo stageNvidiaCDIRefreshDropIns and produce a real CDI spec now that nvidia-smi and
-# ldconfig have succeeded. Any failure here is a genuine CDI failure, not a startup race.
+# nvidia-container-toolkit's post-install enables and immediately starts
+# nvidia-cdi-refresh.{service,path} from inside the aks-gpu install container, before the
+# AKS-managed driver userspace has been staged onto the host, so nvidia-ctk runs against a
+# half-installed driver and fails. Newer aks-gpu images then run
+# "systemctl restart nvidia-cdi-refresh.service" under `set -o errexit`, which turns that failed
+# unit into an aborted driver install and CSE exit ERR_GPU_DRIVERS_START_FAIL.
+#
+# Stage the skip drop-in before the install so the premature run is a no-op rather than fatal.
+# systemd resolves drop-ins at unit load time, so writing them before the units exist is the
+# point: the toolkit's very first start already picks them up. finalizeNvidiaCDIRefresh then
+# generates the spec for real once the driver is usable, so this defers the verdict on CDI
+# health rather than suppressing it.
+stageNvidiaCDIRefreshDropIns() {
+    writeNvidiaCDIRefreshDropIns true
+}
+
+# Generate the CDI spec now that nvidia-smi and ldconfig have succeeded.
+#
+# This deliberately never fails node provisioning. nvidia-ctk cannot produce a spec on every
+# healthy GPU node: an A100 whose MIG mode bit is set with no MIG instances configured (a
+# persistent state inherited from the physical card, unrelated to whether AKS asked for MIG)
+# makes the generated "nvidia.com/gpu=all" device carry empty edits, which nvidia-ctk rejects.
+# CDI is not the path AKS GPU workloads take today -- the nvidia container runtime hook is --
+# so a node that cannot build a spec is still a working GPU node. On that path we leave the
+# tolerant drop-in installed so the .path unit keeps retrying generation (it will succeed if MIG
+# instances appear later) without ever parking the units in a failed state.
 finalizeNvidiaCDIRefresh() {
     local load_state=""
-
-    rm -f "$NVIDIA_CDI_REFRESH_SERVICE_DROP_IN" "$NVIDIA_CDI_REFRESH_PATH_DROP_IN" || return 1
-    rmdir "$(dirname "$NVIDIA_CDI_REFRESH_SERVICE_DROP_IN")" "$(dirname "$NVIDIA_CDI_REFRESH_PATH_DROP_IN")" 2>/dev/null
-    systemctl daemon-reload || return 1
 
     # VHDs whose toolkit predates the CDI refresh units have nothing to reconcile. Treat that as
     # success so older images keep provisioning (6-month VHD support window).
     load_state=$(systemctl show --property=LoadState --value nvidia-cdi-refresh.service 2>/dev/null)
     if [ "$load_state" != "loaded" ]; then
         echo "nvidia-cdi-refresh.service not present (LoadState=${load_state:-unknown}), skipping CDI refresh"
+        rm -f "$NVIDIA_CDI_REFRESH_SERVICE_DROP_IN" "$NVIDIA_CDI_REFRESH_PATH_DROP_IN"
+        systemctl daemon-reload || return 1
         return 0
     fi
 
-    # The units are failed from the premature run; clear that before the authoritative attempt.
+    # Drop ExecCondition so the unit actually runs, but keep the failure tolerance.
+    writeNvidiaCDIRefreshDropIns false || return 1
+
     systemctl stop nvidia-cdi-refresh.path 2>/dev/null
     systemctl reset-failed nvidia-cdi-refresh.service nvidia-cdi-refresh.path 2>/dev/null
 
     # Retry rather than one-shot: nvidia-smi answering does not guarantee every device node and
     # library the generator walks is already visible.
-    retrycmd_if_failure 12 5 30 systemctl start nvidia-cdi-refresh.service || return 1
-    nvidia-ctk cdi list | grep -q "nvidia.com/gpu=" || return 1
+    if retrycmd_if_failure 12 5 30 systemctl start nvidia-cdi-refresh.service && nvidia-ctk cdi list | grep -q "nvidia.com/gpu="; then
+        echo "nvidia-cdi-refresh generated a valid CDI spec"
+    else
+        echo "WARNING: nvidia-cdi-refresh could not generate a CDI spec; continuing without CDI"
+        nvidia-smi --query-gpu=mig.mode.current --format=csv,noheader 2>&1 | head -8
+    fi
 
+    systemctl reset-failed nvidia-cdi-refresh.service nvidia-cdi-refresh.path 2>/dev/null
     systemctl start nvidia-cdi-refresh.path || return 1
     return 0
 }

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1470,13 +1470,19 @@ installGPUDriverImage() {
 NVIDIA_CDI_REFRESH_SERVICE_DROP_IN="/etc/systemd/system/nvidia-cdi-refresh.service.d/10-aks-cdi-refresh.conf"
 NVIDIA_CDI_REFRESH_PATH_DROP_IN="/etc/systemd/system/nvidia-cdi-refresh.path.d/10-aks-cdi-refresh.conf"
 
-# $1: "true" to add ExecCondition=/bin/false, which makes systemd skip the unit and report the
-# job as successful without ever running nvidia-ctk. "false" lets the unit run normally.
+# $1: "true" to add an ExecCondition that always fails, which makes systemd skip the unit and
+# report the job as successful without ever running nvidia-ctk. "false" lets the unit run.
+#
+# The condition command must exit non-zero AND outside SuccessExitStatus: systemd checks an
+# ExecCondition exit status against SuccessExitStatus first, and treats a listed status as
+# "condition met". /bin/false exits 1, which is listed below, so it would let ExecStart run.
+# Exit 3 is unambiguous.
 #
 # Restart=no plus an unlimited start-limit window stop the restart storm that otherwise leaves
 # nvidia-cdi-refresh.path dead with unit-start-limit-hit. SuccessExitStatus covers the nvidia-ctk
 # exits seen on healthy AKS nodes: 1 (spec generation refused), 2 (Go runtime crash against a
-# partially loaded driver) and 127 (nvidia-smi / libnvidia-ml.so not on the host yet).
+# partially loaded driver) and 127 (nvidia-smi / libnvidia-ml.so not on the host yet). It is also
+# the fallback if ExecCondition is ignored, so both layers must be able to stand alone.
 writeNvidiaCDIRefreshDropIns() {
     local skip_run="$1"
 
@@ -1485,7 +1491,7 @@ writeNvidiaCDIRefreshDropIns() {
     {
         printf '[Unit]\nStartLimitIntervalSec=0\n\n[Service]\nRestart=no\nSuccessExitStatus=1 2 127\n'
         if [ "$skip_run" = "true" ]; then
-            printf 'ExecCondition=/bin/false\n'
+            printf "ExecCondition=/bin/sh -c 'exit 3'\n"
         fi
     } > "$NVIDIA_CDI_REFRESH_SERVICE_DROP_IN" || return 1
 

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1467,10 +1467,83 @@ installGPUDriverImage() {
     retrycmd_if_failure 5 10 600 bash -c "$CTR_GPU_INSTALL_CMD $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG gpuinstall /entrypoint.sh install"
 }
 
+NVIDIA_CDI_REFRESH_SERVICE_DROP_IN="/etc/systemd/system/nvidia-cdi-refresh.service.d/10-aks-driver-not-ready.conf"
+NVIDIA_CDI_REFRESH_PATH_DROP_IN="/etc/systemd/system/nvidia-cdi-refresh.path.d/10-aks-driver-not-ready.conf"
+
+# nvidia-container-toolkit's post-install enables and immediately starts
+# nvidia-cdi-refresh.{service,path} from inside the aks-gpu install container, before the
+# AKS-managed driver userspace has been staged onto the host. nvidia-ctk then runs with no
+# nvidia-smi and no libnvidia-ml.so and exits non-zero, systemd burns the unit's start limit
+# retrying, and both units settle into a failed state. Newer aks-gpu images react to that by
+# running "systemctl restart nvidia-cdi-refresh.service" under `set -o errexit`, which turns a
+# cosmetic failed unit into an aborted driver install and CSE exit ERR_GPU_DRIVERS_START_FAIL.
+#
+# Stage the drop-ins before the install so that premature run is tolerated rather than fatal.
+# systemd resolves drop-ins when the unit is loaded, so writing them before the units exist is
+# the point: the toolkit's very first start already picks them up. finalizeNvidiaCDIRefresh
+# removes them and generates the spec for real once the driver is actually usable, so this
+# defers the verdict on CDI health instead of suppressing it.
+stageNvidiaCDIRefreshDropIns() {
+    mkdir -p "$(dirname "$NVIDIA_CDI_REFRESH_SERVICE_DROP_IN")" "$(dirname "$NVIDIA_CDI_REFRESH_PATH_DROP_IN")" || return 1
+
+    # Restart=no plus an unlimited start-limit window stops the restart storm that leaves the
+    # .path unit dead with unit-start-limit-hit. SuccessExitStatus covers nvidia-ctk missing
+    # entirely (127) and failing to build a spec (1), which are the two driver-not-ready modes.
+    cat > "$NVIDIA_CDI_REFRESH_SERVICE_DROP_IN" <<'EOF' || return 1
+[Unit]
+StartLimitIntervalSec=0
+
+[Service]
+Restart=no
+SuccessExitStatus=1 127
+EOF
+
+    cat > "$NVIDIA_CDI_REFRESH_PATH_DROP_IN" <<'EOF' || return 1
+[Unit]
+StartLimitIntervalSec=0
+EOF
+
+    systemctl daemon-reload || return 1
+    return 0
+}
+
+# Undo stageNvidiaCDIRefreshDropIns and produce a real CDI spec now that nvidia-smi and
+# ldconfig have succeeded. Any failure here is a genuine CDI failure, not a startup race.
+finalizeNvidiaCDIRefresh() {
+    local load_state=""
+
+    rm -f "$NVIDIA_CDI_REFRESH_SERVICE_DROP_IN" "$NVIDIA_CDI_REFRESH_PATH_DROP_IN" || return 1
+    rmdir "$(dirname "$NVIDIA_CDI_REFRESH_SERVICE_DROP_IN")" "$(dirname "$NVIDIA_CDI_REFRESH_PATH_DROP_IN")" 2>/dev/null
+    systemctl daemon-reload || return 1
+
+    # VHDs whose toolkit predates the CDI refresh units have nothing to reconcile. Treat that as
+    # success so older images keep provisioning (6-month VHD support window).
+    load_state=$(systemctl show --property=LoadState --value nvidia-cdi-refresh.service 2>/dev/null)
+    if [ "$load_state" != "loaded" ]; then
+        echo "nvidia-cdi-refresh.service not present (LoadState=${load_state:-unknown}), skipping CDI refresh"
+        return 0
+    fi
+
+    # The units are failed from the premature run; clear that before the authoritative attempt.
+    systemctl stop nvidia-cdi-refresh.path 2>/dev/null
+    systemctl reset-failed nvidia-cdi-refresh.service nvidia-cdi-refresh.path 2>/dev/null
+
+    # Retry rather than one-shot: nvidia-smi answering does not guarantee every device node and
+    # library the generator walks is already visible.
+    retrycmd_if_failure 12 5 30 systemctl start nvidia-cdi-refresh.service || return 1
+    nvidia-ctk cdi list | grep -q "nvidia.com/gpu=" || return 1
+
+    systemctl start nvidia-cdi-refresh.path || return 1
+    return 0
+}
+
 configGPUDrivers() {
     if [ "$OS" = "$UBUNTU_OS_NAME" ]; then
         waitForContainerdReady || exit $ERR_GPU_DRIVERS_START_FAIL
         mkdir -p /opt/{actions,gpu}
+        # Must precede the install: the toolkit's post-install starts nvidia-cdi-refresh from
+        # inside the install container, and on newer aks-gpu images its failure aborts the install.
+        logs_to_events "AKS.CSE.configGPUDrivers.stageNvidiaCDIRefreshDropIns" stageNvidiaCDIRefreshDropIns || exit $ERR_GPU_DRIVERS_START_FAIL
         # Normally the image is baked into the VHD; only pull on a cache miss (expected under VHD/CSE
         # version skew). ctr run does not auto-pull, so a failed pull must exit here rather than
         # resurface as an opaque install error. name== is an exact match, not an `images ls` substring.
@@ -1502,6 +1575,11 @@ configGPUDrivers() {
     logs_to_events "AKS.CSE.configGPUDrivers.waitForNvidiaModprobe" "retrycmd_if_failure 120 5 25 nvidia-modprobe -u -c0" || exit $ERR_GPU_DRIVERS_START_FAIL
     logs_to_events "AKS.CSE.configGPUDrivers.waitForNvidiaSmi" "retrycmd_if_failure 120 5 30 nvidia-smi" || exit $ERR_GPU_DRIVERS_START_FAIL
     retrycmd_if_failure 120 5 25 ldconfig || exit $ERR_GPU_DRIVERS_START_FAIL
+
+    # Ubuntu-only: the CDI refresh units ship with the toolkit installed by the aks-gpu image.
+    if isUbuntu; then
+        logs_to_events "AKS.CSE.configGPUDrivers.finalizeNvidiaCDIRefresh" finalizeNvidiaCDIRefresh || exit $ERR_GPU_DRIVERS_START_FAIL
+    fi
 
     # Fix the NVIDIA /dev/char link issue (Mariner/AzureLinux only)
     if isMarinerOrAzureLinux "$OS"; then

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1467,97 +1467,35 @@ installGPUDriverImage() {
     retrycmd_if_failure 5 10 600 bash -c "$CTR_GPU_INSTALL_CMD $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG gpuinstall /entrypoint.sh install"
 }
 
-NVIDIA_CDI_REFRESH_SERVICE_DROP_IN="/etc/systemd/system/nvidia-cdi-refresh.service.d/10-aks-cdi-refresh.conf"
-NVIDIA_CDI_REFRESH_PATH_DROP_IN="/etc/systemd/system/nvidia-cdi-refresh.path.d/10-aks-cdi-refresh.conf"
-
-# $1: "true" to add an ExecCondition that always fails, which makes systemd skip the unit and
-# report the job as successful without ever running nvidia-ctk. "false" lets the unit run.
+# nvidia-cdi-refresh.{service,path} ship with nvidia-container-toolkit-base and are enabled by its
+# dpkg post-install, which runs inside the aks-gpu install container. The service is Type=oneshot
+# with Restart=on-failure/RestartSec=1s and StartLimitBurst=5/StartLimitIntervalSec=10s, so any
+# nvidia-ctk failure burns the start limit within seconds and leaves the service *and* its .path
+# unit permanently failed and unstartable -- which also defeats the .path trigger that would
+# otherwise regenerate the spec once the driver is fully installed.
 #
-# The condition command must exit non-zero AND outside SuccessExitStatus: systemd checks an
-# ExecCondition exit status against SuccessExitStatus first, and treats a listed status as
-# "condition met". /bin/false exits 1, which is listed below, so it would let ExecStart run.
-# Exit 3 is unambiguous.
+# Three nvidia-ctk exit codes are known here, none of which should cost us the node:
+#   1   - "invalid CDI Spec: failed add device \"all\": invalid device, empty device edits" on GPUs
+#         whose MIG mode is enabled with zero MIG instances configured. nvidia-ctk cannot describe
+#         such a device, so this never succeeds no matter how often it is retried.
+#   2   - nvidia-ctk panics when invoked before the driver's userspace libraries are in place.
+#   127 - nvidia-smi is missing or unusable because the toolkit was installed ahead of the driver
+#         (aks-gpu images predating the initialize_nvidia_driver reorder).
 #
-# Restart=no plus an unlimited start-limit window stop the restart storm that otherwise leaves
-# nvidia-cdi-refresh.path dead with unit-start-limit-hit. SuccessExitStatus covers the nvidia-ctk
-# exits seen on healthy AKS nodes: 1 (spec generation refused), 2 (Go runtime crash against a
-# partially loaded driver) and 127 (nvidia-smi / libnvidia-ml.so not on the host yet). It is also
-# the fallback if ExecCondition is ignored, so both layers must be able to stand alone.
-writeNvidiaCDIRefreshDropIns() {
-    local skip_run="$1"
+# Accepting them as success keeps install.sh's "systemctl restart nvidia-cdi-refresh.service" from
+# aborting the GPU driver install, leaves no failed units behind, and preserves the .path trigger so
+# a valid spec is still generated as soon as the driver lands. Every other exit code still fails the
+# unit, so genuinely unexpected breakage stays visible. CDI is not how AKS GPU pods reach the device
+# today -- containerd's default_runtime_name is nvidia-container-runtime -- so a degraded spec on
+# hardware that cannot produce one must never fail node provisioning.
+NVIDIA_CDI_REFRESH_DROP_IN="/etc/systemd/system/nvidia-cdi-refresh.service.d/10-aks-tolerate-generate-failure.conf"
 
-    mkdir -p "$(dirname "$NVIDIA_CDI_REFRESH_SERVICE_DROP_IN")" "$(dirname "$NVIDIA_CDI_REFRESH_PATH_DROP_IN")" || return 1
-
-    {
-        printf '[Unit]\nStartLimitIntervalSec=0\n\n[Service]\nRestart=no\nSuccessExitStatus=1 2 127\n'
-        if [ "$skip_run" = "true" ]; then
-            printf "ExecCondition=/bin/sh -c 'exit 3'\n"
-        fi
-    } > "$NVIDIA_CDI_REFRESH_SERVICE_DROP_IN" || return 1
-
-    printf '[Unit]\nStartLimitIntervalSec=0\n' > "$NVIDIA_CDI_REFRESH_PATH_DROP_IN" || return 1
-
-    systemctl daemon-reload || return 1
-    return 0
-}
-
-# nvidia-container-toolkit's post-install enables and immediately starts
-# nvidia-cdi-refresh.{service,path} from inside the aks-gpu install container, before the
-# AKS-managed driver userspace has been staged onto the host, so nvidia-ctk runs against a
-# half-installed driver and fails. Newer aks-gpu images then run
-# "systemctl restart nvidia-cdi-refresh.service" under `set -o errexit`, which turns that failed
-# unit into an aborted driver install and CSE exit ERR_GPU_DRIVERS_START_FAIL.
-#
-# Stage the skip drop-in before the install so the premature run is a no-op rather than fatal.
-# systemd resolves drop-ins at unit load time, so writing them before the units exist is the
-# point: the toolkit's very first start already picks them up. finalizeNvidiaCDIRefresh then
-# generates the spec for real once the driver is usable, so this defers the verdict on CDI
-# health rather than suppressing it.
-stageNvidiaCDIRefreshDropIns() {
-    writeNvidiaCDIRefreshDropIns true
-}
-
-# Generate the CDI spec now that nvidia-smi and ldconfig have succeeded.
-#
-# This deliberately never fails node provisioning. nvidia-ctk cannot produce a spec on every
-# healthy GPU node: an A100 whose MIG mode bit is set with no MIG instances configured (a
-# persistent state inherited from the physical card, unrelated to whether AKS asked for MIG)
-# makes the generated "nvidia.com/gpu=all" device carry empty edits, which nvidia-ctk rejects.
-# CDI is not the path AKS GPU workloads take today -- the nvidia container runtime hook is --
-# so a node that cannot build a spec is still a working GPU node. On that path we leave the
-# tolerant drop-in installed so the .path unit keeps retrying generation (it will succeed if MIG
-# instances appear later) without ever parking the units in a failed state.
-finalizeNvidiaCDIRefresh() {
-    local load_state=""
-
-    # VHDs whose toolkit predates the CDI refresh units have nothing to reconcile. Treat that as
-    # success so older images keep provisioning (6-month VHD support window).
-    load_state=$(systemctl show --property=LoadState --value nvidia-cdi-refresh.service 2>/dev/null)
-    if [ "$load_state" != "loaded" ]; then
-        echo "nvidia-cdi-refresh.service not present (LoadState=${load_state:-unknown}), skipping CDI refresh"
-        rm -f "$NVIDIA_CDI_REFRESH_SERVICE_DROP_IN" "$NVIDIA_CDI_REFRESH_PATH_DROP_IN"
-        systemctl daemon-reload || return 1
-        return 0
-    fi
-
-    # Drop ExecCondition so the unit actually runs, but keep the failure tolerance.
-    writeNvidiaCDIRefreshDropIns false || return 1
-
-    systemctl stop nvidia-cdi-refresh.path 2>/dev/null
-    systemctl reset-failed nvidia-cdi-refresh.service nvidia-cdi-refresh.path 2>/dev/null
-
-    # Retry rather than one-shot: nvidia-smi answering does not guarantee every device node and
-    # library the generator walks is already visible.
-    if retrycmd_if_failure 12 5 30 systemctl start nvidia-cdi-refresh.service && nvidia-ctk cdi list | grep -q "nvidia.com/gpu="; then
-        echo "nvidia-cdi-refresh generated a valid CDI spec"
-    else
-        echo "WARNING: nvidia-cdi-refresh could not generate a CDI spec; continuing without CDI"
-        nvidia-smi --query-gpu=mig.mode.current --format=csv,noheader 2>&1 | head -8
-    fi
-
-    systemctl reset-failed nvidia-cdi-refresh.service nvidia-cdi-refresh.path 2>/dev/null
-    systemctl start nvidia-cdi-refresh.path || return 1
-    return 0
+configureNvidiaCDIRefresh() {
+    mkdir -p "$(dirname "$NVIDIA_CDI_REFRESH_DROP_IN")" || return 1
+    printf '[Service]\nSuccessExitStatus=1 2 127\n' > "$NVIDIA_CDI_REFRESH_DROP_IN" || return 1
+    # Drop-ins are read when systemd loads a unit, so writing this before the toolkit is installed
+    # means the unit picks it up on its very first start.
+    systemctl daemon-reload || true
 }
 
 configGPUDrivers() {
@@ -1566,7 +1504,7 @@ configGPUDrivers() {
         mkdir -p /opt/{actions,gpu}
         # Must precede the install: the toolkit's post-install starts nvidia-cdi-refresh from
         # inside the install container, and on newer aks-gpu images its failure aborts the install.
-        logs_to_events "AKS.CSE.configGPUDrivers.stageNvidiaCDIRefreshDropIns" stageNvidiaCDIRefreshDropIns || exit $ERR_GPU_DRIVERS_START_FAIL
+        logs_to_events "AKS.CSE.configGPUDrivers.configureNvidiaCDIRefresh" configureNvidiaCDIRefresh || exit $ERR_GPU_DRIVERS_START_FAIL
         # Normally the image is baked into the VHD; only pull on a cache miss (expected under VHD/CSE
         # version skew). ctr run does not auto-pull, so a failed pull must exit here rather than
         # resurface as an opaque install error. name== is an exact match, not an `images ls` substring.
@@ -1598,11 +1536,6 @@ configGPUDrivers() {
     logs_to_events "AKS.CSE.configGPUDrivers.waitForNvidiaModprobe" "retrycmd_if_failure 120 5 25 nvidia-modprobe -u -c0" || exit $ERR_GPU_DRIVERS_START_FAIL
     logs_to_events "AKS.CSE.configGPUDrivers.waitForNvidiaSmi" "retrycmd_if_failure 120 5 30 nvidia-smi" || exit $ERR_GPU_DRIVERS_START_FAIL
     retrycmd_if_failure 120 5 25 ldconfig || exit $ERR_GPU_DRIVERS_START_FAIL
-
-    # Ubuntu-only: the CDI refresh units ship with the toolkit installed by the aks-gpu image.
-    if isUbuntu; then
-        logs_to_events "AKS.CSE.configGPUDrivers.finalizeNvidiaCDIRefresh" finalizeNvidiaCDIRefresh || exit $ERR_GPU_DRIVERS_START_FAIL
-    fi
 
     # Fix the NVIDIA /dev/char link issue (Mariner/AzureLinux only)
     if isMarinerOrAzureLinux "$OS"; then

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1467,27 +1467,13 @@ installGPUDriverImage() {
     retrycmd_if_failure 5 10 600 bash -c "$CTR_GPU_INSTALL_CMD $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG gpuinstall /entrypoint.sh install"
 }
 
-# nvidia-cdi-refresh.{service,path} ship with nvidia-container-toolkit-base and are enabled by its
-# dpkg post-install, which runs inside the aks-gpu install container. The service is Type=oneshot
-# with Restart=on-failure/RestartSec=1s and StartLimitBurst=5/StartLimitIntervalSec=10s, so any
-# nvidia-ctk failure burns the start limit within seconds and leaves the service *and* its .path
-# unit permanently failed and unstartable -- which also defeats the .path trigger that would
-# otherwise regenerate the spec once the driver is fully installed.
-#
-# Three nvidia-ctk exit codes are known here, none of which should cost us the node:
-#   1   - "invalid CDI Spec: failed add device \"all\": invalid device, empty device edits" on GPUs
-#         whose MIG mode is enabled with zero MIG instances configured. nvidia-ctk cannot describe
-#         such a device, so this never succeeds no matter how often it is retried.
-#   2   - nvidia-ctk panics when invoked before the driver's userspace libraries are in place.
-#   127 - nvidia-smi is missing or unusable because the toolkit was installed ahead of the driver
-#         (aks-gpu images predating the initialize_nvidia_driver reorder).
-#
-# Accepting them as success keeps install.sh's "systemctl restart nvidia-cdi-refresh.service" from
-# aborting the GPU driver install, leaves no failed units behind, and preserves the .path trigger so
-# a valid spec is still generated as soon as the driver lands. Every other exit code still fails the
-# unit, so genuinely unexpected breakage stays visible. CDI is not how AKS GPU pods reach the device
-# today -- containerd's default_runtime_name is nvidia-container-runtime -- so a degraded spec on
-# hardware that cannot produce one must never fail node provisioning.
+# nvidia-cdi-refresh.service (nvidia-container-toolkit-base) is Type=oneshot with Restart=on-failure
+# and StartLimitBurst=5/10s, so one nvidia-ctk failure burns the start limit in ~5s and leaves it and
+# its .path unit permanently failed and unstartable -- which fails install.sh's `systemctl restart`
+# (CSE 84) and kills the .path trigger that would otherwise regenerate the spec later. Tolerate the
+# three known codes: 1 (MIG mode on with no MIG instances, which never succeeds), 2 (panic before the
+# driver userspace is ready), 127 (nvidia-smi missing on pre-reorder aks-gpu images). Anything else
+# still fails the unit. GPU pods reach the device via containerd's nvidia-container-runtime, not CDI.
 NVIDIA_CDI_REFRESH_DROP_IN="/etc/systemd/system/nvidia-cdi-refresh.service.d/10-aks-tolerate-generate-failure.conf"
 
 configureNvidiaCDIRefresh() {

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -2658,6 +2658,123 @@ OVERRIDE_EOF
         End
     End
 
+    Describe 'nvidia-cdi-refresh startup race handling'
+        setup_cdi_dropins() {
+            CDI_TEST_DIR=$(mktemp -d)
+            NVIDIA_CDI_REFRESH_SERVICE_DROP_IN="${CDI_TEST_DIR}/nvidia-cdi-refresh.service.d/10-aks-driver-not-ready.conf"
+            NVIDIA_CDI_REFRESH_PATH_DROP_IN="${CDI_TEST_DIR}/nvidia-cdi-refresh.path.d/10-aks-driver-not-ready.conf"
+        }
+        cleanup_cdi_dropins() {
+            rm -rf "${CDI_TEST_DIR}"
+        }
+        BeforeEach 'setup_cdi_dropins'
+        AfterEach 'cleanup_cdi_dropins'
+
+        # Run the wrapped command so real failures propagate, but without the retry sleeps.
+        retrycmd_if_failure() { shift 3; "$@"; }
+
+        Describe 'stageNvidiaCDIRefreshDropIns'
+            It 'tolerates a premature refresh run and reloads systemd'
+                systemctl() { echo "systemctl $*"; return 0; }
+
+                When call stageNvidiaCDIRefreshDropIns
+
+                The status should be success
+                The output should include "systemctl daemon-reload"
+                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "Restart=no"
+                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "SuccessExitStatus=1 127"
+                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "StartLimitIntervalSec=0"
+                The contents of file "${NVIDIA_CDI_REFRESH_PATH_DROP_IN}" should include "StartLimitIntervalSec=0"
+            End
+
+            It 'fails when systemd cannot pick up the drop-ins'
+                systemctl() { return 1; }
+
+                When call stageNvidiaCDIRefreshDropIns
+
+                The status should be failure
+            End
+        End
+
+        Describe 'finalizeNvidiaCDIRefresh'
+            setup_staged_dropins() {
+                mkdir -p "$(dirname "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}")" "$(dirname "${NVIDIA_CDI_REFRESH_PATH_DROP_IN}")"
+                echo "staged" > "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}"
+                echo "staged" > "${NVIDIA_CDI_REFRESH_PATH_DROP_IN}"
+            }
+            BeforeEach 'setup_staged_dropins'
+
+            loaded_systemctl() {
+                if [ "$1" = "show" ]; then
+                    echo "loaded"
+                    return 0
+                fi
+                echo "systemctl $*"
+                return 0
+            }
+
+            It 'removes the drop-ins and starts both units once the spec is valid'
+                systemctl() { loaded_systemctl "$@"; }
+                nvidia-ctk() { echo "nvidia.com/gpu=all"; }
+
+                When call finalizeNvidiaCDIRefresh
+
+                The status should be success
+                The path "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should not be exist
+                The path "${NVIDIA_CDI_REFRESH_PATH_DROP_IN}" should not be exist
+                The output should include "systemctl start nvidia-cdi-refresh.service"
+                The output should include "systemctl start nvidia-cdi-refresh.path"
+            End
+
+            It 'fails when the refresh produces no GPU devices'
+                systemctl() { loaded_systemctl "$@"; }
+                nvidia-ctk() { return 0; }
+
+                When call finalizeNvidiaCDIRefresh
+
+                The status should be failure
+                The output should not include "systemctl start nvidia-cdi-refresh.path"
+            End
+
+            It 'fails when the refresh service cannot start'
+                systemctl() {
+                    if [ "$1" = "show" ]; then
+                        echo "loaded"
+                        return 0
+                    fi
+                    if [ "$1" = "start" ]; then
+                        return 1
+                    fi
+                    return 0
+                }
+                nvidia-ctk() { echo "SHOULD_NOT_RUN"; }
+
+                When call finalizeNvidiaCDIRefresh
+
+                The status should be failure
+                The output should not include "SHOULD_NOT_RUN"
+            End
+
+            It 'skips reconciliation on VHDs whose toolkit has no CDI refresh units'
+                systemctl() {
+                    if [ "$1" = "show" ]; then
+                        echo "not-found"
+                        return 0
+                    fi
+                    echo "systemctl $*"
+                    return 0
+                }
+
+                When call finalizeNvidiaCDIRefresh
+
+                The status should be success
+                The path "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should not be exist
+                The output should include "skipping CDI refresh"
+                The output should not include "systemctl start"
+            End
+        End
+    End
+
     Describe 'configGPUDrivers'
         # Assert the per-step CSE timing event names emitted via logs_to_events,
         # without running the real (hardware/daemon) driver steps. logs_to_events
@@ -2673,6 +2790,8 @@ OVERRIDE_EOF
         createNvidiaSymlinkToAllDeviceNodes() { return 0; }
         systemctlEnableAndStart() { return 0; }
         systemctl() { return 0; }
+        stageNvidiaCDIRefreshDropIns() { return 0; }
+        finalizeNvidiaCDIRefresh() { return 0; }
 
         UBUNTU_OS_NAME="UBUNTU"
         NVIDIA_DRIVER_IMAGE="mcr.example/nvidia/driver"
@@ -2694,6 +2813,60 @@ OVERRIDE_EOF
             The output should include "logs_to_events AKS.CSE.configGPUDrivers.installGPUDriverImage"
             The output should include "logs_to_events AKS.CSE.configGPUDrivers.waitForNvidiaModprobe"
             The output should include "logs_to_events AKS.CSE.configGPUDrivers.waitForNvidiaSmi"
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.stageNvidiaCDIRefreshDropIns"
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.finalizeNvidiaCDIRefresh"
+        End
+
+        It 'stages the CDI refresh drop-ins before the driver install runs on Ubuntu'
+            OS="UBUNTU"
+            isMarinerOrAzureLinux() { return 1; }
+            isAzureLinuxOSGuard() { return 1; }
+            isACL() { return 1; }
+            # eval so the string-form wrapped commands (e.g. "retrycmd_if_failure ... nvidia-smi")
+            # resolve to their mocks instead of being treated as one command name.
+            logs_to_events() { shift; eval "$@"; }
+            NVIDIA_DRIVER_IMAGE_PULL_REF="mcr.example/nvidia/driver"
+            stageNvidiaCDIRefreshDropIns() { echo "STAGE_RAN"; return 0; }
+            installGPUDriverImage() { echo "INSTALL_RAN"; return 0; }
+            finalizeNvidiaCDIRefresh() { echo "FINALIZE_RAN"; return 0; }
+
+            When call configGPUDrivers
+
+            The status should be success
+            # The toolkit starts nvidia-cdi-refresh from inside the install container, so the
+            # drop-ins must already be on disk by then.
+            The line 1 of output should equal "STAGE_RAN"
+            The output should include "INSTALL_RAN"
+            The output should include "FINALIZE_RAN"
+        End
+
+        It 'exits without installing the driver when the CDI drop-ins cannot be staged'
+            OS="UBUNTU"
+            isMarinerOrAzureLinux() { return 1; }
+            isAzureLinuxOSGuard() { return 1; }
+            isACL() { return 1; }
+            logs_to_events() { shift; eval "$@"; }
+            stageNvidiaCDIRefreshDropIns() { return 1; }
+            installGPUDriverImage() { echo "INSTALL_RAN"; return 0; }
+
+            When run configGPUDrivers
+
+            The status should equal 88
+            The output should not include "INSTALL_RAN"
+        End
+
+        It 'exits when the CDI refresh cannot be reconciled after the driver is ready'
+            OS="UBUNTU"
+            isMarinerOrAzureLinux() { return 1; }
+            isAzureLinuxOSGuard() { return 1; }
+            isACL() { return 1; }
+            logs_to_events() { shift; eval "$@"; }
+            NVIDIA_DRIVER_IMAGE_PULL_REF="mcr.example/nvidia/driver"
+            finalizeNvidiaCDIRefresh() { return 1; }
+
+            When run configGPUDrivers
+
+            The status should equal 88
         End
 
         It 'exits at the cache-miss pull step and skips install when the pull fails on Ubuntu'

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -2658,11 +2658,11 @@ OVERRIDE_EOF
         End
     End
 
-    Describe 'nvidia-cdi-refresh startup race handling'
+    Describe 'nvidia-cdi-refresh handling'
         setup_cdi_dropins() {
             CDI_TEST_DIR=$(mktemp -d)
-            NVIDIA_CDI_REFRESH_SERVICE_DROP_IN="${CDI_TEST_DIR}/nvidia-cdi-refresh.service.d/10-aks-driver-not-ready.conf"
-            NVIDIA_CDI_REFRESH_PATH_DROP_IN="${CDI_TEST_DIR}/nvidia-cdi-refresh.path.d/10-aks-driver-not-ready.conf"
+            NVIDIA_CDI_REFRESH_SERVICE_DROP_IN="${CDI_TEST_DIR}/nvidia-cdi-refresh.service.d/10-aks-cdi-refresh.conf"
+            NVIDIA_CDI_REFRESH_PATH_DROP_IN="${CDI_TEST_DIR}/nvidia-cdi-refresh.path.d/10-aks-cdi-refresh.conf"
         }
         cleanup_cdi_dropins() {
             rm -rf "${CDI_TEST_DIR}"
@@ -2674,15 +2674,16 @@ OVERRIDE_EOF
         retrycmd_if_failure() { shift 3; "$@"; }
 
         Describe 'stageNvidiaCDIRefreshDropIns'
-            It 'tolerates a premature refresh run and reloads systemd'
+            It 'skips a premature refresh run and reloads systemd'
                 systemctl() { echo "systemctl $*"; return 0; }
 
                 When call stageNvidiaCDIRefreshDropIns
 
                 The status should be success
                 The output should include "systemctl daemon-reload"
+                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "ExecCondition=/bin/false"
                 The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "Restart=no"
-                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "SuccessExitStatus=1 127"
+                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "SuccessExitStatus=1 2 127"
                 The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "StartLimitIntervalSec=0"
                 The contents of file "${NVIDIA_CDI_REFRESH_PATH_DROP_IN}" should include "StartLimitIntervalSec=0"
             End
@@ -2699,7 +2700,7 @@ OVERRIDE_EOF
         Describe 'finalizeNvidiaCDIRefresh'
             setup_staged_dropins() {
                 mkdir -p "$(dirname "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}")" "$(dirname "${NVIDIA_CDI_REFRESH_PATH_DROP_IN}")"
-                echo "staged" > "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}"
+                echo "ExecCondition=/bin/false" > "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}"
                 echo "staged" > "${NVIDIA_CDI_REFRESH_PATH_DROP_IN}"
             }
             BeforeEach 'setup_staged_dropins'
@@ -2713,46 +2714,54 @@ OVERRIDE_EOF
                 return 0
             }
 
-            It 'removes the drop-ins and starts both units once the spec is valid'
+            It 'lets the unit run and starts both units once the spec is valid'
                 systemctl() { loaded_systemctl "$@"; }
                 nvidia-ctk() { echo "nvidia.com/gpu=all"; }
 
                 When call finalizeNvidiaCDIRefresh
 
                 The status should be success
-                The path "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should not be exist
-                The path "${NVIDIA_CDI_REFRESH_PATH_DROP_IN}" should not be exist
+                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should not include "ExecCondition"
+                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "SuccessExitStatus=1 2 127"
                 The output should include "systemctl start nvidia-cdi-refresh.service"
                 The output should include "systemctl start nvidia-cdi-refresh.path"
+                The output should include "generated a valid CDI spec"
             End
 
-            It 'fails when the refresh produces no GPU devices'
+            It 'does not fail provisioning when the refresh produces no GPU devices'
                 systemctl() { loaded_systemctl "$@"; }
                 nvidia-ctk() { return 0; }
+                nvidia-smi() { echo "Enabled"; }
 
                 When call finalizeNvidiaCDIRefresh
 
-                The status should be failure
-                The output should not include "systemctl start nvidia-cdi-refresh.path"
+                The status should be success
+                The output should include "continuing without CDI"
+                The output should include "systemctl reset-failed"
+                The output should include "systemctl start nvidia-cdi-refresh.path"
+                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "SuccessExitStatus=1 2 127"
             End
 
-            It 'fails when the refresh service cannot start'
+            It 'does not fail provisioning when the refresh service cannot start'
                 systemctl() {
                     if [ "$1" = "show" ]; then
                         echo "loaded"
                         return 0
                     fi
-                    if [ "$1" = "start" ]; then
+                    if [ "$1" = "start" ] && [ "$2" = "nvidia-cdi-refresh.service" ]; then
                         return 1
                     fi
+                    echo "systemctl $*"
                     return 0
                 }
                 nvidia-ctk() { echo "SHOULD_NOT_RUN"; }
+                nvidia-smi() { echo "Enabled"; }
 
                 When call finalizeNvidiaCDIRefresh
 
-                The status should be failure
+                The status should be success
                 The output should not include "SHOULD_NOT_RUN"
+                The output should include "continuing without CDI"
             End
 
             It 'skips reconciliation on VHDs whose toolkit has no CDI refresh units'

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -2681,7 +2681,7 @@ OVERRIDE_EOF
 
                 The status should be success
                 The output should include "systemctl daemon-reload"
-                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "ExecCondition=/bin/false"
+                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "ExecCondition=/bin/sh -c 'exit 3'"
                 The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "Restart=no"
                 The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "SuccessExitStatus=1 2 127"
                 The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "StartLimitIntervalSec=0"
@@ -2700,7 +2700,7 @@ OVERRIDE_EOF
         Describe 'finalizeNvidiaCDIRefresh'
             setup_staged_dropins() {
                 mkdir -p "$(dirname "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}")" "$(dirname "${NVIDIA_CDI_REFRESH_PATH_DROP_IN}")"
-                echo "ExecCondition=/bin/false" > "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}"
+                echo "ExecCondition=/bin/sh -c 'exit 3'" > "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}"
                 echo "staged" > "${NVIDIA_CDI_REFRESH_PATH_DROP_IN}"
             }
             BeforeEach 'setup_staged_dropins'

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -2659,127 +2659,62 @@ OVERRIDE_EOF
     End
 
     Describe 'nvidia-cdi-refresh handling'
-        setup_cdi_dropins() {
+        setup_cdi_dropin() {
             CDI_TEST_DIR=$(mktemp -d)
-            NVIDIA_CDI_REFRESH_SERVICE_DROP_IN="${CDI_TEST_DIR}/nvidia-cdi-refresh.service.d/10-aks-cdi-refresh.conf"
-            NVIDIA_CDI_REFRESH_PATH_DROP_IN="${CDI_TEST_DIR}/nvidia-cdi-refresh.path.d/10-aks-cdi-refresh.conf"
+            NVIDIA_CDI_REFRESH_DROP_IN="${CDI_TEST_DIR}/nvidia-cdi-refresh.service.d/10-aks-tolerate-generate-failure.conf"
         }
-        cleanup_cdi_dropins() {
+        cleanup_cdi_dropin() {
             rm -rf "${CDI_TEST_DIR}"
         }
-        BeforeEach 'setup_cdi_dropins'
-        AfterEach 'cleanup_cdi_dropins'
+        BeforeEach 'setup_cdi_dropin'
+        AfterEach 'cleanup_cdi_dropin'
 
-        # Run the wrapped command so real failures propagate, but without the retry sleeps.
-        retrycmd_if_failure() { shift 3; "$@"; }
-
-        Describe 'stageNvidiaCDIRefreshDropIns'
-            It 'skips a premature refresh run and reloads systemd'
+        Describe 'configureNvidiaCDIRefresh'
+            It 'treats the known nvidia-ctk failures as success and reloads systemd'
                 systemctl() { echo "systemctl $*"; return 0; }
 
-                When call stageNvidiaCDIRefreshDropIns
+                When call configureNvidiaCDIRefresh
 
                 The status should be success
                 The output should include "systemctl daemon-reload"
-                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "ExecCondition=/bin/sh -c 'exit 3'"
-                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "Restart=no"
-                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "SuccessExitStatus=1 2 127"
-                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "StartLimitIntervalSec=0"
-                The contents of file "${NVIDIA_CDI_REFRESH_PATH_DROP_IN}" should include "StartLimitIntervalSec=0"
+                # 1 = MIG mode enabled with no MIG instances, 2 = nvidia-ctk panic before the
+                # driver userspace is ready, 127 = nvidia-smi missing on pre-reorder aks-gpu images.
+                The contents of file "${NVIDIA_CDI_REFRESH_DROP_IN}" should include "[Service]"
+                The contents of file "${NVIDIA_CDI_REFRESH_DROP_IN}" should include "SuccessExitStatus=1 2 127"
             End
 
-            It 'fails when systemd cannot pick up the drop-ins'
+            It 'keeps the units restartable so the .path trigger can still refresh the spec'
+                systemctl() { return 0; }
+
+                When call configureNvidiaCDIRefresh
+
+                The status should be success
+                # Overriding Restart= or the start limit would suppress the toolkit's own retry and
+                # its path-triggered refresh, which is what eventually generates a valid spec once
+                # the driver is fully installed.
+                The contents of file "${NVIDIA_CDI_REFRESH_DROP_IN}" should not include "Restart="
+                The contents of file "${NVIDIA_CDI_REFRESH_DROP_IN}" should not include "StartLimit"
+                The contents of file "${NVIDIA_CDI_REFRESH_DROP_IN}" should not include "ExecCondition"
+            End
+
+            It 'still installs the drop-in when systemd cannot be reloaded'
+                # Drop-ins are read when the unit is first loaded, which happens after the toolkit
+                # post-install runs its own daemon-reload, so this reload is only belt and braces.
                 systemctl() { return 1; }
 
-                When call stageNvidiaCDIRefreshDropIns
+                When call configureNvidiaCDIRefresh
+
+                The status should be success
+                The contents of file "${NVIDIA_CDI_REFRESH_DROP_IN}" should include "SuccessExitStatus=1 2 127"
+            End
+
+            It 'fails when the drop-in directory cannot be created'
+                systemctl() { return 0; }
+                mkdir() { return 1; }
+
+                When call configureNvidiaCDIRefresh
 
                 The status should be failure
-            End
-        End
-
-        Describe 'finalizeNvidiaCDIRefresh'
-            setup_staged_dropins() {
-                mkdir -p "$(dirname "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}")" "$(dirname "${NVIDIA_CDI_REFRESH_PATH_DROP_IN}")"
-                echo "ExecCondition=/bin/sh -c 'exit 3'" > "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}"
-                echo "staged" > "${NVIDIA_CDI_REFRESH_PATH_DROP_IN}"
-            }
-            BeforeEach 'setup_staged_dropins'
-
-            loaded_systemctl() {
-                if [ "$1" = "show" ]; then
-                    echo "loaded"
-                    return 0
-                fi
-                echo "systemctl $*"
-                return 0
-            }
-
-            It 'lets the unit run and starts both units once the spec is valid'
-                systemctl() { loaded_systemctl "$@"; }
-                nvidia-ctk() { echo "nvidia.com/gpu=all"; }
-
-                When call finalizeNvidiaCDIRefresh
-
-                The status should be success
-                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should not include "ExecCondition"
-                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "SuccessExitStatus=1 2 127"
-                The output should include "systemctl start nvidia-cdi-refresh.service"
-                The output should include "systemctl start nvidia-cdi-refresh.path"
-                The output should include "generated a valid CDI spec"
-            End
-
-            It 'does not fail provisioning when the refresh produces no GPU devices'
-                systemctl() { loaded_systemctl "$@"; }
-                nvidia-ctk() { return 0; }
-                nvidia-smi() { echo "Enabled"; }
-
-                When call finalizeNvidiaCDIRefresh
-
-                The status should be success
-                The output should include "continuing without CDI"
-                The output should include "systemctl reset-failed"
-                The output should include "systemctl start nvidia-cdi-refresh.path"
-                The contents of file "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should include "SuccessExitStatus=1 2 127"
-            End
-
-            It 'does not fail provisioning when the refresh service cannot start'
-                systemctl() {
-                    if [ "$1" = "show" ]; then
-                        echo "loaded"
-                        return 0
-                    fi
-                    if [ "$1" = "start" ] && [ "$2" = "nvidia-cdi-refresh.service" ]; then
-                        return 1
-                    fi
-                    echo "systemctl $*"
-                    return 0
-                }
-                nvidia-ctk() { echo "SHOULD_NOT_RUN"; }
-                nvidia-smi() { echo "Enabled"; }
-
-                When call finalizeNvidiaCDIRefresh
-
-                The status should be success
-                The output should not include "SHOULD_NOT_RUN"
-                The output should include "continuing without CDI"
-            End
-
-            It 'skips reconciliation on VHDs whose toolkit has no CDI refresh units'
-                systemctl() {
-                    if [ "$1" = "show" ]; then
-                        echo "not-found"
-                        return 0
-                    fi
-                    echo "systemctl $*"
-                    return 0
-                }
-
-                When call finalizeNvidiaCDIRefresh
-
-                The status should be success
-                The path "${NVIDIA_CDI_REFRESH_SERVICE_DROP_IN}" should not be exist
-                The output should include "skipping CDI refresh"
-                The output should not include "systemctl start"
             End
         End
     End
@@ -2799,8 +2734,7 @@ OVERRIDE_EOF
         createNvidiaSymlinkToAllDeviceNodes() { return 0; }
         systemctlEnableAndStart() { return 0; }
         systemctl() { return 0; }
-        stageNvidiaCDIRefreshDropIns() { return 0; }
-        finalizeNvidiaCDIRefresh() { return 0; }
+        configureNvidiaCDIRefresh() { return 0; }
 
         UBUNTU_OS_NAME="UBUNTU"
         NVIDIA_DRIVER_IMAGE="mcr.example/nvidia/driver"
@@ -2822,11 +2756,10 @@ OVERRIDE_EOF
             The output should include "logs_to_events AKS.CSE.configGPUDrivers.installGPUDriverImage"
             The output should include "logs_to_events AKS.CSE.configGPUDrivers.waitForNvidiaModprobe"
             The output should include "logs_to_events AKS.CSE.configGPUDrivers.waitForNvidiaSmi"
-            The output should include "logs_to_events AKS.CSE.configGPUDrivers.stageNvidiaCDIRefreshDropIns"
-            The output should include "logs_to_events AKS.CSE.configGPUDrivers.finalizeNvidiaCDIRefresh"
+            The output should include "logs_to_events AKS.CSE.configGPUDrivers.configureNvidiaCDIRefresh"
         End
 
-        It 'stages the CDI refresh drop-ins before the driver install runs on Ubuntu'
+        It 'installs the CDI refresh drop-in before the driver install runs on Ubuntu'
             OS="UBUNTU"
             isMarinerOrAzureLinux() { return 1; }
             isAzureLinuxOSGuard() { return 1; }
@@ -2835,47 +2768,31 @@ OVERRIDE_EOF
             # resolve to their mocks instead of being treated as one command name.
             logs_to_events() { shift; eval "$@"; }
             NVIDIA_DRIVER_IMAGE_PULL_REF="mcr.example/nvidia/driver"
-            stageNvidiaCDIRefreshDropIns() { echo "STAGE_RAN"; return 0; }
+            configureNvidiaCDIRefresh() { echo "CONFIGURE_RAN"; return 0; }
             installGPUDriverImage() { echo "INSTALL_RAN"; return 0; }
-            finalizeNvidiaCDIRefresh() { echo "FINALIZE_RAN"; return 0; }
 
             When call configGPUDrivers
 
             The status should be success
             # The toolkit starts nvidia-cdi-refresh from inside the install container, so the
-            # drop-ins must already be on disk by then.
-            The line 1 of output should equal "STAGE_RAN"
+            # drop-in must already be on disk by then.
+            The line 1 of output should equal "CONFIGURE_RAN"
             The output should include "INSTALL_RAN"
-            The output should include "FINALIZE_RAN"
         End
 
-        It 'exits without installing the driver when the CDI drop-ins cannot be staged'
+        It 'exits without installing the driver when the CDI drop-in cannot be installed'
             OS="UBUNTU"
             isMarinerOrAzureLinux() { return 1; }
             isAzureLinuxOSGuard() { return 1; }
             isACL() { return 1; }
             logs_to_events() { shift; eval "$@"; }
-            stageNvidiaCDIRefreshDropIns() { return 1; }
+            configureNvidiaCDIRefresh() { return 1; }
             installGPUDriverImage() { echo "INSTALL_RAN"; return 0; }
 
             When run configGPUDrivers
 
             The status should equal 88
             The output should not include "INSTALL_RAN"
-        End
-
-        It 'exits when the CDI refresh cannot be reconciled after the driver is ready'
-            OS="UBUNTU"
-            isMarinerOrAzureLinux() { return 1; }
-            isAzureLinuxOSGuard() { return 1; }
-            isACL() { return 1; }
-            logs_to_events() { shift; eval "$@"; }
-            NVIDIA_DRIVER_IMAGE_PULL_REF="mcr.example/nvidia/driver"
-            finalizeNvidiaCDIRefresh() { return 1; }
-
-            When run configGPUDrivers
-
-            The status should equal 88
         End
 
         It 'exits at the cache-miss pull step and skips install when the pull fails on Ubuntu'


### PR DESCRIPTION
## What

A two-line systemd drop-in so a transient `nvidia-ctk cdi generate` failure cannot fail node provisioning:

```ini
[Service]
SuccessExitStatus=1 2 127
```

## Why

`nvidia-cdi-refresh.service` ships in `nvidia-container-toolkit-base` with:

```ini
Restart=on-failure
RestartSec=1s
StartLimitBurst=5
StartLimitIntervalSec=10s
```

It is triggered by `nvidia-cdi-refresh.path` watching `modules.dep`, so it can fire while the NVIDIA **kernel module** is present but the **userspace driver libraries** are not yet installed. `nvidia-ctk` then exits 1. From build 175396237, `Test_Ubuntu2204_GPUA100`:

```
nvidia-ctk: level=error msg="failed to write spec: invalid CDI Spec:
            failed add device \"all\": invalid device, empty device edits"
nvidia-ctk: level=error msg="... failed to locate libcuda.so:
            libcuda.so.580.159.04: not found"
systemd[1]: nvidia-cdi-refresh.service: Main process exited, code=exited, status=1/FAILURE
```

With `Restart=on-failure` and a burst of 5 in 10s, one transient failure puts the unit into a **permanently failed and unstartable** state within ~5 seconds, and takes the `.path` unit down with it — so the self-heal that would have fixed things once the driver landed never runs.

The newer `aks-gpu` image then runs an unguarded `systemctl restart nvidia-cdi-refresh.service` under `set -euxo pipefail`. That returns 1, aborts `install.sh`, exhausts `retrycmd_if_failure 5 10 600`, and surfaces as `ERR_GPU_DRIVERS_START_FAIL` (CSE exit 84) → `VMExtensionProvisioningError`.

Treating the known-transient exit codes as success keeps the unit startable and leaves NVIDIA's own retry and path-triggered refresh intact, so the spec is generated as soon as the driver is ready.

## Why not the earlier approach

The first revision of this PR hand-rolled `ExecCondition`, retry and start-limit overrides — 94 lines. That duplicated logic the real unit already has, and setting `Restart=no` actively **suppressed** the upstream self-heal, which is why it then needed its own retry loop. Deleting all of it is both smaller and strictly better behaved.

## Verification

**Direct proof on a real A100 node** (Ubuntu 22.04, `aks-gpu` `580.159.04-20260805223419`, toolkit 1.19.1). `nvidia-ctk` shadowed to `exit 1` to force the race, then the exact `reset-failed` + `restart` sequence `install.sh` performs:

| | `systemctl restart` rc | end state |
|---|---|---|
| with drop-in | `0` ×6 | not failed, `.path` **active** |
| upstream | `1` ×6 | `Job for nvidia-cdi-refresh.service failed…` |

That `rc=1` is precisely what aborts `install.sh`. Restored afterwards; node ended with zero failed units.

**Unmodified node state** after provisioning with this fix:

```
nvidia-cdi-refresh.service   inactive      Result=success  NRestarts=0
nvidia-cdi-refresh.path      active
/var/run/cdi/nvidia.yaml     20002 bytes   ("Generated CDI spec with version 0.5.0")
systemctl list-units --state=failed   ->   (none)
```

**GPU E2E — validated on a VHD built from this fix.**

GPU E2E runs *scriptless*: `aks-node-controller` executes the VHD-baked
`/opt/azure/containers/provision_configs.sh`, not the branch working tree. E2E also selects
images by SIG tag, defaulting to `branch=refs/heads/main`. So a branch-only pipeline run
never exercises a `cse_config.sh` change — earlier runs on this PR booted `main`'s VHD and
proved nothing either way.

Valid run: `[TEST All VHDs]` build **175699947** off a branch carrying this fix **plus**
#8986's bump, producing `2204gen2containerd` version `1.1786138692.16550`, then
`Test_Ubuntu2204_GPUA100` against it with scriptless enabled.

```
--- PASS: Test_Ubuntu2204_GPUA100 (1051.35s)
```

On that node — the exact combination that fails without this change:

```
GPU image             aks-gpu-cuda-lts:580.159.04-20260805223419   (the #8986 bump)
mode                  "Using NBC command for scriptless phase 2"
provision_configs.sh  configureNvidiaCDIRefresh present and executed
SuccessExitStatus     1 2 127                    (drop-in loaded, DropInPaths confirms)
nvidia-cdi-refresh    ran 3x -> "Deactivated successfully", NRestarts=0
nvidia-cdi-refresh.path   active
systemctl --state=failed  -> (none)
nvidia-smi            NVIDIA A100 80GB PCIe, 580.159.04
```

Zero `Failed with result 'exit-code'`, zero `Scheduled restart job`, zero
`VMExtensionProvisioningError`. For reference, the same image without this fix gave 16
`VMExtensionProvisioningError` / CSE 84 in builds 175396237 and 175654248.

**Full-matrix GPU E2E: build 175717340 — succeeded** (`VHD_BUILD_ID=175699947`, so every
node booted a VHD carrying this fix). 18 GPU scenarios ran across 2204 and 2404:

```
unexpectedly entered a failed state          0
nvidia-cdi-refresh.service: Failed with...   0
Scheduled restart job ... nvidia-cdi         0
VMExtensionProvisioningError                 0
bastion tunnel 403                           0
configureNvidiaCDIRefresh on node          16 scenarios
```

The only failures were 5 Ubuntu 2404 scenarios hitting `GalleryImageNotFound` — the 2404
image was still replicating to westus2/southcentralus/southeastasia. All five passed on
retry ("2 runs, 1 failures"). Unrelated to this change.

**Does this mask genuine CDI failures?** No — verified against the spec-generation logs.
15 of 16 scenarios wrote the CDI spec with zero write failures. The one exception,
`..._MIG_Mixed`, shows the transient window and its resolution:

```
00:46:32  nvidia-ctk generate v0.3.0 -> write FAILS (empty device edits)
00:46:47  nvidia-ctk generate v0.3.0 -> write FAILS
00:47:07  nvidia-ctk generate v0.3.0 -> write FAILS
00:50:56  nvidia-ctk generate v0.5.0 -> SUCCESS
```

MIG reconfiguration transiently leaves the `all` device empty; the spec converges to valid.
Without the drop-in those three failures mark the unit failed (tripping the E2E unit
validator) and risk the start limit tearing down the `.path` unit, so the successful
generation at 00:50:56 might never happen. The drop-in preserves convergence rather than
hiding breakage.

That run is also in-pipeline proof the drop-in is effective: `nvidia-ctk` exited non-zero
three times, yet systemd logged `Deactivated successfully` / `Finished` — only possible with
`SuccessExitStatus` applied.

The residual `status=1/FAILURE` hits belong to `node-problem-detector`, `ensure-no-dup`,
`dra-driver-nvidia-gpu` and `fwupd-refresh`; none to nvidia-cdi. `ERR_GPU_DRIVERS_START_FAIL`
appears only as `++ ERR_GPU_DRIVERS_START_FAIL=84` from `set -x`.

**This also fixes a failure already live on `main`.** Build 175689787 (`main` + only the
#9165 bastion fix, old aks-gpu image `…20260629214430`, no CDI fix) fails **every** GPU
scenario, 12/12 across three attempts:

```
FAIL: the following systemd units have unexpectedly entered a failed state:
      [nvidia-cdi-refresh.path nvidia-cdi-refresh.service]
```

`Test_Ubuntu2204_GPUA100`, `Test_Ubuntu2204_GPUNC`, `Test_Ubuntu2404_GPU_A100`,
`Test_Ubuntu2404_GPU_H100` — with 0 bastion 403s and 0 `VMExtensionProvisioningError`. The
transient `nvidia-ctk` failure hits the start limit and takes the `.path` unit down with it,
independently of #8986; #8986's bump only escalates it to a hard CSE 84 because the new
`install.sh` restarts the unit unguarded. This was invisible until #9165 restored SSH, since
the validator could never reach the node.

With this fix on the node: `.path` active, `NRestarts=0`, `systemctl --state=failed` empty.

Direct proof of the mechanism, forcing `nvidia-ctk` to exit 1 on a real A100 node and
emulating aks-gpu `install.sh`'s `reset-failed` + `restart`:

| | `systemctl restart` rc | end state |
|---|---|---|
| with drop-in | `0` x6 | not failed, `.path` active |
| upstream | `1` x6 | `Job for nvidia-cdi-refresh.service failed...` (the pipeline message) |

`make shellspec`: 902 examples, 0 failures. `make generate-testdata`: clean.

## Notes

- Unblocks #8986. MCR tag `580.159.04-20260806020153` is byte-identical to `…20260805223419`, so it carries the same behaviour and Renovate will propose it next.
- Worth guarding the `systemctl restart nvidia-cdi-refresh.service` in aks-gpu's `install.sh` with `|| true` upstream as defence in depth.
- E2E SSH is separately broken by a Bastion 403; fixed in #9165.
