### PR TITLE
fix: support pause 3.10.2 with legacy Windows CSE

### DIFF
--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -166,6 +166,8 @@ func Test_Windows2022CachingRegression(t *testing.T) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) {
 				ValidateFileHasContent(ctx, s, "/AzureData/CustomDataSetupScript.log", "CSEScriptsPackageUrl used for provision is https://packages.aks.azure.com/aks/windows/cse/aks-windows-cse-scripts-v0.0.52.zip")
+				ValidateFileHasContent(ctx, s, "'C:\\Program Files\\containerd\\config.toml'", "mcr.microsoft.com/oss/v2/kubernetes/pause:3.10.2")
+				ValidateFileExcludesContent(ctx, s, "'C:\\Program Files\\containerd\\config.toml'", "pause:3.10.2-windows-")
 			},
 		},
 	})

--- a/parts/windows/kuberneteswindowssetup.ps1.template
+++ b/parts/windows/kuberneteswindowssetup.ps1.template
@@ -485,6 +485,9 @@ function BasePrep {
 # ====== NODE PREP: CLUSTER INTEGRATION ======
 # All operations that should only run when connecting to the actual cluster
 function NodePrep {
+    $containerdConfigPath=[Io.Path]::Combine($global:ContainerdInstallLocation, "config.toml")
+    Update-ContainerdPauseImageConfig -Path $containerdConfigPath
+
     # Write the kubeconfigs here, not in BasePrep: BasePrep is skipped on
     # PIS/VHD-cached nodes, so anything written there is baked with stale
     # bake-time values. Both are only consumed in NodePrep, so write them from

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -392,6 +392,33 @@ function AKS-Expand-Archive {
     }
 }
 
+function Update-ContainerdPauseImageConfig {
+    Param(
+        [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][string]$Path
+    )
+
+    if (-Not (Test-Path -Path $Path -PathType Leaf)) {
+        throw "Containerd config file does not exist: $Path"
+    }
+
+    $legacyPauseImagePattern='(?m)(?<prefix>\b(?:sandbox_image|SandboxImage|sandbox)\s*=\s*["''])(?<image>[^"''\r\n]+)-windows-[a-zA-Z0-9.]+-amd64(?<suffix>["''])'
+    $config=[System.IO.File]::ReadAllText($Path)
+    $updatedConfig=[regex]::Replace($config, $legacyPauseImagePattern, '${prefix}${image}${suffix}')
+    if ($updatedConfig -eq $config) {
+        Write-Log "Containerd pause image references in $Path do not require an update"
+        return
+    }
+
+    [System.IO.File]::WriteAllText($Path, $updatedConfig)
+    Write-Log "Updated legacy pause image references in $Path"
+
+    $containerdService=Get-Service -Name containerd -ErrorAction SilentlyContinue
+    if ($null -ne $containerdService -and $containerdService.Status -eq "Running") {
+        Restart-Service -Name containerd -ErrorAction Stop
+        Write-Log "Restarted containerd to apply the updated pause image references"
+    }
+}
+
 function Retry-Command {
     Param(
         [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][string]
@@ -547,6 +574,8 @@ function Install-Containerd-Based-On-Kubernetes-Version {
     Write-Log "Install Containerd with resolved containerd pacakge url: $ContainerdUrl, Kubernetes version: $KubernetesVersion, Windows version: $windowsVersion."
     Logs-To-Event -TaskName "AKS.WindowsCSE.InstallContainerd" -TaskMessage "Start to install ContainerD. ContainerdUrl: $ContainerdUrl"
     Install-Containerd -ContainerdUrl $ContainerdUrl -CNIBinDir $CNIBinDir -CNIConfDir $CNIConfDir -KubeDir $KubeDir
+    $containerdConfigPath=[Io.Path]::Combine($global:ContainerdInstallLocation, "config.toml")
+    Update-ContainerdPauseImageConfig -Path $containerdConfigPath
 }
 
 function Logs-To-Event {

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -1,4 +1,9 @@
 BeforeAll {
+  if (-not (Get-Command Get-Service -ErrorAction SilentlyContinue)) {
+    function global:Get-Service {}
+    function global:Restart-Service {}
+  }
+
   # Mock Set-Content to avoid permission denied errors
   Mock Set-Content -MockWith {
     param($Path, $Value)
@@ -14,6 +19,62 @@ BeforeAll {
       param($Path, $Value)
       $script:capturedContent = $Value
   } -Verifiable
+}
+
+Describe 'Update-ContainerdPauseImageConfig' {
+  BeforeEach {
+    Mock Write-Log
+    $global:containerdServiceStatus = 'Stopped'
+    Mock Get-Service -MockWith { return [PSCustomObject]@{ Status = $global:containerdServiceStatus } }
+    Mock Restart-Service
+    $configPath = Join-Path $TestDrive 'config.toml'
+    Remove-Item -Path $configPath -Force -ErrorAction SilentlyContinue
+  }
+
+  It 'replaces all legacy Windows-specific pause image references' {
+    $config = @"
+sandbox_image = "mcr.microsoft.com/oss/v2/kubernetes/pause:3.10.2-windows-1809-amd64"
+SandboxImage = "example.azurecr.io/aks/pause:3.10.2-windows-ltsc2022-amd64"
+sandbox = 'mcr.microsoft.com/oss/v2/kubernetes/pause:3.10.2-windows-ltsc2025-amd64'
+"@
+    [System.IO.File]::WriteAllText($configPath, $config)
+
+    Update-ContainerdPauseImageConfig -Path $configPath
+
+    $updatedConfig = [System.IO.File]::ReadAllText($configPath)
+    $updatedConfig | Should -Not -Match '-windows-[a-zA-Z0-9.]+-amd64'
+    $updatedConfig | Should -Match ([regex]::Escape('mcr.microsoft.com/oss/v2/kubernetes/pause:3.10.2'))
+    $updatedConfig | Should -Match ([regex]::Escape('example.azurecr.io/aks/pause:3.10.2'))
+    Assert-MockCalled -CommandName Write-Log -Exactly -Times 1
+    Assert-MockCalled -CommandName Restart-Service -Exactly -Times 0
+  }
+
+  It 'restarts containerd after updating a running service' -Skip:(-not $IsWindows) {
+    $global:containerdServiceStatus = 'Running'
+    [System.IO.File]::WriteAllText($configPath, 'sandbox_image = "mcr.microsoft.com/oss/v2/kubernetes/pause:3.10.2-windows-ltsc2022-amd64"')
+
+    Update-ContainerdPauseImageConfig -Path $configPath
+
+    Assert-MockCalled -CommandName Restart-Service -Exactly -Times 1 -ParameterFilter {
+      $Name -eq 'containerd' -and $ErrorAction -eq 'Stop'
+    }
+  }
+
+  It 'does not change a current pause image reference' {
+    $config = 'sandbox_image = "mcr.microsoft.com/oss/v2/kubernetes/pause:3.10.2"'
+    [System.IO.File]::WriteAllText($configPath, $config)
+
+    Update-ContainerdPauseImageConfig -Path $configPath
+
+    [System.IO.File]::ReadAllText($configPath) | Should -BeExactly $config
+    Assert-MockCalled -CommandName Write-Log -Exactly -Times 1
+    Assert-MockCalled -CommandName Restart-Service -Exactly -Times 0
+  }
+
+  It 'fails when the config does not exist' {
+    { Update-ContainerdPauseImageConfig -Path $configPath } |
+      Should -Throw "Containerd config file does not exist: $configPath"
+  }
 }
 
 Describe 'Install-Containerd-Based-On-Kubernetes-Version' {
@@ -35,6 +96,8 @@ Describe 'Install-Containerd-Based-On-Kubernetes-Version' {
         )
         Write-Host $ContainerdUrl
     } -Verifiable
+    Mock Update-ContainerdPauseImageConfig
+    $global:ContainerdInstallLocation = 'c:\program files\containerd'
 
     $ContainerdWindowsPackageDownloadURL = "https://packages.aks.azure.com/containerd/windows/"
     $StableContainerdPackage = [string]::Format($global:ContainerdPackageTemplate, $global:StableContainerdVersion)
@@ -57,6 +120,9 @@ Describe 'Install-Containerd-Based-On-Kubernetes-Version' {
       $expectedURL = $ContainerdWindowsPackageDownloadURL + $StableContainerdPackage
       & Install-Containerd-Based-On-Kubernetes-Version -ContainerdUrl $ContainerdWindowsPackageDownloadURL -KubernetesVersion "1.27.0" -CNIBinDir "cniBinPath" -CNIConfDir "cniConfigPath" -KubeDir "kubeDir"
       Assert-MockCalled -CommandName "Install-Containerd" -Exactly -Times 1 -ParameterFilter { $ContainerdUrl -eq $expectedURL }
+      Assert-MockCalled -CommandName "Update-ContainerdPauseImageConfig" -Exactly -Times 1 -ParameterFilter {
+        $Path -eq ([Io.Path]::Combine($global:ContainerdInstallLocation, "config.toml"))
+      }
     }
 
     It 'k8s version is equal to MinimalKubernetesVersionWithLatestContainerd' {

--- a/staging/cse/windows/containerdfunc.ps1
+++ b/staging/cse/windows/containerdfunc.ps1
@@ -80,8 +80,6 @@ function CreateHypervisorRuntime {
     [Parameter(Mandatory = $true)][string]
     $image,
     [Parameter(Mandatory = $true)][string]
-    $version,
-    [Parameter(Mandatory = $true)][string]
     $buildNumber
   )
 
@@ -91,7 +89,7 @@ function CreateHypervisorRuntime {
           [plugins.cri.containerd.runtimes.runhcs-wcow-hypervisor-$buildnumber.options]
             Debug = true
             DebugType = 2
-            SandboxImage = "$image-windows-$version-amd64"
+            SandboxImage = "$image"
             SandboxPlatform = "windows/amd64"
             SandboxIsolation = 1
             ScaleCPULimitsToSandbox = true
@@ -109,8 +107,7 @@ function CreateHypervisorRuntimes {
   Write-Log "Adding hyperv runtimes $builds"
   $hypervRuntimes = ""
   ForEach ($buildNumber in $builds) {
-    $windowsVersion = Get-WindowsVersion
-    $runtime = createHypervisorRuntime -image $pauseImage -version $windowsVersion -buildNumber $buildNumber
+    $runtime = CreateHypervisorRuntime -image $image -buildNumber $buildNumber
     if ($hypervRuntimes -eq "") {
       $hypervRuntimes = $runtime
     }

--- a/staging/cse/windows/containerdfunc.tests.ps1
+++ b/staging/cse/windows/containerdfunc.tests.ps1
@@ -70,6 +70,17 @@ Describe "Containerd Functions Tests" {
     . $PSCommandPath.Replace('.tests.ps1', '.ps1')
   }
 
+  Describe "CreateHypervisorRuntime" {
+    It "uses the supplied multi-platform pause image" {
+      $pauseImage = "mcr.microsoft.com/oss/v2/kubernetes/pause:3.10.2"
+
+      $runtime = CreateHypervisorRuntime -image $pauseImage -buildNumber "20348"
+
+      $runtime | Should -Match ([regex]::Escape("SandboxImage = `"$pauseImage`""))
+      $runtime | Should -Not -Match ([regex]::Escape("${pauseImage}-windows-"))
+    }
+  }
+
   Describe "ProcessAndWriteContainerdConfig" {
     BeforeAll {
       Mock Get-Content -ParameterFilter { $Path -like "*kubeclusterconfig.json" } -MockWith {
@@ -123,6 +134,8 @@ Describe "Containerd Functions Tests" {
         $content = Get-Content -Path $configPath -Raw
         $content | Should -Match 'plugins.cri.containerd.runtimes.runhcs-wcow-hypervisor-1234'
         $content | Should -Match 'SandboxIsolation = 1'
+        $content | Should -Match ([regex]::Escape("SandboxImage = `"$pauseImage`""))
+        $content | Should -Not -Match ([regex]::Escape("${pauseImage}-windows-"))
         $content | Should -Not -Match 'version = 3'
       }
 
@@ -184,6 +197,8 @@ Describe "Containerd Functions Tests" {
         $content = Get-Content -Path $configPath -Raw
         $content | Should -Match 'plugins.cri.containerd.runtimes.runhcs-wcow-hypervisor-1234'
         $content | Should -Match 'SandboxIsolation = 1'
+        $content | Should -Match ([regex]::Escape("SandboxImage = `"$pauseImage`""))
+        $content | Should -Not -Match ([regex]::Escape("${pauseImage}-windows-"))
         $content | Should -Match 'version = 3'
       }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

Legacy Windows CSE packages append `-windows-<version>-amd64` to the configured pause image. Pause 3.10.2 is multi-platform and does not publish those aliases, so containerd cannot create pod sandboxes when a new VHD uses an older cached CSE package.

This change normalizes the final generated containerd configuration after BasePrep and again during NodePrep for existing PIS-cached configurations. It also updates current Hyper-V runtime generation to use the supplied multi-platform image directly. The Windows 2022 caching regression scenario verifies that CSE package v0.0.52 produces the direct pause 3.10.2 reference.

**Which issue(s) this PR fixes**:

Related to #9204.