### PR TITLE
chore: upgrade Azure Disk CSI driver versions

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -506,23 +506,23 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azuredisk-csi",
-          "latestVersion": "v1.34.4"
+          "latestVersion": "v1.34.5"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azuredisk-csi",
-          "latestVersion": "v1.33.10"
+          "latestVersion": "v1.33.11"
         }
       ],
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azuredisk-csi",
-          "latestVersion": "v1.34.4-windows-hp",
-          "previousLatestVersion": "v1.34.3-windows-hp"
+          "latestVersion": "v1.34.5-windows-hp",
+          "previousLatestVersion": "v1.34.4-windows-hp"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azuredisk-csi",
-          "latestVersion": "v1.33.10-windows-hp",
-          "previousLatestVersion": "v1.33.9-windows-hp"
+          "latestVersion": "v1.33.11-windows-hp",
+          "previousLatestVersion": "v1.33.10-windows-hp"
         }
       ]
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Azure Disk CSI driver versions in `parts/common/components.json` to keep AgentBaker aligned with the latest published releases.

Specifically:
- bump multi-arch `v1.34.4` -> `v1.34.5`
- bump multi-arch `v1.33.10` -> `v1.33.11`
- bump Windows HostProcess `v1.34.4-windows-hp` -> `v1.34.5-windows-hp`
- bump Windows HostProcess `v1.33.10-windows-hp` -> `v1.33.11-windows-hp`
- advance the corresponding `previousLatestVersion` fields for the Windows entries

**Which issue(s) this PR fixes**:

N/A
