### PR TITLE
fix: read simship image URLs for the 2025-gen2-tl sku

### DIFF
--- a/vhdbuilder/packer/produce-packer-settings-functions.sh
+++ b/vhdbuilder/packer/produce-packer-settings-functions.sh
@@ -119,7 +119,7 @@ function extract_windows_image_urls() {
 		windows_nanoserver_image_url="$(jq -r '.images[] | select(.name == "WINDOWS_2025_NANO_IMAGE_URL") | .value' "$artifact_path"),$(jq -r '.images[] | select(.name == "WINDOWS_2022_NANO_IMAGE_URL") | .value' "$artifact_path")"
 		windows_servercore_image_url="$(jq -r '.images[] | select(.name == "WINDOWS_2025_CORE_IMAGE_URL") | .value' "$artifact_path"),$(jq -r '.images[] | select(.name == "WINDOWS_2022_CORE_IMAGE_URL") | .value' "$artifact_path")"
 		;;
-	"2025-gen2")
+	"2025-gen2" | "2025-gen2-tl")
 		WINDOWS_BASE_IMAGE_URL=$(jq -r '.images[] | select(.name == "WINDOWS_2025_GEN2_BASE_IMAGE_URL") | .value' "$artifact_path")
 		windows_nanoserver_image_url="$(jq -r '.images[] | select(.name == "WINDOWS_2025_NANO_IMAGE_URL") | .value' "$artifact_path"),$(jq -r '.images[] | select(.name == "WINDOWS_2022_NANO_IMAGE_URL") | .value' "$artifact_path")"
 		windows_servercore_image_url="$(jq -r '.images[] | select(.name == "WINDOWS_2025_CORE_IMAGE_URL") | .value' "$artifact_path"),$(jq -r '.images[] | select(.name == "WINDOWS_2022_CORE_IMAGE_URL") | .value' "$artifact_path")"


### PR DESCRIPTION
**What this PR does / why we need it**:

`extract_windows_image_urls()` in `vhdbuilder/packer/produce-packer-settings-functions.sh` matches `WINDOWS_SKU` exactly. When `2025-gen2-tl` was added in #8768 this case statement wasn't updated, so the Trusted Launch SKU falls through to the default branch, prints `Unsupported WINDOWS_SKU: 2025-gen2-tl` and leaves `windows_nanoserver_image_url` and `windows_servercore_image_url` empty. The empty check right after it only echoes a warning, so the build degrades quietly instead of failing.

This only fires on the simship path (`useContainerUrlsFromJson=true`), which is why the `Release_20260715.1` build passed. It bites anyone testing the TL SKU against a WCCT simship payload.

Trusted Launch consumes the same base VHD and the same container images as regular `2025-gen2`. Both stages in `.build-and-test-windows-vhds-template.yaml` already pass the same `$(WINDOWS_2025_GEN2_BASE_IMAGE_URL)`, `$(WINDOWS_2025_NANO_IMAGE_URL)`, `$(WINDOWS_2025_CORE_IMAGE_URL)` and the same payload URL. Only the gallery image definition's security type and packer's security profile differ. So the existing branch is reused as is and no new payload keys are needed.

The PowerShell half of this path (`windows-vhd-content-test.ps1`) already matches on a `*2025*` wildcard, which is why only the bash half missed the SKU.

**Verification**

Sourced the function with a synthetic payload and compared `origin/main` against this branch, `WINDOWS_SKU=2025-gen2-tl`:

```
BEFORE  msg : Unsupported WINDOWS_SKU: 2025-gen2-tl
        base/nano/core: <EMPTY>

AFTER   base: https://sim/2025gen2-base.vhd
        nano: https://sim/nano2025.tar,https://sim/nano2022.tar
        core: https://sim/core2025.tar,https://sim/core2022.tar
```

Output is byte-identical to `2025-gen2`. Unknown SKUs still hit the default branch and print `Unsupported WINDOWS_SKU`. `shellcheck -S error` is clean.

**Which issue(s) this PR fixes**:

N/A
