### PR TITLE
chore: upgrade Azure File CSI driver versions

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -532,8 +532,8 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.35.6",
-          "previousLatestVersion": "v1.35.5"
+          "latestVersion": "v1.35.7",
+          "previousLatestVersion": "v1.35.6"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
@@ -542,15 +542,15 @@
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.34.7",
-          "previousLatestVersion": "v1.34.6"
+          "latestVersion": "v1.34.8",
+          "previousLatestVersion": "v1.34.7"
         }
       ],
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.35.6-windows-hp",
-          "previousLatestVersion": "v1.35.5-windows-hp"
+          "latestVersion": "v1.35.7-windows-hp",
+          "previousLatestVersion": "v1.35.6-windows-hp"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
@@ -559,8 +559,8 @@
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/azurefile-csi",
-          "latestVersion": "v1.34.7-windows-hp",
-          "previousLatestVersion": "v1.34.6-windows-hp"
+          "latestVersion": "v1.34.8-windows-hp",
+          "previousLatestVersion": "v1.34.7-windows-hp"
         }
       ]
     },


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR upgrades the Azure File CSI driver versions referenced by AgentBaker in `parts/common/components.json`.

Updated versions:
- Linux image:
  - `v1.35.6` -> `v1.35.7`
  - `v1.34.7` -> `v1.34.8`
- Windows hostprocess image:
  - `v1.35.6-windows-hp` -> `v1.35.7-windows-hp`
  - `v1.34.7-windows-hp` -> `v1.34.8-windows-hp`

This keeps AgentBaker aligned with the latest Azure File CSI driver patch releases.

**Which issue(s) this PR fixes**:
N/A
