### PR TITLE
feat(anc): check-hotfix fallback to nbc-cmd.sh when config.json absent

### DIFF
--- a/aks-node-controller/app.go
+++ b/aks-node-controller/app.go
@@ -58,6 +58,10 @@ type App struct {
 	// source for check-hotfix's LPS endpoint (apiserver FQDN + cluster CA) and the
 	// cold-start fallback pointer.
 	nodeConfigPath string
+	// nbcCmdPath overrides the default nbc-cmd.sh path for testing. When the main
+	// node config (nodeConfigPath) is absent, check-hotfix parses this existing command
+	// file to obtain API_SERVER_NAME and KUBE_CA_CRT for the LPS connection.
+	nbcCmdPath string
 	// gpuComponentsFilePath overrides the default GPU components.json location for testing.
 	gpuComponentsFilePath string
 	// checkHotfixFetcher overrides the real LPS hotfix-pointer GET for testing, letting

--- a/aks-node-controller/checkhotfix.go
+++ b/aks-node-controller/checkhotfix.go
@@ -31,6 +31,8 @@ import (
 // endpoint resolution, the benign-vs-fatal taxonomy, and the fail-open fetch/parse/stage
 // workflow.
 const (
+	defaultNBCCmdPath = "/opt/azure/containers/aks-node-controller-nbc-cmd.sh"
+
 	// lpsALPNProto is the ALPN protocol the kube-api-proxy envoy uses to route the TLS connection
 	// to the live-patching-service (LPS) gRPC backend. The client dials the apiserver FQDN as SNI
 	// (riding the existing apiserver egress rule) and advertises this ALPN value; envoy then
@@ -280,17 +282,22 @@ func (a *App) fetchHotfix(ctx context.Context) ([]byte, error) {
 }
 
 // lpsTargetFromNodeConfig reads the apiserver FQDN (the forced dial target) and the cluster
-// CA (TLS trust) from the AKSNodeConfig.
+// CA (TLS trust) from the AKSNodeConfig. If the config file is absent (e.g. Staging Phase 2
+// where AKSNodeConfigJSON is empty), it falls back to the existing nbc-cmd.sh file, which
+// contains the same values as command-scoped environment variables.
 //
 // check-hotfix runs before the provisioning scripts (cse_config.sh), so the on-node decoded
 // CA file (/etc/kubernetes/certs/ca.crt) does not exist yet -- it is written later during
-// provisioning. The node config is the only credential source guaranteed to be present at
-// this point and it carries the CA as base64-encoded PEM (the same value cse_config.sh later
-// decodes into that file).
+// provisioning. Depending on the Scriptless phase, either the node config or nbc-cmd carries
+// the CA as base64-encoded PEM (the same value cse_config.sh later decodes into that file).
 func (a *App) lpsTargetFromNodeConfig() (string, []byte, error) {
 	path := a.getNodeConfigPath()
 	raw, err := os.ReadFile(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			slog.Info("node config not found, trying nbc-cmd.sh fallback", "path", path)
+			return a.lpsTargetFromNBCCmd()
+		}
 		return "", nil, fmt.Errorf("reading node config %s: %w", path, err)
 	}
 	cfg, perr := nodeconfigutils.UnmarshalConfigurationV1(raw)
@@ -529,4 +536,41 @@ func (a *App) getNodeConfigPath() string {
 		return a.nodeConfigPath
 	}
 	return nodeconfigutils.AKSNodeConfigFilePath
+}
+
+// getNBCCmdPath returns the injectable nbc-cmd.sh path, defaulting to the standard location.
+func (a *App) getNBCCmdPath() string {
+	if a.nbcCmdPath != "" {
+		return a.nbcCmdPath
+	}
+	return defaultNBCCmdPath
+}
+
+// lpsTargetFromNBCCmd reads the apiserver FQDN and cluster CA from the existing nbc-cmd.sh file.
+// This is the fallback path when the full AKSNodeConfig JSON is not present (e.g. Staging
+// Phase 2). Reuse the parser used by env comparison for the flattened NBC command.
+func (a *App) lpsTargetFromNBCCmd() (string, []byte, error) {
+	path := a.getNBCCmdPath()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", nil, fmt.Errorf("reading nbc-cmd %s: %w", path, err)
+	}
+
+	vars := parseEnvVarsFromNBCCmdContent(string(raw))
+	fqdn := vars["API_SERVER_NAME"]
+	if fqdn == "" {
+		return "", nil, fmt.Errorf("nbc-cmd %s has no API_SERVER_NAME", path)
+	}
+
+	var caPEM []byte
+	if caB64 := vars["KUBE_CA_CRT"]; caB64 != "" {
+		decoded, err := base64.StdEncoding.DecodeString(caB64)
+		if err != nil {
+			return "", nil, fmt.Errorf("decoding nbc-cmd KUBE_CA_CRT: %w", err)
+		}
+		caPEM = decoded
+	}
+
+	slog.Info("loaded LPS target from nbc-cmd.sh fallback", "fqdn", fqdn, "path", path)
+	return fqdn, caPEM, nil
 }

--- a/aks-node-controller/checkhotfix_grpc.go
+++ b/aks-node-controller/checkhotfix_grpc.go
@@ -64,13 +64,14 @@ func (e *lpsGRPCStatusError) Error() string {
 }
 
 // fetchHotfixOverGRPC performs the GetComponentConfig call against the live-patching service: it
-// resolves the apiserver FQDN + cluster CA from the node config, carries the IMDS attested-data
-// document in gRPC metadata, and returns the opaque response bytes for the shared parse/stage path.
+// resolves the apiserver FQDN + cluster CA from the available node bootstrap input, carries the
+// IMDS attested-data document in gRPC metadata, and returns the opaque response bytes for the
+// shared parse/stage path.
 // The gRPC status is mapped onto the benign-vs-fatal taxonomy so handleFetchError is unchanged.
 func (a *App) fetchHotfixOverGRPC(ctx context.Context) ([]byte, error) {
 	fqdn, caPEM, err := a.lpsTargetFromNodeConfig()
 	if err != nil {
-		return nil, fmt.Errorf("resolving LPS endpoint from node config: %w", err)
+		return nil, fmt.Errorf("resolving LPS endpoint: %w", err)
 	}
 
 	token, err := a.attestedToken(ctx)

--- a/aks-node-controller/checkhotfix_test.go
+++ b/aks-node-controller/checkhotfix_test.go
@@ -506,6 +506,7 @@ func TestLPSTargetFromNodeConfig(t *testing.T) {
 		body := `{"version":"v1","api_server_config":{"api_server_name":"myapi.example.com"},"kubernetes_ca_cert":"` + caB64 + `"}`
 		require.NoError(t, os.WriteFile(p, []byte(body), 0644))
 		tt.App.nodeConfigPath = p
+		tt.App.nbcCmdPath = filepath.Join(t.TempDir(), "must-not-be-read.sh")
 
 		fqdn, ca, err := tt.App.lpsTargetFromNodeConfig()
 		require.NoError(t, err)
@@ -524,11 +525,90 @@ func TestLPSTargetFromNodeConfig(t *testing.T) {
 		assert.Contains(t, err.Error(), "api_server_name")
 	})
 
-	t.Run("missing file is an error", func(t *testing.T) {
+	t.Run("missing config.json falls back to nbc-cmd.sh", func(t *testing.T) {
+		dir := t.TempDir()
+		tt := NewTestApp(t, TestAppConfig{})
+		tt.App.nodeConfigPath = filepath.Join(dir, "nope.json")
+
+		caPEM := "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
+		caB64 := base64.StdEncoding.EncodeToString([]byte(caPEM))
+		cmdPath := filepath.Join(dir, "nbc-cmd.sh")
+		cmdContent := fmt.Sprintf(`PROVISION_OUTPUT="/tmp/out"; API_SERVER_NAME=fallback.example.com KUBE_CA_CRT="%s" /usr/bin/nohup /bin/bash -c "/bin/bash /opt/azure/containers/provision_start.sh"`, caB64)
+		require.NoError(t, os.WriteFile(cmdPath, []byte(cmdContent), 0600))
+		tt.App.nbcCmdPath = cmdPath
+
+		fqdn, ca, err := tt.App.lpsTargetFromNodeConfig()
+		require.NoError(t, err)
+		assert.Equal(t, "fallback.example.com", fqdn)
+		assert.Equal(t, []byte(caPEM), ca)
+	})
+
+	t.Run("missing config.json and missing nbc-cmd.sh is an error", func(t *testing.T) {
 		tt := NewTestApp(t, TestAppConfig{})
 		tt.App.nodeConfigPath = filepath.Join(t.TempDir(), "nope.json")
+		tt.App.nbcCmdPath = filepath.Join(t.TempDir(), "also-nope.sh")
 		_, _, err := tt.App.lpsTargetFromNodeConfig()
 		require.Error(t, err)
+	})
+}
+
+func TestLPSTargetFromNBCCmd(t *testing.T) {
+	caPEM := "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
+	caB64 := base64.StdEncoding.EncodeToString([]byte(caPEM))
+
+	t.Run("reads fqdn and decodes CA", func(t *testing.T) {
+		tt := NewTestApp(t, TestAppConfig{})
+		p := filepath.Join(t.TempDir(), "nbc-cmd.sh")
+		content := fmt.Sprintf(`API_SERVER_NAME=myapi.example.com KUBE_CA_CRT="%s" /usr/bin/nohup /bin/bash -c "provision"`, caB64)
+		require.NoError(t, os.WriteFile(p, []byte(content), 0600))
+		tt.App.nbcCmdPath = p
+
+		fqdn, ca, err := tt.App.lpsTargetFromNBCCmd()
+		require.NoError(t, err)
+		assert.Equal(t, "myapi.example.com", fqdn)
+		assert.Equal(t, []byte(caPEM), ca)
+	})
+
+	t.Run("missing API_SERVER_NAME is an error", func(t *testing.T) {
+		tt := NewTestApp(t, TestAppConfig{})
+		p := filepath.Join(t.TempDir(), "nbc-cmd.sh")
+		content := fmt.Sprintf(`KUBE_CA_CRT="%s" /usr/bin/nohup /bin/bash -c "provision"`, caB64)
+		require.NoError(t, os.WriteFile(p, []byte(content), 0600))
+		tt.App.nbcCmdPath = p
+
+		_, _, err := tt.App.lpsTargetFromNBCCmd()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "API_SERVER_NAME")
+	})
+
+	t.Run("missing file is an error", func(t *testing.T) {
+		tt := NewTestApp(t, TestAppConfig{})
+		tt.App.nbcCmdPath = filepath.Join(t.TempDir(), "nope.sh")
+		_, _, err := tt.App.lpsTargetFromNBCCmd()
+		require.Error(t, err)
+	})
+
+	t.Run("CA is optional", func(t *testing.T) {
+		tt := NewTestApp(t, TestAppConfig{})
+		p := filepath.Join(t.TempDir(), "nbc-cmd.sh")
+		require.NoError(t, os.WriteFile(p, []byte(`API_SERVER_NAME=myapi.example.com /usr/bin/nohup /bin/bash -c "provision"`), 0600))
+		tt.App.nbcCmdPath = p
+
+		fqdn, ca, err := tt.App.lpsTargetFromNBCCmd()
+		require.NoError(t, err)
+		assert.Equal(t, "myapi.example.com", fqdn)
+		assert.Nil(t, ca)
+	})
+
+	t.Run("invalid CA is an error", func(t *testing.T) {
+		tt := NewTestApp(t, TestAppConfig{})
+		p := filepath.Join(t.TempDir(), "nbc-cmd.sh")
+		require.NoError(t, os.WriteFile(p, []byte(`API_SERVER_NAME=myapi.example.com KUBE_CA_CRT="not-base64" /usr/bin/nohup /bin/bash -c "provision"`), 0600))
+		tt.App.nbcCmdPath = p
+
+		_, _, err := tt.App.lpsTargetFromNBCCmd()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "KUBE_CA_CRT")
 	})
 }
 

--- a/aks-node-controller/checkhotfix_test.go
+++ b/aks-node-controller/checkhotfix_test.go
@@ -533,7 +533,10 @@ func TestLPSTargetFromNodeConfig(t *testing.T) {
 		caPEM := "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
 		caB64 := base64.StdEncoding.EncodeToString([]byte(caPEM))
 		cmdPath := filepath.Join(dir, "nbc-cmd.sh")
-		cmdContent := fmt.Sprintf(`PROVISION_OUTPUT="/tmp/out"; API_SERVER_NAME=fallback.example.com KUBE_CA_CRT="%s" /usr/bin/nohup /bin/bash -c "/bin/bash /opt/azure/containers/provision_start.sh"`, caB64)
+		cmdContent := fmt.Sprintf(
+			`PROVISION_OUTPUT="/tmp/out"; API_SERVER_NAME=fallback.example.com `+
+				`KUBE_CA_CRT="%s" /usr/bin/nohup /bin/bash -c "/bin/bash /opt/azure/containers/provision_start.sh"`,
+			caB64)
 		require.NoError(t, os.WriteFile(cmdPath, []byte(cmdContent), 0600))
 		tt.App.nbcCmdPath = cmdPath
 

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -700,8 +700,9 @@ func Test_Ubuntu2404_CheckHotfixFromNBCCmd(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Description: "tests that check-hotfix resolves the LPS target from the Phase 2 NBC command",
 		Config: Config{
-			Cluster: ClusterKubenet,
-			VHD:     config.VHDUbuntu2404Gen2Containerd,
+			Cluster:               ClusterKubenet,
+			VHD:                   config.VHDUbuntu2404Gen2Containerd,
+			SkipDefaultValidation: true,
 			Validator: func(ctx context.Context, s *Scenario) error {
 				result, err := execScriptOnVMForScenarioValidateExitCode(
 					ctx,

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	aksnodeconfigv1 "github.com/Azure/agentbaker/aks-node-controller/pkg/gen/aksnodeconfig/v1"
+	"github.com/Azure/agentbaker/e2e/assert"
 	"github.com/Azure/agentbaker/e2e/components"
 	"github.com/Azure/agentbaker/e2e/config"
 	"github.com/Azure/agentbaker/e2e/toolkit"
@@ -690,6 +691,37 @@ func Test_Ubuntu2204_ScriptlessCSECmd_Hotfix(t *testing.T) {
 				// This file does NOT exist on any VHD — it can only be present if cloud-init
 				// processed our write_files entry, proving the hotfix delivery mechanism works.
 				return ValidateFileHasContent(ctx, s, hotfixMarkerPath, hotfixMarkerContent)
+			},
+		},
+	})
+}
+
+func Test_Ubuntu2404_CheckHotfixFromNBCCmd(t *testing.T) {
+	RunScenario(t, &Scenario{
+		Description: "tests that check-hotfix resolves the LPS target from the Phase 2 NBC command",
+		Config: Config{
+			Cluster: ClusterKubenet,
+			VHD:     config.VHDUbuntu2404Gen2Containerd,
+			Validator: func(ctx context.Context, s *Scenario) error {
+				result, err := execScriptOnVMForScenarioValidateExitCode(
+					ctx,
+					s,
+					`sudo test ! -e /opt/azure/containers/aks-node-controller-config.json &&
+sudo test -e /opt/azure/containers/aks-node-controller-nbc-cmd.sh &&
+sudo test -x /opt/azure/containers/aks-node-controller-hotfix &&
+sudo /opt/azure/containers/aks-node-controller-hotfix check-hotfix`,
+					0,
+					"check-hotfix NBC command fallback failed",
+				)
+				if err != nil {
+					return err
+				}
+
+				output := result.stdout + "\n" + result.stderr
+				return errors.Join(
+					assert.Contains(output, "node config not found, trying nbc-cmd.sh fallback"),
+					assert.Contains(output, "loaded LPS target from nbc-cmd.sh fallback"),
+				)
 			},
 		},
 	})

--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -707,10 +707,29 @@ func Test_Ubuntu2404_CheckHotfixFromNBCCmd(t *testing.T) {
 				result, err := execScriptOnVMForScenarioValidateExitCode(
 					ctx,
 					s,
-					`sudo test ! -e /opt/azure/containers/aks-node-controller-config.json &&
-sudo test -e /opt/azure/containers/aks-node-controller-nbc-cmd.sh &&
-sudo test -x /opt/azure/containers/aks-node-controller-hotfix &&
-sudo /opt/azure/containers/aks-node-controller-hotfix check-hotfix`,
+					`set -eu
+config_path=/opt/azure/containers/aks-node-controller-config.json
+nbc_cmd_path=/opt/azure/containers/aks-node-controller-nbc-cmd.sh
+anc_path=/opt/azure/containers/aks-node-controller-hotfix
+
+sudo test ! -e "$config_path" || {
+	echo "$config_path unexpectedly exists" >&2
+	exit 1
+}
+sudo test -e "$nbc_cmd_path" || {
+	echo "$nbc_cmd_path does not exist" >&2
+	exit 1
+}
+if ! sudo test -x "$anc_path"; then
+	anc_path=/opt/azure/containers/aks-node-controller
+fi
+sudo test -x "$anc_path" || {
+	echo "no executable aks-node-controller binary found" >&2
+	exit 1
+}
+
+echo "using ANC binary: $anc_path"
+sudo "$anc_path" check-hotfix`,
 					0,
 					"check-hotfix NBC command fallback failed",
 				)


### PR DESCRIPTION
## Summary
- On Staging Phase 2, `config.json` may not exist (`AKSNodeConfigJSON` empty)
- `check-hotfix` needs apiserver FQDN + cluster CA to connect to LPS
- Previously: silent fail-open, no LPS connection possible
- Now: falls back to parsing the existing `nbc-cmd.sh` for `API_SERVER_NAME` and `KUBE_CA_CRT`

## Approach
- **No new files generated, no ABSvc changes** — purely ANC-side
- Reuses existing `parseEnvVarsFromNBCCmdContent` (strict KEY=value parser, does not source/execute)
- `nbc-cmd.sh` is already on disk via boothook, delivered with `chmod 0600`

## Fallback order
```
config.json exists → read config.json (unchanged)
config.json absent → parse nbc-cmd.sh for FQDN + CA
both absent → error → fail-open (unchanged)
```

## Phased rollout plan

### Phase 1 (this PR)
- ANC-side only: `check-hotfix` falls back to parsing existing `nbc-cmd.sh` when `config.json` is absent
- No new files generated, no ABSvc/template changes
- Reuses existing `parseEnvVarsFromNBCCmdContent` parser
- Backward compatible: `config.json` path unchanged, nbc-cmd.sh is already on disk

### Phase 2 (future PR)
- ABSvc generates a separate `nbc-env.sh` file (env vars only, extracted from same `cse_cmd.sh` rendering)
- `check-hotfix` prefers `nbc-env.sh` over parsing flattened `nbc-cmd.sh` (cleaner, no heuristic parsing)
- `cse_cmd.sh` template unchanged — legacy CSE path unaffected

### Phase 3 (future PR, after legacy CSE deprecation)
- Split `cse_cmd.sh` template into `cse_env.sh` (vars) + `cse_preamble.sh` (cloud-init) + `cse_launch.sh` (nohup)
- Scriptless nbc-cmd.sh sources nbc-env.sh instead of inlining vars
- Single source of truth for env vars — no duplication, no drift
- Legacy CSE path: preamble + inline env (from `cse_env.sh` template) + launch

## Backward compatibility
| Scenario | config.json | nbc-cmd.sh | Result |
|----------|------------|-----------|--------|
| Old ABSvc + new ANC | ✅ | ✅ | Reads config.json |
| New ABSvc + old ANC | ✅ | ✅ | Old ANC ignores nbc-cmd fallback |
| Phase 2 (new ANC) | ❌ | ✅ | **Fallback reads nbc-cmd.sh** ← fixed |
| Both absent | ❌ | ❌ | Error, fail-open (same as before) |

## Test plan
- [x] Unit tests: fallback success, both missing, CA optional, invalid CA
- [x] All existing check-hotfix tests pass
- [x] E2E: `Test_Ubuntu2404_CheckHotfixFromNBCCmd` validates fallback on real node
- [ ] Manual validation on Staging Phase 2 node

## Work items
AB#39353757 AB#39353758
