### PR TITLE
docs: add Ben Brady & Windows CSE code owners; fix testdata generation target

### DIFF
--- a/.pipelines/.vsts-vhd-refresh-testdata.yaml
+++ b/.pipelines/.vsts-vhd-refresh-testdata.yaml
@@ -33,7 +33,7 @@ stages:
           displayName: Generate Testdata
         - task: PublishPipelineArtifact@1
           inputs:
-            targetPath: $(Pipeline.Workspace)/s/pkg/agent/testdata
+            targetPath: $(Pipeline.Workspace)/s/aks-node-controller/parser/testdata
             artifact: testdata
             publishLocation: pipeline
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
       "text": "Ensure all new code is covered by tests.",
     },
     {
-      "text": "If changes are in folder 'parts', 'pkg', run 'make generate' to regenerate the snapshot test data.",
+      "text": "If changes are in folder 'aks-node-controller/parser', run 'make generate-testdata' to regenerate the snapshot test data.",
     }
   ],
   "github.copilot.chat.testGeneration.instructions": [
@@ -46,7 +46,7 @@
       "text": "1. Ensure all tests pass before submitting: `make test`",
     },
     {
-      "text": "2. If changes were made to parts/ or pkg/ directories, run `make generate` to update testdata",
+      "text": "2. If changes were made to aks-node-controller/parser, run `make generate-testdata` to update its testdata",
     },
     {
       "text": "3. Provide a clear description of the changes in the PR description",
@@ -61,13 +61,13 @@
       "text": "When resolving merge conflicts in PRs, use the following strategy for testdata directories:",
     },
     {
-      "text": "1. Accept 'theirs' for the testdata directory: `git checkout --theirs origin/master pkg/agent/testdata`",
+      "text": "1. Accept 'theirs' for the testdata directory: `git checkout --theirs origin/master aks-node-controller/parser/testdata`",
     },
     {
-      "text": "2. Stage the changes: `git add pkg/agent/testdata`",
+      "text": "2. Stage the changes: `git add aks-node-controller/parser/testdata`",
     },
     {
-      "text": "3. Regenerate test data: `make generate`",
+      "text": "3. Regenerate test data: `make generate-testdata`",
     },
     {
       "text": "4. Commit with message 'test: update testdata'",

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @AbelHu @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @sulixu @SriHarsha001 @runzhen @karenychen @xuexu6666 @titilambert
+* @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @AbelHu @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @sulixu @SriHarsha001 @runzhen @karenychen @xuexu6666 @titilambert @benjamin-brady
 
 # Code owners for for cse_cmd.sh and nodecustomdata.yml. This is to ensure that the scriptless v-team is aware of the changes in order to sync with AKSNodeConfig.
 cse_cmd.sh @Devinwong @lilypan26 @r2k1 @timmy-wright @cameronmeissner @awesomenix @djsly
@@ -35,3 +35,7 @@ vhdbuilder/packer/windows/windows_settings.json
 parts/linux/cloud-init/artifacts/localdns_exporter.sh @saewoni @yewmsft @jingwenw15
 spec/parts/linux/cloud-init/artifacts/localdns_exporter_spec.sh @saewoni @yewmsft @jingwenw15
 e2e/localdns/validate-localdns-exporter-metrics.sh @saewoni @yewmsft @jingwenw15
+
+# Code owners for Windows CSE files.
+parts/windows/ @timmy-wright @r2k1 @benjamin-brady @djsly
+staging/cse/windows/ @timmy-wright @r2k1 @benjamin-brady @djsly

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ generate-manifest:
 .PHONY: generate-testdata
 generate-testdata:
 	@echo $(GOFLAGS)
-	GENERATE_TEST_DATA="true" go test ./pkg/agent...
+	cd aks-node-controller && GENERATE_TEST_DATA="true" go test ./parser/...
 
 .PHONY: generate # TODO: ONLY generate go testdata
 generate: bootstrap


### PR DESCRIPTION
## Summary
- Add Ben Brady (`@benjamin-brady`) as a global CODEOWNERS reviewer.
- Add a new Windows CSE code owners section for `parts/windows/` and `staging/cse/windows/` (`@timmy-wright @r2k1 @benjamin-brady @djsly`).
- Fix `make generate-testdata`, which was a no-op since `pkg/agent/testdata` was removed. `GENERATE_TEST_DATA` is now only read by `aks-node-controller/parser` tests, so the target now runs there instead. Updated `.vscode/settings.json` Copilot instructions and the `.pipelines/.vsts-vhd-refresh-testdata.yaml` pipeline artifact path to match.

## Test plan
- Ran `make generate-testdata` locally; confirmed it regenerates `generatedCSECommand` files under `aks-node-controller/parser/testdata/`.