### PR TITLE
feat: add erofs snapshotter configuration for new kata-preview runtime class

### DIFF
--- a/aks-node-controller/parser/templates/containerd.toml.gtpl
+++ b/aks-node-controller/parser/templates/containerd.toml.gtpl
@@ -1,12 +1,26 @@
 version = 2
 oom_score = -999{{if getHasDataDir .KubeletConfig}}
 root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
+{{- if .GetIsKata }}
+[plugins."io.containerd.snapshotter.v1.erofs"]
+  default_size = "10G"
+  enable_fsverity = false
+  ovl_mount_options = []
+
+[plugins."io.containerd.service.v1.diff-service"]
+  default = ["erofs", "walking"]
+
+[plugins."io.containerd.differ.v1.erofs"]
+  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
+  enable_tar_index = false
+{{- end}}
 [plugins."io.containerd.grpc.v1.cri"]
   sandbox_image = "{{ .KubeBinaryConfig.GetPodInfraContainerImageUrl }}"
   enable_cdi = true
   [plugins."io.containerd.grpc.v1.cri".containerd]
     {{- if .GetIsKata }}
     disable_snapshot_annotations = false
+    snapshotter = "overlayfs"
     {{- end}}
     {{- if .GetEnableArtifactStreaming }}
     snapshotter = "overlaybd"
@@ -62,6 +76,7 @@ root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
 {{- if .GetIsKata }}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
+  snapshotter = "overlayfs"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.katacli]
   runtime_type = "io.containerd.runc.v1"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.katacli.options]
@@ -74,6 +89,12 @@ root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
   Root = ""
   CriuPath = ""
   SystemdCgroup = false
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
+  runtime_type = "io.containerd.kata.v2"
+  privileged_without_host_devices = true
+  snapshotter = "erofs"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
+    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-preview.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"

--- a/aks-node-controller/parser/templates/containerd_no_GPU.toml.gtpl
+++ b/aks-node-controller/parser/templates/containerd_no_GPU.toml.gtpl
@@ -1,11 +1,25 @@
 version = 2
 oom_score = -999{{if getHasDataDir .KubeletConfig}}
 root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
+{{- if .GetIsKata }}
+[plugins."io.containerd.snapshotter.v1.erofs"]
+  default_size = "10G"
+  enable_fsverity = false
+  ovl_mount_options = []
+
+[plugins."io.containerd.service.v1.diff-service"]
+  default = ["erofs", "walking"]
+
+[plugins."io.containerd.differ.v1.erofs"]
+  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
+  enable_tar_index = false
+{{- end}}
 [plugins."io.containerd.grpc.v1.cri"]
   sandbox_image = "{{ .KubeBinaryConfig.GetPodInfraContainerImageUrl }}"
   [plugins."io.containerd.grpc.v1.cri".containerd]
     {{- if .GetIsKata }}
     disable_snapshot_annotations = false
+    snapshotter = "overlayfs"
     {{- end}}
     {{- if .GetEnableArtifactStreaming }}
     snapshotter = "overlaybd"
@@ -46,6 +60,7 @@ root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
 {{- if .GetIsKata }}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
+  snapshotter = "overlayfs"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.katacli]
   runtime_type = "io.containerd.runc.v1"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.katacli.options]
@@ -58,6 +73,12 @@ root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
   Root = ""
   CriuPath = ""
   SystemdCgroup = false
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
+  runtime_type = "io.containerd.kata.v2"
+  privileged_without_host_devices = true
+  snapshotter = "erofs"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
+    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-preview.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"

--- a/aks-node-controller/parser/templates/containerd_v2.toml.gtpl
+++ b/aks-node-controller/parser/templates/containerd_v2.toml.gtpl
@@ -1,6 +1,19 @@
 version = 2
 oom_score = -999{{if getHasDataDir .KubeletConfig}}
 root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
+{{- if .GetIsKata }}
+[plugins."io.containerd.snapshotter.v1.erofs"]
+  default_size = "10G"
+  enable_fsverity = false
+  ovl_mount_options = []
+
+[plugins."io.containerd.service.v1.diff-service"]
+  default = ["erofs", "walking"]
+
+[plugins."io.containerd.differ.v1.erofs"]
+  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
+  enable_tar_index = false
+{{- end}}
 [plugins."io.containerd.cri.v1.images"]
 {{- if .GetEnableArtifactStreaming }}
   snapshotter = "overlaybd"
