### PR TITLE
test: tolerate cloud-provider-uninitialized taint on Windows validation pods

### DIFF
--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -793,8 +793,7 @@ func podWindows(s *Scenario, podName string, imageName string) *corev1.Pod {
 			Tolerations: []corev1.Toleration{
 				{
 					Key:      "node.cloudprovider.kubernetes.io/uninitialized",
-					Operator: corev1.TolerationOpEqual,
-					Value:    "true",
+					Operator: corev1.TolerationOpExists,
 					Effect:   corev1.TaintEffectNoSchedule,
 				},
 			},

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -768,9 +768,9 @@ func getNodeSelectorForScenario(s *Scenario) map[string]string {
 	}
 }
 
-func debugDaemonsetWindows(s *Scenario, podName string, imageName string) *appsv1.DaemonSet {
+func debugPodWindows(s *Scenario, podName string, imageName string) *corev1.Pod {
 	deploymentName := fmt.Sprintf("%s-test-%s-pod", s.Runtime.VM.KubeName, podName)
-	return &appsv1.DaemonSet{
+	return &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DaemonSet",
 			APIVersion: "apps/v1",
@@ -779,32 +779,18 @@ func debugDaemonsetWindows(s *Scenario, podName string, imageName string) *appsv
 			Name:      deploymentName,
 			Namespace: "default",
 		},
-		Spec: appsv1.DaemonSetSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app": deploymentName,
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            podName,
+					Image:           imageName,
+					ImagePullPolicy: "IfNotPresent",
+					// this should exist on both servercore and nanoserve
+					Command: []string{"cmd", "/c", "ping", "-t", "localhost"},
 				},
 			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app": deploymentName,
-					},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:            podName,
-							Image:           imageName,
-							ImagePullPolicy: "IfNotPresent",
-							// this should exist on both servercore and nanoserve
-							Command: []string{"cmd", "/c", "ping", "-t", "localhost"},
-						},
-					},
-					Tolerations:  getPodTolerations(),
-					NodeSelector: getNodeSelectorForScenario(s),
-				},
-			},
+			Tolerations:  getPodTolerations(),
+			NodeSelector: getNodeSelectorForScenario(s),
 		},
 	}
 }

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -787,6 +787,17 @@ func podWindows(s *Scenario, podName string, imageName string) *corev1.Pod {
 					Command: []string{"cmd", "/c", "ping", "-t", "localhost"},
 				},
 			},
+			// Tolerate the cloud-provider-uninitialized taint: the node may report Ready before
+			// the Azure cloud-controller-manager removes this taint, which would otherwise leave
+			// this pod Pending (and the test waiting) until the taint clears on its own.
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      "node.cloudprovider.kubernetes.io/uninitialized",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "true",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
 			NodeSelector: map[string]string{
 				"kubernetes.io/hostname": s.Runtime.VM.KubeName,
 			},

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -772,8 +772,8 @@ func debugPodWindows(s *Scenario, podName string, imageName string) *corev1.Pod 
 	deploymentName := fmt.Sprintf("%s-test-%s-pod", s.Runtime.VM.KubeName, podName)
 	return &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "DaemonSet",
-			APIVersion: "apps/v1",
+			Kind:       "Pod",
+			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deploymentName,

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -777,7 +777,7 @@ func podHTTPServerLinux(s *Scenario) *corev1.Pod {
 	}
 }
 
-func podWindows(s *Scenario, podName string, imageName string) *appsv1.DaemonSet {
+func debugDaemonsetWindows(s *Scenario, podName string, imageName string) *appsv1.DaemonSet {
 	deploymentName := fmt.Sprintf("%s-test-%s-pod", s.Runtime.VM.KubeName, podName)
 	return &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -418,19 +418,10 @@ func daemonsetDebug(ctx context.Context, deploymentName string, nodeSelector map
 					},
 				},
 				Spec: corev1.PodSpec{
-					HostNetwork:  isHostNetwork,
-					NodeSelector: nodeSelector,
-					ImagePullSecrets: func() []corev1.LocalObjectReference {
-						if secretName == "" {
-							return nil
-						}
-						return []corev1.LocalObjectReference{
-							{
-								Name: secretName,
-							},
-						}
-					}(),
-					HostPID: true,
+					HostNetwork:      isHostNetwork,
+					NodeSelector:     nodeSelector,
+					ImagePullSecrets: getImagePullSecrets(secretName),
+					HostPID:          true,
 					Containers: []corev1.Container{
 						{
 							Image:   image,
@@ -441,30 +432,45 @@ func daemonsetDebug(ctx context.Context, deploymentName string, nodeSelector map
 							},
 						},
 					},
-					// Set Tolerations to tolerate the node with test taints "testkey1=value1:NoSchedule,testkey2=value2:NoSchedule".
-					// This is to ensure that the pod can be scheduled on the node with the taints.
-					// It won't affect other pods running on the same node.
-					Tolerations: []corev1.Toleration{
-						{
-							Key:      "testkey1",
-							Operator: corev1.TolerationOpEqual,
-							Value:    "value1",
-							Effect:   corev1.TaintEffectNoSchedule,
-						},
-						{
-							Key:      "testkey2",
-							Operator: corev1.TolerationOpEqual,
-							Value:    "value2",
-							Effect:   corev1.TaintEffectNoSchedule,
-						},
-						{
-							Key:      "node.cloudprovider.kubernetes.io/uninitialized",
-							Operator: corev1.TolerationOpExists,
-							Effect:   corev1.TaintEffectNoSchedule,
-						},
-					},
+					Tolerations: getPodTolerations(),
 				},
 			},
