### PR TITLE
test(e2e): use the default VM SKU for kata and build the kata VHD in the PR gate

### DIFF
--- a/.pipelines/.vsts-vhd-builder.yaml
+++ b/.pipelines/.vsts-vhd-builder.yaml
@@ -183,6 +183,32 @@ stages:
           parameters:
             artifactName: azurelinuxv3-gen2
 
+    # Kata VHDs are built here so that VHD-side Kata changes (kata packages, erofs tooling,
+    # kata configuration files) are covered by the E2E stage below. Without this job no Kata
+    # image carries this build's buildId tag, so Test_AzureLinuxV3Gen2Kata silently skips
+    # (the E2E stage sets IgnoreScenariosWithMissingVhd: true).
+    - job: buildAzureLinuxV3gen2kata
+      timeoutInMinutes: 360
+      steps:
+        - bash: |
+            echo '##vso[task.setvariable variable=OS_SKU]AzureLinux'
+            echo '##vso[task.setvariable variable=OS_VERSION]V3kata'
+            echo '##vso[task.setvariable variable=IMG_PUBLISHER]MicrosoftCBLMariner'
+            echo '##vso[task.setvariable variable=IMG_OFFER]azure-linux-3'
+            echo '##vso[task.setvariable variable=IMG_SKU]azure-linux-3-gen2'
+            echo '##vso[task.setvariable variable=IMG_VERSION]latest'
+            echo '##vso[task.setvariable variable=HYPERV_GENERATION]V2'
+            echo '##vso[task.setvariable variable=AZURE_VM_SIZE]Standard_D16ads_v5'
+            echo '##vso[task.setvariable variable=FEATURE_FLAGS]kata'
+            echo '##vso[task.setvariable variable=ARCHITECTURE]X86_64'
+            echo '##vso[task.setvariable variable=ENABLE_FIPS]false'
+            echo '##vso[task.setvariable variable=ENABLE_TRUSTED_LAUNCH]False'
+            echo '##vso[task.setvariable variable=ENABLE_CGROUPV2]True'
+          displayName: Setup Build Variables
+        - template: ./templates/.builder-release-template.yaml
+          parameters:
+            artifactName: azurelinuxv3-gen2-kata
+
     - job: buildAzureLinuxV3ARM64gen2fips
       timeoutInMinutes: 360
       steps:

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -434,16 +434,9 @@ func Test_AzureLinuxV3Gen2Kata(t *testing.T) {
 			Cluster: ClusterKubenet,
 			VHD:     config.VHDAzureLinuxV3Gen2Kata,
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				// Kata launches each pod inside its own VM, which requires nested virtualization
-				// and more headroom than the 2-vCPU e2e default (config.Config.DefaultVMSKU).
-				nbc.ContainerService.Properties.AgentPoolProfiles[0].VMSize = kataVMSize
-				nbc.AgentPoolProfile.VMSize = kataVMSize
 				// Leave unattended upgrades on so that CSE's kata-specific opt-out branch is
 				// actually exercised, which ValidateKataHostReadiness asserts.
 				nbc.DisableUnattendedUpgrades = false
-			},
-			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
-				vmss.SKU.Name = to.Ptr(kataVMSize)
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateKataContainerdConfig(ctx, s)
@@ -456,9 +449,6 @@ func Test_AzureLinuxV3Gen2Kata(t *testing.T) {
 		},
 	})
 }
-
-// kataVMSize is a nested-virtualization capable SKU with enough capacity to host a Kata guest VM.
-const kataVMSize = "Standard_D4ds_v5"
 
 func Test_AzureLinuxV3_CustomCA(t *testing.T) {
 	RunScenario(t, &Scenario{


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up to #9142. Both changes were requested in review there but landed on the branch after it was merged, so they missed the merge.

**1. Use the default VM SKU for the Kata scenario**

`Test_AzureLinuxV3Gen2Kata` pinned `Standard_D4ds_v5`. Reverted to `config.Config.DefaultVMSKU` to avoid consuming extra quota; the default is nested-virtualization capable, which is what Kata requires. This removes the `kataVMSize` constant along with the `VMConfigMutator` and the two `VMSize` assignments that existed only to apply it.

**2. Build the Kata VHD in the Linux VHD PR check-in gate**

`.pipelines/.vsts-vhd-builder.yaml` builds no Kata image today. That means no Kata VHD carries the gate build's `buildId` tag, and since its E2E stage sets `IgnoreScenariosWithMissingVhd: true`, `Test_AzureLinuxV3Gen2Kata` **silently skips** there. VHD-side Kata changes (kata packages, erofs tooling, kata configuration files) therefore get no pre-merge E2E coverage at all — they are only exercised once a release Kata VHD reaches `main`.

Adds `buildAzureLinuxV3gen2kata`, mirroring the job in `.vsts-vhd-builder-release.yaml` (`OS_VERSION=V3kata`, `FEATURE_FLAGS=kata`, `Standard_D16ads_v5`). With this, a Kata image carries the gate's `buildId`, the E2E stage resolves it via `VHD_BUILD_ID`, and the scenario runs against a VHD built from the PR.

**Notes for reviewers**

- This adds a job with a 360-minute timeout to every PR matching the gate's path filter (`vhdbuilder/packer`, `parts/linux/*`, `aks-node-controller/**`, `parts/common/components.json`, `go.mod`, ...). If that cost is higher than wanted, it is a small change to put it behind a pipeline parameter defaulting to false — happy to do that instead.
- On the SKU change: the Kata pod came up in 18s on 4 vCPU / 16 GB in the #9142 E2E run. The default SKU gives the guest VM less headroom, so if the Kata pod starts flaking this is the first thing to revisit.
- Kept as a draft until the new VHD job is confirmed working in this PR's own gate run, since this PR touches `.pipelines/**` and should trigger it.

**Which issue(s) this PR fixes**:

N/A