@@ -56,8 +69,15 @@ root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
   privileged_without_host_devices = true
+  snapshotter = "overlayfs"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
     ConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
+  runtime_type = "io.containerd.kata.v2"
+  privileged_without_host_devices = true
+  snapshotter = "erofs"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
+    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-preview.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"

--- a/aks-node-controller/parser/templates/containerd_v2_no_GPU.toml.gtpl
+++ b/aks-node-controller/parser/templates/containerd_v2_no_GPU.toml.gtpl
@@ -1,6 +1,19 @@
 version = 2
 oom_score = -999{{if getHasDataDir .KubeletConfig}}
 root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
+{{- if .GetIsKata }}
+[plugins."io.containerd.snapshotter.v1.erofs"]
+  default_size = "10G"
+  enable_fsverity = false
+  ovl_mount_options = []
+
+[plugins."io.containerd.service.v1.diff-service"]
+  default = ["erofs", "walking"]
+
+[plugins."io.containerd.differ.v1.erofs"]
+  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
+  enable_tar_index = false
+{{- end}}
 [plugins."io.containerd.cri.v1.images"]
 {{- if .GetEnableArtifactStreaming }}
   snapshotter = "overlaybd"
@@ -43,8 +56,15 @@ root = "{{.KubeletConfig.GetContainerDataDir}}"{{- end}}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
   privileged_without_host_devices = true
+  snapshotter = "overlayfs"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
     ConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
