### PR TITLE
fix: increase image fetcher minimum size, prefetch cilium binaries

### DIFF
--- a/image-fetcher/main.go
+++ b/image-fetcher/main.go
@@ -17,8 +17,8 @@ const (
 	defaultNS     = "k8s.io"
 	// images with compressed content size below this threshold are
 	// unpacked after fetch, effectively turning the operation into a
-	// full pull (~150 MiB compressed ≈ ~300 MiB unpacked).
-	pullSizeThreshold = 150 * 1024 * 1024 // 150 MiB
+	// full pull (~200 MiB compressed ≈ ~400 MiB unpacked).
+	pullSizeThreshold = 200 * 1024 * 1024 // 200 MiB
 )
 
 func main() {

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -328,12 +328,26 @@
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/cilium/cilium-distroless",
           "latestVersion": "v1.18.12-260811",
-          "previousLatestVersion": "v1.18.11-260622"
+          "previousLatestVersion": "v1.18.11-260622",
+          "containerImagePrefetch": {
+            "latestVersion": {
+              "binaries": [
+                "/usr/bin/cilium-agent"
+              ]
+            }
+          }
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/cilium/cilium-distroless",
           "latestVersion": "v1.19.6-260811",
-          "previousLatestVersion": "v1.19.5-260714"
+          "previousLatestVersion": "v1.19.5-260714",
+          "containerImagePrefetch": {
+            "latestVersion": {
+              "binaries": [
+                "/usr/bin/cilium-agent"
+              ]
+            }
+          }
         }
       ],
       "windowsVersions": []
@@ -345,12 +359,26 @@
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/cilium/cilium-distroless-init",
           "latestVersion": "v1.18.12-260811",
-          "previousLatestVersion": "v1.18.11-260622"
+          "previousLatestVersion": "v1.18.11-260622",
+          "containerImagePrefetch": {
+            "latestVersion": {
+              "binaries": [
+                "/opt/cni/bin/cilium-cni"
+              ]
+            }
+          }
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/cilium/cilium-distroless-init",
           "latestVersion": "v1.19.6-260811",
-          "previousLatestVersion": "v1.19.5-260714"
+          "previousLatestVersion": "v1.19.5-260714",
+          "containerImagePrefetch": {
+            "latestVersion": {
+              "binaries": [
+                "/opt/cni/bin/cilium-cni"
+              ]
+            }
+          }
         }
       ],
       "windowsVersions": []


### PR DESCRIPTION
There is a 14s penalty for cilium init image

The init image is 132.6 MB, and  cilium-cni  is a large static Go binary. This copies it from the container’s overlayfs back onto the host OS disk. During that same first-boot window, containerd was pulling/unpacking and starting multiple CSI/CNS containers, including a 136.7 MB Azure File image.

So the likely cause is cold OS-disk reads plus a large write under heavy first-boot I/O contention, not CPU time or network download. The logs prove the  cp  region took 14.88s, but the artifacts lack block-I/O telemetry needed to separate source-read latency from destination-write latency. It is a second, distinct storage penalty from the later 16s Cilium-agent unpack.

Also the agent image is taking 16s because of unpacking the image so increase minimum size to 200MB
