### PR TITLE
feat: add reload plugin to LocalDNS Corefile

### DIFF
--- a/aks-node-controller/parser/helper_test.go
+++ b/aks-node-controller/parser/helper_test.go
@@ -1686,6 +1686,7 @@ health-check.localdns.local:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -1713,6 +1714,7 @@ cluster.local:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -1730,6 +1732,7 @@ testdomain456.com:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -1755,6 +1758,7 @@ testdomain456.com:53 {
         policy sequential
         max_concurrent 2000
     }
+    reload
     ready 169.254.10.11:8181
     cache 3600 {
         success 9984

--- a/aks-node-controller/parser/templates/localdns.toml.gtpl
+++ b/aks-node-controller/parser/templates/localdns.toml.gtpl
@@ -46,6 +46,7 @@ health-check.localdns.local:53 {
         policy {{$forwardPolicy}}
         max_concurrent {{$override.MaxConcurrent}}
     }
+    reload
     ready {{getLocalDnsNodeListenerIp}}:8181
     cache {{$override.CacheDurationInSeconds}} {
         success 9984
@@ -111,6 +112,7 @@ health-check.localdns.local:53 {
         policy {{$forwardPolicy}}
         max_concurrent {{$override.MaxConcurrent}}
     }
+    reload
     ready {{getLocalDnsClusterListenerIp}}:8181
     cache {{$override.CacheDurationInSeconds}} {
         success 9984

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -2309,6 +2309,7 @@ health-check.localdns.local:53 {
         policy {{$forwardPolicy}}
         max_concurrent {{$override.MaxConcurrent}}
     }
+    reload
     ready {{$.NodeListenerIP}}:8181
     cache {{$override.CacheDurationInSeconds}} {
         success 9984
@@ -2374,6 +2375,7 @@ health-check.localdns.local:53 {
         policy {{$forwardPolicy}}
         max_concurrent {{$override.MaxConcurrent}}
     }
+    reload
     ready {{$.ClusterListenerIP}}:8181
     cache {{$override.CacheDurationInSeconds}} {
         success 9984

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -473,6 +473,7 @@ health-check.localdns.local:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -500,6 +501,7 @@ cluster.local:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -517,6 +519,7 @@ testdomain456.com:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -542,6 +545,7 @@ testdomain456.com:53 {
         policy sequential
         max_concurrent 2000
     }
+    reload
     ready 169.254.10.11:8181
     cache 3600 {
         success 9984
@@ -662,6 +666,7 @@ health-check.localdns.local:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -689,6 +694,7 @@ cluster.local:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -706,6 +712,7 @@ testdomain456.com:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -731,6 +738,7 @@ testdomain456.com:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.11:8181
     cache 3600 {
         success 9984
@@ -758,6 +766,7 @@ cluster.local:53 {
         policy round_robin
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.11:8181
     cache 3600 {
         success 9984
@@ -775,6 +784,7 @@ testdomain567.com:53 {
         policy random
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.11:8181
     cache 3600 {
         success 9984


### PR DESCRIPTION
## Change Summary

Adds the CoreDNS `reload` plugin to generated LocalDNS Corefiles so CoreDNS can reload configuration changes without restarting the `localdns` systemd unit.

- Adds server-block-level `reload` directives to the `aks-node-controller` LocalDNS template.
- Adds the same directives to the legacy `pkg/agent` LocalDNS template so both render paths stay consistent.
- Preserves the existing `hosts` plugin `reload 5s` directives, which watch the hosts file rather than the Corefile.
- Updates the LocalDNS Corefile golden tests and assertions for both render paths.

The CoreDNS defaults are used: a 30-second reload interval with 15 seconds of jitter. Configuration changes are therefore applied asynchronously after the file is updated; restarting `localdns.service` is not required.

## Testing

- `cd aks-node-controller && go test ./parser ./pkg/nodeconfigutils`
- `go test ./pkg/agent ./pkg/agent/datamodel`
- Standalone smoke test on LocalDNS-enabled cluster `ldnsreload2243` from run `176179054`:
  - Verified the bundled CoreDNS binary includes the `reload` plugin.
  - Verified LocalDNS readiness on `169.254.10.10:8181` and `169.254.10.11:8181`.
  - Verified cluster DNS resolution through `169.254.10.11`.
  - Restored the original Corefile and confirmed `localdns.service` remained active.

The standalone test validated the rendered configuration and service health. A follow-up test should update the Corefile while the service remains running and verify that the new configuration takes effect without a service restart.