+  runtime_type = "io.containerd.kata.v2"
+  privileged_without_host_devices = true
+  snapshotter = "erofs"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
+    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-preview.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -420,7 +420,7 @@ func Test_AzureLinuxV3(t *testing.T) {
 // scenario exercises that whole path against a real node.
 //
 // The scenario asserts three increasingly strong properties:
-//  1. the rendered /etc/containerd/config.toml contains the Kata runtime handlers,
+//  1. the rendered /etc/containerd/config.toml contains the Kata runtime handlers and EROFS preamble,
 //  2. containerd actually parsed and loaded them (no warnings, handlers in `config dump`),
 //  3. for every handler in kataRuntimeHandlers, a pod scheduled via a Kata RuntimeClass runs
 //     and is genuinely VM-isolated.
@@ -440,6 +440,7 @@ func Test_AzureLinuxV3Gen2Kata(t *testing.T) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateKataContainerdConfig(ctx, s)
+				ValidateKataErofsContainerdConfig(ctx, s)
 				ValidateKataContainerdConfigDump(ctx, s)
 				ValidateKataHostReadiness(ctx, s)
 				for _, handler := range kataRuntimeHandlers {

--- a/e2e/validators_kata.go
+++ b/e2e/validators_kata.go
@@ -17,7 +17,8 @@ import (
 const (
 	// kataRuntimeHandler is the containerd runtime handler name for standard Kata Containers,
 	// emitted by the IsKata block of the containerd config templates in pkg/agent/baker.go.
-	kataRuntimeHandler = "kata"
+	kataRuntimeHandler        = "kata"
+	kataPreviewRuntimeHandler = "kata-preview"
 
 	// kataConfigPath is the Kata configuration file referenced by the "kata" runtime handler's
 	// options.ConfigPath in the rendered containerd config.
@@ -30,12 +31,12 @@ const (
 // kataRuntimeHandlers lists every Kata containerd runtime handler that this scenario expects to
 // be configured and usable on the node. Each one is asserted in the effective containerd config
 // and independently exercised by ValidateKataPodIsIsolated, so covering an additional handler is
-// a one-line change here plus a call in the scenario.
+// a one-line change here.
 //
 // Note that "kata-cc" (confidential containers) is intentionally absent: its handler block is
 // templated for all Kata VHDs, but it targets a different VHD than regular Kata, so this image
 // cannot actually run it.
-var kataRuntimeHandlers = []string{kataRuntimeHandler}
+var kataRuntimeHandlers = []string{kataRuntimeHandler, kataPreviewRuntimeHandler}
 
 // ValidateKataContainerdConfig asserts that AgentBaker rendered a containerd configuration
 // containing the Kata runtime handlers on a Kata-enabled VHD.
@@ -61,6 +62,26 @@ func ValidateKataContainerdConfig(ctx context.Context, s *Scenario) {
 	// Kata relies on snapshot annotations being forwarded to the snapshotter; the template sets
 	// this explicitly under IsKata and disabling it breaks image pulling for Kata pods.
 	ValidateFileHasContent(ctx, s, containerdConfigPath, "disable_snapshot_annotations = false")
+}
+
+// ValidateKataErofsContainerdConfig checks that the EROFS snapshotter is configured and that
+// containerd loaded all of its EROFS plugins successfully.
+func ValidateKataErofsContainerdConfig(ctx context.Context, s *Scenario) {
+	s.T.Helper()
+
+	ValidateFileHasContent(ctx, s, containerdConfigPath, `[plugins."io.containerd.snapshotter.v1.erofs"]`)
+
+	execResult := execScriptOnVMForScenarioValidateExitCode(ctx, s,
+		"sudo ctr plugins list | grep erofs", 0, "unable to list EROFS containerd plugins")
+	normalizedPluginList := strings.Join(strings.Fields(execResult.stdout), " ")
+	for _, expectedPlugin := range []string{
+		"io.containerd.mount-handler.v1 erofs linux/amd64 ok",
+		"io.containerd.snapshotter.v1 erofs linux/amd64 ok",
+		"io.containerd.differ.v1 erofs linux/amd64 ok",
+	} {
+		assert.Contains(s.T, normalizedPluginList, expectedPlugin,
+			"expected healthy EROFS plugin %q.\nPlugin list:\n%s", expectedPlugin, execResult.stdout)
+	}
 }
 
 // ValidateKataContainerdConfigDump asserts that containerd itself accepted the rendered

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -1933,12 +1933,26 @@ const (
 	containerdV1ConfigTemplate ContainerdConfigTemplate = `version = 2
 oom_score = -999{{if HasDataDir }}
 root = "{{GetDataDir}}"{{- end}}
+{{- if IsKata }}
+[plugins."io.containerd.snapshotter.v1.erofs"]
+  default_size = "10G"
+  enable_fsverity = false
+  ovl_mount_options = []
+
+[plugins."io.containerd.service.v1.diff-service"]
+  default = ["erofs", "walking"]
+
+[plugins."io.containerd.differ.v1.erofs"]
+  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
+  enable_tar_index = false
+{{- end}}
 [plugins."io.containerd.grpc.v1.cri"]
   sandbox_image = "{{GetPodInfraContainerSpec}}"
   enable_cdi = true
   [plugins."io.containerd.grpc.v1.cri".containerd]
     {{- if IsKata }}
     disable_snapshot_annotations = false
+    snapshotter = "overlayfs"
     {{- end}}
     {{- if IsArtifactStreamingEnabled }}
     snapshotter = "overlaybd"
@@ -1995,8 +2009,15 @@ root = "{{GetDataDir}}"{{- end}}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
   privileged_without_host_devices = true
+  snapshotter = "overlayfs"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
     ConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
+  runtime_type = "io.containerd.kata.v2"
+  privileged_without_host_devices = true
+  snapshotter = "erofs"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
+    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-preview.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"
@@ -2013,6 +2034,19 @@ root = "{{GetDataDir}}"{{- end}}
 	containerdV2ConfigTemplate ContainerdConfigTemplate = `version = 2
 oom_score = -999{{if HasDataDir }}
 root = "{{GetDataDir}}"{{- end}}
+{{- if IsKata }}
+[plugins."io.containerd.snapshotter.v1.erofs"]
+  default_size = "10G"
+  enable_fsverity = false
+  ovl_mount_options = []
+
+[plugins."io.containerd.service.v1.diff-service"]
+  default = ["erofs", "walking"]
+
+[plugins."io.containerd.differ.v1.erofs"]
+  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
+  enable_tar_index = false
+{{- end}}
 [plugins."io.containerd.cri.v1.images"]
 {{- if IsArtifactStreamingEnabled }}
   snapshotter = "overlaybd"
@@ -2068,8 +2102,15 @@ root = "{{GetDataDir}}"{{- end}}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
   privileged_without_host_devices = true
+  snapshotter = "overlayfs"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
     ConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
+  runtime_type = "io.containerd.kata.v2"
+  privileged_without_host_devices = true
+  snapshotter = "erofs"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
+    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-preview.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"
@@ -2086,6 +2127,19 @@ root = "{{GetDataDir}}"{{- end}}
 	containerdV2NoGPUConfigTemplate ContainerdConfigTemplate = `version = 2
 oom_score = -999{{if HasDataDir }}
 root = "{{GetDataDir}}"{{- end}}
+{{- if IsKata }}
+[plugins."io.containerd.snapshotter.v1.erofs"]
+  default_size = "10G"
+  enable_fsverity = false
+  ovl_mount_options = []
+
+[plugins."io.containerd.service.v1.diff-service"]
+  default = ["erofs", "walking"]
+
+[plugins."io.containerd.differ.v1.erofs"]
+  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
+  enable_tar_index = false
+{{- end}}
 [plugins."io.containerd.cri.v1.images"]
 {{- if IsArtifactStreamingEnabled }}
   snapshotter = "overlaybd"
@@ -2128,8 +2182,15 @@ root = "{{GetDataDir}}"{{- end}}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
   privileged_without_host_devices = true
+  snapshotter = "overlayfs"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
     ConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
+  runtime_type = "io.containerd.kata.v2"
+  privileged_without_host_devices = true
+  snapshotter = "erofs"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
+    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-preview.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"
@@ -2139,11 +2200,25 @@ root = "{{GetDataDir}}"{{- end}}
 	containerdV1NoGPUConfigTemplate ContainerdConfigTemplate = `version = 2
 oom_score = -999{{if HasDataDir }}
 root = "{{GetDataDir}}"{{- end}}
+{{- if IsKata }}
+[plugins."io.containerd.snapshotter.v1.erofs"]
+  default_size = "10G"
+  enable_fsverity = false
+  ovl_mount_options = []
+
+[plugins."io.containerd.service.v1.diff-service"]
+  default = ["erofs", "walking"]
+
+[plugins."io.containerd.differ.v1.erofs"]
+  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
+  enable_tar_index = false
+{{- end}}
 [plugins."io.containerd.grpc.v1.cri"]
   sandbox_image = "{{GetPodInfraContainerSpec}}"
   [plugins."io.containerd.grpc.v1.cri".containerd]
     {{- if IsKata }}
     disable_snapshot_annotations = false
+    snapshotter = "overlayfs"
     {{- end}}
     {{- if IsArtifactStreamingEnabled }}
     snapshotter = "overlaybd"
@@ -2185,8 +2260,15 @@ root = "{{GetDataDir}}"{{- end}}
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
   privileged_without_host_devices = true
+  snapshotter = "overlayfs"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
     ConfigPath = "/usr/share/defaults/kata-containers/configuration.toml"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview]
+  runtime_type = "io.containerd.kata.v2"
+  privileged_without_host_devices = true
+  snapshotter = "erofs"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-preview.options]
+    ConfigPath = "/usr/share/defaults/kata-containers/configuration-clh-preview.toml"
 [proxy_plugins]
   [proxy_plugins.tardev]
     type = "snapshot"


### PR DESCRIPTION
This is a redo of https://github.com/Azure/AgentBaker/pull/9085 now that we have released the required kata components in Azurelinux. 

Kata's VM templating feature requires a blockfile snapshotter (erofs). Configure the kata runtime block as such in /etc/containerd/config.toml

Erofs snapshotter will be used for VM templating, arbitrary snapshot/restore API, and kata-cc will, in a future change, switch over to using it over tardev snapshotter.

There is no risk of regression or backwards-compatibility issues in AKS kata; the erofs snapshotter configuration is gated behind a new runtime class, kata-preview.

What this PR does / why we need it:

Introduce new kata-preview runtime class block in containerd config.toml
Introduce erofs snapshotter block in containerd config.toml
Configure erofs snapshotter to be used by kata-preview only.
Which issue(s) this PR fixes:
No existing issue; this is being done to enable a new incoming kata feature.