### PR TITLE
fix: preserve prefer_udp in LocalDNS Corefile

### DIFF
--- a/aks-node-controller/parser/helper_test.go
+++ b/aks-node-controller/parser/helper_test.go
@@ -1683,6 +1683,7 @@ health-check.localdns.local:53 {
         fallthrough
     }
     forward . 168.63.129.16 {
+        prefer_udp
         policy sequential
         max_concurrent 1000
     }
@@ -1727,6 +1728,7 @@ testdomain456.com:53 {
     log
     bind 169.254.10.10
     forward . 10.0.0.10 {
+        prefer_udp
         policy sequential
         max_concurrent 1000
     }
@@ -1752,6 +1754,7 @@ testdomain456.com:53 {
         fallthrough
     }
     forward . 10.0.0.10 {
+        prefer_udp
         policy sequential
         max_concurrent 2000
     }

--- a/aks-node-controller/parser/templates/localdns.toml.gtpl
+++ b/aks-node-controller/parser/templates/localdns.toml.gtpl
@@ -43,6 +43,9 @@ health-check.localdns.local:53 {
         {{- if eq $override.Protocol "ForceTCP"}}
         force_tcp
         {{- end}}
+        {{- if eq $override.Protocol "PreferUDP"}}
+        prefer_udp
+        {{- end}}
         policy {{$forwardPolicy}}
         max_concurrent {{$override.MaxConcurrent}}
     }
@@ -107,6 +110,9 @@ health-check.localdns.local:53 {
     {{- end}}
         {{- if eq $override.Protocol "ForceTCP"}}
         force_tcp
+        {{- end}}
+        {{- if eq $override.Protocol "PreferUDP"}}
+        prefer_udp
         {{- end}}
         policy {{$forwardPolicy}}
         max_concurrent {{$override.MaxConcurrent}}

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -2306,6 +2306,9 @@ health-check.localdns.local:53 {
         {{- if eq $override.Protocol "ForceTCP"}}
         force_tcp
         {{- end}}
+        {{- if eq $override.Protocol "PreferUDP"}}
+        prefer_udp
+        {{- end}}
         policy {{$forwardPolicy}}
         max_concurrent {{$override.MaxConcurrent}}
     }
@@ -2370,6 +2373,9 @@ health-check.localdns.local:53 {
     {{- end}}
         {{- if eq $override.Protocol "ForceTCP"}}
         force_tcp
+        {{- end}}
+        {{- if eq $override.Protocol "PreferUDP"}}
+        prefer_udp
         {{- end}}
         policy {{$forwardPolicy}}
         max_concurrent {{$override.MaxConcurrent}}

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -470,6 +470,7 @@ health-check.localdns.local:53 {
         fallthrough
     }
     forward . 168.63.129.16 {
+        prefer_udp
         policy sequential
         max_concurrent 1000
     }
@@ -514,6 +515,7 @@ testdomain456.com:53 {
     log
     bind 169.254.10.10
     forward . 10.0.0.10 {
+        prefer_udp
         policy sequential
         max_concurrent 1000
     }
@@ -539,6 +541,7 @@ testdomain456.com:53 {
         fallthrough
     }
     forward . 10.0.0.10 {
+        prefer_udp
         policy sequential
         max_concurrent 2000
     }
@@ -659,6 +662,7 @@ health-check.localdns.local:53 {
         fallthrough
     }
     forward . 168.63.129.16 {
+        prefer_udp
         policy sequential
         max_concurrent 1000
     }
@@ -703,6 +707,7 @@ testdomain456.com:53 {
     log
     bind 169.254.10.10
     forward . 10.0.0.10 {
+        prefer_udp
         policy sequential
         max_concurrent 1000
     }
@@ -728,6 +733,7 @@ testdomain456.com:53 {
         fallthrough
     }
     forward . 10.0.0.10 {
+        prefer_udp
         policy sequential
         max_concurrent 1000
     }
@@ -772,6 +778,7 @@ testdomain567.com:53 {
     errors
     bind 169.254.10.11
     forward . 168.63.129.16 {
+        prefer_udp
         policy random
         max_concurrent 1000
     }
@@ -837,6 +844,7 @@ testdomain567.com:53 {
 				Expect(localDNSCoreFile).To(ContainSubstring("bind 169.254.10.10"))
 				Expect(localDNSCoreFile).To(ContainSubstring("bind 169.254.10.11"))
 				Expect(localDNSCoreFile).To(ContainSubstring("forward . 168.63.129.16"))
+				Expect(localDNSCoreFile).To(ContainSubstring("prefer_udp"))
 				Expect(localDNSCoreFile).To(ContainSubstring("nsid localdns"))
 				Expect(localDNSCoreFile).To(ContainSubstring("nsid localdns-pod"))
 			})


### PR DESCRIPTION
## Change summary

Preserves CoreDNS prefer_udp behavior when LocalDNS overrides specify Protocol: PreferUDP.

- Updates the aks-node-controller LocalDNS Corefile template to render prefer_udp in forward blocks when the override protocol is PreferUDP.
- Updates the legacy pkg/agent LocalDNS Corefile renderer with the same prefer_udp handling so scriptless and non-scriptless render paths stay consistent.
- Keeps existing force_tcp behavior intact for Protocol: ForceTCP.
- Updates LocalDNS Corefile golden/assertion coverage so PreferUDP is emitted for both render paths.

This fixes a mismatch where LocalDNS override data could carry Protocol: PreferUDP, but the generated Corefile did not preserve that setting.

## Testing

- GOPROXY=https://proxy.golang.org,direct go test ./pkg/agent
- cd aks-node-controller && GOPROXY=https://proxy.golang.org,direct go test ./...