+		},
+	}
+}
+
+func getImagePullSecrets(secretName string) []corev1.LocalObjectReference {
+	if secretName == "" {
+		return nil
+	}
+	return []corev1.LocalObjectReference{
+		{
+			Name: secretName,
+		},
+	}
+}
+
+func getPodTolerations() []corev1.Toleration {
+	// Set Tolerations to tolerate the node with test taints "testkey1=value1:NoSchedule,testkey2=value2:NoSchedule".
+	// This is to ensure that the pod can be scheduled on the node with the taints.
+	// It won't affect other pods running on the same node.
+	return []corev1.Toleration{
+		{
+			Key:      "testkey1",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "value1",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "testkey2",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "value2",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "node.cloudprovider.kubernetes.io/uninitialized",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
 		},
 	}
 }
@@ -771,34 +777,44 @@ func podHTTPServerLinux(s *Scenario) *corev1.Pod {
 	}
 }
 
-func podWindows(s *Scenario, podName string, imageName string) *corev1.Pod {
-	return &corev1.Pod{
+func podWindows(s *Scenario, podName string, imageName string) *appsv1.DaemonSet {
+	deploymentName := fmt.Sprintf("%s-test-%s-pod", s.Runtime.VM.KubeName, podName)
+	return &appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DaemonSet",
+			APIVersion: "apps/v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-test-%s-pod", s.Runtime.VM.KubeName, podName),
+			Name:      deploymentName,
 			Namespace: "default",
 		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:            podName,
-					Image:           imageName,
-					ImagePullPolicy: "IfNotPresent",
-					// this should exist on both servercore and nanoserve
-					Command: []string{"cmd", "/c", "ping", "-t", "localhost"},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": deploymentName,
 				},
 			},
-			// Tolerate the cloud-provider-uninitialized taint: the node may report Ready before
-			// the Azure cloud-controller-manager removes this taint, which would otherwise leave
-			// this pod Pending (and the test waiting) until the taint clears on its own.
-			Tolerations: []corev1.Toleration{
-				{
-					Key:      "node.cloudprovider.kubernetes.io/uninitialized",
-					Operator: corev1.TolerationOpExists,
-					Effect:   corev1.TaintEffectNoSchedule,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": deploymentName,
+					},
 				},
-			},
-			NodeSelector: map[string]string{
-				"kubernetes.io/hostname": s.Runtime.VM.KubeName,
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            podName,
+							Image:           imageName,
+							ImagePullPolicy: "IfNotPresent",
+							// this should exist on both servercore and nanoserve
+							Command: []string{"cmd", "/c", "ping", "-t", "localhost"},
+						},
+					},
+					Tolerations: getPodTolerations(),
+					NodeSelector: map[string]string{
+						"kubernetes.io/hostname": s.Runtime.VM.KubeName,
+					},
+				},
 			},
 		},
 	}

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -756,24 +756,15 @@ func podHTTPServerLinux(s *Scenario) *corev1.Pod {
 			// Set Tolerations to tolerate the node with test taints "testkey1=value1:NoSchedule,testkey2=value2:NoSchedule".
 			// This is to ensure that the pod can be scheduled on the node with the taints.
 			// It won't affect other pods running on the same node.
-			Tolerations: []corev1.Toleration{
-				{
-					Key:      "testkey1",
-					Operator: corev1.TolerationOpEqual,
-					Value:    "value1",
-					Effect:   corev1.TaintEffectNoSchedule,
-				},
-				{
-					Key:      "testkey2",
-					Operator: corev1.TolerationOpEqual,
-					Value:    "value2",
-					Effect:   corev1.TaintEffectNoSchedule,
-				},
-			},
-			NodeSelector: map[string]string{
-				"kubernetes.io/hostname": s.Runtime.VM.KubeName,
-			},
+			Tolerations:  getPodTolerations(),
+			NodeSelector: getNodeSelectorForScenario(s),
 		},
