### PR TITLE
fix: pin 2404 kernel to 6.8.0-1062-azure due to perf regression

### DIFF
--- a/vhdbuilder/packer/pre-install-dependencies.sh
+++ b/vhdbuilder/packer/pre-install-dependencies.sh
@@ -185,6 +185,18 @@ if [[ ${UBUNTU_RELEASE//./} -ge 2204 && "${ENABLE_FIPS,,}" != "true" ]]; then
       "linux-headers-azure-lts-${UBUNTU_RELEASE}"
     )
     echo "Installing fde LTS kernel for CVM Ubuntu ${UBUNTU_RELEASE}"
+  elif [ "${UBUNTU_RELEASE}" = "24.04" ]; then
+    # Pin to 6.8.0-1062-azure to avoid regression in 6.8.0-1063-azure
+    # (LP #2070072 conntrack-on-promisc revert + LP #2144730 ITS mitigation).
+    KERNEL_IMAGE="linux-image-6.8.0-1062-azure"
+    KERNEL_PACKAGES=(
+      "linux-image-6.8.0-1062-azure"
+      "linux-tools-6.8.0-1062-azure"
+      "linux-cloud-tools-6.8.0-1062-azure"
+      "linux-headers-6.8.0-1062-azure"
+      "linux-modules-extra-6.8.0-1062-azure"
+    )
+    echo "Installing pinned LTS kernel 6.8.0-1062-azure for Ubuntu 24.04 (regression in 1063)"
   else
     # Use LTS kernel for other versions
     KERNEL_IMAGE="linux-image-azure-lts-${UBUNTU_RELEASE}"
@@ -197,9 +209,13 @@ if [[ ${UBUNTU_RELEASE//./} -ge 2204 && "${ENABLE_FIPS,,}" != "true" ]]; then
     echo "Installing LTS kernel for Ubuntu ${UBUNTU_RELEASE}"
   fi
 
-  # Add modules-extra only when the package exists in the current apt repo
+  # Add modules-extra only when the package exists in the current apt repo.
+  # Skip for the pinned 24.04 case: the exact-version modules-extra is already in
+  # KERNEL_PACKAGES, and the LTS metapackage would pull the newer (pinned-out) kernel.
   MODULES_EXTRA_PKG="linux-modules-extra-azure-lts-${UBUNTU_RELEASE}"
-  if apt-cache show "${MODULES_EXTRA_PKG}" &>/dev/null; then
+  if [ "$KERNEL_IMAGE" = "linux-image-6.8.0-1062-azure" ]; then
+    echo "Pinned kernel selected - using exact-version modules-extra, skipping ${MODULES_EXTRA_PKG}"
+  elif apt-cache show "${MODULES_EXTRA_PKG}" &>/dev/null; then
     KERNEL_PACKAGES+=("${MODULES_EXTRA_PKG}")
   else
     echo "Package ${MODULES_EXTRA_PKG} not available - skipping"

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -794,20 +794,37 @@ testLtsKernel() {
   # shellcheck disable=SC3010
   if [[ "$os_sku" == "Ubuntu" && ${enable_fips,,} != "true" ]] ; then
     echo "OS is Ubuntu, FIPS is not enabled, check LTS kernel version"
+    # CVM builds use linux-image-azure-fde-lts-* (different flavor), skip exact pin check
+    local is_cvm=false
+    if grep -q "cvm" <<< "$FEATURE_FLAGS"; then
+      is_cvm=true
+    fi
+
     # Check the Ubuntu version and set the expected kernel version
-    if [ "$os_version" = "22.04" ]; then
+    if [ "$os_version" = "24.04" ] && [ "$is_cvm" = "false" ]; then
+      # Pinned to exact version to avoid regression in 6.8.0-1063-azure
+      expected_kernel="6.8.0-1062-azure"
+    elif [ "$os_version" = "22.04" ]; then
       expected_kernel="5.15"
     elif [ "$os_version" = "24.04" ]; then
       expected_kernel="6.8"
     else
       # TODO(2604): update once 26.04 LTS kernel metapackage is available
-      echo "LTS kernel not installed for: $os_version"
+      echo "LTS kernel not installed for: $os_version, skipping check"
+      echo "$test:Finish"
+      return
     fi
 
     kernel=$(uname -r)
     echo "Current kernel version: $kernel"
     # shellcheck disable=SC3010
-    if [[ "$kernel" == *"$expected_kernel"* ]]; then
+    if [ "$os_version" = "24.04" ] && [ "$is_cvm" = "false" ]; then
+      if [[ "$kernel" == "$expected_kernel" ]]; then
+        echo "Kernel version matches pinned version ($expected_kernel)."
+      else
+        err $test "Kernel version does not match pinned version. Expected exactly $expected_kernel, found $kernel."
+      fi
+    elif [[ "$kernel" == *"$expected_kernel"* ]]; then
       echo "Kernel version is as expected ($expected_kernel)."
     else
       err $test "Kernel version is not as expected. Expected $expected_kernel, found $kernel."


### PR DESCRIPTION
>Holding at 6.8.0-1062 forgoes 507 CVE fixes from the 1063 security rebase + 1064 roll-up. ~35 are critical-class (UAF/OOB/double-free/race) in cloud-reachable paths — core net/netfilter/TCP-IP, KVM, NVMe-oF/RDMA, the Azure mana NIC driver (CVE-2026-43056), and SMB/NFS. Rollback should therefore be a temporary, targeted mitigation for affected workloads, with a fixed 1064-base kernel (regressions reverted) prioritized.

Kernel **6.8.0-1063-azure (Ubuntu 24.04 / noble)** introduces a regression affecting networking dataplane and CPU-bound workloads. 6.8.0-1062-azure and 6.8.0-1059-azure are unaffected. The regression is in the kernel only — userspace (iptables  1.8.10-3ubuntu2 , etc.) is unchanged across the affected/unaffected builds, so package versions do not explain the symptoms.

**Root cause — two independent 1063-only changes**

1. LP #2070072 —  SAUCE: Revert "netfilter: br_netfilter: skip conntrack input hook for promisc packets" 
• Reverts a perf optimization (added to fix a bridge hairpinning bug). The conntrack input hook now runs on every promisc-mode packet.
• Impact: nf_tables ruleset programming instability and elevated per-packet conntrack CPU on bridge/promisc dataplanes. Observed as a NAT ruleset that reports a successful sync but does not persist ( nft list ruleset  empty despite hundreds of programmed rules), causing loss of service DNAT → TCP retransmit stalls (65/134/285/365s) and 5xx.
2. LP #2144730 — "ITS mitigation is not enabled on affected CPUs"
• Enables ITS mitigation (aligned branch/return thunks, CVE-2024-28956) on affected Intel SKUs.
• Impact: extra indirect-branch overhead on JIT/dispatch-heavy workloads (observed ~2x CPU/request on a managed-runtime service). Confirmed active:  indirect_target_selection: Mitigation: Aligned branch/return thunks .

**Observed impact (all on kernel 6.8.0-1063-azure)**

• Dataplane: nf_tables NAT rules fail to persist on affected nodes → service routing/DNAT loss → connection stalls and 5xx.
• CPU: ~2x CPU/request + intermittent 5xx on an indirect-branch-heavy workload, immediately after upgrade from a 1062-based image.
• Mitigation confirmed in the field: rolling the affected nodes back to a pre-1063 image cleared the issue in every case.

**Repro status**

Attribution is from the  6.8.0-1059/1062 → 1063  changelog diff plus field rollback evidence. A clean same-SKU 1062-vs-1063 A/B is still pending (test nodes landed on differing CPU SKUs).