### PR TITLE
fix: remove TLS settings from WS2022 VHDs.

### DIFF
--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -71,7 +71,6 @@ func Test_Windows2022_AzureNetwork(t *testing.T) {
 				ValidateDotnetNotInstalledWindows(ctx, s)
 				ValidateWindowsSystemServicesRestartConfiguration(ctx, s)
 				ValidateCollectWindowsLogsScript(ctx, s)
-				ValidateWindowsSecureTLSEnabled(ctx, s)
 			},
 		},
 	})
@@ -121,7 +120,6 @@ func Test_Windows2022Gen2AzureNetwork(t *testing.T) {
 				ValidateFileHasContent(ctx, s, "/AzureData/CustomDataSetupScript.log", "CSEScriptsPackageUrl used for provision is https://packages.aks.azure.com/aks/windows/cse/aks-windows-cse-scripts-current.zip")
 				ValidateWindowsSystemServicesRestartConfiguration(ctx, s)
 				ValidateCollectWindowsLogsScript(ctx, s)
-				ValidateWindowsSecureTLSEnabled(ctx, s)
 			},
 		},
 	})

--- a/parts/windows/kuberneteswindowssetup.ps1.template
+++ b/parts/windows/kuberneteswindowssetup.ps1.template
@@ -460,7 +460,7 @@ function BasePrep {
     Update-DefenderPreferences
 
     $windowsVersion=Get-WindowsVersion
-    if ($windowsVersion -eq "1809" -or $windowsVersion -eq "ltsc2022") {
+    if ($windowsVersion -eq "1809") {
         Logs-To-Event -TaskName "AKS.WindowsCSE.EnableSecureTLS" -TaskMessage "Start to enable secure TLS protocols"
         try {
             . C:\k\windowssecuretls.ps1


### PR DESCRIPTION

Remove setting of TLS for Windows 2022. The problem that caused us to do this was a red herring.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