+	}
+}
+
+func getNodeSelectorForScenario(s *Scenario) map[string]string {
+	return map[string]string{
+		"kubernetes.io/hostname": s.Runtime.VM.KubeName,
 	}
 }
 
@@ -810,10 +801,8 @@ func debugDaemonsetWindows(s *Scenario, podName string, imageName string) *appsv
 							Command: []string{"cmd", "/c", "ping", "-t", "localhost"},
 						},
 					},
-					Tolerations: getPodTolerations(),
-					NodeSelector: map[string]string{
-						"kubernetes.io/hostname": s.Runtime.VM.KubeName,
-					},
+					Tolerations:  getPodTolerations(),
+					NodeSelector: getNodeSelectorForScenario(s),
 				},
 			},
 		},

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -416,12 +416,12 @@ func ValidateNodeCanRunAPod(ctx context.Context, s *Scenario) {
 	if s.IsWindows() {
 		serverCorePods := components.GetServercoreImagesForVHD(s.VHD)
 		for i, pod := range serverCorePods {
-			ValidatePodRunning(ctx, s, podWindows(s, fmt.Sprintf("servercore%d", i), pod))
+			ValidatePodRunning(ctx, s, debugDaemonsetWindows(s, fmt.Sprintf("servercore%d", i), pod))
 		}
 
 		nanoServerPods := components.GetNanoserverImagesForVhd(s.VHD)
 		for i, pod := range nanoServerPods {
-			ValidatePodRunning(ctx, s, podWindows(s, fmt.Sprintf("nanoserver%d", i), pod))
+			ValidatePodRunning(ctx, s, debugDaemonsetWindows(s, fmt.Sprintf("nanoserver%d", i), pod))
 		}
 	} else {
 		ValidatePodRunningWithRetry(ctx, s, podHTTPServerLinux(s), 3)

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -413,18 +413,19 @@ func maybeSkipScenario(ctx context.Context, t testing.TB, s *Scenario) {
 }
 
 func ValidateNodeCanRunAPod(ctx context.Context, s *Scenario) {
+	numberRetries := 3
 	if s.IsWindows() {
 		serverCorePods := components.GetServercoreImagesForVHD(s.VHD)
 		for i, pod := range serverCorePods {
-			ValidatePodRunningWithRetry(ctx, s, debugPodWindows(s, fmt.Sprintf("servercore%d", i), pod), 3)
+			ValidatePodRunningWithRetry(ctx, s, debugPodWindows(s, fmt.Sprintf("servercore%d", i), pod), numberRetries)
 		}
 
 		nanoServerPods := components.GetNanoserverImagesForVhd(s.VHD)
 		for i, pod := range nanoServerPods {
-			ValidatePodRunningWithRetry(ctx, s, debugPodWindows(s, fmt.Sprintf("nanoserver%d", i), pod), 3)
+			ValidatePodRunningWithRetry(ctx, s, debugPodWindows(s, fmt.Sprintf("nanoserver%d", i), pod), numberRetries)
 		}
 	} else {
-		ValidatePodRunningWithRetry(ctx, s, podHTTPServerLinux(s), 3)
+		ValidatePodRunningWithRetry(ctx, s, podHTTPServerLinux(s), numberRetries)
 	}
 }
 

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -416,12 +416,12 @@ func ValidateNodeCanRunAPod(ctx context.Context, s *Scenario) {
 	if s.IsWindows() {
 		serverCorePods := components.GetServercoreImagesForVHD(s.VHD)
 		for i, pod := range serverCorePods {
-			ValidatePodRunningWithRetry(ctx, s, debugPodWindows(s, fmt.Sprintf("servercore%d", i), pod))
+			ValidatePodRunningWithRetry(ctx, s, debugPodWindows(s, fmt.Sprintf("servercore%d", i), pod), 3)
 		}
 
 		nanoServerPods := components.GetNanoserverImagesForVhd(s.VHD)
 		for i, pod := range nanoServerPods {
-			ValidatePodRunningWithRetry(ctx, s, debugPodWindows(s, fmt.Sprintf("nanoserver%d", i), pod))
+			ValidatePodRunningWithRetry(ctx, s, debugPodWindows(s, fmt.Sprintf("nanoserver%d", i), pod), 3)
 		}
 	} else {
 		ValidatePodRunningWithRetry(ctx, s, podHTTPServerLinux(s), 3)

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -416,12 +416,12 @@ func ValidateNodeCanRunAPod(ctx context.Context, s *Scenario) {
 	if s.IsWindows() {
 		serverCorePods := components.GetServercoreImagesForVHD(s.VHD)
 		for i, pod := range serverCorePods {
-			ValidatePodRunning(ctx, s, debugDaemonsetWindows(s, fmt.Sprintf("servercore%d", i), pod))
+			ValidatePodRunningWithRetry(ctx, s, debugPodWindows(s, fmt.Sprintf("servercore%d", i), pod))
 		}
 
 		nanoServerPods := components.GetNanoserverImagesForVhd(s.VHD)
 		for i, pod := range nanoServerPods {
-			ValidatePodRunning(ctx, s, debugDaemonsetWindows(s, fmt.Sprintf("nanoserver%d", i), pod))
+			ValidatePodRunningWithRetry(ctx, s, debugPodWindows(s, fmt.Sprintf("nanoserver%d", i), pod))
 		}
 	} else {
 		ValidatePodRunningWithRetry(ctx, s, podHTTPServerLinux(s), 3)

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -23,9 +23,10 @@ func ValidatePodRunningWithRetry(ctx context.Context, s *Scenario, pod *corev1.P
 	for i := range maxRetries {
 		err = startPodAndCheckItRuns(ctx, s, pod)
 		// crude expenential backoff: 2s, 4s, 8s, ...
-		retryBackoff := time.Duration(1<<uint(i)) * time.Second
+		retryBackoff := time.Duration(1 << uint(i))
 		if err != nil {
-			time.Sleep(retryBackoff)
+			s.T.Logf("sleeping %d seconds before retrying pod %q", retryBackoff, pod.Name)
+			time.Sleep(retryBackoff * time.Second)
 			s.T.Logf("retrying pod %q validation (%d/%d)", pod.Name, i+1, maxRetries)
 			continue
 		}

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -22,8 +22,10 @@ func ValidatePodRunningWithRetry(ctx context.Context, s *Scenario, pod *corev1.P
 	var err error
 	for i := range maxRetries {
 		err = startPodAndCheckItRuns(ctx, s, pod)
+		// crude expenential backoff: 2s, 4s, 8s, ...
+		retryBackoff := time.Duration(1<<uint(i)) * time.Second
 		if err != nil {
-			time.Sleep(1 * time.Second)
+			time.Sleep(retryBackoff)
 			s.T.Logf("retrying pod %q validation (%d/%d)", pod.Name, i+1, maxRetries)
 			continue
 		}

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -19,19 +19,20 @@ import (
 )
 
 func ValidatePodRunningWithRetry(ctx context.Context, s *Scenario, pod *corev1.Pod, maxRetries int) {
-	var err error
-	for i := range maxRetries {
-		err = startPodAndCheckItRuns(ctx, s, pod)
+	i := 1
+	err := startPodAndCheckItRuns(ctx, s, pod)
+
+	for i <= maxRetries && err != nil {
 		// crude expenential backoff: 2s, 4s, 8s, ...
 		retryBackoff := time.Duration(1 << uint(i))
-		if err != nil {
-			s.T.Logf("sleeping %d seconds before retrying pod %q", retryBackoff, pod.Name)
-			time.Sleep(retryBackoff * time.Second)
-			s.T.Logf("retrying pod %q validation (%d/%d)", pod.Name, i+1, maxRetries)
-			continue
-		}
-		break
+		s.T.Logf("sleeping %d seconds before retrying pod %q", retryBackoff, pod.Name)
+		time.Sleep(retryBackoff * time.Second)
+		s.T.Logf("retrying pod %q validation (%d/%d)", pod.Name, i+1, maxRetries)
+
+		i++
+		err = startPodAndCheckItRuns(ctx, s, pod)
 	}
+
 	require.NoErrorf(s.T, err, "failed to validate pod running %q", pod.Name)
 }
 


### PR DESCRIPTION
## Summary
Windows E2E validation pods (`podWindows`, used for the servercore/nanoserver checks) had no tolerations. If the target node reported `Ready=True` before the Azure cloud-controller-manager removed its `node.cloudprovider.kubernetes.io/uninitialized:NoSchedule` taint, the validation pod stayed `Pending` until the 360s pod-wait timed out, failing the test with a misleading `FailedScheduling` error rather than a real product/VHD issue.

Investigated from build 176544987 (windows-2022-containerd-gen2): node `winw06a000000` reported ready at 887.774s still carrying the `uninitialized` taint; the validation pod then failed to schedule and the test timed out at 1250.370s.

## Change
Add a toleration for `node.cloudprovider.kubernetes.io/uninitialized:NoSchedule` to `podWindows()` so the validation pod schedules onto the target node as soon as it's Ready, without waiting on CCM taint removal.

## Testing
- `go build ./...` and `go vet ./...` pass in `e2e/`.
- `gofmt -l` clean.