### PR TITLE
fix(e2e): keep localdns reply-direction NOTRACK rules allowlisted

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -21,3 +21,23 @@ jobs:
         set -ex
         make test
       name: Run unit tests for go code in the repository
+
+  e2e-unit-test:
+    # e2e is a separate Go module, so `make test` in the root module does not reach it. Run the
+    # e2e tests that need neither Azure credentials nor network so they gate pull requests.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      with:
+        go-version-file: e2e/go.mod
+        cache-dependency-path: e2e/go.sum
+    - name: Run iptables allowlist unit tests
+      working-directory: ./e2e
+      run: |
+        set -ex
+        go test -v -run '^Test_iptables' .

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -303,6 +303,12 @@ func getIPTablesRulesCompatibleWithEBPFHostRouting() (map[string][]string, []str
 		},
 		"raw": {
 			`^-A (PREROUTING|OUTPUT) -d 169\.254\.10\.(10|11)\/32 -p (tcp|udp) -m comment --comment "localdns: skip conntrack" -m (tcp|udp) --dport 53 -j NOTRACK$`,
+			// Reply-direction localdns NOTRACK rules. localdns.sh is baked into the VHD (packer file
+			// provisioner) rather than delivered via CSE, so VHDs published while #9230 was on main
+			// still install these rules and remain in support for 6 months. This entry must stay
+			// even though #9230 was reverted in #9247, otherwise every scenario booting one of those
+			// VHDs fails this validator.
+			`^-A OUTPUT -s 169\.254\.10\.(10|11)\/32 -p (tcp|udp) -m comment --comment "localdns: skip conntrack" -m (tcp|udp) --sport 53 -j NOTRACK$`,
 		},
 		"security": {
 			`-A OUTPUT -d 168\.63\.129\.16/32 -p tcp -m tcp --dport 53 -j ACCEPT`,

--- a/e2e/validation_iptables_test.go
+++ b/e2e/validation_iptables_test.go
@@ -120,10 +120,25 @@ func Test_iptablesRuleMatchesAnyPattern(t *testing.T) {
 			wantMatch: false,
 		},
 		{
-			name:     "invalid pattern is reported",
+			name:     "invalid pattern is reported when nothing matches",
 			rule:     `-A OUTPUT -j DROP`,
 			patterns: []string{`^-A (OUTPUT`},
 			wantErr:  true,
+		},
+		{
+			// An entry pasted verbatim out of `iptables -S` need not be a valid regex. It must
+			// still get its literal-substring chance, and must not be reported as an error once
+			// the rule is accounted for.
+			name:      "invalid pattern still matches literally",
+			rule:      `-A OUTPUT -m comment --comment "kube-proxy (v1.31" -j ACCEPT`,
+			patterns:  []string{`--comment "kube-proxy (v1.31"`},
+			wantMatch: true,
+		},
+		{
+			name:      "invalid pattern is not reported when a later pattern matches",
+			rule:      `-A OUTPUT -j DROP`,
+			patterns:  []string{`^-A (OUTPUT`, `^-A OUTPUT -j DROP$`},
+			wantMatch: true,
 		},
 	}
 

