### PR TITLE
fix: lower acr-credential-provider linux PMC gate from 1.34 to 1.33

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1820,21 +1820,6 @@
           "r2604": {
             "versionsV2": [
               {
-                "k8sVersion": "1.33",
-                "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=26.04",
-                "latestVersion": "1.33.17-ubuntu26.04u1"
-              },
-              {
-                "k8sVersion": "1.34",
-                "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=26.04",
-                "latestVersion": "1.34.13-ubuntu26.04u1"
-              },
-              {
-                "k8sVersion": "1.35",
-                "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=26.04",
-                "latestVersion": "1.35.8-ubuntu26.04u1"
-              },
-              {
                 "k8sVersion": "1.36",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=26.04",
                 "latestVersion": "1.36.5-ubuntu26.04u1",

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -1820,6 +1820,21 @@
           "r2604": {
             "versionsV2": [
               {
+                "k8sVersion": "1.33",
+                "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=26.04",
+                "latestVersion": "1.33.17-ubuntu26.04u1"
+              },
+              {
+                "k8sVersion": "1.34",
+                "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=26.04",
+                "latestVersion": "1.34.13-ubuntu26.04u1"
+              },
+              {
+                "k8sVersion": "1.35",
+                "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=26.04",
+                "latestVersion": "1.35.8-ubuntu26.04u1"
+              },
+              {
                 "k8sVersion": "1.36",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=26.04",
                 "latestVersion": "1.36.5-ubuntu26.04u1",
@@ -1829,6 +1844,11 @@
           },
           "r2404": {
             "versionsV2": [
+              {
+                "k8sVersion": "1.33",
+                "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=24.04",
+                "latestVersion": "1.33.17-ubuntu24.04u1"
+              },
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=24.04",
@@ -1852,6 +1872,11 @@
           "r2204": {
             "versionsV2": [
               {
+                "k8sVersion": "1.33",
+                "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=22.04",
+                "latestVersion": "1.33.17-ubuntu22.04u1"
+              },
+              {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=22.04",
                 "latestVersion": "1.34.13-ubuntu22.04u1",
@@ -1874,6 +1899,11 @@
           "r2004": {
             "versionsV2": [
               {
+                "k8sVersion": "1.33",
+                "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=20.04",
+                "latestVersion": "1.33.17-ubuntu20.04u1"
+              },
+              {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=20.04",
                 "latestVersion": "1.34.13-ubuntu20.04u1",
@@ -1885,6 +1915,11 @@
         "azurelinux": {
           "v3.0": {
             "versionsV2": [
+              {
+                "k8sVersion": "1.33",
+                "renovateTag": "RPM_registry=https://packages.microsoft.com/azurelinux/3.0/prod/cloud-native/x86_64/repodata, name=azure-acr-credential-provider, os=azurelinux, release=3.0",
+                "latestVersion": "1.33.17-1.azl3"
+              },
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "RPM_registry=https://packages.microsoft.com/azurelinux/3.0/prod/cloud-native/x86_64/repodata, name=azure-acr-credential-provider, os=azurelinux, release=3.0",

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1068,9 +1068,9 @@ EOF
         echo "Configure credential provider for both image-credential-provider-config and image-credential-provider-bin-dir flags are specified in KUBELET_FLAGS"
         logs_to_events "AKS.CSE.ensureKubelet.configCredentialProvider" configCredentialProvider
         # Install credential provider from URL:
-        # 1. If k8s version < 1.34.0, skip_bypass_k8s_version_check != true, and not Flatcar (which falls back to URL later).
+        # 1. If k8s version < 1.33.0, skip_bypass_k8s_version_check != true, and not Flatcar (which falls back to URL later).
         # 2. For Azure Linux v2 due to lack of PMC packages (if not network isolated).
-        if { ! isFlatcar && ! isACL && [ "${SHOULD_ENFORCE_KUBE_PMC_INSTALL}" != true ] && ! semverCompare "${KUBERNETES_VERSION:-0.0.0}" 1.34.0; } ||
+        if { ! isFlatcar && ! isACL && [ "${SHOULD_ENFORCE_KUBE_PMC_INSTALL}" != true ] && ! semverCompare "${KUBERNETES_VERSION:-0.0.0}" 1.33.0; } ||
            { isMarinerOrAzureLinux && [ "${OS_VERSION}" = 2.0 ] && [ -z "${BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER}" ]; }
         then
             logs_to_events "AKS.CSE.ensureKubelet.installCredentialProviderFromUrl" installCredentialProviderFromUrl

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -2308,6 +2308,7 @@ OVERRIDE_EOF
         }
 
         BeforeEach 'setup_ensure_kubelet'
+        AfterEach 'cleanup_ensure_kubelet'
         setup_ensure_kubelet() {
             mkdir -p /opt/azure/containers
             KUBELET_FLAGS="--image-credential-provider-config=/etc/kubernetes/credential-provider-config.yaml --image-credential-provider-bin-dir=/var/lib/kubelet/credential-provider"
@@ -2322,6 +2323,12 @@ OVERRIDE_EOF
             BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER=""
             KUBE_RESERVED_CGROUP=""
             SYSTEM_RESERVED_CGROUP=""
+        }
+
+        cleanup_ensure_kubelet() {
+            rm -f /etc/default/kubelet /var/lib/kubelet/kubeconfig /var/lib/kubelet/bootstrap-kubeconfig \
+                /opt/azure/containers/kubelet.sh /opt/azure/containers/tls-bootstrap-start-time \
+                /etc/systemd/system/kubelet.service.d/10-{watchdog,credential-validation,tlsbootstrap,ensure-imds-restriction,containerd-base-flag}.conf
         }
 
         setKubeletNodeIPFlag() { :; }

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -2301,6 +2301,87 @@ OVERRIDE_EOF
         End
     End
 
+    Describe 'ensureKubelet credential provider installation gate'
+        logs_to_events() {
+            echo "logs_to_events $1 $2"
+            eval "$2"
+        }
+
+        BeforeEach 'setup_ensure_kubelet'
+        setup_ensure_kubelet() {
+            mkdir -p /opt/azure/containers
+            KUBELET_FLAGS="--image-credential-provider-config=/etc/kubernetes/credential-provider-config.yaml --image-credential-provider-bin-dir=/var/lib/kubelet/credential-provider"
+            NETWORK_POLICY=""
+            KUBELET_IMAGE=""
+            KUBELET_NODE_LABELS=""
+            AZURE_ENVIRONMENT_FILEPATH=""
+            API_SERVER_NAME="example.invalid"
+            ENABLE_IMDS_RESTRICTION="false"
+            INSERT_IMDS_RESTRICTION_RULE_TO_MANGLE_TABLE="false"
+            SHOULD_ENFORCE_KUBE_PMC_INSTALL=""
+            BOOTSTRAP_PROFILE_CONTAINER_REGISTRY_SERVER=""
+            KUBE_RESERVED_CGROUP=""
+            SYSTEM_RESERVED_CGROUP=""
+        }
+
+        setKubeletNodeIPFlag() { :; }
+        getPrimaryNicIP() { echo "10.0.0.4"; }
+        configCredentialProvider() { :; }
+        resolveKubeletReservedCgroups() { :; }
+        systemctl() { :; }
+        systemctlEnableAndStartNoBlock() { :; }
+        tee() { cat > /dev/null; }
+
+        Describe 'on Ubuntu'
+            OS="UBUNTU"
+            Include "./parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh"
+            Include "./parts/linux/cloud-init/artifacts/ubuntu/cse_install_ubuntu.sh"
+
+            It 'installs the credential provider from URL below Kubernetes 1.33'
+                installCredentialProviderFromUrl() { echo "installCredentialProviderFromUrl"; }
+                installCredentialProviderFromPkg() { echo "installCredentialProviderFromPkg $1"; }
+                KUBERNETES_VERSION="1.32.99"
+
+                When call ensureKubelet
+
+                The output should include "installCredentialProviderFromUrl"
+                The output should not include "installCredentialProviderFromPkg"
+                The status should be success
+            End
+
+            It 'installs the credential provider from PMC at Kubernetes 1.33'
+                installCredentialProviderFromUrl() { echo "installCredentialProviderFromUrl"; }
+                installCredentialProviderFromPkg() { echo "installCredentialProviderFromPkg $1"; }
+                KUBERNETES_VERSION="1.33.0"
+
+                When call ensureKubelet
+
+                The output should include "installCredentialProviderFromPkg 1.33.0"
+                The output should not include "installCredentialProviderFromUrl"
+                The status should be success
+            End
+        End
+
+        Describe 'on Azure Linux'
+            OS="AZURELINUX"
+            OS_VERSION="3.0"
+            Include "./parts/linux/cloud-init/artifacts/mariner/cse_helpers_mariner.sh"
+            Include "./parts/linux/cloud-init/artifacts/mariner/cse_install_mariner.sh"
+
+            It 'installs the credential provider from PMC at Kubernetes 1.33'
+                installCredentialProviderFromUrl() { echo "installCredentialProviderFromUrl"; }
+                installCredentialProviderFromPkg() { echo "installCredentialProviderFromPkg $1"; }
+                KUBERNETES_VERSION="1.33.0"
+
+                When call ensureKubelet
+
+                The output should include "installCredentialProviderFromPkg 1.33.0"
+                The output should not include "installCredentialProviderFromUrl"
+                The status should be success
+            End
+        End
+    End
+
     Describe 'configureKubeletAndKubectl'
         # Mock required functions and variables
         logs_to_events() {

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -2339,6 +2339,15 @@ OVERRIDE_EOF
         systemctlEnableAndStartNoBlock() { :; }
         tee() { cat > /dev/null; }
 
+        # ensureKubelet enables xtrace mid-function and never restores it, so the
+        # trace would leak onto ShellSpec's stderr and fail the example. Wrap the
+        # call to discard that trace and restore set +x before returning.
+        invoke_ensure_kubelet() {
+            ensureKubelet 2>/dev/null
+            { local rc=$?; set +x; } 2>/dev/null
+            return "$rc"
+        }
+
         Describe 'on Ubuntu'
             OS="UBUNTU"
             Include "./parts/linux/cloud-init/artifacts/ubuntu/cse_helpers_ubuntu.sh"
@@ -2349,7 +2358,7 @@ OVERRIDE_EOF
                 installCredentialProviderFromPkg() { echo "installCredentialProviderFromPkg $1"; }
                 KUBERNETES_VERSION="1.32.99"
 
-                When call ensureKubelet
+                When call invoke_ensure_kubelet
 
                 The output should include "installCredentialProviderFromUrl"
                 The output should not include "installCredentialProviderFromPkg"
@@ -2361,7 +2370,7 @@ OVERRIDE_EOF
                 installCredentialProviderFromPkg() { echo "installCredentialProviderFromPkg $1"; }
                 KUBERNETES_VERSION="1.33.0"
 
-                When call ensureKubelet
+                When call invoke_ensure_kubelet
 
                 The output should include "installCredentialProviderFromPkg 1.33.0"
                 The output should not include "installCredentialProviderFromUrl"
@@ -2380,7 +2389,7 @@ OVERRIDE_EOF
                 installCredentialProviderFromPkg() { echo "installCredentialProviderFromPkg $1"; }
                 KUBERNETES_VERSION="1.33.0"
 
-                When call ensureKubelet
+                When call invoke_ensure_kubelet
 
                 The output should include "installCredentialProviderFromPkg 1.33.0"
                 The output should not include "installCredentialProviderFromUrl"


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
This PR lowers the Linux PMC install gate for acr-credential-provider in ensureKubelet from 1.34.0 to 1.33.0 so that 1.33 nodes install the already-patched credential provider from PMC, and adds the azure-acr-credential-provider entries to `components.json` so the patched package is baked into the VHD.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #9189 
