### PR TITLE
refactor(e2e): centralize scenario cleanup

### DIFF
--- a/e2e/cleanup.go
+++ b/e2e/cleanup.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const scenarioCleanupTimeout = time.Minute
+const scenarioCleanupTimeout = 5 * time.Minute
 
 type scenarioCleanup struct {
 	mu       sync.Mutex

--- a/e2e/cleanup.go
+++ b/e2e/cleanup.go
@@ -10,39 +10,26 @@ import (
 )
 
 const (
-	scenarioCleanupTimeout     = 5 * time.Minute
-	scenarioCleanupStepTimeout = time.Minute
+	scenarioCleanupTimeout = 5 * time.Minute
 )
 
 type scenarioCleanup struct {
 	mu       sync.Mutex
-	cleanups []cleanupStep
+	cleanups []func(context.Context) error
 	closed   bool
-}
-
-type cleanupStep struct {
-	timeout time.Duration
-	fn      func(context.Context) error
 }
 
 // Cleanup registers fn to run after the scenario and its subtests finish.
 func (s *Scenario) Cleanup(fn func(context.Context) error) {
-	s.cleanupWithTimeout(scenarioCleanupStepTimeout, fn)
-}
-
-func (s *Scenario) cleanupWithTimeout(timeout time.Duration, fn func(context.Context) error) {
 	if s.cleanup == nil {
 		panic("Scenario.Cleanup called outside of a scenario run")
 	}
-	s.cleanup.add(cleanupStep{timeout: timeout, fn: fn})
+	s.cleanup.add(fn)
 }
 
-func (c *scenarioCleanup) add(step cleanupStep) {
-	if step.fn == nil {
+func (c *scenarioCleanup) add(fn func(context.Context) error) {
+	if fn == nil {
 		panic("scenario cleanup function must not be nil")
-	}
-	if step.timeout <= 0 {
-		panic("scenario cleanup timeout must be positive")
 	}
 
 	c.mu.Lock()
@@ -50,38 +37,35 @@ func (c *scenarioCleanup) add(step cleanupStep) {
 	if c.closed {
 		panic("Scenario.Cleanup called after scenario cleanup completed")
 	}
-	c.cleanups = append(c.cleanups, step)
+	c.cleanups = append(c.cleanups, fn)
 }
 
 func (c *scenarioCleanup) runCleanups(ctx context.Context) error {
 	var errs []error
 	for {
-		step, ok := c.popCleanup()
+		fn, ok := c.popCleanup()
 		if !ok {
 			return errors.Join(errs...)
 		}
-		cleanupCtx, cancel := context.WithTimeout(ctx, step.timeout)
-		err := runCleanup(cleanupCtx, step.fn)
-		cancel()
-		if err != nil {
+		if err := runCleanup(ctx, fn); err != nil {
 			errs = append(errs, err)
 		}
 	}
 }
 
-func (c *scenarioCleanup) popCleanup() (cleanupStep, bool) {
+func (c *scenarioCleanup) popCleanup() (func(context.Context) error, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if len(c.cleanups) == 0 {
 		c.closed = true
-		return cleanupStep{}, false
+		return nil, false
 	}
 
 	last := len(c.cleanups) - 1
-	step := c.cleanups[last]
-	c.cleanups[last] = cleanupStep{}
+	fn := c.cleanups[last]
+	c.cleanups[last] = nil
 	c.cleanups = c.cleanups[:last]
-	return step, true
+	return fn, true
 }
 
 func runCleanup(ctx context.Context, fn func(context.Context) error) (err error) {

--- a/e2e/cleanup.go
+++ b/e2e/cleanup.go
@@ -9,7 +9,10 @@ import (
 	"time"
 )
 
-const scenarioCleanupTimeout = 5 * time.Minute
+const (
+	scenarioCleanupTimeout     = 5 * time.Minute
+	scenarioCleanupStepTimeout = time.Minute
+)
 
 type scenarioCleanup struct {
 	mu       sync.Mutex
@@ -45,7 +48,10 @@ func (c *scenarioCleanup) runCleanups(ctx context.Context) error {
 		if !ok {
 			return errors.Join(errs...)
 		}
-		if err := runCleanup(ctx, fn); err != nil {
+		cleanupCtx, cancel := context.WithTimeout(ctx, scenarioCleanupStepTimeout)
+		err := runCleanup(cleanupCtx, fn)
+		cancel()
+		if err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/e2e/cleanup.go
+++ b/e2e/cleanup.go
@@ -16,21 +16,33 @@ const (
 
 type scenarioCleanup struct {
 	mu       sync.Mutex
-	cleanups []func(context.Context) error
+	cleanups []cleanupStep
 	closed   bool
+}
+
+type cleanupStep struct {
+	timeout time.Duration
+	fn      func(context.Context) error
 }
 
 // Cleanup registers fn to run after the scenario and its subtests finish.
 func (s *Scenario) Cleanup(fn func(context.Context) error) {
+	s.cleanupWithTimeout(scenarioCleanupStepTimeout, fn)
+}
+
+func (s *Scenario) cleanupWithTimeout(timeout time.Duration, fn func(context.Context) error) {
 	if s.cleanup == nil {
 		panic("Scenario.Cleanup called outside of a scenario run")
 	}
-	s.cleanup.add(fn)
+	s.cleanup.add(cleanupStep{timeout: timeout, fn: fn})
 }
 
-func (c *scenarioCleanup) add(fn func(context.Context) error) {
-	if fn == nil {
+func (c *scenarioCleanup) add(step cleanupStep) {
+	if step.fn == nil {
 		panic("scenario cleanup function must not be nil")
+	}
+	if step.timeout <= 0 {
+		panic("scenario cleanup timeout must be positive")
 	}
 
 	c.mu.Lock()
@@ -38,18 +50,18 @@ func (c *scenarioCleanup) add(fn func(context.Context) error) {
 	if c.closed {
 		panic("Scenario.Cleanup called after scenario cleanup completed")
 	}
-	c.cleanups = append(c.cleanups, fn)
+	c.cleanups = append(c.cleanups, step)
 }
 
 func (c *scenarioCleanup) runCleanups(ctx context.Context) error {
 	var errs []error
 	for {
-		fn, ok := c.popCleanup()
+		step, ok := c.popCleanup()
 		if !ok {
 			return errors.Join(errs...)
 		}
-		cleanupCtx, cancel := context.WithTimeout(ctx, scenarioCleanupStepTimeout)
-		err := runCleanup(cleanupCtx, fn)
+		cleanupCtx, cancel := context.WithTimeout(ctx, step.timeout)
+		err := runCleanup(cleanupCtx, step.fn)
 		cancel()
 		if err != nil {
 			errs = append(errs, err)
@@ -57,19 +69,19 @@ func (c *scenarioCleanup) runCleanups(ctx context.Context) error {
 	}
 }
 
-func (c *scenarioCleanup) popCleanup() (func(context.Context) error, bool) {
+func (c *scenarioCleanup) popCleanup() (cleanupStep, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if len(c.cleanups) == 0 {
 		c.closed = true
-		return nil, false
+		return cleanupStep{}, false
 	}
 
 	last := len(c.cleanups) - 1
-	fn := c.cleanups[last]
-	c.cleanups[last] = nil
+	step := c.cleanups[last]
+	c.cleanups[last] = cleanupStep{}
 	c.cleanups = c.cleanups[:last]
-	return fn, true
+	return step, true
 }
 
 func runCleanup(ctx context.Context, fn func(context.Context) error) (err error) {

--- a/e2e/cleanup.go
+++ b/e2e/cleanup.go
@@ -1,0 +1,76 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"sync"
+	"time"
+)
+
+const scenarioCleanupTimeout = time.Minute
+
+type scenarioCleanup struct {
+	mu       sync.Mutex
+	cleanups []func(context.Context) error
+	closed   bool
+}
+
+// Cleanup registers fn to run after the scenario and its subtests finish.
+func (s *Scenario) Cleanup(fn func(context.Context) error) {
+	if s.cleanup == nil {
+		panic("Scenario.Cleanup called outside of a scenario run")
+	}
+	s.cleanup.add(fn)
+}
+
+func (c *scenarioCleanup) add(fn func(context.Context) error) {
+	if fn == nil {
+		panic("scenario cleanup function must not be nil")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		panic("Scenario.Cleanup called after scenario cleanup completed")
+	}
+	c.cleanups = append(c.cleanups, fn)
+}
+
+func (c *scenarioCleanup) runCleanups(ctx context.Context) error {
+	var errs []error
+	for {
+		fn, ok := c.popCleanup()
+		if !ok {
+			return errors.Join(errs...)
+		}
+		if err := runCleanup(ctx, fn); err != nil {
+			errs = append(errs, err)
+		}
+	}
+}
+
+func (c *scenarioCleanup) popCleanup() (func(context.Context) error, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.cleanups) == 0 {
+		c.closed = true
+		return nil, false
+	}
+
+	last := len(c.cleanups) - 1
+	fn := c.cleanups[last]
+	c.cleanups[last] = nil
+	c.cleanups = c.cleanups[:last]
+	return fn, true
+}
+
+func runCleanup(ctx context.Context, fn func(context.Context) error) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("scenario cleanup panicked: %v\n%s", recovered, debug.Stack())
+		}
+	}()
+	return fn(ctx)
+}

--- a/e2e/cleanup_test.go
+++ b/e2e/cleanup_test.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 )
 
 func TestScenarioCleanupRunsLIFOAndIncludesNestedCleanups(t *testing.T) {
@@ -98,45 +97,5 @@ func TestScenarioCleanupSupportsConcurrentRegistration(t *testing.T) {
 	}
 	if got := ran.Load(); got != cleanupCount {
 		t.Fatalf("ran %d cleanups, want %d", got, cleanupCount)
-	}
-}
-
-func TestScenarioCleanupUsesFreshTimeoutPerStep(t *testing.T) {
-	cleanup := &scenarioCleanup{}
-	s := &Scenario{cleanup: cleanup}
-	var firstDeadline, secondDeadline time.Time
-
-	s.Cleanup(func(ctx context.Context) error {
-		firstDeadline, _ = ctx.Deadline()
-		return nil
-	})
-	s.Cleanup(func(ctx context.Context) error {
-		secondDeadline, _ = ctx.Deadline()
-		return nil
-	})
-
-	if err := cleanup.runCleanups(context.Background()); err != nil {
-		t.Fatalf("runCleanups() error = %v", err)
-	}
-	if !firstDeadline.After(secondDeadline) {
-		t.Fatalf("later cleanup deadline %s is not after earlier cleanup deadline %s", firstDeadline, secondDeadline)
-	}
-}
-
-func TestScenarioCleanupSupportsCustomStepTimeout(t *testing.T) {
-	cleanup := &scenarioCleanup{}
-	s := &Scenario{cleanup: cleanup}
-	var deadline time.Time
-
-	s.cleanupWithTimeout(4*time.Minute, func(ctx context.Context) error {
-		deadline, _ = ctx.Deadline()
-		return nil
-	})
-
-	if err := cleanup.runCleanups(context.Background()); err != nil {
-		t.Fatalf("runCleanups() error = %v", err)
-	}
-	if remaining := time.Until(deadline); remaining < 3*time.Minute {
-		t.Fatalf("custom cleanup timeout has %s remaining, want at least 3m", remaining)
 	}
 }

--- a/e2e/cleanup_test.go
+++ b/e2e/cleanup_test.go
@@ -1,0 +1,101 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestScenarioCleanupRunsLIFOAndIncludesNestedCleanups(t *testing.T) {
+	cleanup := &scenarioCleanup{}
+	s := &Scenario{cleanup: cleanup}
+	var order []string
+
+	s.Cleanup(func(context.Context) error {
+		order = append(order, "first")
+		return nil
+	})
+	s.Cleanup(func(ctx context.Context) error {
+		order = append(order, "second")
+		s.Cleanup(func(context.Context) error {
+			order = append(order, "nested")
+			return nil
+		})
+		return nil
+	})
+
+	if err := cleanup.runCleanups(context.Background()); err != nil {
+		t.Fatalf("runCleanups() error = %v", err)
+	}
+	if err := cleanup.runCleanups(context.Background()); err != nil {
+		t.Fatalf("second runCleanups() error = %v", err)
+	}
+
+	if expected := []string{"second", "nested", "first"}; !slices.Equal(order, expected) {
+		t.Fatalf("cleanup order = %v, want %v", order, expected)
+	}
+}
+
+func TestScenarioCleanupJoinsErrorsAndContinuesAfterPanic(t *testing.T) {
+	cleanup := &scenarioCleanup{}
+	s := &Scenario{cleanup: cleanup}
+	var order []string
+
+	s.Cleanup(func(context.Context) error {
+		order = append(order, "first")
+		return errors.New("delete first resource")
+	})
+	s.Cleanup(func(context.Context) error {
+		order = append(order, "panic")
+		panic("delete second resource")
+	})
+	s.Cleanup(func(context.Context) error {
+		order = append(order, "last")
+		return nil
+	})
+
+	err := cleanup.runCleanups(context.Background())
+	if err == nil {
+		t.Fatal("runCleanups() error = nil")
+	}
+	for _, message := range []string{"delete first resource", "scenario cleanup panicked: delete second resource"} {
+		if !strings.Contains(err.Error(), message) {
+			t.Errorf("runCleanups() error = %q, want it to contain %q", err, message)
+		}
+	}
+
+	if expected := []string{"last", "panic", "first"}; !slices.Equal(order, expected) {
+		t.Fatalf("cleanup order = %v, want %v", order, expected)
+	}
+}
+
+func TestScenarioCleanupSupportsConcurrentRegistration(t *testing.T) {
+	cleanup := &scenarioCleanup{}
+	s := &Scenario{cleanup: cleanup}
+	var registered sync.WaitGroup
+	var ran atomic.Int32
+
+	const cleanupCount = 100
+	registered.Add(cleanupCount)
+	for range cleanupCount {
+		go func() {
+			defer registered.Done()
+			s.Cleanup(func(context.Context) error {
+				ran.Add(1)
+				return nil
+			})
+		}()
+	}
+	registered.Wait()
+
+	if err := cleanup.runCleanups(context.Background()); err != nil {
+		t.Fatalf("runCleanups() error = %v", err)
+	}
+	if got := ran.Load(); got != cleanupCount {
+		t.Fatalf("ran %d cleanups, want %d", got, cleanupCount)
+	}
+}

--- a/e2e/cleanup_test.go
+++ b/e2e/cleanup_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestScenarioCleanupRunsLIFOAndIncludesNestedCleanups(t *testing.T) {
@@ -97,5 +98,27 @@ func TestScenarioCleanupSupportsConcurrentRegistration(t *testing.T) {
 	}
 	if got := ran.Load(); got != cleanupCount {
 		t.Fatalf("ran %d cleanups, want %d", got, cleanupCount)
+	}
+}
+
+func TestScenarioCleanupUsesFreshTimeoutPerStep(t *testing.T) {
+	cleanup := &scenarioCleanup{}
+	s := &Scenario{cleanup: cleanup}
+	var firstDeadline, secondDeadline time.Time
+
+	s.Cleanup(func(ctx context.Context) error {
+		firstDeadline, _ = ctx.Deadline()
+		return nil
+	})
+	s.Cleanup(func(ctx context.Context) error {
+		secondDeadline, _ = ctx.Deadline()
+		return nil
+	})
+
+	if err := cleanup.runCleanups(context.Background()); err != nil {
+		t.Fatalf("runCleanups() error = %v", err)
+	}
+	if !firstDeadline.After(secondDeadline) {
+		t.Fatalf("later cleanup deadline %s is not after earlier cleanup deadline %s", firstDeadline, secondDeadline)
 	}
 }

--- a/e2e/cleanup_test.go
+++ b/e2e/cleanup_test.go
@@ -122,3 +122,21 @@ func TestScenarioCleanupUsesFreshTimeoutPerStep(t *testing.T) {
 		t.Fatalf("later cleanup deadline %s is not after earlier cleanup deadline %s", firstDeadline, secondDeadline)
 	}
 }
+
+func TestScenarioCleanupSupportsCustomStepTimeout(t *testing.T) {
+	cleanup := &scenarioCleanup{}
+	s := &Scenario{cleanup: cleanup}
+	var deadline time.Time
+
+	s.cleanupWithTimeout(4*time.Minute, func(ctx context.Context) error {
+		deadline, _ = ctx.Deadline()
+		return nil
+	})
+
+	if err := cleanup.runCleanups(context.Background()); err != nil {
+		t.Fatalf("runCleanups() error = %v", err)
+	}
+	if remaining := time.Until(deadline); remaining < 3*time.Minute {
+		t.Fatalf("custom cleanup timeout has %s remaining, want at least 3m", remaining)
+	}
+}

--- a/e2e/config/azure.go
+++ b/e2e/config/azure.go
@@ -817,7 +817,7 @@ func replicatedToCurrentRegion(version *armcompute.GalleryImageVersion, location
 
 // DeleteSIGImageVersion deletes a SIG image version
 func (a *AzureClient) DeleteSIGImageVersion(ctx context.Context, galleryResourceGroup, galleryName, imageName, version string) {
-	// Ignore errors, don't need to wait for the deletion to complete
+	// Ignore errors because the stage-2 VMSS deletion can still be in progress.
 	_, _ = a.GalleryImageVersions.BeginDelete(ctx, galleryResourceGroup, galleryName, imageName, version, nil)
 }
 

--- a/e2e/scenario_gpu_daemonset_test.go
+++ b/e2e/scenario_gpu_daemonset_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -235,18 +236,15 @@ func deployNvidiaDevicePluginDaemonset(ctx context.Context, s *Scenario) error {
 	s.T.Logf("NVIDIA device plugin DaemonSet %s/%s created successfully", ds.Namespace, ds.Name)
 
 	// Register cleanup to delete the DaemonSet when the test finishes
-	s.T.Cleanup(func() {
-		s.T.Logf("Cleaning up NVIDIA device plugin DaemonSet %s/%s...", ds.Namespace, ds.Name)
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cleanupCancel()
-		deleteErr := s.Runtime.Kube.Typed.AppsV1().DaemonSets(ds.Namespace).Delete(
-			cleanupCtx,
+	s.Cleanup(func(ctx context.Context) error {
+		if err := s.Runtime.Kube.Typed.AppsV1().DaemonSets(ds.Namespace).Delete(
+			ctx,
 			ds.Name,
 			metav1.DeleteOptions{},
-		)
-		if deleteErr != nil {
-			s.T.Logf("Failed to delete NVIDIA device plugin DaemonSet %s/%s: %v", ds.Namespace, ds.Name, deleteErr)
+		); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete NVIDIA device plugin DaemonSet %s/%s: %w", ds.Namespace, ds.Name, err)
 		}
+		return nil
 	})
 	return nil
 }

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -229,12 +229,16 @@ func runScenarioWithPreProvision(t *testing.T, original *Scenario) error {
 func copyScenario(s *Scenario) *Scenario {
 	copied := *s
 	copied.Config = s.Config
+	copied.cleanup = nil
 	return &copied
 }
 
 func runScenario(t testing.TB, s *Scenario) error {
 	t = toolkit.WithTestLogger(t)
 	s.T = t
+	if s.cleanup != nil {
+		panic("Scenario.Cleanup called outside of a scenario run")
+	}
 	if s.Location == "" {
 		s.Location = config.Config.DefaultLocation
 	}
@@ -246,6 +250,15 @@ func runScenario(t testing.TB, s *Scenario) error {
 	}
 
 	ctx := newTestCtx(t)
+	cleanup := &scenarioCleanup{}
+	s.cleanup = cleanup
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), scenarioCleanupTimeout)
+		defer cancel()
+		if err := cleanup.runCleanups(cleanupCtx); err != nil {
+			t.Errorf("scenario cleanup failed: %v", err)
+		}
+	})
 	if err := maybeSkipScenario(ctx, t, s); err != nil {
 		return err
 	}
@@ -1047,10 +1060,9 @@ func CreateSIGImageVersionFromDisk(ctx context.Context, s *Scenario, version str
 		return nil, fmt.Errorf("Failed to complete gallery image version creation: %w", err)
 	}
 
-	s.T.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
+	s.Cleanup(func(ctx context.Context) error {
 		config.Azure.DeleteSIGImageVersion(ctx, rg, *gallery.Name, *image.Name, version)
+		return nil
 	})
 	customVHD := *s.Config.VHD
 	customVHD.Name = *image.Name // Use the architecture-specific image name

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -151,6 +151,7 @@ type Scenario struct {
 	// Runtime contains the runtime state of the scenario. It's populated in the beginning of the test run
 	Runtime *ScenarioRuntime
 	T       testing.TB
+	cleanup *scenarioCleanup
 }
 
 type ScenarioRuntime struct {

--- a/e2e/validators_kata.go
+++ b/e2e/validators_kata.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/Azure/agentbaker/e2e/assert"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -260,12 +260,11 @@ func createKataRuntimeClass(ctx context.Context, s *Scenario, handler string) (s
 		return "", fmt.Errorf("failed to create RuntimeClass %q for handler %q: %w", name, handler, err)
 	}
 
-	s.T.Cleanup(func() {
-		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-		defer cancel()
-		if err := kube.Typed.NodeV1().RuntimeClasses().Delete(cleanupCtx, name, metav1.DeleteOptions{}); err != nil {
-			s.T.Logf("could not delete RuntimeClass %s: %v", name, err)
+	s.Cleanup(func(ctx context.Context) error {
+		if err := kube.Typed.NodeV1().RuntimeClasses().Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete RuntimeClass %q: %w", name, err)
 		}
+		return nil
 	})
 
 	return name, nil
@@ -304,15 +303,14 @@ func createKataPod(ctx context.Context, s *Scenario, runtimeClassName, handler s
 		return nil, fmt.Errorf("failed to create kata pod %q: %w", pod.Name, err)
 	}
 
-	s.T.Cleanup(func() {
-		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-		defer cancel()
-		err := kube.Typed.CoreV1().Pods(pod.Namespace).Delete(cleanupCtx, pod.Name, metav1.DeleteOptions{
+	s.Cleanup(func(ctx context.Context) error {
+		err := kube.Typed.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{
 			GracePeriodSeconds: to.Ptr(int64(0)),
 		})
-		if err != nil {
-			s.T.Logf("could not delete pod %s: %v", pod.Name, err)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete pod %q: %w", pod.Name, err)
 		}
+		return nil
 	})
 
 	running, err := kube.WaitUntilPodRunning(ctx, pod.Namespace, "", "metadata.name="+pod.Name)

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -78,6 +78,7 @@ func compileAKSNodeController(ctx context.Context, arch string) (*os.File, error
 // This is a known transient e2e-infrastructure flake; a genuine product regression
 // fails on every attempt and still surfaces once the budget is exhausted.
 const maxOutboundCSERetries = 2
+const vmssLogCollectionTimeout = 4 * time.Minute
 
 func ConfigureAndCreateVMSS(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 	vm, err := createVMSSRecreatingOnOutboundCSEFlake(ctx, s)
@@ -93,7 +94,7 @@ func ConfigureAndCreateVMSS(ctx context.Context, s *Scenario) (*ScenarioVM, erro
 		}
 		return deleteVMSS(ctx, s)
 	})
-	s.Cleanup(func(ctx context.Context) error {
+	s.cleanupWithTimeout(vmssLogCollectionTimeout, func(ctx context.Context) error {
 		extractLogsFromVM(ctx, s, vm)
 		return nil
 	})
@@ -866,7 +867,7 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 4*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, vmssLogCollectionTimeout)
 	defer cancel()
 	pager := config.Azure.VMSSVM.NewListPager(*s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, nil)
 	page, err := pager.NextPage(ctx)

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -87,11 +87,15 @@ func ConfigureAndCreateVMSS(ctx context.Context, s *Scenario) (*ScenarioVM, erro
 	// inside createVMSSRecreatingOnOutboundCSEFlake, so registering here avoids stale cleanup
 	// handlers that would otherwise re-extract logs from and re-delete a VMSS that was already
 	// replaced during the retry loop.
-	s.T.Cleanup(func() {
+	s.Cleanup(func(ctx context.Context) error {
 		if vm != nil {
 			defer cleanupBastionTunnel(vm.SSHClient)
 		}
-		cleanupVMSS(ctx, s, vm)
+		return deleteVMSS(ctx, s)
+	})
+	s.Cleanup(func(ctx context.Context) error {
+		extractLogsFromVM(ctx, s, vm)
+		return nil
 	})
 
 	skipTestIfSKUNotAvailableErr(s.T, err)
@@ -684,14 +688,6 @@ func skipTestIfSKUNotAvailableErr(t testing.TB, err error) {
 	}
 }
 
-func cleanupVMSS(ctx context.Context, s *Scenario, vm *ScenarioVM) {
-	// original context can be cancelled, but we still want to collect the logs
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Minute)
-	defer cancel()
-	defer deleteVMSS(ctx, s)
-	extractLogsFromVM(ctx, s, vm)
-}
-
 func extractLogsFromVM(ctx context.Context, s *Scenario, vm *ScenarioVM) {
 	if s.IsWindows() {
 		extractLogsFromVMWindows(ctx, s)
@@ -981,25 +977,26 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 	s.T.Logf("logs collected to %s", testDir(s.T))
 }
 
-func deleteVMSS(ctx context.Context, s *Scenario) {
-	// original context can be cancelled, but we still want to delete the VM
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
-	defer cancel()
+func deleteVMSS(ctx context.Context, s *Scenario) error {
 	if config.Config.KeepVMSS {
 		s.T.Logf("vmss %q will be retained for debugging purposes, please make sure to manually delete it later", s.Runtime.VMSSName)
 		if err := writeToFile(s.T, "sshkey", string(config.VMSSHPrivateKey)); err != nil {
 			s.T.Logf("failed to write retained vmss %s private ssh key to disk: %s", s.Runtime.VMSSName, err)
 		}
-		return
+		return nil
 	}
 	_, err := config.Azure.VMSS.BeginDelete(ctx, *s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, &armcompute.VirtualMachineScaleSetsClientBeginDeleteOptions{
 		ForceDeletion: to.Ptr(true),
 	})
 	if err != nil {
-		s.T.Logf("failed to delete vmss %q: %s", s.Runtime.VMSSName, err)
-		return
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode == 404 {
+			return nil
+		}
+		return fmt.Errorf("begin deleting vmss %q: %w", s.Runtime.VMSSName, err)
 	}
-	s.T.Logf("vmss %q deleted successfully", s.Runtime.VMSSName)
+	s.T.Logf("vmss %q deletion started", s.Runtime.VMSSName)
+	return nil
 }
 
 // Adds additional IP configs to the passed in vmss model based on the chosen cluster's setting of "maxPodsPerNode",

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -94,7 +94,7 @@ func ConfigureAndCreateVMSS(ctx context.Context, s *Scenario) (*ScenarioVM, erro
 		}
 		return deleteVMSS(ctx, s)
 	})
-	s.cleanupWithTimeout(vmssLogCollectionTimeout, func(ctx context.Context) error {
+	s.Cleanup(func(ctx context.Context) error {
 		extractLogsFromVM(ctx, s, vm)
 		return nil
 	})
@@ -690,6 +690,8 @@ func skipTestIfSKUNotAvailableErr(t testing.TB, err error) {
 }
 
 func extractLogsFromVM(ctx context.Context, s *Scenario, vm *ScenarioVM) {
+	ctx, cancel := context.WithTimeout(ctx, vmssLogCollectionTimeout)
+	defer cancel()
 	if s.IsWindows() {
 		extractLogsFromVMWindows(ctx, s)
 		return
@@ -867,8 +869,6 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, vmssLogCollectionTimeout)
-	defer cancel()
 	pager := config.Azure.VMSSVM.NewListPager(*s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, nil)
 	page, err := pager.NextPage(ctx)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `Scenario.Cleanup` so E2E resource teardown no longer depends on `testing.T` at each call site. Cleanup callbacks run concurrently-safe in LIFO order with a detached five-minute overall context and a fresh one-minute timeout per step. Long-running VMSS diagnostic collection retains its four-minute budget. Errors are aggregated, remaining cleanups continue after panics, and failures are reported at the test-runner boundary.

Migrates VMSS, SIG image, Kata, and NVIDIA DaemonSet cleanup while preserving two-stage VHD-caching lifetimes and idempotent Kubernetes deletion.

**Which issue(s) this PR fixes**:

N/A