### PR TITLE
fix: fail GPU E2E tests on SKU capacity issues

### DIFF
--- a/.pipelines/e2e-gpu.yaml
+++ b/.pipelines/e2e-gpu.yaml
@@ -3,7 +3,8 @@ variables:
   TAGS_TO_RUN: "gpu=true"
   TAGS_TO_SKIP: "os=windows,os=azurelinux,os=azurecontainerlinux"
   SKIP_E2E_TESTS: false
-  SKIP_TESTS_WITH_SKU_CAPACITY_ISSUE: false
+  # PRs skip quota/capacity-constrained scenarios; main and scheduled runs fail them.
+  SKIP_TESTS_WITH_SKU_CAPACITY_ISSUE: $[eq(variables['Build.Reason'], 'PullRequest')]
   E2E_GO_TEST_TIMEOUT: "75m"
   E2E_FAILED_TESTS_RETRY_COUNT: 2
   DISABLE_SCRIPTLESS_COMPILATION: true

--- a/.pipelines/e2e-gpu.yaml
+++ b/.pipelines/e2e-gpu.yaml
@@ -3,7 +3,7 @@ variables:
   TAGS_TO_RUN: "gpu=true"
   TAGS_TO_SKIP: "os=windows,os=azurelinux,os=azurecontainerlinux"
   SKIP_E2E_TESTS: false
-  SKIP_TESTS_WITH_SKU_CAPACITY_ISSUE: true
+  SKIP_TESTS_WITH_SKU_CAPACITY_ISSUE: false
   E2E_GO_TEST_TIMEOUT: "75m"
   E2E_FAILED_TESTS_RETRY_COUNT: 2
   DISABLE_SCRIPTLESS_COMPILATION: true


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
Sets `SKIP_TESTS_WITH_SKU_CAPACITY_ISSUE=false` for the Ubuntu AgentBaker GPU E2E pipeline.

  SKU quota/capacity errors will now fail the pipeline instead of silently skipping GPU scenarios, ensuring missing GPU coverage
  is visible. The Azure Linux GPU E2E pipeline remains unchanged.
**Which issue(s) this PR fixes**:
N/A
