### PR TITLE
test: add logging to e2es when a pod doesn't stay in pending state

### DIFF
--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -126,14 +126,12 @@ func (k *Kubeclient) WaitUntilPodRunning(ctx context.Context, namespace string, 
 		// Check for container failure states
 		for _, containerStatus := range pod.Status.ContainerStatuses {
 			if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == "CrashLoopBackOff" {
-				logPodDebugInfo(ctx, k, pod)
 				return false, fmt.Errorf("pod %s is in CrashLoopBackOff state", pod.Name)
 			}
 		}
 
 		switch pod.Status.Phase {
 		case corev1.PodFailed:
-			logPodDebugInfo(ctx, k, pod)
 			return false, fmt.Errorf("pod %s has failed", pod.Name)
 		case corev1.PodPending:
 			return false, nil // Keep polling
@@ -148,10 +146,19 @@ func (k *Kubeclient) WaitUntilPodRunning(ctx context.Context, namespace string, 
 			}
 			return false, nil // Running but not ready yet
 		default:
-			logPodDebugInfo(ctx, k, pod)
 			return false, fmt.Errorf("pod %s is in unexpected phase %s", pod.Name, pod.Status.Phase)
 		}
 	})
+
+	// Dump events/logs/container statuses for any failure to wait for the pod to be running,
+	// including a Pending pod that never transitioned before the poll's own deadline expired
+	// (e.g. a stuck image pull or sandbox creation) which would otherwise surface as a bare
+	// "context deadline exceeded" with no diagnostic information.
+	if err != nil && pod != nil {
+		debugCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		logPodDebugInfo(debugCtx, k, pod)
+	}
 
 	return pod, err
 }

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -21,7 +21,7 @@ import (
 func ValidatePodRunningWithRetry(ctx context.Context, s *Scenario, pod *corev1.Pod, maxRetries int) {
 	var err error
 	for i := range maxRetries {
-		err = validatePodRunning(ctx, s, pod)
+		err = startPodAndCheckItRuns(ctx, s, pod)
 		if err != nil {
 			time.Sleep(1 * time.Second)
 			s.T.Logf("retrying pod %q validation (%d/%d)", pod.Name, i+1, maxRetries)
@@ -33,7 +33,7 @@ func ValidatePodRunningWithRetry(ctx context.Context, s *Scenario, pod *corev1.P
 }
 
 func ValidatePodRunning(ctx context.Context, s *Scenario, pod *corev1.Pod) {
-	require.NoErrorf(s.T, validatePodRunning(ctx, s, pod), "failed to validate pod running %q", pod.Name)
+	require.NoErrorf(s.T, startPodAndCheckItRuns(ctx, s, pod), "failed to validate pod running %q", pod.Name)
 }
 
 func ValidateCommonLinux(ctx context.Context, s *Scenario) {
@@ -148,7 +148,7 @@ func ValidateCommonWindows(ctx context.Context, s *Scenario) {
 	ValidateKubeletServingCertificateRotation(ctx, s)
 }
 
-func validatePodRunning(ctx context.Context, s *Scenario, pod *corev1.Pod) error {
+func startPodAndCheckItRuns(ctx context.Context, s *Scenario, pod *corev1.Pod) error {
 	kube := s.Runtime.Kube
 	truncatePodName(s.T, pod)
 	start := time.Now()


### PR DESCRIPTION

add logging to e2es when a pod doesn't stays in pending state

**What this PR does / why we need it**:

Debugging some windows e2e failures and need some more information.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