--- a/e2e/validation_iptables_test.go
+++ b/e2e/validation_iptables_test.go
@@ -1,0 +1,147 @@
+package e2e
+
+import (
+	"regexp"
+	"testing"
+)
+
+// localdnsRawRules are raw-table rules exactly as `iptables -t raw -S` prints them on a node.
+//
+// The request-direction rules are produced by build_localdns_iptable_rules in
+// parts/linux/cloud-init/artifacts/localdns.sh. The reply-direction rules are not produced by
+// localdns.sh on main today, but they are baked into VHDs published while #9230 was on main,
+// and those VHDs stay in support for 6 months. Both directions must therefore stay allowlisted.
+var localdnsRawRules = []string{
+	`-A PREROUTING -d 169.254.10.10/32 -p tcp -m comment --comment "localdns: skip conntrack" -m tcp --dport 53 -j NOTRACK`,
+	`-A PREROUTING -d 169.254.10.10/32 -p udp -m comment --comment "localdns: skip conntrack" -m udp --dport 53 -j NOTRACK`,
+	`-A PREROUTING -d 169.254.10.11/32 -p tcp -m comment --comment "localdns: skip conntrack" -m tcp --dport 53 -j NOTRACK`,
+	`-A PREROUTING -d 169.254.10.11/32 -p udp -m comment --comment "localdns: skip conntrack" -m udp --dport 53 -j NOTRACK`,
+	`-A OUTPUT -d 169.254.10.10/32 -p tcp -m comment --comment "localdns: skip conntrack" -m tcp --dport 53 -j NOTRACK`,
+	`-A OUTPUT -d 169.254.10.10/32 -p udp -m comment --comment "localdns: skip conntrack" -m udp --dport 53 -j NOTRACK`,
+	`-A OUTPUT -d 169.254.10.11/32 -p tcp -m comment --comment "localdns: skip conntrack" -m tcp --dport 53 -j NOTRACK`,
+	`-A OUTPUT -d 169.254.10.11/32 -p udp -m comment --comment "localdns: skip conntrack" -m udp --dport 53 -j NOTRACK`,
+	`-A OUTPUT -s 169.254.10.10/32 -p tcp -m comment --comment "localdns: skip conntrack" -m tcp --sport 53 -j NOTRACK`,
+	`-A OUTPUT -s 169.254.10.10/32 -p udp -m comment --comment "localdns: skip conntrack" -m udp --sport 53 -j NOTRACK`,
+	`-A OUTPUT -s 169.254.10.11/32 -p tcp -m comment --comment "localdns: skip conntrack" -m tcp --sport 53 -j NOTRACK`,
+	`-A OUTPUT -s 169.254.10.11/32 -p udp -m comment --comment "localdns: skip conntrack" -m udp --sport 53 -j NOTRACK`,
+}
+
+// allowlistPatternsForTable mirrors how ValidateIPTablesCompatibleWithCiliumEBPF assembles the
+// pattern set for a single table.
+func allowlistPatternsForTable(table string) []string {
+	tablePatterns, globalPatterns := getIPTablesRulesCompatibleWithEBPFHostRouting()
+	return append(append([]string{}, globalPatterns...), tablePatterns[table]...)
+}
+
+// Test_iptablesAllowlist_patternsCompile guards against a malformed entry in the allowlist. Such
+// an entry never matches, so it would otherwise surface as an unrelated "unsupported iptables
+// rule" failure in every scenario.
+func Test_iptablesAllowlist_patternsCompile(t *testing.T) {
+	tablePatterns, globalPatterns := getIPTablesRulesCompatibleWithEBPFHostRouting()
+
+	assertCompiles := func(scope string, patterns []string) {
+		t.Helper()
+		for _, pattern := range patterns {
+			if _, err := regexp.Compile(pattern); err != nil {
+				t.Errorf("%s pattern %q does not compile: %v", scope, pattern, err)
+			}
+		}
+	}
+
+	assertCompiles("global", globalPatterns)
+	for table, patterns := range tablePatterns {
+		assertCompiles(table, patterns)
+	}
+}
+
+// Test_iptablesAllowlist_localdnsRules pins the LocalDNS NOTRACK rules to the raw-table allowlist.
+// Dropping either direction turns every Linux scenario red, because ValidateCommonLinux runs
+// ValidateIPTablesCompatibleWithCiliumEBPF against whatever localdns.sh the booted VHD baked in.
+func Test_iptablesAllowlist_localdnsRules(t *testing.T) {
+	patterns := allowlistPatternsForTable("raw")
+
+	for _, rule := range localdnsRawRules {
+		matched, err := iptablesRuleMatchesAnyPattern(rule, patterns)
+		if err != nil {
+			t.Fatalf("matching rule %q: %v", rule, err)
+		}
+		if !matched {
+			t.Errorf("LocalDNS rule is not allowlisted for eBPF host routing: %s", rule)
+		}
+	}
+}
+
+// Test_iptablesAllowlist_rejectsUnknownRule proves the allowlist still fails closed, so the test
+// above cannot be satisfied by an overly broad pattern.
+func Test_iptablesAllowlist_rejectsUnknownRule(t *testing.T) {
+	patterns := allowlistPatternsForTable("raw")
+	rule := `-A OUTPUT -d 10.0.0.1/32 -p tcp -m tcp --dport 8080 -j DROP`
+
+	matched, err := iptablesRuleMatchesAnyPattern(rule, patterns)
+	if err != nil {
+		t.Fatalf("matching rule %q: %v", rule, err)
+	}
+	if matched {
+		t.Errorf("expected unknown rule to be rejected, but it matched: %s", rule)
+	}
+}
+
+func Test_iptablesRuleMatchesAnyPattern(t *testing.T) {
+	testCases := []struct {
+		name      string
+		rule      string
+		patterns  []string
+		wantMatch bool
+		wantErr   bool
+	}{
+		{
+			name:      "regex pattern matches",
+			rule:      `-A OUTPUT -s 169.254.10.10/32 --sport 53 -j NOTRACK`,
+			patterns:  []string{`^-A OUTPUT -s 169\.254\.10\.(10|11)/32 --sport 53 -j NOTRACK$`},
+			wantMatch: true,
+		},
+		{
+			// "[bar]" is a character class as a regex, so this entry can only match literally.
+			name:      "literal substring matches when the regex does not",
+			rule:      `-A OUTPUT -m set --match-set foo[bar] src -j DROP`,
+			patterns:  []string{`--match-set foo[bar] src`},
+			wantMatch: true,
+		},
+		{
+			name:      "no pattern matches",
+			rule:      `-A OUTPUT -j DROP`,
+			patterns:  []string{`^-A INPUT`},
+			wantMatch: false,
+		},
+		{
+			name:      "empty patterns are skipped",
+			rule:      `-A OUTPUT -j DROP`,
+			patterns:  []string{"", "   "},
+			wantMatch: false,
+		},
+		{
+			name:     "invalid pattern is reported",
+			rule:     `-A OUTPUT -j DROP`,
+			patterns: []string{`^-A (OUTPUT`},
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, err := iptablesRuleMatchesAnyPattern(tc.rule, tc.patterns)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for patterns %v, got none", tc.patterns)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if matched != tc.wantMatch {
+				t.Errorf("got match=%v, want %v", matched, tc.wantMatch)
+			}
+		})
+	}
+}

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -3396,12 +3396,16 @@ func ValidateIPTablesCompatibleWithCiliumEBPF(ctx context.Context, s *Scenario) 
 
 // iptablesRuleMatchesAnyPattern reports whether rule is accounted for by any of the given
 // allowlist patterns. A pattern matches either as a regular expression or as a literal
