### PR TITLE
fix: add fcher to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,11 +9,11 @@ nodecustomdata.yml @Devinwong @lilypan26 @r2k1 @timmy-wright @cameronmeissner @a
 
 # These include security patch owners since security patch script changes will cause the related custom data snapshots to change
 
-pkg/agent/testdata/ @yewmsft @YaoC @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @AbelHu @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @SriHarsha001
+pkg/agent/testdata/ @yewmsft @YaoC @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @AbelHu @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @SriHarsha001 $fcher
 
 # Code owners for the security patch release notes
 
-vhdbuilder/release-notes/security-patch/ @yagmurbaydogan @yewmsft @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @AbelHu @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @SriHarsha001
+vhdbuilder/release-notes/security-patch/ @yagmurbaydogan @yewmsft @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @AbelHu @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @SriHarsha001 $fcher
 
 # Code owners for security patching
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @AbelHu @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @sulixu @SriHarsha001 @runzhen @karenychen @xuexu6666 @titilambert @benjamin-brady
+* @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @AbelHu @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @sulixu @SriHarsha001 @runzhen @karenychen @xuexu6666 @titilambert @benjamin-brady @fcher
 
 # Code owners for cse_cmd.sh and nodecustomdata.yml. This is to ensure that the scriptless v-team is aware of the changes in order to sync with AKSNodeConfig
 


### PR DESCRIPTION
## Summary
- add `@fcher` to the repository-wide CODEOWNERS rule

## Testing
- not applicable (ownership metadata only)