### PR TITLE
test(e2e): use NBC managed GPU activation on Ubuntu 24.04

### DIFF
--- a/e2e/scenario_gpu_managed_experience_test.go
+++ b/e2e/scenario_gpu_managed_experience_test.go
@@ -305,7 +305,7 @@ func Test_DCGM_Exporter_Compatibility(t *testing.T) {
 
 func Test_Ubuntu2404_NvidiaDevicePluginRunning(t *testing.T) {
 	RunScenario(t, &Scenario{
-		Description: "Tests that NVIDIA device plugin and DCGM Exporter are running & functional on Ubuntu 24.04 GPU nodes",
+		Description: "Tests that NVIDIA device plugin and DCGM Exporter work on Ubuntu 24.04 via NBC EnableManagedGPU without a VMSS tag",
 		Tags: Tags{
 			GPU: true,
 		},
@@ -318,13 +318,12 @@ func Test_Ubuntu2404_NvidiaDevicePluginRunning(t *testing.T) {
 				nbc.EnableGPUDevicePluginIfNeeded = true
 				nbc.EnableNvidia = true
 				nbc.ManagedGPUExperienceAFECEnabled = true
+				nbc.EnableManagedGPU = true
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
 				vmss.SKU.Name = to.Ptr("Standard_NV6ads_A10_v5")
-				if vmss.Tags == nil {
-					vmss.Tags = map[string]*string{}
-				}
-				vmss.Tags["EnableManagedGPUExperience"] = to.Ptr("true")
+				// Do not set EnableManagedGPUExperience: this test verifies that
+				// the NBC EnableManagedGPU field activates the managed GPU path.
 
 				// Enable the AKS VM extension for GPU nodes
 				extension, err := createVMExtensionLinuxAKSNode(t.Context(), vmss.Location)


### PR DESCRIPTION
## What this PR does

Updates `Test_Ubuntu2404_NvidiaDevicePluginRunning` to:

- enable managed GPU through the NBC/protobuf `EnableManagedGPU` field
- omit the legacy `EnableManagedGPUExperience` VMSS tag
- retain the existing device-plugin, DCGM, workload, and NPD validation coverage

## Validation

- formatted with `gofmt`
- E2E package compiled successfully in a clean worktree

Fixes #