-// substring, so plain (unescaped) entries in the allowlist keep working.
+// substring, so plain entries pasted straight out of `iptables -S` keep working even when they
+// are not valid regular expressions.
 //
-// An invalid pattern is returned as an error rather than treated as "no match": otherwise a
-// typo in the allowlist silently degrades into a confusing "unsupported iptables rule"
-// failure across every scenario.
+// A pattern that fails to compile still gets its literal-substring chance. It is only reported
+// as an error if the rule went unmatched overall, because in that case the malformed pattern is
+// the likely culprit and would otherwise silently degrade into a confusing "unsupported
+// iptables rule" failure across every scenario.
 func iptablesRuleMatchesAnyPattern(rule string, patterns []string) (bool, error) {
+	var firstErr error
+
 	for _, pattern := range patterns {
 		pattern = strings.TrimSpace(pattern)
 		if pattern == "" {
@@ -3409,8 +3413,8 @@ func iptablesRuleMatchesAnyPattern(rule string, patterns []string) (bool, error)
 		}
 
 		matched, err := regexp.MatchString(pattern, rule)
-		if err != nil {
-			return false, fmt.Errorf("invalid iptables allowlist pattern %q: %w", pattern, err)
+		if err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("invalid iptables allowlist pattern %q: %w", pattern, err)
 		}
 		if matched {
 			return true, nil
@@ -3422,7 +3426,7 @@ func iptablesRuleMatchesAnyPattern(rule string, patterns []string) (bool, error)
 		}
 	}
 
-	return false, nil
+	return false, firstErr
 }
 
 // ValidateAppArmorBasic validates that AppArmor is running without requiring aa-status

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -3373,24 +3373,9 @@ func ValidateIPTablesCompatibleWithCiliumEBPF(ctx context.Context, s *Scenario) 
 				continue
 			}
 
-			matched := false
-			for _, pattern := range allPatterns {
-				pattern = strings.TrimSpace(pattern)
-				if pattern == "" {
-					continue
-				}
-
-				// Try regex match
-				matched, _ = regexp.MatchString(pattern, rule)
-				if matched {
-					break
-				}
-
-				// Also try exact match for non-regex patterns
-				if strings.Contains(rule, pattern) {
-					matched = true
-					break
-				}
+			matched, err := iptablesRuleMatchesAnyPattern(rule, allPatterns)
+			if err != nil {
+				return fmt.Errorf("table %s: %w", table, err)
 			}
 
 			if !matched {
@@ -3407,6 +3392,37 @@ func ValidateIPTablesCompatibleWithCiliumEBPF(ctx context.Context, s *Scenario) 
 			"This may indicate an unsupported iptables rule when eBPF host routing is enabled. "+
 			"Contact acndp@microsoft.com for details.",
 	)
+}
+
+// iptablesRuleMatchesAnyPattern reports whether rule is accounted for by any of the given
+// allowlist patterns. A pattern matches either as a regular expression or as a literal
+// substring, so plain (unescaped) entries in the allowlist keep working.
+//
+// An invalid pattern is returned as an error rather than treated as "no match": otherwise a
+// typo in the allowlist silently degrades into a confusing "unsupported iptables rule"
+// failure across every scenario.
+func iptablesRuleMatchesAnyPattern(rule string, patterns []string) (bool, error) {
+	for _, pattern := range patterns {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+
+		matched, err := regexp.MatchString(pattern, rule)
+		if err != nil {
+			return false, fmt.Errorf("invalid iptables allowlist pattern %q: %w", pattern, err)
+		}
+		if matched {
+			return true, nil
+		}
+
+		// Also try exact match for non-regex patterns.
+		if strings.Contains(rule, pattern) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // ValidateAppArmorBasic validates that AppArmor is running without requiring aa-status


### PR DESCRIPTION
## What type of PR is this?

/kind bug
/kind cleanup

## What this PR does / why we need it

`Agentbaker GPU E2E` has been red on `main` since #9247 merged. All 18 real-node GPU scenarios (A100 x2, H100, A10 x2, NC, RTXPro6000, GridDriver, NoDriver, NvidiaDevicePlugin, MIG, DRA) fail on the same assertion from `ValidateIPTablesCompatibleWithCiliumEBPF`:

```
Rule in table raw did not match any pattern:
-A OUTPUT -s 169.254.10.10/32 -p tcp -m comment --comment "localdns: skip conntrack" -m tcp --sport 53 -j NOTRACK
...
Rules found that do not match any of the given patterns.
```

### Root cause

#9247 reverted #9230. That revert removed the reply-direction NOTRACK rules from `localdns.sh` **and** removed the matching entry from the e2e iptables allowlist. Those two removals do not take effect at the same time:

- `localdns.sh` is baked into the VHD by the packer `file` provisioner (`vhdbuilder/packer/*.json`). It is **not** delivered through CSE custom data. A change to it only reaches a node when a **new VHD is published**.
- The e2e allowlist lives in the test code and takes effect on the **next pipeline run**.

So every VHD published while #9230 was on `main` still installs the reply-direction rules, and those VHDs stay in support for **6 months** — but the test stopped accepting them immediately.

Timeline (UTC):

| When | What |
| --- | --- |
| 08-17 22:44 | `ea63b859a0` (#9230) adds reply rules + allowlist entry |
| 08-18 08:29 | VHD `1.1787040551.32430` published — rules baked in |
| 08-18 18:44 | build 177153237 green |
| 08-19 01:51 | `7716637881` (#9247) reverts both |
| 08-19 02:00+ | builds 177223847, 177234019, 177266063 red |

`main` may partially self-heal as post-revert VHDs roll out, but any run pinned to `VHD_BUILD_ID` in the 08-18 → 08-19 window, and any release branch still on those images, stays red. The allowlist is also required again the moment #9230 is re-landed.

## Changes

**`e2e/validation.go`** — restore the reply-direction pattern in the `raw` table. The allowlist describes what a node is *permitted* to have, not what `main` currently installs, so it must cover the whole supported VHD window.

**`e2e/validators.go`** — extract the matching loop into `iptablesRuleMatchesAnyPattern` and stop discarding the `regexp.MatchString` error. Previously a malformed allowlist entry silently degraded to "no match", which surfaces as a confusing *"unsupported iptables rule"* failure on every scenario rather than pointing at the bad pattern. The loop also assigned to the outer `matched` variable; the extraction removes that hazard. Matching semantics (regex OR literal substring, blank patterns skipped) are unchanged — note in particular that a pattern which is *not* valid regex syntax still gets its literal-substring chance, since the allowlist is deliberately fed rules pasted out of `iptables -S` (a comment like `--comment "kube-proxy (v1.31"` is not a valid regex). The compile error is only surfaced when the rule went unmatched overall, i.e. exactly when the malformed pattern is the likely culprit.

**`.github/workflows/go-test.yml`** — `e2e/` is a separate Go module, so `make test` in the root module never reaches it and `check-coverage.yml` explicitly filters it out. Without this, the new tests could only fail *inside* the ADO E2E pipeline they exist to protect, and could not block the PR causing the regression. Added an `e2e-unit-test` job modelled on the existing `version-consistency` job in `validate-components.yml`, scoped to tests needing neither Azure credentials nor network.

**`e2e/validation_iptables_test.go`** (new) — pure unit tests, no Azure resources needed:

- every global and per-table allowlist pattern compiles
- both request- and reply-direction LocalDNS rules are allowlisted (the regression guard)
- the allowlist still fails closed on an unknown rule, so the guard can't be satisfied by an overly broad pattern
- table-driven coverage of the new helper, including the invalid-pattern error path

## Does this PR introduce a user-facing change?

```release-note
NONE
```

## Testing / verification

Product behaviour is unchanged — this only touches e2e test code.

```
$ cd e2e && go build ./... && go vet ./...
$ go test -run 'Test_iptables' -v ./
--- PASS: Test_iptablesAllowlist_patternsCompile
--- PASS: Test_iptablesAllowlist_localdnsRules
--- PASS: Test_iptablesAllowlist_rejectsUnknownRule
--- PASS: Test_iptablesRuleMatchesAnyPattern (5 subtests)
ok  github.com/Azure/agentbaker/e2e
```

Negative check — deleting the restored pattern reproduces the pipeline failure exactly:

```
--- FAIL: Test_iptablesAllowlist_localdnsRules
    LocalDNS rule is not allowlisted for eBPF host routing: -A OUTPUT -s 169.254.10.10/32 -p tcp ... --sport 53 -j NOTRACK
    (x4, matching the 4 unmatched rules per node in build 177266063)
```

Refs #9230, #9247. ADO build 177266063 (definition 443878, `Agentbaker GPU E2E`).

