### PR TITLE
refactor(e2e): log through a Logger interface instead of testing.TB

### DIFF
--- a/e2e/artifact_streaming.go
+++ b/e2e/artifact_streaming.go
@@ -74,9 +74,9 @@ func ValidateArtifactStreamingImagePull(ctx context.Context, s *Scenario) error 
 	// rootfs is mounted, so the assertion must run with the pod still alive.
 	kube := s.Runtime.Kube
 	pod := podStreamingImageLinux(s, image)
-	truncatePodName(s.T, pod)
+	truncatePodName(s.Logger, pod)
 
-	s.T.Logf("launching pod %q from artifact-streaming image %q", pod.Name, image)
+	s.Logger.Logf("launching pod %q from artifact-streaming image %q", pod.Name, image)
 	if _, err := kube.Typed.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create artifact-streaming pod %q: %w", pod.Name, err)
 	}
@@ -85,7 +85,7 @@ func ValidateArtifactStreamingImagePull(ctx context.Context, s *Scenario) error 
 		defer cancel()
 		grace := int64(0)
 		if err := kube.Typed.CoreV1().Pods(pod.Namespace).Delete(delCtx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &grace}); err != nil {
-			s.T.Logf("could not delete artifact-streaming pod %q: %v", pod.Name, err)
+			s.Logger.Logf("could not delete artifact-streaming pod %q: %v", pod.Name, err)
 		}
 	}()
 
@@ -135,8 +135,6 @@ func ValidateArtifactStreamingImagePull(ctx context.Context, s *Scenario) error 
 // commands available. There is currently no armcontainerregistry SDK surface for creating a
 // streaming artifact; swap this for an SDK call if/when one is published.
 func ensureStreamingArtifactForImage(ctx context.Context, s *Scenario, acrName, repoTag string) error {
-	s.T.Helper()
-
 	// 1. Import a concrete manifest into the ACR (cache rules are lazy/pull-through; import gives us
 	//    a real artifact we can attach a streaming referrer to). --force makes re-runs idempotent.
 	importCmd := exec.CommandContext(ctx, "az", "acr", "import",
@@ -155,7 +153,7 @@ func ensureStreamingArtifactForImage(ctx context.Context, s *Scenario, acrName, 
 	//    conversion is done — nothing to do. ACR publishes the streaming referrer only once the
 	//    overlaybd blobs exist, so this is a reliable "ready" signal.
 	if streamingReferrerReady(ctx, s, acrName, repoTag) {
-		s.T.Logf("overlaybd streaming referrer already exists for %q in ACR %q, skipping create", repoTag, acrName)
+		s.Logger.Logf("overlaybd streaming referrer already exists for %q in ACR %q, skipping create", repoTag, acrName)
 		return nil
 	}
 
@@ -166,7 +164,7 @@ func ensureStreamingArtifactForImage(ctx context.Context, s *Scenario, acrName, 
 		"--subscription", config.Config.SubscriptionID,
 	)
 	out, err := streamCmd.CombinedOutput()
-	s.T.Logf("az acr artifact-streaming create output:\n%s", string(out))
+	s.Logger.Logf("az acr artifact-streaming create output:\n%s", string(out))
 
 	// 4. Wait for the async conversion to finish. Prefer polling the returned operation; fall back
 	//    to polling for the referrer if no operation ID was printed (e.g. CLI-version differences).
@@ -188,7 +186,6 @@ func ensureStreamingArtifactForImage(ctx context.Context, s *Scenario, acrName, 
 // waitForStreamingOperationSucceeded polls `az acr artifact-streaming operation show` until the
 // conversion operation reports Succeeded, returning an error on a Failed status or timeout.
 func waitForStreamingOperationSucceeded(ctx context.Context, s *Scenario, acrName, repository, operationID string) error {
-	s.T.Helper()
 	const timeout = 8 * time.Minute
 	deadline := time.Now().Add(timeout)
 	for {
@@ -203,7 +200,7 @@ func waitForStreamingOperationSucceeded(ctx context.Context, s *Scenario, acrNam
 		status := strings.ToLower(string(out))
 		switch {
 		case err == nil && strings.Contains(status, "succeeded"):
-			s.T.Logf("overlaybd streaming conversion operation %s for %q succeeded", operationID, repository)
+			s.Logger.Logf("overlaybd streaming conversion operation %s for %q succeeded", operationID, repository)
 			return nil
 		case err == nil && strings.Contains(status, "failed"):
 			return fmt.Errorf("overlaybd streaming conversion operation %s for %q failed:\n%s", operationID, repository, string(out))
@@ -220,7 +217,6 @@ func waitForStreamingOperationSucceeded(ctx context.Context, s *Scenario, acrNam
 // backstop for the operation poll (covers CLI versions that don't print an operation ID and any lag
 // between the operation completing and the referrer being listable).
 func waitForStreamingReferrerReady(ctx context.Context, s *Scenario, acrName, repoTag string) error {
-	s.T.Helper()
 	const timeout = 3 * time.Minute
 	deadline := time.Now().Add(timeout)
 	for {
@@ -238,7 +234,6 @@ func waitForStreamingReferrerReady(ctx context.Context, s *Scenario, acrName, re
 // referrer in the ACR. It filters `list-referrers` by the overlaybd streaming artifactType so it
 // does not match unrelated referrers (signatures, SBOMs). Best-effort: any CLI error returns false.
 func streamingReferrerReady(ctx context.Context, s *Scenario, acrName, repoTag string) bool {
-	s.T.Helper()
 	cmd := exec.CommandContext(ctx, "az", "acr", "manifest", "list-referrers",
 		"--name", repoTag,
 		"--registry", acrName,
@@ -248,7 +243,7 @@ func streamingReferrerReady(ctx context.Context, s *Scenario, acrName, repoTag s
 	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		s.T.Logf("could not list overlaybd streaming referrers for %q in ACR %q: %v\n%s", repoTag, acrName, err, string(out))
+		s.Logger.Logf("could not list overlaybd streaming referrers for %q in ACR %q: %v\n%s", repoTag, acrName, err, string(out))
 		return false
 	}
 	// A matching referrer is present iff the (type-filtered) manifest list has at least one digest.
@@ -276,44 +271,43 @@ func repoNameWithoutTag(repoTag string) string {
 // logArtifactStreamingDiagnostics dumps overlaybd's on-node log tail and exporter metrics to help
 // triage streaming failures. Best-effort only — never fails the test.
 func logArtifactStreamingDiagnostics(ctx context.Context, s *Scenario) {
-	s.T.Helper()
 	if obdLog, err := execScriptOnVMForScenario(ctx, s,
 		"sudo tail -n 50 /var/log/overlaybd.log 2>/dev/null || sudo journalctl -u overlaybd-tcmu --no-pager 2>/dev/null | tail -n 50 || true"); err != nil {
-		s.T.Logf("overlaybd log tail: could not be collected: %v", err)
+		s.Logger.Logf("overlaybd log tail: could not be collected: %v", err)
 	} else {
-		s.T.Logf("overlaybd log tail:\n%s", obdLog.stdout)
+		s.Logger.Logf("overlaybd log tail:\n%s", obdLog.stdout)
 	}
 
 	if metrics, err := execScriptOnVMForScenario(ctx, s,
 		"sudo curl -s --max-time 5 http://localhost:9863/metrics 2>/dev/null | grep -iE 'overlaybd|obd' | head -n 30 || true"); err != nil {
-		s.T.Logf("overlaybd exporter (:9863) metrics sample: could not be collected: %v", err)
+		s.Logger.Logf("overlaybd exporter (:9863) metrics sample: could not be collected: %v", err)
 	} else {
-		s.T.Logf("overlaybd exporter (:9863) metrics sample:\n%s", metrics.stdout)
+		s.Logger.Logf("overlaybd exporter (:9863) metrics sample:\n%s", metrics.stdout)
 	}
 
 	// acr-mirror is what discovers the ACR streaming referrer and redirects the pull to the
 	// overlaybd manifest; if it can't (auth/config), the pull silently falls back to overlayfs.
 	if mirror, err := execScriptOnVMForScenario(ctx, s,
 		"sudo journalctl -u acr-mirror --no-pager 2>/dev/null | tail -n 40 || true"); err != nil {
-		s.T.Logf("acr-mirror journal tail: could not be collected: %v", err)
+		s.Logger.Logf("acr-mirror journal tail: could not be collected: %v", err)
 	} else {
-		s.T.Logf("acr-mirror journal tail:\n%s", mirror.stdout)
+		s.Logger.Logf("acr-mirror journal tail:\n%s", mirror.stdout)
 	}
 
 	if snapshotter, err := execScriptOnVMForScenario(ctx, s,
 		"sudo journalctl -u overlaybd-snapshotter --no-pager 2>/dev/null | tail -n 40 || true"); err != nil {
-		s.T.Logf("overlaybd-snapshotter journal tail: could not be collected: %v", err)
+		s.Logger.Logf("overlaybd-snapshotter journal tail: could not be collected: %v", err)
 	} else {
-		s.T.Logf("overlaybd-snapshotter journal tail:\n%s", snapshotter.stdout)
+		s.Logger.Logf("overlaybd-snapshotter journal tail:\n%s", snapshotter.stdout)
 	}
 
 	// Which snapshotter backs the pulled image, and the containerd hosts.toml that routes
 	// azurecr.io pulls through acr-mirror.
 	if images, err := execScriptOnVMForScenario(ctx, s,
 		"sudo ctr -n k8s.io images ls 2>/dev/null | grep -iE 'base-core|REF' || true; echo '--- certs.d ---'; sudo cat /etc/containerd/certs.d/*azurecr.io*/hosts.toml 2>/dev/null || true"); err != nil {
-		s.T.Logf("containerd images + azurecr.io hosts.toml: could not be collected: %v", err)
+		s.Logger.Logf("containerd images + azurecr.io hosts.toml: could not be collected: %v", err)
 	} else {
-		s.T.Logf("containerd images + azurecr.io hosts.toml:\n%s", images.stdout)
+		s.Logger.Logf("containerd images + azurecr.io hosts.toml:\n%s", images.stdout)
 	}
 }
 

--- a/e2e/config/azure_vmext_test.go
+++ b/e2e/config/azure_vmext_test.go
@@ -121,7 +121,7 @@ func Test_parseVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := toolkit.ContextWithT(context.Background(), t)
+			ctx := toolkit.ContextWithLogger(context.Background(), toolkit.NewTestLogger(t))
 			img := &armcompute.VirtualMachineExtensionImage{Name: tt.inputName}
 			result := parseVersion(ctx, img)
 
@@ -274,7 +274,7 @@ func Test_getLatestVMExtensionImageVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := toolkit.ContextWithT(context.Background(), t)
+			ctx := toolkit.ContextWithLogger(context.Background(), toolkit.NewTestLogger(t))
 			got, err := getLatestVMExtensionImageVersion(
 				ctx,
 				tt.mock,

--- a/e2e/cse_timing.go
+++ b/e2e/cse_timing.go
@@ -68,10 +68,10 @@ func (r *CSETimingReport) TotalCSEDuration() time.Duration {
 }
 
 // LogReport logs all task timings to the test logger.
-func (r *CSETimingReport) LogReport(_ context.Context, t interface{ Logf(string, ...any) }) {
-	t.Logf("=== CSE Task Timing Report ===")
-	t.Logf("%-60s %12s %12s", "Task", "Duration", "Start→End")
-	t.Logf("%s", strings.Repeat("-", 90))
+func (r *CSETimingReport) LogReport(_ context.Context, logger toolkit.Logger) {
+	logger.Logf("=== CSE Task Timing Report ===")
+	logger.Logf("%-60s %12s %12s", "Task", "Duration", "Start→End")
+	logger.Logf("%s", strings.Repeat("-", 90))
 
 	sorted := make([]CSETaskTiming, len(r.Tasks))
 	copy(sorted, r.Tasks)
@@ -80,7 +80,7 @@ func (r *CSETimingReport) LogReport(_ context.Context, t interface{ Logf(string,
 	})
 
 	for _, task := range sorted {
-		t.Logf("%-60s %10.2fs   %s → %s",
+		logger.Logf("%-60s %10.2fs   %s → %s",
 			task.TaskName,
 			task.Duration.Seconds(),
 			task.StartTime.Format("15:04:05.000"),
@@ -89,14 +89,14 @@ func (r *CSETimingReport) LogReport(_ context.Context, t interface{ Logf(string,
 	}
 
 	if total := r.TotalCSEDuration(); total > 0 {
-		t.Logf("%s", strings.Repeat("-", 90))
-		t.Logf("%-60s %10.2fs", "TOTAL (cse_start)", total.Seconds())
+		logger.Logf("%s", strings.Repeat("-", 90))
+		logger.Logf("%-60s %10.2fs", "TOTAL (cse_start)", total.Seconds())
 	}
 
 	if r.Provision != nil {
-		t.Logf("\n=== Provision Summary ===")
-		t.Logf("ExitCode: %s, ExecDuration: %ss", r.Provision.ExitCode, r.Provision.ExecDuration)
-		t.Logf("KernelStart: %s, CSEStart: %s, GuestAgent: %s",
+		logger.Logf("\n=== Provision Summary ===")
+		logger.Logf("ExitCode: %s, ExecDuration: %ss", r.Provision.ExitCode, r.Provision.ExecDuration)
+		logger.Logf("KernelStart: %s, CSEStart: %s, GuestAgent: %s",
 			r.Provision.KernelStartTime, r.Provision.CSEStartTime, r.Provision.GuestAgentStartTime)
 	}
 }
@@ -135,13 +135,13 @@ func ExtractCSETimings(ctx context.Context, s *Scenario) (*CSETimingReport, erro
 		startTime, err := parseCSETimestamp(startTimestamp)
 		if err != nil {
 			parseErrors++
-			s.T.Logf("WARNING: failed to parse CSE start timestamp for task %s: %v", taskName, err)
+			s.Logger.Logf("WARNING: failed to parse CSE start timestamp for task %s: %v", taskName, err)
 			continue
 		}
 		endTime, err := parseCSETimestamp(endTimestamp)
 		if err != nil {
 			parseErrors++
-			s.T.Logf("WARNING: failed to parse CSE end timestamp for task %s: %v", taskName, err)
+			s.Logger.Logf("WARNING: failed to parse CSE end timestamp for task %s: %v", taskName, err)
 			continue
 		}
 
@@ -154,7 +154,7 @@ func ExtractCSETimings(ctx context.Context, s *Scenario) (*CSETimingReport, erro
 	}
 
 	if parseErrors > 0 {
-		s.T.Logf("WARNING: %d CSE timing lines in cluster-provision.log could not be parsed", parseErrors)
+		s.Logger.Logf("WARNING: %d CSE timing lines in cluster-provision.log could not be parsed", parseErrors)
 	}
 	if len(report.Tasks) == 0 {
 		return report, fmt.Errorf("no CSE task timings were parsed from cluster-provision.log (%d parse errors)", parseErrors)
@@ -254,8 +254,7 @@ type CSETimingThresholds struct {
 // ValidateCSETimings extracts, logs, and validates CSE task timings.
 // It emits one subtest per threshold so ADO can track each timing check.
 func ValidateCSETimings(ctx context.Context, s *Scenario, thresholds CSETimingThresholds) (*CSETimingReport, error) {
-	s.T.Helper()
-	defer toolkit.LogStep(s.T, "validating CSE task timings")()
+	defer toolkit.LogStep(s.Logger, "validating CSE task timings")()
 
 	tRunner := toolkit.UnwrapTestingT(s.T)
 	if tRunner == nil {
@@ -271,7 +270,7 @@ func ValidateCSETimings(ctx context.Context, s *Scenario, thresholds CSETimingTh
 		}
 	}
 
-	report.LogReport(ctx, s.T)
+	report.LogReport(ctx, s.Logger)
 
 	if len(report.Tasks) == 0 {
 		return report, errors.New("no CSE task timings were parsed; cannot validate performance thresholds")
@@ -345,7 +344,7 @@ func ValidateCSETimings(ctx context.Context, s *Scenario, thresholds CSETimingTh
 
 	for _, suffix := range sortedSuffixes {
 		if !matchedSuffixes[suffix] {
-			s.T.Logf("⚠️  threshold suffix %q did not match any CSE task — task may not fire on this install path, or may have been renamed", suffix)
+			s.Logger.Logf("⚠️  threshold suffix %q did not match any CSE task — task may not fire on this install path, or may have been renamed", suffix)
 		}
 	}
 

--- a/e2e/exec.go
+++ b/e2e/exec.go
@@ -146,7 +146,6 @@ func runSSHCommandWithPrivateKeyFile(
 }
 
 func execScriptOnVm(ctx context.Context, s *Scenario, vm *ScenarioVM, script string) (*podExecResult, error) {
-	s.T.Helper()
 	if vm == nil {
 		return nil, fmt.Errorf("cannot execute script on a nil VM")
 	}
@@ -159,7 +158,6 @@ func execOnUnprivilegedPod(ctx context.Context, kube *Kubeclient, namespace stri
 }
 
 func execOnVMForScenarioOnUnprivilegedPod(ctx context.Context, s *Scenario, cmd string) (*podExecResult, error) {
-	s.T.Helper()
 	nonHostPod, err := s.Runtime.Kube.GetPodNetworkDebugPodForNode(ctx, s.Runtime.VM.KubeName)
 	if err != nil {
 		return nil, fmt.Errorf("get non-host debug pod: %w", err)
@@ -172,7 +170,6 @@ func execOnVMForScenarioOnUnprivilegedPod(ctx context.Context, s *Scenario, cmd 
 }
 
 func execScriptOnVMForScenario(ctx context.Context, s *Scenario, cmd string) (*podExecResult, error) {
-	s.T.Helper()
 	result, err := execScriptOnVm(ctx, s, s.Runtime.VM, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("execute command %q on VM: %w", cmd, err)
@@ -181,7 +178,6 @@ func execScriptOnVMForScenario(ctx context.Context, s *Scenario, cmd string) (*p
 }
 
 func execScriptOnVMForScenarioValidateExitCode(ctx context.Context, s *Scenario, cmd string, expectedExitCode int, additionalErrorMessage string) (*podExecResult, error) {
-	s.T.Helper()
 	execResult, err := execScriptOnVMForScenario(ctx, s, cmd)
 	if err != nil {
 		return nil, err
@@ -189,7 +185,7 @@ func execScriptOnVMForScenarioValidateExitCode(ctx context.Context, s *Scenario,
 
 	expectedExitCodeStr := fmt.Sprint(expectedExitCode)
 	if expectedExitCodeStr != execResult.exitCode {
-		s.T.Logf("Command: %s\nStdout: %s\nStderr: %s", cmd, execResult.stdout, execResult.stderr)
+		s.Logger.Logf("Command: %s\nStdout: %s\nStderr: %s", cmd, execResult.stdout, execResult.stderr)
 		return execResult, fmt.Errorf("expected exit code %s, got %s for command %q: %s", expectedExitCodeStr, execResult.exitCode, cmd, additionalErrorMessage)
 	}
 	return execResult, nil

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/Azure/agentbaker/e2e/config"
@@ -166,14 +165,14 @@ func (k *Kubeclient) WaitUntilPodRunning(ctx context.Context, namespace string, 
 	return pod, err
 }
 
-func (k *Kubeclient) WaitUntilNodeReady(ctx context.Context, t testing.TB, vmssName string) (string, error) {
-	defer toolkit.LogStepf(t, "waiting for node %s to be ready", vmssName)()
+func (k *Kubeclient) WaitUntilNodeReady(ctx context.Context, logger toolkit.Logger, vmssName string) (string, error) {
+	defer toolkit.LogStepf(logger, "waiting for node %s to be ready", vmssName)()
 	var lastNode *corev1.Node
 
 	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
 		nodes, err := k.Typed.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		if err != nil {
-			t.Logf("error listing nodes: %v", err)
+			logger.Logf("error listing nodes: %v", err)
 			return false, nil
 		}
 
@@ -189,12 +188,12 @@ func (k *Kubeclient) WaitUntilNodeReady(ctx context.Context, t testing.TB, vmssN
 
 			for _, cond := range node.Status.Conditions {
 				if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
-					t.Logf("node %s is ready. Taints: %s Conditions: %s", node.Name, string(nodeTaints), string(nodeConditions))
+					logger.Logf("node %s is ready. Taints: %s Conditions: %s", node.Name, string(nodeTaints), string(nodeConditions))
 					return true, nil
 				}
 			}
 
-			t.Logf("node %s is not ready. Taints: %s Conditions: %s", node.Name, string(nodeTaints), string(nodeConditions))
+			logger.Logf("node %s is not ready. Taints: %s Conditions: %s", node.Name, string(nodeTaints), string(nodeConditions))
 		}
 
 		return false, nil

--- a/e2e/log.go
+++ b/e2e/log.go
@@ -3,17 +3,17 @@ package e2e
 import (
 	"os"
 	"path/filepath"
-	"testing"
 
 	"github.com/Azure/agentbaker/e2e/config"
 )
 
-func testDir(t testing.TB) string {
-	return filepath.Join(config.Config.E2ELoggingDir, t.Name())
+// testDir is the directory holding the artifacts of the test named testName.
+func testDir(testName string) string {
+	return filepath.Join(config.Config.E2ELoggingDir, testName)
 }
 
-func writeToFile(t testing.TB, fileName, content string) error {
-	dirPath := testDir(t)
+func writeToFile(testName, fileName, content string) error {
+	dirPath := testDir(testName)
 	// Create the directory if it doesn't exist
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
 		return err
@@ -23,10 +23,10 @@ func writeToFile(t testing.TB, fileName, content string) error {
 	return os.WriteFile(fullPath, []byte(content), 0600)
 }
 
-func dumpFileMapToDir(t testing.TB, files map[string]string) error {
+func dumpFileMapToDir(testName string, files map[string]string) error {
 	for fileName, contents := range files {
 		fileName = filepath.Base(fileName)
-		if err := writeToFile(t, fileName, contents); err != nil {
+		if err := writeToFile(testName, fileName, contents); err != nil {
 			return err
 		}
 	}

--- a/e2e/log_test.go
+++ b/e2e/log_test.go
@@ -1,0 +1,59 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Azure/agentbaker/e2e/config"
+)
+
+// TestArtifactHelpersUseTheGivenTestName pins the artifact path helpers to an
+// explicit test name so writing scenario artifacts no longer needs a testing.TB.
+func TestArtifactHelpersUseTheGivenTestName(t *testing.T) {
+	loggingDir := t.TempDir()
+	original := config.Config.E2ELoggingDir
+	config.Config.E2ELoggingDir = loggingDir
+	t.Cleanup(func() { config.Config.E2ELoggingDir = original })
+
+	const testName = "TestScenario/subtest"
+
+	if got, want := testDir(testName), filepath.Join(loggingDir, testName); got != want {
+		t.Errorf("testDir: got %q, want %q", got, want)
+	}
+
+	if err := writeToFile(testName, "single.log", "single"); err != nil {
+		t.Fatalf("writeToFile: %v", err)
+	}
+	if err := dumpFileMapToDir(testName, map[string]string{"/var/log/nested/mapped.log": "mapped"}); err != nil {
+		t.Fatalf("dumpFileMapToDir: %v", err)
+	}
+
+	for name, want := range map[string]string{"single.log": "single", "mapped.log": "mapped"} {
+		got, err := os.ReadFile(filepath.Join(testDir(testName), name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if string(got) != want {
+			t.Errorf("%s: got %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestGenerateVMSSNameLinuxUsesTheGivenTestName(t *testing.T) {
+	name := generateVMSSNameLinux("TestScenario_Ubuntu2204/vhd_caching")
+
+	if len(name) > 57 {
+		t.Errorf("name %q is longer than the 57 character VMSS limit", name)
+	}
+	if strings.ContainsAny(name, "_/") || strings.Contains(name, "Test") {
+		t.Errorf("name %q still contains characters that are invalid for a VMSS name", name)
+	}
+	if name != strings.ToLower(name) {
+		t.Errorf("name %q is not lowercase", name)
+	}
+	if !strings.Contains(name, "scenarioubuntu2204") {
+		t.Errorf("name %q does not carry the test name", name)
+	}
+}

--- a/e2e/scenario_gpu_daemonset_test.go
+++ b/e2e/scenario_gpu_daemonset_test.go
@@ -85,7 +85,7 @@ func Test_Ubuntu2204_NvidiaDevicePlugin_Daemonset(t *testing.T) {
 					return err
 				}
 
-				s.T.Logf("NVIDIA device plugin DaemonSet is functioning correctly")
+				s.Logger.Logf("NVIDIA device plugin DaemonSet is functioning correctly")
 				return nil
 			},
 		},
@@ -95,7 +95,7 @@ func Test_Ubuntu2204_NvidiaDevicePlugin_Daemonset(t *testing.T) {
 // validateNvidiaDevicePluginServiceNotRunning verifies that the systemd-based
 // NVIDIA device plugin service is not running (since we're testing the DaemonSet model).
 func validateNvidiaDevicePluginServiceNotRunning(ctx context.Context, s *Scenario) error {
-	s.T.Logf("Verifying that nvidia-device-plugin.service is not running...")
+	s.Logger.Logf("Verifying that nvidia-device-plugin.service is not running...")
 
 	// Check if the service exists and is inactive
 	// Using "is-active" which returns non-zero if not active
@@ -110,7 +110,7 @@ func validateNvidiaDevicePluginServiceNotRunning(ctx context.Context, s *Scenari
 		"nvidia-device-plugin.service is unexpectedly running - this test requires the systemd service to be disabled"); err != nil {
 		return err
 	}
-	s.T.Logf("Confirmed nvidia-device-plugin.service is not active (status: %s)", output)
+	s.Logger.Logf("Confirmed nvidia-device-plugin.service is not active (status: %s)", output)
 	return nil
 }
 
@@ -215,7 +215,7 @@ func nvidiaDevicePluginDaemonset(nodeName string) *appsv1.DaemonSet {
 // deployNvidiaDevicePluginDaemonset creates the NVIDIA device plugin DaemonSet in the cluster
 // and registers cleanup to delete it when the test finishes.
 func deployNvidiaDevicePluginDaemonset(ctx context.Context, s *Scenario) error {
-	s.T.Logf("Deploying NVIDIA device plugin as DaemonSet...")
+	s.Logger.Logf("Deploying NVIDIA device plugin as DaemonSet...")
 
 	ds := nvidiaDevicePluginDaemonset(s.Runtime.VM.KubeName)
 
@@ -233,7 +233,7 @@ func deployNvidiaDevicePluginDaemonset(ctx context.Context, s *Scenario) error {
 		return fmt.Errorf("create NVIDIA device plugin DaemonSet %s/%s: %w", ds.Namespace, ds.Name, err)
 	}
 
-	s.T.Logf("NVIDIA device plugin DaemonSet %s/%s created successfully", ds.Namespace, ds.Name)
+	s.Logger.Logf("NVIDIA device plugin DaemonSet %s/%s created successfully", ds.Namespace, ds.Name)
 
 	// Register cleanup to delete the DaemonSet when the test finishes
 	s.Cleanup(func(ctx context.Context) error {
@@ -253,7 +253,7 @@ func deployNvidiaDevicePluginDaemonset(ctx context.Context, s *Scenario) error {
 // Uses the existing WaitUntilPodRunning helper which handles CrashLoopBackOff and other failure states.
 func waitForNvidiaDevicePluginDaemonsetReady(ctx context.Context, s *Scenario) error {
 	dsName := nvidiaDevicePluginDaemonsetName(s.Runtime.VM.KubeName)
-	s.T.Logf("Waiting for NVIDIA device plugin DaemonSet pod to be ready on node %s...", s.Runtime.VM.KubeName)
+	s.Logger.Logf("Waiting for NVIDIA device plugin DaemonSet pod to be ready on node %s...", s.Runtime.VM.KubeName)
 
 	if _, err := s.Runtime.Kube.WaitUntilPodRunning(
 		ctx,
@@ -264,6 +264,6 @@ func waitForNvidiaDevicePluginDaemonsetReady(ctx context.Context, s *Scenario) e
 		return fmt.Errorf("wait for NVIDIA device plugin DaemonSet pod to be ready: %w", err)
 	}
 
-	s.T.Logf("NVIDIA device plugin DaemonSet pod is ready")
+	s.Logger.Logf("NVIDIA device plugin DaemonSet pod is ready")
 	return nil
 }

--- a/e2e/scenario_gpu_managed_experience_test.go
+++ b/e2e/scenario_gpu_managed_experience_test.go
@@ -302,10 +302,10 @@ func Test_DCGM_Exporter_Compatibility(t *testing.T) {
 			return "", "", "", err
 		}
 
-		s.T.Logf("Expected versions from components.json:")
-		s.T.Logf("  dcgm-exporter: %s", dcgmExporterVersion)
-		s.T.Logf("  datacenter-gpu-manager-4-core: %s", expectedCoreVersion)
-		s.T.Logf("  datacenter-gpu-manager-4-proprietary: %s", expectedPropVersion)
+		s.Logger.Logf("Expected versions from components.json:")
+		s.Logger.Logf("  dcgm-exporter: %s", dcgmExporterVersion)
+		s.Logger.Logf("  datacenter-gpu-manager-4-core: %s", expectedCoreVersion)
+		s.Logger.Logf("  datacenter-gpu-manager-4-proprietary: %s", expectedPropVersion)
 
 		return dcgmExporterVersion, expectedCoreVersion, expectedPropVersion, nil
 	}
@@ -326,9 +326,9 @@ func Test_DCGM_Exporter_Compatibility(t *testing.T) {
 		actualCoreVersion := coreMatches[1]
 		actualPropVersion := propMatches[1]
 
-		s.T.Logf("Actual versions from dcgm-exporter package:")
-		s.T.Logf("  datacenter-gpu-manager-4-core: %s", actualCoreVersion)
-		s.T.Logf("  datacenter-gpu-manager-4-proprietary: %s", actualPropVersion)
+		s.Logger.Logf("Actual versions from dcgm-exporter package:")
+		s.Logger.Logf("  datacenter-gpu-manager-4-core: %s", actualCoreVersion)
+		s.Logger.Logf("  datacenter-gpu-manager-4-proprietary: %s", actualPropVersion)
 
 		return actualCoreVersion, actualPropVersion, nil
 	}
@@ -353,21 +353,21 @@ func Test_DCGM_Exporter_Compatibility(t *testing.T) {
 						}
 
 						// Step 2: Download dcgm-exporter package from PMC
-						s.T.Logf("Downloading dcgm-exporter package from PMC...")
+						s.Logger.Logf("Downloading dcgm-exporter package from PMC...")
 						downloadCmd := fmt.Sprintf(tc.downloadCmd, dcgmExporterVersion)
 						if _, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, downloadCmd, 0, "Failed to download dcgm-exporter package"); err != nil {
 							return err
 						}
 
 						// Step 3: Extract dependency versions from the package
-						s.T.Logf("Extracting dependency versions from package...")
+						s.Logger.Logf("Extracting dependency versions from package...")
 						result, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, tc.extractDepsCmd, 0, "Failed to extract dependencies from package")
 						if err != nil {
 							return err
 						}
 
 						dependsOutput := result.stdout
-						s.T.Logf("Package dependencies: %s", dependsOutput)
+						s.Logger.Logf("Package dependencies: %s", dependsOutput)
 
 						// Step 4: Parse and verify versions match components.json
 						actualCoreVersion, actualPropVersion, err := parseVersions(s, tc, dependsOutput)
@@ -387,7 +387,7 @@ func Test_DCGM_Exporter_Compatibility(t *testing.T) {
 							return err
 						}
 
-						s.T.Logf("✅ Version compatibility verified: dcgm-exporter %s is compatible with DCGM packages %s",
+						s.Logger.Logf("✅ Version compatibility verified: dcgm-exporter %s is compatible with DCGM packages %s",
 							dcgmExporterVersion, expectedCoreVersion)
 						return nil
 					},

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -64,14 +64,15 @@ func constructErrorMessage(subscriptionID, location string) string {
 	return fmt.Sprintf("Received second cancellation signal, forcing exit.\nPlease check https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/%s/resourceGroups/%s/overview and delete any resources created by the test suite", subscriptionID, config.ResourceGroupName(location))
 }
 
-func newTestCtx(t testing.TB) context.Context {
+func newTestCtx(t testing.TB, logger toolkit.Logger) context.Context {
 	if testCtx.Err() != nil {
 		t.Skip("test suite is shutting down")
 	}
 	ctx, cancel := context.WithTimeout(testCtx, config.Config.TestTimeout)
 	t.Cleanup(cancel)
-	// T should be used only for logging, not for assertions or any other logic
-	ctx = toolkit.ContextWithT(ctx, t)
+	// only a logger is put in the context, implementation code must not be able
+	// to control the test through it
+	ctx = toolkit.ContextWithLogger(ctx, logger)
 	return ctx
 }
 
@@ -139,14 +140,14 @@ func runScenarioWithPreProvision(t *testing.T, original *Scenario) error {
 		if validationErr != nil {
 			return validationErr
 		}
-		t.Log("=== Creating VHD Image ===")
+		toolkit.Log(ctx, "=== Creating VHD Image ===")
 		var err error
 		customVHD, err = CreateImage(ctx, stage1)
 		if err != nil {
 			return err
 		}
 		customVHDJSON, _ := json.MarshalIndent(customVHD, "", "  ")
-		t.Logf("Created custom VHD image: %s", string(customVHDJSON))
+		toolkit.Logf(ctx, "Created custom VHD image: %s", string(customVHDJSON))
 		cleanupBastionTunnel(firstStage.Runtime.VM.SSHClient)
 		firstStage.Runtime.VM.SSHClient = nil
 		return nil
@@ -234,8 +235,10 @@ func copyScenario(s *Scenario) *Scenario {
 }
 
 func runScenario(t testing.TB, s *Scenario) error {
-	t = toolkit.WithTestLogger(t)
+	t = toolkit.WithFailureFormatting(t)
 	s.T = t
+	s.testName = t.Name()
+	s.Logger = toolkit.NewTestLogger(t)
 	if s.cleanup != nil {
 		panic("Scenario.Cleanup called outside of a scenario run")
 	}
@@ -249,7 +252,7 @@ func runScenario(t testing.TB, s *Scenario) error {
 		s.K8sSystemPoolSKU = config.Config.DefaultVMSKU
 	}
 
-	ctx := newTestCtx(t)
+	ctx := newTestCtx(t, s.Logger)
 	cleanup := &scenarioCleanup{}
 	s.cleanup = cleanup
 	t.Cleanup(func() {
@@ -271,7 +274,7 @@ func runScenario(t testing.TB, s *Scenario) error {
 	}
 	ctrruntimelog.SetLogger(zap.New())
 
-	defer toolkit.LogStep(t, "running scenario")()
+	defer toolkit.LogStep(s.Logger, "running scenario")()
 
 	cluster, err := s.Config.Cluster(ctx, ClusterRequest{
 		Location:         s.Location,
@@ -292,8 +295,8 @@ func runScenario(t testing.TB, s *Scenario) error {
 	clusterLocation := *cluster.Model.Location
 	resourceGroup := config.ResourceGroupName(clusterLocation)
 	subscriptionID := config.Config.SubscriptionID
-	t.Logf("using cluster %s in rg=%s sub=%s", clusterName, resourceGroup, subscriptionID)
-	t.Logf("portal: https://portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s/overview",
+	s.Logger.Logf("using cluster %s in rg=%s sub=%s", clusterName, resourceGroup, subscriptionID)
+	s.Logger.Logf("portal: https://portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s/overview",
 		subscriptionID, resourceGroup, clusterName)
 
 	if s.Runtime == nil {
@@ -319,13 +322,13 @@ func runScenario(t testing.TB, s *Scenario) error {
 		return err
 	}
 
-	t.Logf("Choosing the private ACR %q for the vm validation", config.GetPrivateACRName(s.Tags.NonAnonymousACR, s.Location))
+	s.Logger.Logf("Choosing the private ACR %q for the vm validation", config.GetPrivateACRName(s.Tags.NonAnonymousACR, s.Location))
 
 	return validateVM(vmssCtx, s)
 }
 
 func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
-	defer toolkit.LogStep(s.T, "preparing AKS node")()
+	defer toolkit.LogStep(s.Logger, "preparing AKS node")()
 
 	nbc, err := getBaseNBC(ctx, s.Runtime.Cluster, s.VHD)
 	if err != nil {
@@ -397,7 +400,7 @@ func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 		return nil, fmt.Errorf("checking if VM size %q supports only Gen2: %w", config.Config.DefaultVMSKU, err)
 	}
 	if gen2Only && s.Config.VHD.UnsupportedGen2 {
-		s.T.Logf("VM size %q only supports Gen2 hypervisor but image does not, falling back to vm size that supported gen 1 %q", config.Config.DefaultVMSKU, config.DefaultV5VMSKU)
+		s.Logger.Logf("VM size %q only supports Gen2 hypervisor but image does not, falling back to vm size that supported gen 1 %q", config.Config.DefaultVMSKU, config.DefaultV5VMSKU)
 		config.Config.DefaultVMSKU = config.DefaultV5VMSKU
 	}
 	supportsNVMe, err := CachedVMSizeSupportsNVMe(ctx, VMSizeSKURequest{
@@ -409,7 +412,7 @@ func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 	}
 	if supportsNVMe {
 		if s.Config.VHD.UnsupportedNVMe {
-			s.T.Logf("VM size %q supports NVMe disk controller but image does not support NVMe, falling back to vm size that supports SCSI %q", config.Config.DefaultVMSKU, config.DefaultV5VMSKU)
+			s.Logger.Logf("VM size %q supports NVMe disk controller but image does not support NVMe, falling back to vm size that supports SCSI %q", config.Config.DefaultVMSKU, config.DefaultV5VMSKU)
 			config.Config.DefaultVMSKU = config.DefaultV5VMSKU
 		} else {
 			s.Config.UseNVMe = true
@@ -423,7 +426,7 @@ func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 		return scenarioVM, err
 	}
 	if err != nil {
-		return scenarioVM, fmt.Errorf("create vmss %q, check %s for vm logs: %w", s.Runtime.VMSSName, testDir(s.T), err)
+		return scenarioVM, fmt.Errorf("create vmss %q, check %s for vm logs: %w", s.Runtime.VMSSName, testDir(s.testName), err)
 	}
 	if scenarioVM == nil || scenarioVM.VM == nil {
 		return nil, fmt.Errorf("create vmss %q returned an incomplete VM", s.Runtime.VMSSName)
@@ -436,7 +439,7 @@ func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 	if !s.Config.SkipDefaultValidation {
 		vmssCreatedAt := time.Now()         // Record the start time
 		creationElapse := time.Since(start) // Calculate the elapsed time
-		scenarioVM.KubeName, err = s.Runtime.Kube.WaitUntilNodeReady(ctx, s.T, s.Runtime.VMSSName)
+		scenarioVM.KubeName, err = s.Runtime.Kube.WaitUntilNodeReady(ctx, s.Logger, s.Runtime.VMSSName)
 		if err != nil {
 			return scenarioVM, err
 		}
@@ -485,7 +488,7 @@ func maybeSkipScenario(ctx context.Context, t testing.TB, s *Scenario) error {
 		}
 		return fmt.Errorf("failing scenario %q: could not find image for VHD %s: %w", t.Name(), s.VHD.Distro, err)
 	}
-	t.Logf("TAGS %+v", s.Tags)
+	s.Logger.Logf("TAGS %+v", s.Tags)
 	return nil
 }
 
@@ -509,7 +512,7 @@ func ValidateNodeCanRunAPod(ctx context.Context, s *Scenario) error {
 }
 
 func validateVM(ctx context.Context, s *Scenario) error {
-	defer toolkit.LogStep(s.T, "validating VM")()
+	defer toolkit.LogStep(s.Logger, "validating VM")()
 	if !s.Config.SkipSSHConnectivityValidation {
 		if err := validateSSHConnectivity(ctx, s); err != nil {
 			return err
@@ -544,9 +547,9 @@ func validateVM(ctx context.Context, s *Scenario) error {
 	}
 	err := errors.Join(errs...)
 	if err != nil {
-		s.T.Log("VM validation failed")
+		s.Logger.Log("VM validation failed")
 	} else {
-		s.T.Log("VM validation succeeded")
+		s.Logger.Log("VM validation succeeded")
 	}
 	return err
 }
@@ -575,7 +578,7 @@ func getCustomScriptExtensionStatus(s *Scenario, vmssVM *armcompute.VirtualMachi
 		if err == nil && freshVM.Properties != nil && freshVM.Properties.InstanceView != nil {
 			vmssVM.Properties.InstanceView = freshVM.Properties.InstanceView
 		} else if err != nil {
-			s.T.Logf("warning: failed to re-fetch VM instance view for CSE status: %v", err)
+			s.Logger.Logf("warning: failed to re-fetch VM instance view for CSE status: %v", err)
 		}
 	}
 
@@ -606,14 +609,14 @@ func getCustomScriptExtensionStatus(s *Scenario, vmssVM *armcompute.VirtualMachi
 				// Only write when the message has actual content to avoid overwriting
 				// with an empty file from a status entry that has no output.
 				if status.Message != nil && *status.Message != "" {
-					logDir := testDir(s.T)
+					logDir := testDir(s.testName)
 					if err := os.MkdirAll(logDir, 0755); err == nil {
 						logFile := filepath.Join(logDir, "windows-cse-output.log")
 						err = os.WriteFile(logFile, []byte(*status.Message), 0644)
 						if err != nil {
-							s.T.Logf("failed to save Windows CSE output to %s: %v", logFile, err)
+							s.Logger.Logf("failed to save Windows CSE output to %s: %v", logFile, err)
 						} else {
-							s.T.Logf("saved Windows CSE output to %s (%d bytes)", logFile, len(*status.Message))
+							s.Logger.Logf("saved Windows CSE output to %s (%d bytes)", logFile, len(*status.Message))
 						}
 					}
 				}
@@ -765,7 +768,6 @@ func createVMExtensionLinuxAKSNode(ctx context.Context, location *string) (*armc
 // It is generally slower than SSH because each call creates a VirtualMachineRunCommand
 // resource on the VM and waits for it to provision.
 func RunCommand(ctx context.Context, s *Scenario, command string) (armcompute.VirtualMachineRunCommandInstanceView, error) {
-	s.T.Helper()
 	if s.Runtime == nil || s.Runtime.Cluster == nil || s.Runtime.Cluster.Model == nil ||
 		s.Runtime.Cluster.Model.Properties == nil || s.Runtime.Cluster.Model.Properties.NodeResourceGroup == nil ||
 		s.Runtime.VM == nil || s.Runtime.VM.VM == nil || s.Runtime.VM.VM.InstanceID == nil {
@@ -932,7 +934,7 @@ func CreateImage(ctx context.Context, s *Scenario) (*config.Image, error) {
 		return nil, fmt.Errorf("scenario runtime is incomplete for image creation")
 	}
 	if s.IsWindows() {
-		s.T.Log("Running sysprep on Windows VM...")
+		s.Logger.Log("Running sysprep on Windows VM...")
 		res, err := RunCommand(ctx, s, windowsSysprepScript)
 		var stdout, stderr string
 		if res.Output != nil {
@@ -941,9 +943,9 @@ func CreateImage(ctx context.Context, s *Scenario) (*config.Image, error) {
 		if res.Error != nil {
 			stderr = strings.TrimSpace(*res.Error)
 		}
-		s.T.Logf("Sysprep stdout: %s", stdout)
+		s.Logger.Logf("Sysprep stdout: %s", stdout)
 		if stderr != "" {
-			s.T.Logf("Sysprep stderr: %s", stderr)
+			s.Logger.Logf("Sysprep stderr: %s", stderr)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to run sysprep on Windows VM for image creation: %w", err)
@@ -959,7 +961,7 @@ func CreateImage(ctx context.Context, s *Scenario) (*config.Image, error) {
 		return nil, fmt.Errorf("VMSS VM is missing its managed OS disk ID")
 	}
 
-	s.T.Log("Deallocating VMSS VM...")
+	s.Logger.Log("Deallocating VMSS VM...")
 	poll, err := config.Azure.VMSSVM.BeginDeallocate(ctx, *s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, *s.Runtime.VM.VM.InstanceID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to begin deallocate: %w", err)
@@ -988,7 +990,7 @@ func CreateImage(ctx context.Context, s *Scenario) (*config.Image, error) {
 func CreateSIGImageVersionFromDisk(ctx context.Context, s *Scenario, version string, diskResourceID string) (*config.Image, error) {
 	startTime := time.Now()
 	defer func() {
-		s.T.Logf("Created SIG image version %s from disk %s in %s", version, diskResourceID, time.Since(startTime))
+		s.Logger.Logf("Created SIG image version %s from disk %s in %s", version, diskResourceID, time.Since(startTime))
 	}()
 	if s.Runtime == nil || s.Runtime.VM == nil || s.Runtime.VM.VM == nil ||
 		s.Runtime.VM.VM.Properties == nil || s.Runtime.VM.VM.Properties.InstanceView == nil {
@@ -1024,10 +1026,10 @@ func CreateSIGImageVersionFromDisk(ctx context.Context, s *Scenario, version str
 		return nil, fmt.Errorf("failed to create or get gallery image: incomplete image metadata returned")
 	}
 
-	s.T.Logf("Created gallery image: %s", *image.ID)
+	s.Logger.Logf("Created gallery image: %s", *image.ID)
 
 	// Create the image version directly from the disk
-	s.T.Logf("Creating gallery image version: %s in %s", version, *image.ID)
+	s.Logger.Logf("Creating gallery image version: %s in %s", version, *image.ID)
 	createVersionOp, err := config.Azure.GalleryImageVersions.BeginCreateOrUpdate(ctx, rg, *gallery.Name, *image.Name, version, armcompute.GalleryImageVersion{
 		Location: to.Ptr(s.Location),
 		Properties: &armcompute.GalleryImageVersionProperties{
@@ -1106,7 +1108,7 @@ func validateSSHConnectivity(ctx context.Context, s *Scenario) error {
 	}
 
 	// Retry logic with exponential backoff for scenarios that may reboot
-	s.T.Logf("SSH connectivity validation will retry for up to %s if reboot-related errors are encountered", s.Config.WaitForSSHAfterReboot)
+	s.Logger.Logf("SSH connectivity validation will retry for up to %s if reboot-related errors are encountered", s.Config.WaitForSSHAfterReboot)
 	startTime := time.Now()
 	var lastSSHError error
 
@@ -1114,7 +1116,7 @@ func validateSSHConnectivity(ctx context.Context, s *Scenario) error {
 		err := attemptSSHConnection(ctx, s)
 		if err == nil {
 			elapsed := time.Since(startTime)
-			s.T.Logf("SSH connectivity established after %s", elapsed)
+			s.Logger.Logf("SSH connectivity established after %s", elapsed)
 			return true, nil
 		}
 
@@ -1132,7 +1134,7 @@ func validateSSHConnectivity(ctx context.Context, s *Scenario) error {
 
 		// Check if this is a reboot-related error
 		if isRebootRelatedSSHError(err, stderr) {
-			s.T.Logf("Detected reboot-related SSH error, will retry: %v", err)
+			s.Logger.Logf("Detected reboot-related SSH error, will retry: %v", err)
 			return false, nil // Continue polling
 		}
 
@@ -1163,7 +1165,7 @@ func attemptSSHConnection(ctx context.Context, s *Scenario) error {
 		return fmt.Errorf("SSH_CONNECTION_OK not found on %s: %s", s.Runtime.VM.PrivateIP, connectionResult.String())
 	}
 
-	s.T.Logf("SSH connectivity to %s verified successfully", s.Runtime.VM.PrivateIP)
+	s.Logger.Logf("SSH connectivity to %s verified successfully", s.Runtime.VM.PrivateIP)
 	return nil
 }
 

--- a/e2e/toolkit/log.go
+++ b/e2e/toolkit/log.go
@@ -8,108 +8,188 @@ import (
 	"time"
 )
 
-// testLoggerKey is a private key to prevent *testing.T from being easily accessed
-type testLoggerKey struct{}
+// Logger is the minimal logging capability used by e2e implementation code.
+//
+// It deliberately offers logging only. It has no test-control methods (Fatal,
+// Error, Skip, Failed, Name, Cleanup) and does not embed testing.TB, so
+// implementation code cannot change the outcome of a test through a Logger.
+// testing.T stays at the test entry points and the runner adapter.
+type Logger interface {
+	Log(args ...any)
+	Logf(format string, args ...any)
+}
 
-func ContextWithT(ctx context.Context, t testing.TB) context.Context {
-	if t == nil {
-		log.Println("WARNING: No *testing.T provided, this function should only be called from a test")
+// tbBacked is implemented by loggers that write to a testing.TB. It is
+// unexported on purpose: only this package can reach the testing.TB behind a
+// Logger, and it does so for two reasons only:
+//   - marking a frame as a test helper so log lines keep pointing at the caller,
+//   - reading Failed() to pick the step status marker in LogStep.
+type tbBacked interface {
+	testingTB() testing.TB
+}
+
+// tbOf returns the testing.TB backing logger, or nil when the logger is not
+// backed by one. It returns the testing.TB instead of marking the frame itself
+// because testing.TB.Helper marks the frame that calls it, so callers have to
+// invoke Helper from their own frame.
+func tbOf(logger Logger) testing.TB {
+	if backed, ok := logger.(tbBacked); ok {
+		return backed.testingTB()
+	}
+	return nil
+}
+
+// loggerKey is a private key so the logger can only be read through
+// LoggerFromContext.
+type loggerKey struct{}
+
+// ContextWithLogger returns a context carrying logger. Implementation code
+// reads it back with LoggerFromContext, Log, Logf or the LogStep helpers.
+func ContextWithLogger(ctx context.Context, logger Logger) context.Context {
+	if logger == nil {
+		log.Println("WARNING: no logger provided, falling back to the standard logger")
 		return ctx
 	}
-	return context.WithValue(ctx, testLoggerKey{}, t)
+	return context.WithValue(ctx, loggerKey{}, logger)
+}
+
+// LoggerFromContext returns the Logger stored in ctx. When ctx carries no
+// logger it returns a logger backed by the standard library, so logging still
+// works outside a test.
+func LoggerFromContext(ctx context.Context) Logger {
+	if logger, ok := ctx.Value(loggerKey{}).(Logger); ok && logger != nil {
+		return logger
+	}
+	return stdLogger{}
 }
 
 func Logf(ctx context.Context, format string, args ...any) {
-	t, ok := ctx.Value(testLoggerKey{}).(testing.TB)
-	if !ok || t == nil {
-		log.Printf(format+"WARNING: No *testing.T in Context, this function should only be called from ", args...)
-		return
+	logger := LoggerFromContext(ctx)
+	if tb := tbOf(logger); tb != nil {
+		tb.Helper()
 	}
-	t.Helper()
-	t.Logf(format, args...)
+	logger.Logf(format, args...)
 }
 
 func Log(ctx context.Context, args ...any) {
-	t, ok := ctx.Value(testLoggerKey{}).(testing.TB)
-	if !ok || t == nil {
-		log.Println("WARNING: No *testing.T in Context, this function should only be called from a test")
-		return
+	logger := LoggerFromContext(ctx)
+	if tb := tbOf(logger); tb != nil {
+		tb.Helper()
 	}
-	t.Helper()
-	t.Log(args...)
+	logger.Log(args...)
 }
 
+// stdLogger writes to the standard library logger. It is the fallback used when
+// no logger is attached to the context.
+type stdLogger struct{}
+
+func (stdLogger) Log(args ...any) {
+	log.Println(args...)
+}
+
+func (stdLogger) Logf(format string, args ...any) {
+	log.Printf(format, args...)
+}
+
+// testLogger writes to a testing.TB and prefixes every line with the time
+// elapsed since the logger was created. It holds the testing.TB in an
+// unexported field rather than embedding it, so none of the test-control
+// methods leak to callers.
 type testLogger struct {
+	tb    testing.TB
+	start time.Time
+}
+
+// NewTestLogger returns a Logger that writes to tb. Call it at the test runner
+// boundary and pass the returned Logger down to implementation code.
+func NewTestLogger(tb testing.TB) Logger {
+	return &testLogger{tb: tb, start: time.Now()}
+}
+
+func (l *testLogger) testingTB() testing.TB {
+	return l.tb
+}
+
+func (l *testLogger) elapsed() string {
+	return fmt.Sprintf("[%.3fs]", time.Since(l.start).Seconds())
+}
+
+func (l *testLogger) Log(args ...any) {
+	l.tb.Helper()
+	args = append([]any{l.elapsed()}, args...)
+	l.tb.Log(args...)
+}
+
+func (l *testLogger) Logf(format string, args ...any) {
+	l.tb.Helper()
+	l.tb.Logf(l.elapsed()+" "+format, args...)
+}
+
+// failureFormatter decorates the failure reporting of a testing.TB with the
+// elapsed time and a visible marker. Reporting failures is test control, not
+// logging, so this stays a testing.TB and belongs to the runner boundary.
+type failureFormatter struct {
 	testing.TB
 	start time.Time
 }
 
-func (t *testLogger) elapsed() string {
+// WithFailureFormatting wraps t so reported failures carry the elapsed time and
+// a visible marker. Use it only at the test runner boundary.
+func WithFailureFormatting(t testing.TB) testing.TB {
+	return &failureFormatter{TB: t, start: time.Now()}
+}
+
+func (t *failureFormatter) elapsed() string {
 	return fmt.Sprintf("[%.3fs]", time.Since(t.start).Seconds())
 }
 
-func (t *testLogger) Log(args ...any) {
-	t.Helper()
-	args = append([]any{t.elapsed()}, args...)
-	t.TB.Log(args...)
-}
-
-func (t *testLogger) Logf(format string, args ...any) {
-	t.Helper()
-	t.TB.Logf(t.elapsed()+" "+format, args...)
-}
-
 // formatError formats the ERROR prefix with emoji
-func (t *testLogger) formatError() string {
+func (t *failureFormatter) formatError() string {
 	return "🔴 FAIL:"
 }
 
-func (t *testLogger) Fatal(args ...any) {
+func (t *failureFormatter) Fatal(args ...any) {
 	t.Helper()
 	args = append([]any{t.elapsed(), t.formatError()}, args...)
 	t.TB.Fatal(args...)
 }
 
-func (t *testLogger) Fatalf(format string, args ...any) {
+func (t *failureFormatter) Fatalf(format string, args ...any) {
 	t.Helper()
 	t.TB.Fatalf(t.elapsed()+" "+t.formatError()+" "+format, args...)
 }
 
-func (t *testLogger) Error(args ...any) {
+func (t *failureFormatter) Error(args ...any) {
 	t.Helper()
 	args = append([]any{t.elapsed(), t.formatError()}, args...)
 	t.TB.Error(args...)
 }
 
-func (t *testLogger) Errorf(format string, args ...any) {
+func (t *failureFormatter) Errorf(format string, args ...any) {
 	t.Helper()
 	t.TB.Errorf(t.elapsed()+" "+t.formatError()+" "+format, args...)
 }
 
-func (t *testLogger) FailNow() {
+func (t *failureFormatter) FailNow() {
 	t.Helper()
-	t.Log(t.formatError())
+	t.TB.Log(t.elapsed(), t.formatError())
 	t.TB.FailNow()
 }
 
-func (t *testLogger) Fail() {
+func (t *failureFormatter) Fail() {
 	t.Helper()
-	t.Log(t.formatError())
+	t.TB.Log(t.elapsed(), t.formatError())
 	t.TB.Fail()
 }
 
-func WithTestLogger(t testing.TB) testing.TB {
-	return &testLogger{TB: t, start: time.Now()}
-}
-
 // UnwrapTestingT extracts the underlying *testing.T from a testing.TB,
-// unwrapping testLogger wrappers if needed. Returns nil if the
+// unwrapping runner decorators if needed. Returns nil if the
 // underlying type is not *testing.T (e.g. *testing.B).
 func UnwrapTestingT(tb testing.TB) *testing.T {
 	switch v := tb.(type) {
 	case *testing.T:
 		return v
-	case *testLogger:
+	case *failureFormatter:
 		return UnwrapTestingT(v.TB)
 	default:
 		return nil
@@ -119,48 +199,59 @@ func UnwrapTestingT(tb testing.TB) *testing.T {
 // LogStep logs "→ msg..." at the start and "✓ msg done (Xs)" or "✗ msg failed (Xs)"
 // when the returned function is called. Intended for use with defer:
 //
-//	defer toolkit.LogStep(t, "creating firewall")()
-func LogStep(t testing.TB, msg string) func() {
-	t.Helper()
-	t.Log("→", msg+"...")
+//	defer toolkit.LogStep(logger, "creating firewall")()
+func LogStep(logger Logger, msg string) func() {
+	if tb := tbOf(logger); tb != nil {
+		tb.Helper()
+	}
+	logger.Log("→", msg+"...")
 	start := time.Now()
-	alreadyFailed := t.Failed()
+	alreadyFailed := failed(logger)
 	return func() {
-		t.Helper()
+		if tb := tbOf(logger); tb != nil {
+			tb.Helper()
+		}
 		elapsed := time.Since(start).Seconds()
-		if !alreadyFailed && t.Failed() {
-			t.Logf("✗ %s failed (%.1fs)", msg, elapsed)
+		if !alreadyFailed && failed(logger) {
+			logger.Logf("✗ %s failed (%.1fs)", msg, elapsed)
 		} else {
-			t.Logf("✓ %s done (%.1fs)", msg, elapsed)
+			logger.Logf("✓ %s done (%.1fs)", msg, elapsed)
 		}
 	}
 }
 
 // LogStepf is like LogStep but accepts a format string.
-func LogStepf(t testing.TB, format string, args ...any) func() {
-	t.Helper()
-	msg := fmt.Sprintf(format, args...)
-	return LogStep(t, msg)
+func LogStepf(logger Logger, format string, args ...any) func() {
+	if tb := tbOf(logger); tb != nil {
+		tb.Helper()
+	}
+	return LogStep(logger, fmt.Sprintf(format, args...))
 }
 
-// LogStepCtx is like LogStep but extracts testing.TB from context.
+// LogStepCtx is like LogStep but takes the logger from the context.
 func LogStepCtx(ctx context.Context, msg string) func() {
-	t, ok := ctx.Value(testLoggerKey{}).(testing.TB)
-	if !ok || t == nil {
-		log.Printf("→ %s...", msg)
-		start := time.Now()
-		return func() {
-			log.Printf("✓ %s done (%.1fs)", msg, time.Since(start).Seconds())
-		}
+	logger := LoggerFromContext(ctx)
+	if tb := tbOf(logger); tb != nil {
+		tb.Helper()
 	}
-	t.Helper()
-	return LogStep(t, msg)
+	return LogStep(logger, msg)
 }
 
 // LogStepCtxf is like LogStepCtx but accepts a format string.
 func LogStepCtxf(ctx context.Context, format string, args ...any) func() {
-	if t, ok := ctx.Value(testLoggerKey{}).(testing.TB); ok {
-		t.Helper()
+	logger := LoggerFromContext(ctx)
+	if tb := tbOf(logger); tb != nil {
+		tb.Helper()
 	}
-	return LogStepCtx(ctx, fmt.Sprintf(format, args...))
+	return LogStep(logger, fmt.Sprintf(format, args...))
+}
+
+// failed reports whether the test behind logger has already failed. It is used
+// only to pick the step status marker; failure state is never exposed through
+// the Logger interface.
+func failed(logger Logger) bool {
+	if tb := tbOf(logger); tb != nil {
+		return tb.Failed()
+	}
+	return false
 }

--- a/e2e/toolkit/log_test.go
+++ b/e2e/toolkit/log_test.go
@@ -1,0 +1,213 @@
+package toolkit
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// recordingTB records what an implementation writes to a testing.TB. The
+// embedded testing.TB is nil on purpose: any call to a method the tests do not
+// expect panics instead of silently passing.
+type recordingTB struct {
+	testing.TB
+	logs   []string
+	errors []string
+	failed bool
+}
+
+func (r *recordingTB) Helper() {}
+
+func (r *recordingTB) Log(args ...any) {
+	r.logs = append(r.logs, strings.TrimSuffix(fmt.Sprintln(args...), "\n"))
+}
+
+func (r *recordingTB) Logf(format string, args ...any) {
+	r.logs = append(r.logs, fmt.Sprintf(format, args...))
+}
+
+func (r *recordingTB) Error(args ...any) {
+	r.errors = append(r.errors, strings.TrimSuffix(fmt.Sprintln(args...), "\n"))
+	r.failed = true
+}
+
+func (r *recordingTB) Errorf(format string, args ...any) {
+	r.errors = append(r.errors, fmt.Sprintf(format, args...))
+	r.failed = true
+}
+
+func (r *recordingTB) Failed() bool { return r.failed }
+
+var elapsedPrefix = regexp.MustCompile(`^\[\d+\.\d{3}s\] `)
+
+func TestTestLoggerPrefixesElapsedTime(t *testing.T) {
+	rec := &recordingTB{}
+	logger := NewTestLogger(rec)
+
+	logger.Log("hello", "world")
+	logger.Logf("count %d", 3)
+
+	if len(rec.logs) != 2 {
+		t.Fatalf("expected 2 log lines, got %d: %v", len(rec.logs), rec.logs)
+	}
+	for _, line := range rec.logs {
+		if !elapsedPrefix.MatchString(line) {
+			t.Errorf("line %q does not start with an elapsed time prefix", line)
+		}
+	}
+	if got, want := elapsedPrefix.ReplaceAllString(rec.logs[0], ""), "hello world"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if got, want := elapsedPrefix.ReplaceAllString(rec.logs[1], ""), "count 3"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestLoggerDoesNotExposeTestControl locks in the boundary this package exists
+// for: implementation code holding a Logger must not be able to reach any
+// test-control capability.
+func TestLoggerDoesNotExposeTestControl(t *testing.T) {
+	logger := NewTestLogger(&recordingTB{})
+
+	if _, ok := logger.(testing.TB); ok {
+		t.Error("Logger must not satisfy testing.TB")
+	}
+	if _, ok := logger.(interface{ Error(args ...any) }); ok {
+		t.Error("Logger must not expose Error")
+	}
+	if _, ok := logger.(interface{ Errorf(string, ...any) }); ok {
+		t.Error("Logger must not expose Errorf")
+	}
+	if _, ok := logger.(interface{ Fatal(args ...any) }); ok {
+		t.Error("Logger must not expose Fatal")
+	}
+	if _, ok := logger.(interface{ Skip(args ...any) }); ok {
+		t.Error("Logger must not expose Skip")
+	}
+	if _, ok := logger.(interface{ Failed() bool }); ok {
+		t.Error("Logger must not expose Failed")
+	}
+	if _, ok := logger.(interface{ Name() string }); ok {
+		t.Error("Logger must not expose Name")
+	}
+	if _, ok := logger.(interface{ Cleanup(func()) }); ok {
+		t.Error("Logger must not expose Cleanup")
+	}
+	if _, ok := logger.(interface{ Helper() }); ok {
+		t.Error("Logger must not expose Helper")
+	}
+}
+
+func TestContextLoggerRoundTrip(t *testing.T) {
+	rec := &recordingTB{}
+	logger := NewTestLogger(rec)
+	ctx := ContextWithLogger(context.Background(), logger)
+
+	if LoggerFromContext(ctx) != logger {
+		t.Fatal("LoggerFromContext did not return the logger stored in the context")
+	}
+
+	Log(ctx, "from context")
+	Logf(ctx, "formatted %s", "value")
+
+	if len(rec.logs) != 2 {
+		t.Fatalf("expected 2 log lines, got %v", rec.logs)
+	}
+	if got, want := elapsedPrefix.ReplaceAllString(rec.logs[0], ""), "from context"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if got, want := elapsedPrefix.ReplaceAllString(rec.logs[1], ""), "formatted value"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestLoggerFromContextFallsBackToStandardLogger(t *testing.T) {
+	logger := LoggerFromContext(context.Background())
+	if logger == nil {
+		t.Fatal("LoggerFromContext returned nil")
+	}
+	if _, ok := logger.(stdLogger); !ok {
+		t.Fatalf("expected the standard logger fallback, got %T", logger)
+	}
+	// must not panic without a test in the context
+	Log(context.Background(), "no logger in context")
+	Logf(context.Background(), "no logger in %s", "context")
+	LogStepCtx(context.Background(), "step without a logger")()
+	LogStepCtxf(context.Background(), "step %d without a logger", 2)()
+}
+
+func TestContextWithNilLoggerKeepsContext(t *testing.T) {
+	ctx := ContextWithLogger(context.Background(), nil)
+	if _, ok := LoggerFromContext(ctx).(stdLogger); !ok {
+		t.Fatal("a nil logger must leave the context without a logger")
+	}
+}
+
+func TestLogStepReportsSuccess(t *testing.T) {
+	rec := &recordingTB{}
+	LogStep(NewTestLogger(rec), "creating firewall")()
+
+	if len(rec.logs) != 2 {
+		t.Fatalf("expected 2 log lines, got %v", rec.logs)
+	}
+	if got, want := elapsedPrefix.ReplaceAllString(rec.logs[0], ""), "→ creating firewall..."; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if got := elapsedPrefix.ReplaceAllString(rec.logs[1], ""); !strings.HasPrefix(got, "✓ creating firewall done (") {
+		t.Errorf("got %q, want a success marker", got)
+	}
+}
+
+func TestLogStepReportsFailureRaisedDuringTheStep(t *testing.T) {
+	rec := &recordingTB{}
+	done := LogStepf(NewTestLogger(rec), "creating %s", "firewall")
+	rec.failed = true
+	done()
+
+	if got := elapsedPrefix.ReplaceAllString(rec.logs[1], ""); !strings.HasPrefix(got, "✗ creating firewall failed (") {
+		t.Errorf("got %q, want a failure marker", got)
+	}
+}
+
+func TestLogStepIgnoresFailureRaisedBeforeTheStep(t *testing.T) {
+	rec := &recordingTB{failed: true}
+	LogStep(NewTestLogger(rec), "collecting logs")()
+
+	if got := elapsedPrefix.ReplaceAllString(rec.logs[1], ""); !strings.HasPrefix(got, "✓ collecting logs done (") {
+		t.Errorf("got %q, want a success marker for a failure that predates the step", got)
+	}
+}
+
+func TestFailureFormattingDecoratesFailures(t *testing.T) {
+	rec := &recordingTB{}
+	tb := WithFailureFormatting(rec)
+
+	tb.Error("something broke")
+	tb.Errorf("%s broke", "something else")
+
+	if len(rec.errors) != 2 {
+		t.Fatalf("expected 2 errors, got %v", rec.errors)
+	}
+	for _, line := range rec.errors {
+		if !elapsedPrefix.MatchString(line) {
+			t.Errorf("error %q does not start with an elapsed time prefix", line)
+		}
+		if !strings.Contains(line, "🔴 FAIL:") {
+			t.Errorf("error %q does not carry the failure marker", line)
+		}
+	}
+}
+
+func TestUnwrapTestingT(t *testing.T) {
+	if got := UnwrapTestingT(t); got != t {
+		t.Errorf("expected the testing.T itself, got %v", got)
+	}
+	if got := UnwrapTestingT(WithFailureFormatting(t)); got != t {
+		t.Errorf("expected the decorator to unwrap to the testing.T, got %v", got)
+	}
+	if got := UnwrapTestingT(&recordingTB{}); got != nil {
+		t.Errorf("expected nil for a testing.TB that is not a *testing.T, got %v", got)
+	}
+}

--- a/e2e/toolkit/strings.go
+++ b/e2e/toolkit/strings.go
@@ -3,7 +3,7 @@ package toolkit
 import (
 	"context"
 	"strconv"
-	"testing"
+
 	"time"
 )
 
@@ -16,9 +16,9 @@ func StrToInt32(s string) int32 {
 }
 
 func LogDuration(ctx context.Context, duration time.Duration, warningDuration time.Duration, message string) {
-	if t, ok := ctx.Value(testLoggerKey{}).(testing.TB); ok {
+	if tb := tbOf(LoggerFromContext(ctx)); tb != nil {
 		// exclude this function from log stack trace
-		t.Helper()
+		tb.Helper()
 	}
 	if duration > warningDuration {
 		Logf(ctx, "⚠️ ##vso[task.logissue type=warning;] %s", message)

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -14,6 +14,7 @@ import (
 
 	aksnodeconfigv1 "github.com/Azure/agentbaker/aks-node-controller/pkg/gen/aksnodeconfig/v1"
 	"github.com/Azure/agentbaker/e2e/config"
+	"github.com/Azure/agentbaker/e2e/toolkit"
 	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
@@ -150,7 +151,19 @@ type Scenario struct {
 
 	// Runtime contains the runtime state of the scenario. It's populated in the beginning of the test run
 	Runtime *ScenarioRuntime
-	T       testing.TB
+
+	// T is reserved for test control only: reporting failures, skipping and
+	// creating sub-tests. Use Logger for logging, never T.
+	T testing.TB
+
+	// Logger writes the scenario log. It is set by the test runner before the
+	// scenario starts and carries no test-control capability.
+	Logger toolkit.Logger
+
+	// testName is the name of the test running the scenario. It is used to name
+	// the artifacts the scenario writes to disk.
+	testName string
+
 	cleanup *scenarioCleanup
 }
 

--- a/e2e/validate_localdns_exporter_metrics.go
+++ b/e2e/validate_localdns_exporter_metrics.go
@@ -21,8 +21,6 @@ var validateLocalDNSExporterMetricsScript string
 // this, we encode the script in base64, upload it in small chunks via multiple
 // SSH commands, then decode and execute it on the VM.
 func ValidateLocalDNSExporterMetrics(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-
 	// Check if the node has the localdns-exporter label. This label is only set by CSE
 	// when the VHD has localdns-exporter.socket installed (see cse_main.sh). If the label
 	// is absent, the VHD predates the exporter feature — skip validation with a warning
@@ -35,11 +33,11 @@ func ValidateLocalDNSExporterMetrics(ctx context.Context, s *Scenario) error {
 	}
 
 	if _, exists := node.Labels[exporterLabelKey]; !exists {
-		s.T.Logf("WARNING: node %q does not have label %q — localdns exporter not installed on this VHD, skipping exporter validation",
+		s.Logger.Logf("WARNING: node %q does not have label %q — localdns exporter not installed on this VHD, skipping exporter validation",
 			s.Runtime.VM.KubeName, exporterLabelKey)
 		return nil
 	}
-	s.T.Logf("node %q has label %q — proceeding with full exporter validation", s.Runtime.VM.KubeName, exporterLabelKey)
+	s.Logger.Logf("node %q has label %q — proceeding with full exporter validation", s.Runtime.VM.KubeName, exporterLabelKey)
 
 	encoded := base64.StdEncoding.EncodeToString([]byte(validateLocalDNSExporterMetricsScript))
 	remotePath := "/home/azureuser/validate_localdns_exporter_metrics.sh"
@@ -83,6 +81,6 @@ func ValidateLocalDNSExporterMetrics(ctx context.Context, s *Scenario) error {
 		"localdns exporter metrics validation failed\nstdout: %s\nstderr: %s", result.stdout, result.stderr); err != nil {
 		return err
 	}
-	s.T.Logf("localdns exporter metrics validation output:\n%s", result.stdout)
+	s.Logger.Logf("localdns exporter metrics validation output:\n%s", result.stdout)
 	return nil
 }

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -24,9 +24,9 @@ func ValidatePodRunningWithRetry(ctx context.Context, s *Scenario, pod *corev1.P
 
 	for i <= maxRetries && err != nil {
 		retryBackoff := time.Duration(1 << uint(i))
-		s.T.Logf("sleeping %d seconds before retrying pod %q", retryBackoff, pod.Name)
+		s.Logger.Logf("sleeping %d seconds before retrying pod %q", retryBackoff, pod.Name)
 		time.Sleep(retryBackoff * time.Second)
-		s.T.Logf("retrying pod %q validation (%d/%d)", pod.Name, i+1, maxRetries)
+		s.Logger.Logf("retrying pod %q validation (%d/%d)", pod.Name, i+1, maxRetries)
 
 		i++
 		err = startPodAndCheckItRuns(ctx, s, pod)
@@ -121,7 +121,7 @@ func ValidateCommonLinux(ctx context.Context, s *Scenario) error {
 			case err != nil:
 				errs = append(errs, fmt.Errorf("failed to detect hosts plugin artifacts on the VHD: %w", err))
 			case !hasHostsPluginArtifacts:
-				s.T.Logf("WARNING: VHD does not have aks-localdns-hosts-setup.service — skipping hosts plugin validation")
+				s.Logger.Logf("WARNING: VHD does not have aks-localdns-hosts-setup.service — skipping hosts plugin validation")
 			default:
 				errs = append(errs,
 					// Validate hosts file contains resolved IPs for critical FQDNs (IPs resolved dynamically).
@@ -193,10 +193,10 @@ func ValidateCommonWindows(ctx context.Context, s *Scenario) error {
 
 func startPodAndCheckItRuns(ctx context.Context, s *Scenario, pod *corev1.Pod) error {
 	kube := s.Runtime.Kube
-	truncatePodName(s.T, pod)
+	truncatePodName(s.Logger, pod)
 	start := time.Now()
 
-	s.T.Logf("creating pod %q", pod.Name)
+	s.Logger.Logf("creating pod %q", pod.Name)
 	_, err := kube.Typed.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create pod %q: %v", pod.Name, err)
@@ -206,7 +206,7 @@ func startPodAndCheckItRuns(ctx context.Context, s *Scenario, pod *corev1.Pod) e
 		defer cancel()
 		err := kube.Typed.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: to.Ptr(int64(0))})
 		if err != nil {
-			s.T.Logf("couldn't not delete pod %s: %v", pod.Name, err)
+			s.Logger.Logf("couldn't not delete pod %s: %v", pod.Name, err)
 		}
 	}()
 
@@ -221,14 +221,13 @@ func startPodAndCheckItRuns(ctx context.Context, s *Scenario, pod *corev1.Pod) e
 
 	timeForReady := time.Since(start)
 	toolkit.LogDuration(ctx, timeForReady, time.Minute, fmt.Sprintf("Time for pod %q to get ready was %s", pod.Name, timeForReady))
-	s.T.Logf("node health validation: test pod %q is running on node %q", pod.Name, s.Runtime.VM.KubeName)
+	s.Logger.Logf("node health validation: test pod %q is running on node %q", pod.Name, s.Runtime.VM.KubeName)
 	return nil
 }
 
 // Waits until the specified resource is available on the given node.
 // Returns an error if the resource is not available within the specified timeout period.
 func waitUntilResourceAvailable(ctx context.Context, s *Scenario, resourceName string) error {
-	s.T.Helper()
 	nodeName := s.Runtime.VM.KubeName
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
@@ -244,7 +243,7 @@ func waitUntilResourceAvailable(ctx context.Context, s *Scenario, resourceName s
 			}
 
 			if isResourceAvailable(node, resourceName) {
-				s.T.Logf("resource %q is available", resourceName)
+				s.Logger.Logf("resource %q is available", resourceName)
 				return nil
 			}
 		}
@@ -262,8 +261,6 @@ func isResourceAvailable(node *corev1.Node, resourceName string) bool {
 }
 
 func dllLoadedWindows(ctx context.Context, s *Scenario, dllName string) (bool, error) {
-	s.T.Helper()
-
 	steps := []string{
 		"$ErrorActionPreference = \"Continue\"",
 		fmt.Sprintf("tasklist /m %s", dllName),
@@ -274,7 +271,7 @@ func dllLoadedWindows(ctx context.Context, s *Scenario, dllName string) (bool, e
 	}
 	dllLoaded := strings.Contains(execResult.stdout, dllName)
 
-	s.T.Logf("stdout: %s\nstderr: %s", execResult.stdout, execResult.stderr)
+	s.Logger.Logf("stdout: %s\nstderr: %s", execResult.stdout, execResult.stderr)
 	return dllLoaded, nil
 }
 
@@ -348,7 +345,7 @@ func getIPTablesRulesCompatibleWithEBPFHostRouting() (map[string][]string, []str
 // result itself — a single observation of an unexpected exit code is enough
 // to fail loudly.
 func validateWireServerBlocked(ctx context.Context, s *Scenario) error {
-	defer toolkit.LogStep(s.T, "validating wireserver is blocked from unprivileged pods")()
+	defer toolkit.LogStep(s.Logger, "validating wireserver is blocked from unprivileged pods")()
 
 	nonHostPod, err := s.Runtime.Kube.GetPodNetworkDebugPodForNode(ctx, s.Runtime.VM.KubeName)
 	if err != nil {
@@ -385,9 +382,9 @@ func validateWireServerBlocked(ctx context.Context, s *Scenario) error {
 			r, execErr := execOnUnprivilegedPod(attemptCtx, s.Runtime.Kube, nonHostPod.Namespace, nonHostPod.Name, check.cmd)
 			if execErr != nil {
 				if errors.Is(execErr, context.DeadlineExceeded) {
-					s.T.Logf("wireserver check %q: exec attempt timed out after 15s (retrying): %v", check.desc, execErr)
+					s.Logger.Logf("wireserver check %q: exec attempt timed out after 15s (retrying): %v", check.desc, execErr)
 				} else {
-					s.T.Logf("wireserver check %q: exec error (retrying): %v", check.desc, execErr)
+					s.Logger.Logf("wireserver check %q: exec error (retrying): %v", check.desc, execErr)
 				}
 				return false, nil
 			}

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -15,7 +15,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -57,14 +56,14 @@ func validateTLSBootstrappingLinux(ctx context.Context, s *Scenario) error {
 	var errs []error
 	switch {
 	case s.SecureTLSBootstrappingEnabled() && s.Tags.BootstrapTokenFallback:
-		s.T.Logf("will validate bootstrapping mode: secure TLS bootstrapping failure with bootstrap token fallback")
+		s.Logger.Logf("will validate bootstrapping mode: secure TLS bootstrapping failure with bootstrap token fallback")
 		errs = append(errs, assert.Equal(
 			!strings.Contains(kubeletLogs, "unable to validate bootstrap credentials") && strings.Contains(kubeletLogs, "kubelet bootstrap token credential is valid"),
 			true,
 			"expected to have successfully validated bootstrap token credential before kubelet startup, but did not",
 		))
 	case s.SecureTLSBootstrappingEnabled():
-		s.T.Logf("will validate bootstrapping mode: secure TLS bootstrapping")
+		s.Logger.Logf("will validate bootstrapping mode: secure TLS bootstrapping")
 		errs = append(errs,
 			ValidateSystemdUnitIsRunning(ctx, s, "secure-tls-bootstrap"),
 			validateKubeletClientCSRCreatedBySecureTLSBootstrapping(ctx, s),
@@ -75,7 +74,7 @@ func validateTLSBootstrappingLinux(ctx context.Context, s *Scenario) error {
 			),
 		)
 	default:
-		s.T.Logf("will validate bootstrapping mode: bootstrap token")
+		s.Logger.Logf("will validate bootstrapping mode: bootstrap token")
 		errs = append(errs,
 			ValidateSystemdUnitIsNotRunning(ctx, s, "secure-tls-bootstrap"),
 			ValidateSystemdUnitIsNotFailed(ctx, s, "secure-tls-bootstrap"),
@@ -106,13 +105,13 @@ func validateTLSBootstrappingWindows(ctx context.Context, s *Scenario) error {
 	}
 	switch {
 	case s.SecureTLSBootstrappingEnabled() && s.Tags.BootstrapTokenFallback:
-		s.T.Logf("will validate bootstrapping mode: secure TLS bootstrapping failure with bootstrap token fallback")
+		s.Logger.Logf("will validate bootstrapping mode: secure TLS bootstrapping failure with bootstrap token fallback")
 		// nothing to validate other than node readiness
 	case s.SecureTLSBootstrappingEnabled():
-		s.T.Logf("will validate bootstrapping mode: secure TLS bootstrapping")
+		s.Logger.Logf("will validate bootstrapping mode: secure TLS bootstrapping")
 		errs = append(errs, validateKubeletClientCSRCreatedBySecureTLSBootstrapping(ctx, s))
 	default:
-		s.T.Logf("will validate bootstrapping mode: bootstrap token")
+		s.Logger.Logf("will validate bootstrapping mode: bootstrap token")
 		// nothing to validate other than node readiness
 	}
 	return errors.Join(errs...)
@@ -129,7 +128,7 @@ func ValidateKubeletServingCertificateRotation(ctx context.Context, s *Scenario)
 
 func validateKubeletServingCertificateRotationLinux(ctx context.Context, s *Scenario) error {
 	if _, ok := s.Runtime.VM.VMSS.Tags["aks-disable-kubelet-serving-certificate-rotation"]; ok {
-		s.T.Logf("linux VMSS has KSCR disablement tag, will validate that KSCR has been disabled")
+		s.Logger.Logf("linux VMSS has KSCR disablement tag, will validate that KSCR has been disabled")
 		errs := []error{
 			ValidateDirectoryContent(ctx, s, "/etc/kubernetes/certs", []string{"kubeletserver.crt", "kubeletserver.key"}),
 			ValidateFileExcludesContent(ctx, s, "/etc/default/kubelet", "kubernetes.azure.com/kubelet-serving-ca=cluster"),
@@ -149,7 +148,7 @@ func validateKubeletServingCertificateRotationLinux(ctx context.Context, s *Scen
 		}
 		return errors.Join(errs...)
 	}
-	s.T.Logf("will validate linux KSCR enablement")
+	s.Logger.Logf("will validate linux KSCR enablement")
 	errs := []error{
 		ValidateDirectoryContent(ctx, s, "/var/lib/kubelet/pki", []string{"kubelet-server-current.pem"}),
 		ValidateFileHasContent(ctx, s, "/etc/default/kubelet", "kubernetes.azure.com/kubelet-serving-ca=cluster"),
@@ -172,13 +171,13 @@ func validateKubeletServingCertificateRotationLinux(ctx context.Context, s *Scen
 
 func validateKubeletServingCertificateRotationWindows(ctx context.Context, s *Scenario) error {
 	if _, ok := s.Runtime.VM.VMSS.Tags["aks-disable-kubelet-serving-certificate-rotation"]; ok {
-		s.T.Logf("windows VMSS has KSCR disablement tag, will validate that KSCR has been disabled")
+		s.Logger.Logf("windows VMSS has KSCR disablement tag, will validate that KSCR has been disabled")
 		return errors.Join(
 			ValidateDirectoryContent(ctx, s, "c:\\k\\pki", []string{"kubelet.crt", "kubelet.key"}),
 			ValidateWindowsProcessDoesNotContainArgumentStrings(ctx, s, "kubelet.exe", []string{"--rotate-server-certificates=true", "kubernetes.azure.com/kubelet-serving-ca=cluster"}),
 		)
 	}
-	s.T.Logf("will validate windows KSCR enablement")
+	s.Logger.Logf("will validate windows KSCR enablement")
 	return errors.Join(
 		ValidateDirectoryContent(ctx, s, "c:\\k\\pki", []string{"kubelet-server-current.pem"}),
 		ValidateWindowsProcessContainsArgumentStrings(ctx, s, "kubelet.exe", []string{"--rotate-server-certificates=true", "kubernetes.azure.com/kubelet-serving-ca=cluster"}),
@@ -284,7 +283,6 @@ func ValidateSSHServiceEnabled(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateDirectoryContent(ctx context.Context, s *Scenario, path string, files []string) error {
-	s.T.Helper()
 	var steps []string
 	if s.IsWindows() {
 		steps = []string{
@@ -309,7 +307,6 @@ func ValidateDirectoryContent(ctx context.Context, s *Scenario, path string, fil
 }
 
 func ValidateSysctlConfig(ctx context.Context, s *Scenario, customSysctls map[string]string) error {
-	s.T.Helper()
 	keysToCheck := make([]string, 0, len(customSysctls))
 	for k := range customSysctls {
 		keysToCheck = append(keysToCheck, k)
@@ -330,7 +327,6 @@ func ValidateSysctlConfig(ctx context.Context, s *Scenario, customSysctls map[st
 }
 
 func ValidateCustomLinuxOSConfigPersistsAfterReboot(ctx context.Context, s *Scenario, customSysctls map[string]string, customContainerdUlimits map[string]string, swapFileSizeMB int32, thpEnabled, thpDefrag string) error {
-	s.T.Helper()
 	if err := validateCustomLinuxOSConfig(ctx, s, customSysctls, customContainerdUlimits, swapFileSizeMB, thpEnabled, thpDefrag); err != nil {
 		return err
 	}
@@ -341,7 +337,6 @@ func ValidateCustomLinuxOSConfigPersistsAfterReboot(ctx context.Context, s *Scen
 }
 
 func validateCustomLinuxOSConfig(ctx context.Context, s *Scenario, customSysctls map[string]string, customContainerdUlimits map[string]string, swapFileSizeMB int32, thpEnabled, thpDefrag string) error {
-	s.T.Helper()
 	return errors.Join(
 		ValidateSysctlConfig(ctx, s, customSysctls),
 		ValidateUlimitSettings(ctx, s, customContainerdUlimits),
@@ -351,7 +346,6 @@ func validateCustomLinuxOSConfig(ctx context.Context, s *Scenario, customSysctls
 }
 
 func ValidateTransparentHugePageConfig(ctx context.Context, s *Scenario, thpEnabled, thpDefrag string) error {
-	s.T.Helper()
 	command := []string{"set -ex"}
 	if thpEnabled != "" {
 		command = append(command,
@@ -371,7 +365,6 @@ func ValidateTransparentHugePageConfig(ctx context.Context, s *Scenario, thpEnab
 }
 
 func ValidateSwapFileConfig(ctx context.Context, s *Scenario, swapFileSizeMB int32) error {
-	s.T.Helper()
 	if swapFileSizeMB <= 0 {
 		return nil
 	}
@@ -391,7 +384,6 @@ func ValidateSwapFileConfig(ctx context.Context, s *Scenario, swapFileSizeMB int
 }
 
 func RebootVMAndWaitForSSH(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	bootIDResult, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, "cat /proc/sys/kernel/random/boot_id", 0, "could not read boot ID before reboot")
 	if err != nil {
 		return fmt.Errorf("read boot ID before reboot: %w", err)
@@ -411,7 +403,7 @@ func RebootVMAndWaitForSSH(ctx context.Context, s *Scenario) error {
 	err = wait.PollUntilContextTimeout(ctx, 15*time.Second, waitTimeout, true, func(ctx context.Context) (bool, error) {
 		sshClient, err := DialSSHOverBastion(ctx, s.Runtime.Cluster.Bastion, s.Runtime.VM.PrivateIP, config.VMSSHPrivateKey)
 		if err != nil {
-			s.T.Logf("waiting for SSH after reboot: %v", err)
+			s.Logger.Logf("waiting for SSH after reboot: %v", err)
 			return false, nil
 		}
 
@@ -420,14 +412,14 @@ func RebootVMAndWaitForSSH(ctx context.Context, s *Scenario) error {
 		cancel()
 		if err != nil {
 			cleanupBastionTunnel(sshClient)
-			s.T.Logf("waiting for boot ID after reboot: %v", err)
+			s.Logger.Logf("waiting for boot ID after reboot: %v", err)
 			return false, nil
 		}
 
 		afterRebootBootID := strings.TrimSpace(execResult.stdout)
 		if afterRebootBootID == "" || afterRebootBootID == beforeRebootBootID {
 			cleanupBastionTunnel(sshClient)
-			s.T.Logf("waiting for VM reboot to complete: boot ID is still %q", afterRebootBootID)
+			s.Logger.Logf("waiting for VM reboot to complete: boot ID is still %q", afterRebootBootID)
 			return false, nil
 		}
 
@@ -445,7 +437,6 @@ func RebootVMAndWaitForSSH(ctx context.Context, s *Scenario) error {
 // then verifies that each interface has the expected configuration settings (e.g., rx buffer size).
 // The nicConfig map specifies the ethtool settings to validate (key: setting name, value: expected value).
 func ValidateNetworkInterfaceConfig(ctx context.Context, s *Scenario, nicConfig map[string]string) error {
-	s.T.Helper()
 	// Get list of NICs using udevadm (same logic as udev rule)
 	getNicsCommand := []string{
 		"#!/usr/bin/env bash",
@@ -463,7 +454,7 @@ func ValidateNetworkInterfaceConfig(ctx context.Context, s *Scenario, nicConfig 
 	if err != nil {
 		return fmt.Errorf("get NICs to configure: %w", err)
 	}
-	s.T.Logf("NICs to configure:\n%s", nicsResult.stdout)
+	s.Logger.Logf("NICs to configure:\n%s", nicsResult.stdout)
 
 	// Parse NIC output - it may be multi-line with header
 	lines := strings.Split(strings.TrimSpace(nicsResult.stdout), "\n")
@@ -480,10 +471,10 @@ func ValidateNetworkInterfaceConfig(ctx context.Context, s *Scenario, nicConfig 
 
 	nics := strings.Split(nicsOutput, ",")
 
-	s.T.Logf("Parsed NICs list: %v (count: %d)", nics, len(nics))
+	s.Logger.Logf("Parsed NICs list: %v (count: %d)", nics, len(nics))
 
 	if len(nics) == 0 || (len(nics) == 1 && strings.TrimSpace(nics[0]) == "") {
-		s.T.Logf("No PCI devices (NICs) with enP* slot pattern found - skipping network interface config validation")
+		s.Logger.Logf("No PCI devices (NICs) with enP* slot pattern found - skipping network interface config validation")
 		return nil
 	}
 
@@ -495,7 +486,7 @@ func ValidateNetworkInterfaceConfig(ctx context.Context, s *Scenario, nicConfig 
 			continue
 		}
 
-		s.T.Logf("Validating network interface config for NIC: %s", nic)
+		s.Logger.Logf("Validating network interface config for NIC: %s", nic)
 
 		// Get full ethtool output for debugging
 		debugCommand := []string{
@@ -507,7 +498,7 @@ func ValidateNetworkInterfaceConfig(ctx context.Context, s *Scenario, nicConfig 
 		if err != nil {
 			return errors.Join(append(errs, fmt.Errorf("get ethtool output for nic %s: %w", nic, err))...)
 		}
-		s.T.Logf("Full ethtool output for %s:\n%s", nic, debugResult.stdout)
+		s.Logger.Logf("Full ethtool output for %s:\n%s", nic, debugResult.stdout)
 		oldEthtool := strings.Contains(debugResult.stdout, "Current hardware settings")
 
 		for setting, expectedValue := range nicConfig {
@@ -526,7 +517,7 @@ func ValidateNetworkInterfaceConfig(ctx context.Context, s *Scenario, nicConfig 
 				return errors.Join(append(errs, fmt.Errorf("get ethtool setting %s for nic %s: %w", setting, nic, err))...)
 			}
 			actualValue := strings.TrimSpace(execResult.stdout)
-			s.T.Logf("Ethtool setting %s for NIC %s: expected=%s, actual=%s", setting, nic, expectedValue, actualValue)
+			s.Logger.Logf("Ethtool setting %s for NIC %s: expected=%s, actual=%s", setting, nic, expectedValue, actualValue)
 			errs = append(errs, assert.Equal(actualValue, expectedValue, "expected %s to be %s on nic %s, but got %s.\nFull ethtool output:\n%s", setting, expectedValue, nic, actualValue, debugResult.stdout))
 		}
 	}
@@ -535,7 +526,6 @@ func ValidateNetworkInterfaceConfig(ctx context.Context, s *Scenario, nicConfig 
 
 // ValidateAzureNetworkFiles checks that udev rules files exist.
 func ValidateAzureNetworkFiles(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	return errors.Join(
 		ValidateFileExists(ctx, s, "/opt/azure-network/configure-azure-network.sh"),
 		ValidateFileExists(ctx, s, "/etc/udev/rules.d/99-azure-network.rules"),
@@ -543,7 +533,6 @@ func ValidateAzureNetworkFiles(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateNvidiaSMINotInstalled(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		"sudo nvidia-smi",
@@ -556,14 +545,12 @@ func ValidateNvidiaSMINotInstalled(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateNvidiaSMIInstalled(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{"set -ex", "sudo nvidia-smi"}
 	_, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, strings.Join(command, "\n"), 0, "could not execute nvidia-smi command")
 	return err
 }
 
 func ValidateNvidiaModProbeInstalled(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		"sudo nvidia-modprobe",
@@ -573,7 +560,6 @@ func ValidateNvidiaModProbeInstalled(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateNvidiaGRIDLicenseValid(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		// Capture the license status output, or continue silently if not found
@@ -589,7 +575,6 @@ func ValidateNvidiaGRIDLicenseValid(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateNvidiaPersistencedRunning(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		// Check that nvidia-persistenced.service is active by capturing its is-active output
@@ -605,7 +590,6 @@ func ValidateNvidiaPersistencedRunning(ctx context.Context, s *Scenario) error {
 // cuda/grid driver. This is the grid-v20-specific check: if SKU->driver-type
 // selection regressed, nvidia-smi would report a different driver major.
 func ValidateNvidiaGridV20DriverInstalled(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		"driver_version=$(sudo nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n1 | tr -d '[:space:]')",
@@ -617,7 +601,6 @@ func ValidateNvidiaGridV20DriverInstalled(ctx context.Context, s *Scenario) erro
 }
 
 func ValidateNonEmptyDirectory(ctx context.Context, s *Scenario, dirName string) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		fmt.Sprintf("sudo ls -1q %s | grep -q '^.*$' && true || false", dirName),
@@ -627,7 +610,6 @@ func ValidateNonEmptyDirectory(ctx context.Context, s *Scenario, dirName string)
 }
 
 func ValidateEmptyDirectory(ctx context.Context, s *Scenario, dirName string) error {
-	s.T.Helper()
 	command := fmt.Sprintf("! [ -d '%s' ] || [ -z \"$(ls -A '%s')\" ]", dirName, dirName)
 	_, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, command, 0,
 		fmt.Sprintf("expected directory %s to be empty or not exist", dirName))
@@ -635,7 +617,6 @@ func ValidateEmptyDirectory(ctx context.Context, s *Scenario, dirName string) er
 }
 
 func ValidateInspektorGadget(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	skipFile := "/etc/ig.d/skip_vhd_ig"
 	serviceName := "ig-import-gadgets.service"
 	servicePath := "/usr/lib/systemd/system/" + serviceName
@@ -648,11 +629,11 @@ func ValidateInspektorGadget(ctx context.Context, s *Scenario) error {
 		return fmt.Errorf("check for Inspektor Gadget sentinel file %s: %w", skipFile, err)
 	}
 	if !skipFileExists {
-		s.T.Logf("Skipping Inspektor Gadget validation: sentinel file %s not found (VHD does not have IG installed)", skipFile)
+		s.Logger.Logf("Skipping Inspektor Gadget validation: sentinel file %s not found (VHD does not have IG installed)", skipFile)
 		return nil
 	}
 
-	s.T.Logf("skip_vhd_ig sentinel file found, validating Inspektor Gadget installation")
+	s.Logger.Logf("skip_vhd_ig sentinel file found, validating Inspektor Gadget installation")
 
 	errs := []error{ValidateSystemdUnitIsNotFailed(ctx, s, serviceName)}
 	if _, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, fmt.Sprintf("systemctl is-enabled %s | grep -qx disabled", serviceName), 0, fmt.Sprintf("%s should be disabled", serviceName)); err != nil {
@@ -667,13 +648,13 @@ func ValidateInspektorGadget(ctx context.Context, s *Scenario) error {
 	// Validate that gadgets were actually imported
 	trackingFile := "/var/lib/ig/imported-gadgets.txt"
 	errs = append(errs, ValidateFileExists(ctx, s, trackingFile))
-	s.T.Logf("Validating imported gadgets tracking file is not empty")
+	s.Logger.Logf("Validating imported gadgets tracking file is not empty")
 	if _, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, fmt.Sprintf("test -s %s", trackingFile), 0, "tracking file should not be empty"); err != nil {
 		errs = append(errs, err)
 	}
 
 	// Verify ig image list shows imported gadgets
-	s.T.Logf("Validating ig image list shows imported gadgets")
+	s.Logger.Logf("Validating ig image list shows imported gadgets")
 	result, err := execScriptOnVMForScenario(ctx, s, "sudo ig image list")
 	if err != nil {
 		return errors.Join(append(errs, fmt.Errorf("run ig image list: %w", err))...)
@@ -684,7 +665,7 @@ func ValidateInspektorGadget(ctx context.Context, s *Scenario) error {
 	if len(result.stdout) == 0 {
 		return errors.Join(append(errs, errors.New("ig image list returned empty output, expected at least one imported gadget"))...)
 	}
-	s.T.Logf("ig image list output:\n%s", result.stdout)
+	s.Logger.Logf("ig image list output:\n%s", result.stdout)
 
 	// Run a simple gadget as a functional test.
 	// We dynamically get the trace_exec tag from ig image list since gadgets are imported
@@ -693,7 +674,7 @@ func ValidateInspektorGadget(ctx context.Context, s *Scenario) error {
 	// We use timeout(1) to kill the gadget after 3s in case it hangs.
 	// The ig --timeout flag expects an integer (seconds), not a duration string.
 	// Exit codes: 0 = success, 124 = timeout killed it (also OK), anything else = failure.
-	s.T.Logf("Running functional test with trace_exec gadget")
+	s.Logger.Logf("Running functional test with trace_exec gadget")
 	funcTestScript := `
 set -e
 TRACE_EXEC_TAG=$(sudo ig image list | grep trace_exec | awk '{print $2}')
@@ -715,12 +696,11 @@ echo "trace_exec gadget ran successfully"
 	if joined := errors.Join(errs...); joined != nil {
 		return joined
 	}
-	s.T.Logf("Inspektor Gadget functional validation passed")
+	s.Logger.Logf("Inspektor Gadget functional validation passed")
 	return nil
 }
 
 func ValidateFileExists(ctx context.Context, s *Scenario, fileName string) error {
-	s.T.Helper()
 	exists, err := fileExist(ctx, s, fileName)
 	if err != nil {
 		return fmt.Errorf("check existence of file %s: %w", fileName, err)
@@ -733,12 +713,10 @@ func ValidateFileExists(ctx context.Context, s *Scenario, fileName string) error
 // Kernel FIPS mode (/proc/sys/crypto/fips_enabled == 1) is universal and is asserted by
 // ValidateFIPSProvider; callers should compose the two validators when both are needed.
 func ValidateACLFIPSEnabled(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	return ValidateFileExists(ctx, s, "/etc/system-fips")
 }
 
 func ValidateFileDoesNotExist(ctx context.Context, s *Scenario, fileName string) error {
-	s.T.Helper()
 	exists, err := fileExist(ctx, s, fileName)
 	if err != nil {
 		return fmt.Errorf("check existence of file %s: %w", fileName, err)
@@ -747,7 +725,6 @@ func ValidateFileDoesNotExist(ctx context.Context, s *Scenario, fileName string)
 }
 
 func ValidateFileIsRegularFile(ctx context.Context, s *Scenario, fileName string) error {
-	s.T.Helper()
 	steps := []string{
 		"set -ex",
 		fmt.Sprintf("stat --printf=%%F %s | grep 'regular file'", fileName),
@@ -761,7 +738,6 @@ func ValidateFileIsRegularFile(ctx context.Context, s *Scenario, fileName string
 }
 
 func fileExist(ctx context.Context, s *Scenario, fileName string) (bool, error) {
-	s.T.Helper()
 	if s.IsWindows() {
 		steps := []string{
 			"$ErrorActionPreference = \"Stop\"",
@@ -771,7 +747,7 @@ func fileExist(ctx context.Context, s *Scenario, fileName string) (bool, error) 
 		if err != nil {
 			return false, err
 		}
-		s.T.Logf("stdout: %s\nstderr: %s", execResult.stdout, execResult.stderr)
+		s.Logger.Logf("stdout: %s\nstderr: %s", execResult.stdout, execResult.stderr)
 		return execResult.exitCode == "0", nil
 	}
 	steps := []string{
@@ -786,7 +762,6 @@ func fileExist(ctx context.Context, s *Scenario, fileName string) (bool, error) 
 }
 
 func getFileContent(ctx context.Context, s *Scenario, fileName string) (string, error) {
-	s.T.Helper()
 	var steps []string
 
 	if s.IsWindows() {
@@ -813,7 +788,6 @@ func getFileContent(ctx context.Context, s *Scenario, fileName string) (string, 
 }
 
 func fileHasContent(ctx context.Context, s *Scenario, fileName string, contents string) (bool, error) {
-	s.T.Helper()
 	if contents == "" {
 		return false, fmt.Errorf("test setup failure: can't validate that a file has contents with an empty string. Filename: %s", fileName)
 	}
@@ -839,7 +813,6 @@ func fileHasContent(ctx context.Context, s *Scenario, fileName string, contents 
 }
 
 func fileHasExactContent(ctx context.Context, s *Scenario, fileName string, contents string) (bool, error) {
-	s.T.Helper()
 	if contents == "" {
 		return false, fmt.Errorf("test setup failure: can't validate that a file has contents with an empty string. Filename: %s", fileName)
 	}
@@ -875,7 +848,6 @@ func fileHasExactContent(ctx context.Context, s *Scenario, fileName string, cont
 // The contents doesn't need to be surrounded by non-word characters.
 // E.g.: searching "bcd" in "abcdef" is a match, thus the validation passes.
 func ValidateFileHasContent(ctx context.Context, s *Scenario, fileName string, contents string) error {
-	s.T.Helper()
 	hasContent, err := fileHasContent(ctx, s, fileName, contents)
 	if err != nil {
 		return fmt.Errorf("check whether file %s has contents %q: %w", fileName, contents, err)
@@ -894,7 +866,6 @@ func ValidateFileHasContent(ctx context.Context, s *Scenario, fileName string, c
 // The contents doesn't need to be surrounded by non-word characters.
 // E.g.: searching "bcd" in "abcdef" is a match, thus the validation fails.
 func ValidateFileExcludesContent(ctx context.Context, s *Scenario, fileName string, contents string) error {
-	s.T.Helper()
 	hasContent, err := fileHasContent(ctx, s, fileName, contents)
 	if err != nil {
 		return fmt.Errorf("check whether file %s has contents %q: %w", fileName, contents, err)
@@ -913,7 +884,6 @@ func ValidateFileExcludesContent(ctx context.Context, s *Scenario, fileName stri
 // The contents needs to be surrounded by non-word characters.
 // E.g.: searching "bcd" in "abcdef" is not a match, thus the validation passes.
 func ValidateFileExcludesExactContent(ctx context.Context, s *Scenario, fileName string, contents string) error {
-	s.T.Helper()
 	hasContent, err := fileHasExactContent(ctx, s, fileName, contents)
 	if err != nil {
 		return fmt.Errorf("check whether file %s has exact contents %q: %w", fileName, contents, err)
@@ -929,7 +899,6 @@ func ValidateFileExcludesExactContent(ctx context.Context, s *Scenario, fileName
 //  3. /opt/cni/bin/portmap runs without panicking (regression guard for ICM 51000001009688
 //     where the OpenSSL FIPS provider was not loaded on AzureLinux V3 FIPS nodes).
 func ValidateFIPSProvider(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	var errs []error
 
 	// 1. Kernel FIPS mode.
@@ -961,7 +930,7 @@ func ValidateFIPSProvider(ctx context.Context, s *Scenario) error {
 		errs = append(errs, assert.Equal(opensslProviderActive(providers.stdout, "fips", "symcrypt"), true,
 			"expected openssl to have an active fips or symcrypt provider, got:\n%s", providers.stdout))
 	case strings.HasPrefix(version, "1.1."):
-		s.T.Logf("openssl providers check skipped: detected version %q (legacy FIPS module)", strings.TrimSpace(opensslVersion.stdout))
+		s.Logger.Logf("openssl providers check skipped: detected version %q (legacy FIPS module)", strings.TrimSpace(opensslVersion.stdout))
 	default:
 		return errors.Join(append(errs, fmt.Errorf("unexpected openssl version %q: FIPS VHDs are expected to ship OpenSSL 3.x or 1.1.x", strings.TrimSpace(opensslVersion.stdout)))...)
 	}
@@ -977,11 +946,11 @@ func ValidateFIPSProvider(ctx context.Context, s *Scenario) error {
 		return errors.Join(append(errs, fmt.Errorf("check whether %s is executable: %w", portmapBin, err))...)
 	}
 	if portmapPresent.exitCode != "0" {
-		s.T.Logf("portmap panic check skipped: %s not present or not executable on this VHD", portmapBin)
+		s.Logger.Logf("portmap panic check skipped: %s not present or not executable on this VHD", portmapBin)
 		if joined := errors.Join(errs...); joined != nil {
 			return joined
 		}
-		s.T.Logf("FIPS provider validation passed")
+		s.Logger.Logf("FIPS provider validation passed")
 		return nil
 	}
 	portmap, err := execScriptOnVMForScenario(ctx, s, fmt.Sprintf("%s < /dev/null", portmapBin))
@@ -1006,7 +975,7 @@ func ValidateFIPSProvider(ctx context.Context, s *Scenario) error {
 	if joined := errors.Join(errs...); joined != nil {
 		return joined
 	}
-	s.T.Logf("FIPS provider validation passed")
+	s.Logger.Logf("FIPS provider validation passed")
 	return nil
 }
 
@@ -1054,7 +1023,6 @@ func opensslProviderActive(output string, providerPrefixes ...string) bool {
 }
 
 func ServiceCanRestartValidator(ctx context.Context, s *Scenario, serviceName string, restartTimeoutInSeconds int) error {
-	s.T.Helper()
 	steps := []string{
 		"set -ex",
 		// Verify the service is active - print the state then verify so we have logs
@@ -1088,7 +1056,6 @@ func ServiceCanRestartValidator(ctx context.Context, s *Scenario, serviceName st
 }
 
 func ValidateSystemdUnitIsRunning(ctx context.Context, s *Scenario, serviceName string) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		// Print the service status for logging purposes
@@ -1102,7 +1069,6 @@ func ValidateSystemdUnitIsRunning(ctx context.Context, s *Scenario, serviceName 
 }
 
 func ValidateSystemdUnitIsNotRunning(ctx context.Context, s *Scenario, serviceName string) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		// Print the service status for logging purposes (allow failure)
@@ -1116,7 +1082,6 @@ func ValidateSystemdUnitIsNotRunning(ctx context.Context, s *Scenario, serviceNa
 }
 
 func ValidateWindowsServiceIsRunning(ctx context.Context, s *Scenario, serviceName string) error {
-	s.T.Helper()
 	command := []string{
 		"$ErrorActionPreference = \"Stop\"",
 		// Print the service status for logging purposes
@@ -1131,7 +1096,6 @@ func ValidateWindowsServiceIsRunning(ctx context.Context, s *Scenario, serviceNa
 }
 
 func ValidateWindowsServiceIsNotRunning(ctx context.Context, s *Scenario, serviceName string) error {
-	s.T.Helper()
 	command := []string{
 		"$ErrorActionPreference = \"Continue\"",
 		// Print the service status for logging purposes
@@ -1148,7 +1112,6 @@ func ValidateWindowsServiceIsNotRunning(ctx context.Context, s *Scenario, servic
 }
 
 func ValidateDotnetNotInstalledWindows(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{
 		"$ErrorActionPreference = \"Continue\"",
 		"$dotnetCmd = Get-Command dotnet -ErrorAction SilentlyContinue",
@@ -1163,7 +1126,6 @@ func ValidateDotnetNotInstalledWindows(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateWindowsSystemServiceRestartConfiguration(ctx context.Context, s *Scenario, serviceName string) error {
-	s.T.Helper()
 	command := []string{
 		fmt.Sprintf("sc.exe qfailure %s", serviceName),
 	}
@@ -1214,7 +1176,6 @@ func ValidateWindowsSystemServicesRestartConfiguration(ctx context.Context, s *S
 }
 
 func ValidateSystemdUnitIsNotFailed(ctx context.Context, s *Scenario, serviceName string) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		fmt.Sprintf("systemctl --no-pager -n 5 status %s || true", serviceName),
@@ -1236,7 +1197,6 @@ func ValidateSystemdUnitIsNotFailed(ctx context.Context, s *Scenario, serviceNam
 // ran successfully and produced a guest agent event file containing kubelet config telemetry.
 // Guarded: skips gracefully on VHDs that don't have the service baked in yet.
 func ValidateKubeletActiveFlagsEvent(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Guard: skip on VHDs that don't have the service
 	serviceCheck, err := execOnVMForScenarioOnUnprivilegedPod(ctx, s,
 		"systemctl cat emit-kubelet-active-flags.service 2>/dev/null")
@@ -1244,7 +1204,7 @@ func ValidateKubeletActiveFlagsEvent(ctx context.Context, s *Scenario) error {
 		return fmt.Errorf("check whether emit-kubelet-active-flags.service exists: %w", err)
 	}
 	if serviceCheck.exitCode != "0" {
-		s.T.Log("emit-kubelet-active-flags.service not on this VHD, skipping validation")
+		s.Logger.Log("emit-kubelet-active-flags.service not on this VHD, skipping validation")
 		return nil
 	}
 	command := []string{
@@ -1336,7 +1296,7 @@ func ValidateNoFailedSystemdUnits(ctx context.Context, s *Scenario) error {
 		}
 		failedUnitLogs[unit.Name+".log"] = unitLogs.String()
 	}
-	if err := dumpFileMapToDir(s.T, failedUnitLogs); err != nil {
+	if err := dumpFileMapToDir(s.testName, failedUnitLogs); err != nil {
 		errs = append(errs, fmt.Errorf("dump failed systemd unit logs: %w", err))
 	}
 
@@ -1350,7 +1310,6 @@ func ValidateNoFailedSystemdUnits(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateUlimitSettings(ctx context.Context, s *Scenario, ulimits map[string]string) error {
-	s.T.Helper()
 	ulimitKeys := make([]string, 0, len(ulimits))
 	for k := range ulimits {
 		ulimitKeys = append(ulimitKeys, k)
@@ -1370,7 +1329,6 @@ func ValidateUlimitSettings(ctx context.Context, s *Scenario, ulimits map[string
 }
 
 func ValidateInstalledPackageVersion(ctx context.Context, s *Scenario, component, version string) error {
-	s.T.Helper()
 	var installedCommand string
 	switch s.VHD.OS {
 	case config.OSUbuntu:
@@ -1386,7 +1344,7 @@ func ValidateInstalledPackageVersion(ctx context.Context, s *Scenario, component
 	}
 	for _, line := range strings.Split(execResult.stdout, "\n") {
 		if strings.Contains(line, component) && strings.Contains(line, version) {
-			s.T.Logf("found %s %s in the installed packages", component, version)
+			s.Logger.Logf("found %s %s in the installed packages", component, version)
 			return nil
 		}
 	}
@@ -1394,7 +1352,6 @@ func ValidateInstalledPackageVersion(ctx context.Context, s *Scenario, component
 }
 
 func ValidateKubeletNodeIP(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	execResult, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, "sudo cat /etc/default/kubelet", 0, "could not read kubelet config")
 	if err != nil {
 		return fmt.Errorf("read kubelet config: %w", err)
@@ -1424,7 +1381,6 @@ func ValidateKubeletNodeIP(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateIMDSRestrictionRule(ctx context.Context, s *Scenario, table string) error {
-	s.T.Helper()
 	cmd := fmt.Sprintf("sudo iptables -t %s -S | grep -q 'AKS managed: added by AgentBaker ensureIMDSRestriction for IMDS restriction feature'", table)
 	if _, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, cmd, 0, "expected to find IMDS restriction rule, but did not"); err != nil {
 		return fmt.Errorf("check IMDS restriction rule in table %s: %w", table, err)
@@ -1433,7 +1389,6 @@ func ValidateIMDSRestrictionRule(ctx context.Context, s *Scenario, table string)
 }
 
 func ValidateMultipleKubeProxyVersionsExist(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	execResult, err := execScriptOnVMForScenario(ctx, s, "sudo ctr --namespace k8s.io images list | grep kube-proxy | awk '{print $1}' | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+'")
 	if err != nil {
 		return fmt.Errorf("list kube-proxy images: %w", err)
@@ -1456,13 +1411,12 @@ func ValidateMultipleKubeProxyVersionsExist(ctx context.Context, s *Scenario) er
 	case 1:
 		return fmt.Errorf("only one kube-proxy version exists: %v", versionMap)
 	default:
-		s.T.Logf("Multiple kube-proxy versions exist: %v", versionMap)
+		s.Logger.Logf("Multiple kube-proxy versions exist: %v", versionMap)
 		return nil
 	}
 }
 
 func ValidateKubeletHasNotStopped(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := "sudo journalctl -u kubelet"
 	execResult, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, command, 0, "could not retrieve kubelet logs with journalctl")
 	if err != nil {
@@ -1476,7 +1430,6 @@ func ValidateKubeletHasNotStopped(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateServicesDoNotRestartKubelet(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// grep all filesin /etc/systemd/system/ for /restart\s+kubelet/ and count results
 	command := "sudo grep -rl 'restart[[:space:]]\\+kubelet' /etc/systemd/system/"
 	if _, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, command, 1, "expected to find no services containing 'restart kubelet' in /etc/systemd/system/"); err != nil {
@@ -1487,7 +1440,6 @@ func ValidateServicesDoNotRestartKubelet(ctx context.Context, s *Scenario) error
 
 // ValidateKubeletHasFlags checks kubelet is started with the right flags and configs.
 func ValidateKubeletHasFlags(ctx context.Context, s *Scenario, filePath string) error {
-	s.T.Helper()
 	execResult, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, "sudo journalctl -u kubelet", 0, "could not retrieve kubelet logs with journalctl")
 	if err != nil {
 		return fmt.Errorf("retrieve kubelet logs with journalctl: %w", err)
@@ -1497,7 +1449,6 @@ func ValidateKubeletHasFlags(ctx context.Context, s *Scenario, filePath string) 
 }
 
 func ValidateContainerd2Properties(ctx context.Context, s *Scenario, versions []string) error {
-	s.T.Helper()
 	if err := assert.Equal(len(versions), 1, "expected exactly one version for moby-containerd but got %d", len(versions)); err != nil {
 		return err
 	}
@@ -1539,7 +1490,6 @@ func ValidateContainerRuntimePlugins(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateNPDGPUCountPlugin(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		// Check NPD GPU count plugin config exists
@@ -1552,13 +1502,12 @@ func ValidateNPDGPUCountPlugin(ctx context.Context, s *Scenario) error {
 }
 
 func validateNPDCondition(ctx context.Context, s *Scenario, conditionType, conditionReason string, conditionStatus corev1.ConditionStatus, conditionMessage, conditionMessageErr string) error {
-	s.T.Helper()
 	// Wait for NPD to report initial condition
 	var condition *corev1.NodeCondition
 	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 		node, err := s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
 		if err != nil {
-			s.T.Logf("Failed to get node %q: %v", s.Runtime.VM.KubeName, err)
+			s.Logger.Logf("Failed to get node %q: %v", s.Runtime.VM.KubeName, err)
 			return false, nil // Continue polling on transient errors
 		}
 
@@ -1590,14 +1539,12 @@ func validateNPDCondition(ctx context.Context, s *Scenario, conditionType, condi
 }
 
 func ValidateNPDGPUCountCondition(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Validate that NPD is reporting healthy GPU count
 	return validateNPDCondition(ctx, s, "GPUMissing", "NoGPUMissing", corev1.ConditionFalse,
 		"All GPUs are present", "expected GPUMissing message to indicate correct count")
 }
 
 func ValidateNPDGPUCountAfterFailure(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		// Stop all services that are holding on to the GPUs
@@ -1634,14 +1581,12 @@ func ValidateNPDGPUCountAfterFailure(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateNPDIBLinkFlappingCondition(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Validate that NPD is reporting no IB link flapping
 	return validateNPDCondition(ctx, s, "IBLinkFlapping", "NoIBLinkFlapping", corev1.ConditionFalse,
 		"IB link is stable", "expected IBLinkFlapping message to indicate no flapping")
 }
 
 func ValidateNPDIBLinkFlappingAfterFailure(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Simulate IB link flapping
 	command := []string{
 		"set -ex",
@@ -1662,7 +1607,6 @@ func ValidateNPDIBLinkFlappingAfterFailure(ctx context.Context, s *Scenario) err
 }
 
 func ValidateNPDUnhealthyNvidiaDevicePlugin(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		// Check NPD unhealthy Nvidia device plugin config exists
@@ -1675,14 +1619,12 @@ func ValidateNPDUnhealthyNvidiaDevicePlugin(ctx context.Context, s *Scenario) er
 }
 
 func ValidateNPDUnhealthyNvidiaDevicePluginCondition(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Validate that NPD is reporting healthy Nvidia device plugin
 	return validateNPDCondition(ctx, s, "UnhealthyNvidiaDevicePlugin", "HealthyNvidiaDevicePlugin", corev1.ConditionFalse,
 		"NVIDIA device plugin is running properly", "expected UnhealthyNvidiaDevicePlugin message to indicate healthy status")
 }
 
 func ValidateNPDUnhealthyNvidiaDevicePluginAfterFailure(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Stop Nvidia device plugin systemd service to simulate failure
 	command := []string{
 		"set -ex",
@@ -1709,7 +1651,6 @@ func ValidateNPDUnhealthyNvidiaDevicePluginAfterFailure(ctx context.Context, s *
 }
 
 func ValidateNPDUnhealthyNvidiaDCGMServices(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		// Check NPD unhealthy Nvidia DCGM services config exists
@@ -1722,14 +1663,12 @@ func ValidateNPDUnhealthyNvidiaDCGMServices(ctx context.Context, s *Scenario) er
 }
 
 func ValidateNPDUnhealthyNvidiaDCGMServicesCondition(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Validate that NPD is reporting healthy Nvidia DCGM services
 	return validateNPDCondition(ctx, s, "UnhealthyNvidiaDCGMServices", "HealthyNvidiaDCGMServices", corev1.ConditionFalse,
 		"NVIDIA DCGM services are running properly", "expected UnhealthyNvidiaDCGMServices message to indicate healthy status")
 }
 
 func ValidateNPDUnhealthyNvidiaDCGMServicesAfterFailure(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Stop nvidia-dcgm systemd service to simulate failure
 	command := []string{
 		"set -ex",
@@ -1770,7 +1709,6 @@ func ValidateNPDUnhealthyNvidiaDCGMServicesAfterFailure(ctx context.Context, s *
 }
 
 func ValidateNPDHealthyNvidiaGridLicenseStatus(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		// Check NPD unhealthy Nvidia GRID license check config exists
@@ -1785,7 +1723,6 @@ func ValidateNPDHealthyNvidiaGridLicenseStatus(ctx context.Context, s *Scenario)
 }
 
 func ValidateNPDUnhealthyNvidiaGridLicenseStatusAfterFailure(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Stop nvidia-gridd systemd service to simulate failure
 	command := []string{
 		"set -ex",
@@ -1812,7 +1749,6 @@ func ValidateNPDUnhealthyNvidiaGridLicenseStatusAfterFailure(ctx context.Context
 }
 
 func ValidateRuncVersion(ctx context.Context, s *Scenario, versions []string) error {
-	s.T.Helper()
 	if err := assert.Equal(len(versions), 1, "expected exactly one version for moby-runc but got %d", len(versions)); err != nil {
 		return err
 	}
@@ -1832,7 +1768,6 @@ func ValidateRuncVersion(ctx context.Context, s *Scenario, versions []string) er
 }
 
 func ValidateKubeletArgs(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	return ValidateWindowsProcessHasCliArguments(ctx, s, "kubelet.exe", []string{"--rotate-certificates=true", "--client-ca-file=c:\\k\\ca.crt", "--windows-priorityclass=ABOVE_NORMAL_PRIORITY_CLASS"})
 }
 
@@ -1840,7 +1775,6 @@ func ValidateKubeletArgs(ctx context.Context, s *Scenario) error {
 // with nssm's AppPriority set to ABOVE_NORMAL_PRIORITY_CLASS, and that the running containerd
 // process actually has that OS process priority class applied.
 func ValidateContainerdWindowsPriorityClass(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	nssmCommand := strings.Join([]string{
 		"$ErrorActionPreference = 'Stop'",
 		"& \"c:\\k\\nssm.exe\" get containerd AppPriority",
@@ -1911,7 +1845,6 @@ func validateWindowsProccessArgumentString(ctx context.Context, s *Scenario, pro
 }
 
 func ValidateWindowsVersionFromWindowsSettings(ctx context.Context, s *Scenario, windowsVersion string) error {
-	s.T.Helper()
 	steps := []string{
 		"(Get-ItemProperty -Path \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\" -Name BuildLabEx).BuildLabEx",
 	}
@@ -1927,14 +1860,13 @@ func ValidateWindowsVersionFromWindowsSettings(ctx context.Context, s *Scenario,
 	}
 	podExecResultStdout := strings.TrimSpace(podExecResult.stdout)
 
-	s.T.Logf("Found windows version in windows_settings: \"%s\": \"%s\" (\"%s\")", windowsVersion, osMajorVersion, osVersion)
-	s.T.Logf("Windows version returned from VM \"%s\"", podExecResultStdout)
+	s.Logger.Logf("Found windows version in windows_settings: \"%s\": \"%s\" (\"%s\")", windowsVersion, osMajorVersion, osVersion)
+	s.Logger.Logf("Windows version returned from VM \"%s\"", podExecResultStdout)
 
 	return assert.Contains(podExecResultStdout, osMajorVersion)
 }
 
 func ValidateWindowsProductName(ctx context.Context, s *Scenario, productName string) error {
-	s.T.Helper()
 	steps := []string{
 		"(Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").ProductName",
 	}
@@ -1953,7 +1885,6 @@ func ValidateWindowsProductName(ctx context.Context, s *Scenario, productName st
 // TLS 1.2 is enabled, TLS 1.0/1.1 and SSLv2/SSLv3 are disabled, RC4 is disabled, and the configured
 // cipher suite order does not include any 64-bit block ciphers (3DES/DES/RC2).
 func ValidateWindowsSecureTLSEnabled(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	steps := []string{
 		"$ErrorActionPreference = 'Stop'",
 		"$tls12ClientEnabled = (Get-ItemProperty -Path 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\SCHANNEL\\Protocols\\TLS 1.2\\Client' -Name Enabled).Enabled",
@@ -2012,7 +1943,6 @@ func ValidateWindowsSecureTLSEnabled(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateWindowsDisplayVersion(ctx context.Context, s *Scenario, displayVersion string) error {
-	s.T.Helper()
 	steps := []string{
 		"(Get-ItemProperty \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\").DisplayVersion",
 	}
@@ -2023,7 +1953,7 @@ func ValidateWindowsDisplayVersion(ctx context.Context, s *Scenario, displayVers
 	}
 	podExecResultStdout := strings.TrimSpace(podExecResult.stdout)
 
-	s.T.Logf("Windows display version returned from VM \"%s\". Expected display version \"%s\"", podExecResultStdout, displayVersion)
+	s.Logger.Logf("Windows display version returned from VM \"%s\". Expected display version \"%s\"", podExecResultStdout, displayVersion)
 
 	return assert.Contains(podExecResultStdout, displayVersion)
 }
@@ -2034,17 +1964,14 @@ func getWindowsSettingsJson() []byte {
 }
 
 func ValidateCiliumIsRunningWindows(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	return ValidateJsonFileHasField(ctx, s, "/k/azurecni/netconf/10-azure.conflist", "plugins.ipam.type", "azure-cns")
 }
 
 func ValidateCiliumIsNotRunningWindows(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	return ValidateJsonFileDoesNotHaveField(ctx, s, "/k/azurecni/netconf/10-azure.conflist", "plugins.ipam.type", "azure-cns")
 }
 
 func ValidateWindowsCiliumIsRunning(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	var errs []error
 
 	expectedServices := []string{"ebpfcore", "netebpfext", "neteventebpfext", "xdp", "wtc", "hns"}
@@ -2060,7 +1987,6 @@ func ValidateWindowsCiliumIsRunning(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateWindowsCiliumIsNotRunning(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// some of the services used by windows cilium are dependencies of other services, so they may be running even if cilium is not
 	// for example, ebpfcore is used by Guest Proxy Agent (GPA), so it may be running even if cilium is not
 	// so, we only check that cilium-specific dlls are not loaded, as that is a stronger indication that cilium is not running
@@ -2073,7 +1999,6 @@ func ValidateWindowsCiliumIsNotRunning(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateDllLoadedWindows(ctx context.Context, s *Scenario, dllName string) error {
-	s.T.Helper()
 	loaded, err := dllLoadedWindows(ctx, s, dllName)
 	if err != nil {
 		return fmt.Errorf("check whether DLL %s is loaded: %w", dllName, err)
@@ -2082,7 +2007,6 @@ func ValidateDllLoadedWindows(ctx context.Context, s *Scenario, dllName string) 
 }
 
 func ValidateDllIsNotLoadedWindows(ctx context.Context, s *Scenario, dllName string) error {
-	s.T.Helper()
 	loaded, err := dllLoadedWindows(ctx, s, dllName)
 	if err != nil {
 		return fmt.Errorf("check whether DLL %s is loaded: %w", dllName, err)
@@ -2091,7 +2015,6 @@ func ValidateDllIsNotLoadedWindows(ctx context.Context, s *Scenario, dllName str
 }
 
 func ValidateJsonFileHasField(ctx context.Context, s *Scenario, fileName string, jsonPath string, expectedValue string) error {
-	s.T.Helper()
 	got, err := GetFieldFromJsonObjectOnNode(ctx, s, fileName, jsonPath)
 	if err != nil {
 		return fmt.Errorf("get field %s from json file %s: %w", jsonPath, fileName, err)
@@ -2100,7 +2023,6 @@ func ValidateJsonFileHasField(ctx context.Context, s *Scenario, fileName string,
 }
 
 func ValidateJsonFileDoesNotHaveField(ctx context.Context, s *Scenario, fileName string, jsonPath string, valueNotToBe string) error {
-	s.T.Helper()
 	got, err := GetFieldFromJsonObjectOnNode(ctx, s, fileName, jsonPath)
 	if err != nil {
 		return fmt.Errorf("get field %s from json file %s: %w", jsonPath, fileName, err)
@@ -2124,7 +2046,6 @@ func GetFieldFromJsonObjectOnNode(ctx context.Context, s *Scenario, fileName str
 
 // ValidateTaints checks if the node has the expected taints that are set in the kubelet config with --register-with-taints flag
 func ValidateTaints(ctx context.Context, s *Scenario, expectedTaints string) error {
-	s.T.Helper()
 	node, err := s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("get node %q: %w", s.Runtime.VM.KubeName, err)
@@ -2142,7 +2063,6 @@ func ValidateTaints(ctx context.Context, s *Scenario, expectedTaints string) err
 
 // ValidateLocalDNSService checks if the localdns service is in the expected state (enabled or disabled).
 func ValidateLocalDNSService(ctx context.Context, s *Scenario, state string) error {
-	s.T.Helper()
 	serviceName := "localdns"
 
 	var script string
@@ -2187,7 +2107,6 @@ test "$enabled" = "disabled" || { echo "expected disabled, got $enabled"; exit 1
 // ValidateLocalDNSResolution checks if the DNS resolution for an external domain is successful from localdns clusterlistenerIP.
 // It uses the 'dig' command to check the DNS resolution and expects a successful response.
 func ValidateLocalDNSResolution(ctx context.Context, s *Scenario, server string) error {
-	s.T.Helper()
 	testdomain := "bing.com"
 	command := fmt.Sprintf("dig %s +timeout=1 +tries=1", testdomain)
 	execResult, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, command, 0, "dns resolution failed")
@@ -2205,7 +2124,6 @@ func ValidateLocalDNSResolution(ctx context.Context, s *Scenario, server string)
 // can rotate between queries. We verify presence, not exact IP matching.
 // The hosts file is populated asynchronously by the aks-localdns-hosts-setup timer/service, so we poll with a timeout.
 func ValidateLocalDNSHostsFile(ctx context.Context, s *Scenario, fqdns []string) error {
-	s.T.Helper()
 	// Build script that polls until all FQDNs have at least one IPv4 entry in hosts file
 	script := fmt.Sprintf(`set -euo pipefail
 hosts_file="/etc/localdns/hosts"
@@ -2283,7 +2201,6 @@ func quoteFQDNsForBash(fqdns []string) string {
 // ValidateAKSLocalDNSHostsSetupService checks that aks-localdns-hosts-setup.service ran successfully
 // and the aks-localdns-hosts-setup.timer is active to ensure periodic refresh of /etc/localdns/hosts.
 func ValidateAKSLocalDNSHostsSetupService(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Check that aks-localdns-hosts-setup.service (oneshot) completed without failure
 	if err := ValidateSystemdUnitIsNotFailed(ctx, s, "aks-localdns-hosts-setup.service"); err != nil {
 		return err
@@ -2302,11 +2219,10 @@ func ValidateAKSLocalDNSHostsSetupService(ctx context.Context, s *Scenario) erro
 // We intentionally do NOT assert on DNS flags (AA, RA) because CoreDNS can set these
 // regardless of which plugin served the response.
 func ValidateLocalDNSHostsPluginBypass(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Step 1: Verify the node has the hosts plugin annotation
 	// The annotation is set asynchronously by localdns.sh (background job waiting for kubeconfig + node registration)
 	// Poll for up to 5 minutes with exponential backoff to avoid flaky failures
-	s.T.Log("Polling for node annotation kubernetes.azure.com/localdns-hosts-plugin=enabled...")
+	s.Logger.Log("Polling for node annotation kubernetes.azure.com/localdns-hosts-plugin=enabled...")
 	annotationKey := "kubernetes.azure.com/localdns-hosts-plugin"
 
 	var node *corev1.Node
@@ -2323,12 +2239,12 @@ func ValidateLocalDNSHostsPluginBypass(ctx context.Context, s *Scenario) error {
 
 		annotationValue, exists = node.Annotations[annotationKey]
 		if exists && annotationValue == "enabled" {
-			s.T.Logf("✓ Node annotation %s=%s found after %d attempts", annotationKey, annotationValue, attempt)
+			s.Logger.Logf("✓ Node annotation %s=%s found after %d attempts", annotationKey, annotationValue, attempt)
 			break
 		}
 
 		if attempt == maxAttempts {
-			s.T.Logf("WARNING: node %q annotation %q not found or not 'enabled' after %d attempts (~5 minutes). Current value: exists=%v, value=%q. Annotation is best-effort in production, continuing with stronger validators.",
+			s.Logger.Logf("WARNING: node %q annotation %q not found or not 'enabled' after %d attempts (~5 minutes). Current value: exists=%v, value=%q. Annotation is best-effort in production, continuing with stronger validators.",
 				s.Runtime.VM.KubeName, annotationKey, maxAttempts, exists, annotationValue)
 		}
 
@@ -2337,12 +2253,12 @@ func ValidateLocalDNSHostsPluginBypass(ctx context.Context, s *Scenario) error {
 		if sleepDuration > 10*time.Second {
 			sleepDuration = 10 * time.Second
 		}
-		s.T.Logf("Attempt %d/%d: annotation not ready (exists=%v, value=%q), retrying in %v...", attempt, maxAttempts, exists, annotationValue, sleepDuration)
+		s.Logger.Logf("Attempt %d/%d: annotation not ready (exists=%v, value=%q), retrying in %v...", attempt, maxAttempts, exists, annotationValue, sleepDuration)
 		time.Sleep(sleepDuration)
 	}
 
 	// Step 2: Verify the Corefile has the hosts plugin configured
-	s.T.Log("Verifying Corefile contains hosts plugin configuration...")
+	s.Logger.Log("Verifying Corefile contains hosts plugin configuration...")
 	corefileCheckScript := `set -euo pipefail
 corefile="/opt/azure/containers/localdns/updated.localdns.corefile"
 
@@ -2399,7 +2315,7 @@ echo "=== Corefile validation successful ==="
 	// it's a real FQDN that aks-localdns-hosts-setup.service populates from the NBC's CriticalFQDNs list.
 	// This avoids race conditions with the aks-localdns-hosts-setup.timer overwriting fake test entries.
 	testFQDN := s.GetDefaultFQDNsForValidation()[0]
-	s.T.Logf("Testing hosts plugin resolves %s from /etc/localdns/hosts with matching IPs", testFQDN)
+	s.Logger.Logf("Testing hosts plugin resolves %s from /etc/localdns/hosts with matching IPs", testFQDN)
 
 	script := fmt.Sprintf(`set -euo pipefail
 test_fqdn=%q
@@ -2483,8 +2399,7 @@ echo "  Resolved IPs match /etc/localdns/hosts entries"
 //  2. Query localdns for AAAA records for that FQDN
 //  3. Verify the returned IPv6 addresses match the hosts file entries
 func ValidateLocalDNSHostsPluginIPv6(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-	s.T.Log("Testing hosts plugin serves IPv6 entries from hosts file")
+	s.Logger.Log("Testing hosts plugin serves IPv6 entries from hosts file")
 
 	script := `set -euo pipefail
 hosts_file="/etc/localdns/hosts"
@@ -2577,8 +2492,7 @@ echo "IPv6 entries in hosts file are correctly served by CoreDNS hosts plugin"
 //  4. Wait for CoreDNS reload (5s), verify canary resolves (hosts plugin picks up new file)
 //  5. Restore original hosts file and stop/start localdns to leave node in clean state
 func ValidateLocalDNSHostsPluginColdStart(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-	s.T.Log("Testing localdns cold start with empty hosts file then population")
+	s.Logger.Log("Testing localdns cold start with empty hosts file then population")
 
 	script := `#!/bin/bash
 set -euo pipefail
@@ -2822,7 +2736,6 @@ echo "  2. Hosts file populated later: CoreDNS picks it up via reload"
 //     unit, for faster dispatch - see baker.go boothookTemplate), with stdout/stderr redirected to
 //     /var/log/azure/aks-node-controller.output.
 func ValidateANCLauncherOutput(ctx context.Context, s *Scenario, expectedContent string) error {
-	s.T.Helper()
 	if s.VHD.Flatcar {
 		return ValidateJournalctlOutput(ctx, s, "aks-node-controller.service", expectedContent)
 	}
@@ -2831,7 +2744,6 @@ func ValidateANCLauncherOutput(ctx context.Context, s *Scenario, expectedContent
 
 // ValidateJournalctlOutput checks if specific content exists in the systemd service logs
 func ValidateJournalctlOutput(ctx context.Context, s *Scenario, serviceName string, expectedContent string) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		// Get the service logs and check for the expected content
@@ -2857,8 +2769,7 @@ func ValidateNodeProblemDetector(ctx context.Context, s *Scenario) error {
 }
 
 func RestartNodeProblemDetector(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-	s.T.Log("restarting node-problem-detector to pick up managed GPU health checks")
+	s.Logger.Log("restarting node-problem-detector to pick up managed GPU health checks")
 	command := []string{
 		"set -ex",
 		"sudo systemctl restart node-problem-detector",
@@ -2871,7 +2782,6 @@ func RestartNodeProblemDetector(ctx context.Context, s *Scenario) error {
 }
 
 func ValidateNodeExporter(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	skipFile := "/etc/node-exporter.d/skip_vhd_node_exporter"
 	serviceName := "node-exporter.service"
 
@@ -2883,11 +2793,11 @@ func ValidateNodeExporter(ctx context.Context, s *Scenario) error {
 		return fmt.Errorf("check existence of file %s: %w", skipFile, err)
 	}
 	if !exists {
-		s.T.Logf("Skipping node-exporter validation: sentinel file %s not found (VHD does not have node-exporter installed)", skipFile)
+		s.Logger.Logf("Skipping node-exporter validation: sentinel file %s not found (VHD does not have node-exporter installed)", skipFile)
 		return nil
 	}
 
-	s.T.Logf("skip_vhd_node_exporter sentinel file found, validating node-exporter installation")
+	s.Logger.Logf("skip_vhd_node_exporter sentinel file found, validating node-exporter installation")
 
 	// Validate service is running
 	var errs []error
@@ -2914,7 +2824,7 @@ func ValidateNodeExporter(ctx context.Context, s *Scenario) error {
 
 	// Validate the metrics contract consumed by the AKS Prometheus default profile. Scrape the node IP directly
 	// so this also verifies that the endpoint is reachable on the address used by monitoring infrastructure.
-	s.T.Logf("Validating node-exporter metrics on port 19100")
+	s.Logger.Logf("Validating node-exporter metrics on port 19100")
 	metricsURL := fmt.Sprintf("http://%s:19100/metrics", s.Runtime.VM.PrivateIP)
 	errs = append(errs, scrapeAndValidateNodeExporter(ctx, s, metricsURL))
 
@@ -2926,12 +2836,11 @@ func ValidateNodeExporter(ctx context.Context, s *Scenario) error {
 	if err := errors.Join(errs...); err != nil {
 		return err
 	}
-	s.T.Logf("node-exporter validation passed")
+	s.Logger.Logf("node-exporter validation passed")
 	return nil
 }
 
 func scrapeAndValidateNodeExporter(ctx context.Context, s *Scenario, metricsURL string) error {
-	s.T.Helper()
 	result, err := execScriptOnVMForScenario(ctx, s, fmt.Sprintf("curl --noproxy '*' -sS --max-time 10 %q", metricsURL))
 	if err != nil {
 		return fmt.Errorf("scrape node-exporter metrics from %s: %w", metricsURL, err)
@@ -2970,7 +2879,7 @@ func ValidateNPDFilesystemCorruption(ctx context.Context, s *Scenario) (err erro
 	if err != nil {
 		return fmt.Errorf("read NPD filesystem corruption plugin config and script: %w", err)
 	}
-	s.T.Logf("NPD filesystem corruption plugin config and script:\nstdout:\n%s\nstderr:\n%s", diagResult.stdout, diagResult.stderr)
+	s.Logger.Logf("NPD filesystem corruption plugin config and script:\nstdout:\n%s\nstderr:\n%s", diagResult.stdout, diagResult.stderr)
 
 	// Simulate filesystem corruption by replacing the check script with one that
 	// always reports corruption. This is the most reliable approach because:
@@ -3001,7 +2910,7 @@ func ValidateNPDFilesystemCorruption(ctx context.Context, s *Scenario) (err erro
 			err = errors.Join(err, fmt.Errorf("restore original check_fs_corruption.sh: %w", restoreErr))
 			return
 		}
-		s.T.Logf("Restored original check_fs_corruption.sh:\nstdout:\n%s\nstderr:\n%s", restoreResult.stdout, restoreResult.stderr)
+		s.Logger.Logf("Restored original check_fs_corruption.sh:\nstdout:\n%s\nstderr:\n%s", restoreResult.stdout, restoreResult.stderr)
 	}()
 
 	// Verify the replacement script works correctly
@@ -3015,7 +2924,7 @@ func ValidateNPDFilesystemCorruption(ctx context.Context, s *Scenario) (err erro
 	if err != nil {
 		return fmt.Errorf("verify simulated filesystem corruption: %w", err)
 	}
-	s.T.Logf("Simulation verification:\nstdout:\n%s\nstderr:\n%s", verifyResult.stdout, verifyResult.stderr)
+	s.Logger.Logf("Simulation verification:\nstdout:\n%s\nstderr:\n%s", verifyResult.stdout, verifyResult.stderr)
 
 	// Wait for NPD to detect the problem. NPD's custom plugin monitor polls
 	// every 5 minutes. With continuous simulation, the first check cycle after
@@ -3024,7 +2933,7 @@ func ValidateNPDFilesystemCorruption(ctx context.Context, s *Scenario) (err erro
 	err = wait.PollUntilContextTimeout(ctx, 10*time.Second, 8*time.Minute, true, func(ctx context.Context) (bool, error) {
 		node, err := s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
 		if err != nil {
-			s.T.Logf("Failed to get node %q: %v", s.Runtime.VM.KubeName, err)
+			s.Logger.Logf("Failed to get node %q: %v", s.Runtime.VM.KubeName, err)
 			return false, nil // Continue polling on transient errors
 		}
 
@@ -3050,13 +2959,12 @@ func ValidateNPDFilesystemCorruption(ctx context.Context, s *Scenario) (err erro
 }
 
 func ValidateEnableNvidiaResource(ctx context.Context, s *Scenario) error {
-	s.T.Logf("waiting for Nvidia GPU resource to be available")
+	s.Logger.Logf("waiting for Nvidia GPU resource to be available")
 	return waitUntilResourceAvailable(ctx, s, "nvidia.com/gpu")
 }
 
 func ValidateNvidiaDevicePluginServiceRunning(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-	s.T.Logf("validating that NVIDIA device plugin systemd service is running")
+	s.Logger.Logf("validating that NVIDIA device plugin systemd service is running")
 
 	command := []string{
 		"set -ex",
@@ -3070,8 +2978,7 @@ func ValidateNvidiaDevicePluginServiceRunning(ctx context.Context, s *Scenario) 
 }
 
 func ValidateNodeAdvertisesGPUResources(ctx context.Context, s *Scenario, gpuCountExpected int64, resourceName string) error {
-	s.T.Helper()
-	s.T.Logf("validating that node advertises GPU resources")
+	s.Logger.Logf("validating that node advertises GPU resources")
 
 	// First, wait for the GPU resource to be available
 	if err := waitUntilResourceAvailable(ctx, s, resourceName); err != nil {
@@ -3095,13 +3002,12 @@ func ValidateNodeAdvertisesGPUResources(ctx context.Context, s *Scenario, gpuCou
 	if err := assert.Equal(gpuCount, gpuCountExpected, "node should advertise %s=%d, but got %s=%d", resourceName, gpuCountExpected, resourceName, gpuCount); err != nil {
 		return err
 	}
-	s.T.Logf("node %s advertises %s=%d resources", nodeName, resourceName, gpuCount)
+	s.Logger.Logf("node %s advertises %s=%d resources", nodeName, resourceName, gpuCount)
 	return nil
 }
 
 func ValidateGPUWorkloadSchedulable(ctx context.Context, s *Scenario, gpuCount int, resourceName string) error {
-	s.T.Helper()
-	s.T.Logf("validating that GPU workloads can be scheduled")
+	s.Logger.Logf("validating that GPU workloads can be scheduled")
 
 	// Wait for resources to be available and add delay for device health
 	if err := waitUntilResourceAvailable(ctx, s, resourceName); err != nil {
@@ -3140,13 +3046,12 @@ func ValidateGPUWorkloadSchedulable(ctx context.Context, s *Scenario, gpuCount i
 		return fmt.Errorf("run GPU workload pod: %w", err)
 	}
 
-	s.T.Logf("GPU workload is schedulable and runs successfully")
+	s.Logger.Logf("GPU workload is schedulable and runs successfully")
 	return nil
 }
 
 // ValidatePubkeySSHDisabled validates that SSH with private key authentication is disabled by checking sshd_config
 func ValidatePubkeySSHDisabled(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Part 1. Use VMSS RunCommand to check sshd_config directly on the node
 	resp, err := RunCommand(ctx, s, `#!/bin/bash
 # Check if PubkeyAuthentication is disabled in sshd_config
@@ -3163,7 +3068,7 @@ fi`)
 		return fmt.Errorf("run command to check sshd_config: %w", err)
 	}
 	stdout := lo.FromPtr(resp.Output)
-	s.T.Logf("Run command stdout: %s\nstderr: %s", stdout, lo.FromPtr(resp.Error))
+	s.Logger.Logf("Run command stdout: %s\nstderr: %s", stdout, lo.FromPtr(resp.Error))
 
 	// Check if the command execution was successful by looking for our success message in the output
 	if err := assert.Contains(stdout, "SUCCESS: PubkeyAuthentication is disabled", "PubkeyAuthentication is not properly disabled"); err != nil {
@@ -3176,13 +3081,12 @@ fi`)
 		return err
 	}
 
-	s.T.Logf("PubkeyAuthentication is properly disabled as expected")
+	s.Logger.Logf("PubkeyAuthentication is properly disabled as expected")
 	return nil
 }
 
 // ValidateSSHServiceDisabled validates that the SSH daemon service is disabled and stopped on the node
 func ValidateSSHServiceDisabled(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Use VMSS RunCommand to check SSH service status directly on the node
 	// Ubuntu uses 'ssh' as service name, while AzureLinux and Mariner use 'sshd'
 	resp, err := RunCommand(ctx, s, `#!/bin/bash
@@ -3224,19 +3128,18 @@ fi`)
 		return fmt.Errorf("run command to check SSH service status: %w", err)
 	}
 	stdout := lo.FromPtr(resp.Output)
-	s.T.Logf("Run command stdout: %s\nstderr: %s", stdout, lo.FromPtr(resp.Error))
+	s.Logger.Logf("Run command stdout: %s\nstderr: %s", stdout, lo.FromPtr(resp.Error))
 
 	// Check if the command execution was successful by looking for our success message in the output
 	if err := assert.Contains(stdout, "SUCCESS: SSH service is disabled and stopped", "SSH service is not properly disabled and stopped"); err != nil {
 		return err
 	}
 
-	s.T.Logf("SSH service is properly disabled and stopped as expected")
+	s.Logger.Logf("SSH service is properly disabled and stopped as expected")
 	return nil
 }
 
 func ValidateNvidiaDCGMExporterSystemDServiceRunning(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		// Verify nvidia-dcgm service is running
@@ -3251,7 +3154,6 @@ func ValidateNvidiaDCGMExporterSystemDServiceRunning(ctx context.Context, s *Sce
 }
 
 func ValidateNvidiaDCGMExporterIsScrapable(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		// Check if nvidia-dcgm-exporter is scrapable on port 19400
@@ -3264,7 +3166,6 @@ func ValidateNvidiaDCGMExporterIsScrapable(ctx context.Context, s *Scenario) err
 }
 
 func ValidateNvidiaDCGMExporterScrapeCommonMetric(ctx context.Context, s *Scenario, metric string) error {
-	s.T.Helper()
 	command := []string{
 		"set -ex",
 		// Verify the most universal GPU metric is present
@@ -3277,8 +3178,7 @@ func ValidateNvidiaDCGMExporterScrapeCommonMetric(ctx context.Context, s *Scenar
 }
 
 func ValidateMIGModeEnabled(ctx context.Context, s *Scenario, gpuCountExpected int) error {
-	s.T.Helper()
-	s.T.Logf("validating that MIG mode is enabled on %d GPUs", gpuCountExpected)
+	s.Logger.Logf("validating that MIG mode is enabled on %d GPUs", gpuCountExpected)
 
 	command := []string{
 		"set -ex",
@@ -3290,7 +3190,7 @@ func ValidateMIGModeEnabled(ctx context.Context, s *Scenario, gpuCountExpected i
 	}
 
 	stdout := strings.TrimSpace(execResult.stdout)
-	s.T.Logf("MIG mode status: %s", stdout)
+	s.Logger.Logf("MIG mode status: %s", stdout)
 	gpuStatuses := strings.Split(stdout, "\n")
 	if err := assert.Equal(len(gpuStatuses), gpuCountExpected, "expected MIG status for %d GPUs, but got: %s", gpuCountExpected, stdout); err != nil {
 		return err
@@ -3302,13 +3202,12 @@ func ValidateMIGModeEnabled(ctx context.Context, s *Scenario, gpuCountExpected i
 	if err := errors.Join(errs...); err != nil {
 		return err
 	}
-	s.T.Logf("MIG mode is enabled on %d GPUs", gpuCountExpected)
+	s.Logger.Logf("MIG mode is enabled on %d GPUs", gpuCountExpected)
 	return nil
 }
 
 func ValidateMIGInstancesCreated(ctx context.Context, s *Scenario, migProfile string, instanceCountExpected int) error {
-	s.T.Helper()
-	s.T.Logf("validating that %d MIG instances are created with profile %s", instanceCountExpected, migProfile)
+	s.Logger.Logf("validating that %d MIG instances are created with profile %s", instanceCountExpected, migProfile)
 
 	command := []string{
 		"set -ex",
@@ -3333,14 +3232,13 @@ func ValidateMIGInstancesCreated(ctx context.Context, s *Scenario, migProfile st
 	if err := assert.Equal(instanceCount, instanceCountExpected, "expected %d MIG instances with profile %s, but found %d.\nOutput:\n%s", instanceCountExpected, migProfile, instanceCount, stdout); err != nil {
 		return err
 	}
-	s.T.Logf("%d MIG instances with profile %s are created", instanceCountExpected, migProfile)
+	s.Logger.Logf("%d MIG instances with profile %s are created", instanceCountExpected, migProfile)
 	return nil
 }
 
 // ValidateIPTablesCompatibleWithCiliumEBPF validates that all iptables rules in each table match the provided patterns which are accounted for
 // when eBPF host routing is enabled.
 func ValidateIPTablesCompatibleWithCiliumEBPF(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	tablePatterns, globalPatterns := getIPTablesRulesCompatibleWithEBPFHostRouting()
 	tables := []string{"filter", "mangle", "nat", "raw", "security"}
 	success := true
@@ -3394,7 +3292,7 @@ func ValidateIPTablesCompatibleWithCiliumEBPF(ctx context.Context, s *Scenario) 
 			}
 
 			if !matched {
-				s.T.Logf("Rule in table %s did not match any pattern: %s", table, rule)
+				s.Logger.Logf("Rule in table %s did not match any pattern: %s", table, rule)
 				success = false
 			}
 		}
@@ -3411,7 +3309,6 @@ func ValidateIPTablesCompatibleWithCiliumEBPF(ctx context.Context, s *Scenario) 
 
 // ValidateAppArmorBasic validates that AppArmor is running without requiring aa-status
 func ValidateAppArmorBasic(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Check if AppArmor module is enabled in the kernel
 	command := []string{
 		"set -ex",
@@ -3448,19 +3345,18 @@ func ValidateAppArmorBasic(ctx context.Context, s *Scenario) error {
 	return errors.Join(errs...)
 }
 
-func truncatePodName(t testing.TB, pod *corev1.Pod) {
+func truncatePodName(logger toolkit.Logger, pod *corev1.Pod) {
 	name := pod.Name
 	if len(pod.Name) < 63 {
 		return
 	}
 	pod.Name = pod.Name[:63]
 	pod.Name = strings.TrimRight(pod.Name, "-")
-	t.Logf("truncated pod name %q to %q", name, pod.Name)
+	logger.Logf("truncated pod name %q to %q", name, pod.Name)
 }
 
 // ValidateNodeHasLabel checks if the node has the expected label with the expected value
 func ValidateNodeHasLabel(ctx context.Context, s *Scenario, labelKey, expectedValue string) error {
-	s.T.Helper()
 	node, err := s.Runtime.Kube.Typed.CoreV1().Nodes().Get(ctx, s.Runtime.VM.KubeName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("get node %q: %w", s.Runtime.VM.KubeName, err)
@@ -3510,7 +3406,6 @@ func ValidateScriptlessNBCCSECmd(ctx context.Context, s *Scenario) error {
 
 // ValidateScriptlessPhase3 validates that there are not diffs between ANC generated cse cmd NBC cse cmd vars
 func ValidateScriptlessPhase3(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	if s.Runtime.AKSNodeConfig == nil || !usesScriptlessNBCCSECmd(s) {
 		return nil
 	}
@@ -3534,7 +3429,6 @@ func ValidateScriptlessPhase3(ctx context.Context, s *Scenario) error {
 // ValidateStaleCachedKubeBinariesRemoved validates that stale versioned kube binaries (e.g. kubelet-1.29.0, kubectl-1.29.0)
 // have been removed from /opt/bin/ after the correct version is installed.
 func ValidateStaleCachedKubeBinariesRemoved(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// List any remaining versioned kubelet/kubectl binaries in /opt/bin/
 	cmd := `find /opt/bin -maxdepth 1 \( -name "kubelet-*" -o -name "kubectl-*" \) -type f 2>/dev/null`
 	result, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, cmd, 0, "could not list stale cached binaries")
@@ -3547,7 +3441,6 @@ func ValidateStaleCachedKubeBinariesRemoved(ctx context.Context, s *Scenario) er
 
 // ValidateRxBufferDefault validates rx buffer config using default values based on VM's CPU count
 func ValidateRxBufferDefault(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	skipValidationForDistro := s.VHD.Distro == datamodel.AKSAzureLinuxV3Gen2 || s.VHD.Distro.IsACLDistro()
 
 	vmSKU := config.Config.DefaultVMSKU
@@ -3589,7 +3482,7 @@ func ValidateRxBufferDefault(ctx context.Context, s *Scenario) error {
 		expectedRx = "2048"
 	}
 
-	s.T.Logf("VM has %d CPUs, expecting rx buffer size: %s", cpuCount, expectedRx)
+	s.Logger.Logf("VM has %d CPUs, expecting rx buffer size: %s", cpuCount, expectedRx)
 
 	customNicConfig := map[string]string{
 		"rx": expectedRx,
@@ -3607,8 +3500,7 @@ func ValidateRxBufferDefault(ctx context.Context, s *Scenario) error {
 // ValidateMANAPCIDevice checks that the MANA PCI device is exposed to the VM.
 // MANA hardware is identified by PCI device ID 0x00ba (Microsoft Corporation).
 func ValidateMANAPCIDevice(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-	defer toolkit.LogStep(s.T, "validating MANA PCI device is present")()
+	defer toolkit.LogStep(s.Logger, "validating MANA PCI device is present")()
 	cmd := "grep -Rqi '^0x00ba$' /sys/bus/pci/devices/*/device 2>/dev/null"
 	if _, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, cmd, 0,
 		"MANA PCI device (0x00ba) not found in /sys/bus/pci/devices"); err != nil {
@@ -3621,8 +3513,7 @@ func ValidateMANAPCIDevice(ctx context.Context, s *Scenario) error {
 // in the running kernel. For built-in drivers they appear in modules.builtin;
 // for loadable modules they must be present in lsmod.
 func ValidateMANADriverLoaded(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-	defer toolkit.LogStep(s.T, "validating MANA kernel driver is loaded")()
+	defer toolkit.LogStep(s.Logger, "validating MANA kernel driver is loaded")()
 	cmd := `lsmod | grep -q '^mana ' || grep -q '/mana\.ko' /lib/modules/$(uname -r)/modules.builtin`
 	if _, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, cmd, 0,
 		"MANA kernel driver (mana) not found in lsmod or modules.builtin"); err != nil {
@@ -3634,8 +3525,7 @@ func ValidateMANADriverLoaded(ctx context.Context, s *Scenario) error {
 // ValidateAcceleratedNetworkingVFBonded checks that the accelerated networking
 // VF interface exists and is properly bonded to the primary eth0 interface.
 func ValidateAcceleratedNetworkingVFBonded(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-	defer toolkit.LogStep(s.T, "validating accelerated networking VF is bonded to eth0")()
+	defer toolkit.LogStep(s.Logger, "validating accelerated networking VF is bonded to eth0")()
 	// Look for any interface that has "master eth0" in ip link output,
 	// indicating it is bonded as a VF to the primary synthetic NIC.
 	cmd := `ip link show | grep 'master eth0'`
@@ -3644,15 +3534,14 @@ func ValidateAcceleratedNetworkingVFBonded(ctx context.Context, s *Scenario) err
 	if err != nil {
 		return fmt.Errorf("check accelerated networking VF bonding: %w", err)
 	}
-	s.T.Logf("Accelerated networking VF bonding: %s", strings.TrimSpace(result.stdout))
+	s.Logger.Logf("Accelerated networking VF bonding: %s", strings.TrimSpace(result.stdout))
 	return nil
 }
 
 // ValidateAcceleratedNetworkingVFHardware verifies the accelerated networking VF
 // is backed by a PCI function and bound to a kernel network driver.
 func ValidateAcceleratedNetworkingVFHardware(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-	defer toolkit.LogStep(s.T, "validating accelerated networking VF PCI hardware")()
+	defer toolkit.LogStep(s.Logger, "validating accelerated networking VF PCI hardware")()
 
 	cmd := strings.Join([]string{
 		"set -e",
@@ -3683,7 +3572,7 @@ func ValidateAcceleratedNetworkingVFHardware(ctx context.Context, s *Scenario) e
 	if err != nil {
 		return fmt.Errorf("check accelerated networking VF PCI hardware: %w", err)
 	}
-	s.T.Logf("Accelerated networking VF hardware: %s", strings.TrimSpace(result.stdout))
+	s.Logger.Logf("Accelerated networking VF hardware: %s", strings.TrimSpace(result.stdout))
 	return nil
 }
 
@@ -3694,7 +3583,6 @@ func ValidateAcceleratedNetworkingVFHardware(ctx context.Context, s *Scenario) e
 // - V5: enP* (e.g., enP30832p0s0)
 // - V6+: ens1 or enp0s0
 func ValidateMANAVFBonded(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	return ValidateAcceleratedNetworkingVFBonded(ctx, s)
 }
 
@@ -3704,8 +3592,7 @@ func ValidateMANAVFBonded(ctx context.Context, s *Scenario) error {
 // It sends HTTP requests from a pod to the node's default gateway and verifies
 // that the VF TX packet counters increase by at least that amount.
 func ValidateAcceleratedNetworkingTrafficFlowing(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-	defer toolkit.LogStep(s.T, "validating traffic is flowing through accelerated networking VF")()
+	defer toolkit.LogStep(s.Logger, "validating traffic is flowing through accelerated networking VF")()
 
 	const requestCount = 10
 	getVFTxPackets := `val=$(sudo ethtool -S eth0 | awk '/^[[:space:]]*vf_tx_packets:/{print $2; exit}'); [ -n "$val" ] && echo "$val" || { echo "vf_tx_packets not found in ethtool -S eth0 output" >&2; exit 1; }`
@@ -3719,7 +3606,7 @@ func ValidateAcceleratedNetworkingTrafficFlowing(ctx context.Context, s *Scenari
 	if err != nil {
 		return fmt.Errorf("parse vf_tx_packets before value %q: %w", resultBefore.stdout, err)
 	}
-	s.T.Logf("Accelerated networking VF tx packets before: %d", countBefore)
+	s.Logger.Logf("Accelerated networking VF tx packets before: %d", countBefore)
 
 	// Generate traffic from a pod on this node using curl to the node's default
 	// gateway. We use vf_tx_packets (not rx) so the test passes regardless of
@@ -3736,7 +3623,7 @@ func ValidateAcceleratedNetworkingTrafficFlowing(ctx context.Context, s *Scenari
 	if err := assert.NotEqual(gatewayIP, "", "default gateway IP is empty"); err != nil {
 		return err
 	}
-	s.T.Logf("Accelerated networking traffic test: using gateway %s as target", gatewayIP)
+	s.Logger.Logf("Accelerated networking traffic test: using gateway %s as target", gatewayIP)
 
 	// The "; true" ensures exit 0 regardless of curl's result — the gateway has
 	// no HTTP server so connections will fail, but TCP SYN packets still traverse
@@ -3758,7 +3645,7 @@ func ValidateAcceleratedNetworkingTrafficFlowing(ctx context.Context, s *Scenari
 	}
 
 	delta := countAfter - countBefore
-	s.T.Logf("Accelerated networking VF tx packets after: %d (delta: %d, expected >= %d)", countAfter, delta, requestCount)
+	s.Logger.Logf("Accelerated networking VF tx packets after: %d (delta: %d, expected >= %d)", countAfter, delta, requestCount)
 
 	return assert.Equal(delta >= requestCount, true,
 		"vf_tx_packets increased by %d but expected at least %d \u2014 traffic may not be flowing through the accelerated networking VF", delta, requestCount)
@@ -3767,7 +3654,6 @@ func ValidateAcceleratedNetworkingTrafficFlowing(ctx context.Context, s *Scenari
 // ValidateMANATrafficFlowing checks that network traffic is actually flowing through
 // the MANA Virtual Function rather than the slower synthetic (NetVSC) path.
 func ValidateMANATrafficFlowing(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	return ValidateAcceleratedNetworkingTrafficFlowing(ctx, s)
 }
 
@@ -3776,7 +3662,6 @@ func ValidateMANATrafficFlowing(ctx context.Context, s *Scenario) error {
 // the VF interface is bonded to eth0, PCI-backed and driver-bound, and traffic
 // is flowing through the VF.
 func ValidateMANA(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	if err := ValidateMANAPCIDevice(ctx, s); err != nil {
 		return err
 	}
@@ -3809,7 +3694,6 @@ func hasMANAHardware(ctx context.Context, s *Scenario) (bool, error) {
 // - Memory issues (OOM killer, page allocation failure, memory corruption)
 // - I/O and filesystem errors (I/O error, filesystem errors, nvme/ata/scsi errors)
 func ValidateKernelLogs(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	if s.VHD != nil && s.VHD.SkipOldVHDValidations {
 		return nil
 	}
@@ -3880,10 +3764,10 @@ func ValidateKernelLogs(ctx context.Context, s *Scenario) error {
 			return fmt.Errorf("retrieve full kernel logs: %w", err)
 		}
 		logFileName := "kernel-log.txt"
-		if err := writeToFile(s.T, logFileName, fullDmesgResult.stdout); err != nil {
-			s.T.Logf("Warning: failed to write kernel log to file: %v", err)
+		if err := writeToFile(s.testName, logFileName, fullDmesgResult.stdout); err != nil {
+			s.Logger.Logf("Warning: failed to write kernel log to file: %v", err)
 		} else {
-			s.T.Logf("Full kernel log written to: %s/%s", testDir(s.T), logFileName)
+			s.Logger.Logf("Full kernel log written to: %s/%s", testDir(s.testName), logFileName)
 		}
 
 		// Log each category of issues found
@@ -3895,7 +3779,7 @@ func ValidateKernelLogs(ctx context.Context, s *Scenario) error {
 		return errors.New(summary.String())
 	}
 
-	s.T.Logf("No critical kernel issues found")
+	s.Logger.Logf("No critical kernel issues found")
 	return nil
 }
 
@@ -3905,15 +3789,14 @@ func ValidateKernelLogs(ctx context.Context, s *Scenario) error {
 // - No errors from ExtHandler
 // Skipped on Flatcar and OSGuard VHDs which manage WALinuxAgent independently.
 func ValidateWaagentLog(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	if s.VHD.Flatcar || strings.Contains(string(s.VHD.Distro), "osguard") || s.VHD.SkipOldVHDValidations {
-		s.T.Logf("Skipping waagent log validation: not applicable for %s", s.VHD.Distro)
+		s.Logger.Logf("Skipping waagent log validation: not applicable for %s", s.VHD.Distro)
 		return nil
 	}
 
 	versions := components.GetExpectedPackageVersions("walinuxagent", "default", "current")
 	if len(versions) == 0 || versions[0] == "<SKIP>" {
-		s.T.Log("Skipping waagent log validation: no walinuxagent version in components.json")
+		s.Logger.Log("Skipping waagent log validation: no walinuxagent version in components.json")
 		return nil
 	}
 	expectedVersion := versions[0]
@@ -3962,10 +3845,10 @@ func ValidateWaagentLog(ctx context.Context, s *Scenario) error {
 	errOutput := strings.TrimSpace(extHandlerErrors.stdout)
 	if errOutput != "" {
 		logFileName := "waagent-exthandler-errors.log"
-		if err := writeToFile(s.T, logFileName, logContents); err != nil {
-			s.T.Logf("Warning: failed to write waagent log to file: %v", err)
+		if err := writeToFile(s.testName, logFileName, logContents); err != nil {
+			s.Logger.Logf("Warning: failed to write waagent log to file: %v", err)
 		} else {
-			s.T.Logf("Full waagent log written to: %s/%s", testDir(s.T), logFileName)
+			s.Logger.Logf("Full waagent log written to: %s/%s", testDir(s.testName), logFileName)
 		}
 		errs = append(errs, fmt.Errorf("ExtHandler errors found in waagent.log:\n%s", errOutput))
 	}
@@ -3973,14 +3856,13 @@ func ValidateWaagentLog(ctx context.Context, s *Scenario) error {
 	if err := errors.Join(errs...); err != nil {
 		return err
 	}
-	s.T.Logf("waagent.log validation passed: WALinuxAgent-%s running correctly with no ExtHandler errors", expectedVersion)
+	s.Logger.Logf("waagent.log validation passed: WALinuxAgent-%s running correctly with no ExtHandler errors", expectedVersion)
 	return nil
 }
 
 // ValidateCollectWindowsLogsScript runs c:\k\debug\collect-windows-logs.ps1 on the node
 // and verifies that a zip archive was produced by the script.
 func ValidateCollectWindowsLogsScript(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	command := []string{
 		"$ErrorActionPreference = \"Stop\"",
 		"cd c:/",
@@ -4022,9 +3904,8 @@ func ValidateCollectWindowsLogsScript(ctx context.Context, s *Scenario) error {
 // To add a new CVE mitigation, append the module name to BOTH lists below —
 // the absence-check list AND the default presence + load-refusal list.
 func ValidateVulnerableKernelModulesDisabled(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	if s.VHD.Flatcar && s.VHD.OS != config.OSACL {
-		s.T.Log("Skipping vulnerable kernel module validation: not applicable for Flatcar")
+		s.Logger.Log("Skipping vulnerable kernel module validation: not applicable for Flatcar")
 		return nil
 	}
 
@@ -4147,7 +4028,6 @@ func kernelModuleFullBlockValidationScript() string {
 // This avoids hardcoding "eth1" which can be wrong when SR-IOV VFs or predictable
 // naming (ens*/enP*) are in use.
 func resolveSecondaryNICName(ctx context.Context, s *Scenario) (string, error) {
-	s.T.Helper()
 	// Get the secondary NIC's MAC from IMDS, then look it up in sysfs.
 	// -sf makes curl fail with non-zero exit on HTTP errors (403/404) instead
 	// of silently returning the error body as the "MAC".
@@ -4170,7 +4050,6 @@ func resolveSecondaryNICName(ctx context.Context, s *Scenario) (string, error) {
 
 // ValidateSecondaryNICUp checks that the given network interface is UP and has an IPv4 address.
 func ValidateSecondaryNICUp(ctx context.Context, s *Scenario, ifaceName string) error {
-	s.T.Helper()
 	cmd := fmt.Sprintf("ip addr show %s", ifaceName)
 	result, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, cmd, 0,
 		fmt.Sprintf("failed to get interface info for %s", ifaceName))
@@ -4187,7 +4066,6 @@ func ValidateSecondaryNICUp(ctx context.Context, s *Scenario, ifaceName string) 
 
 // ValidateSecondaryNICDualStack checks that the given network interface is UP and has both IPv4 and IPv6 addresses.
 func ValidateSecondaryNICDualStack(ctx context.Context, s *Scenario, ifaceName string) error {
-	s.T.Helper()
 	cmd := fmt.Sprintf("ip addr show %s", ifaceName)
 	result, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, cmd, 0,
 		fmt.Sprintf("failed to get interface info for %s", ifaceName))
@@ -4207,8 +4085,7 @@ func ValidateSecondaryNICDualStack(ctx context.Context, s *Scenario, ifaceName s
 }
 
 func ValidateDraDriverNvidiaGpuServiceRunning(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-	s.T.Logf("validating DRA driver NVIDIA GPU systemd service is running")
+	s.Logger.Logf("validating DRA driver NVIDIA GPU systemd service is running")
 
 	command := []string{
 		"set -ex",
@@ -4222,8 +4099,7 @@ func ValidateDraDriverNvidiaGpuServiceRunning(ctx context.Context, s *Scenario) 
 }
 
 func ValidateDRAWorkloadSchedulable(ctx context.Context, s *Scenario) (err error) {
-	s.T.Helper()
-	s.T.Logf("validating that DRA workloads can be scheduled")
+	s.Logger.Logf("validating that DRA workloads can be scheduled")
 
 	time.Sleep(20 * time.Second) // Same delay as existing GPU tests
 
@@ -4322,14 +4198,13 @@ func ValidateDRAWorkloadSchedulable(ctx context.Context, s *Scenario) (err error
 		return fmt.Errorf("run DRA workload pod: %w", err)
 	}
 
-	s.T.Logf("GPU workload is schedulable and runs successfully")
+	s.Logger.Logf("GPU workload is schedulable and runs successfully")
 	return nil
 }
 
 // ValidateRCV1PCertMode validates that the rcv1p certificate endpoint mode was used during
 // Linux node provisioning, certificates were downloaded and installed, and a refresh task was scheduled.
 func ValidateRCV1PCertMode(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	var errs []error
 	errs = append(errs,
 		// Validate the provisioning log shows rcv1p mode was selected
@@ -4385,7 +4260,6 @@ func rcv1pTrustStoreDir(s *Scenario) string {
 // ValidateRCV1PCertModeWindows validates that the rcv1p certificate endpoint mode was used during
 // Windows node provisioning, certificates were downloaded and installed, and a refresh task was scheduled.
 func ValidateRCV1PCertModeWindows(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	// Validate CA certificates were downloaded to C:\ca (matches Windows Get-CACertificates
 	// behavior; import into Cert:\LocalMachine\Root is handled out-of-band by the platform/
 	// refresh task, not by CSE).
@@ -4421,7 +4295,6 @@ func ValidateRCV1PCertModeWindows(ctx context.Context, s *Scenario) error {
 // wireserver returns IsOptedInForRootCerts=false and no certificates are installed,
 // even in the RCV1P subscription with PlatformSettingsOverride registered.
 func ValidateRCV1PNotOptedIn(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	var errs []error
 	errs = append(errs,
 		// Validate the provisioning log shows rcv1p mode was selected
@@ -4457,7 +4330,6 @@ func ValidateRCV1PNotOptedIn(ctx context.Context, s *Scenario) error {
 // no certificates are installed to C:\ca and no refresh scheduled task is registered,
 // even in the RCV1P subscription with PlatformSettingsOverride registered.
 func ValidateRCV1PNotOptedInWindows(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
 	errs := []error{
 		// Validate the provisioning log shows wireserver was queried
 		ValidateFileHasContent(ctx, s, "C:\\AzureData\\CustomDataSetupScript.log",
@@ -4495,7 +4367,6 @@ func ValidateRCV1PNotOptedInWindows(ctx context.Context, s *Scenario) error {
 
 // ValidateServiceInSlice asserts that the given systemd service is running in the expected slice.
 func ValidateServiceInSlice(ctx context.Context, s *Scenario, service, expectedSlice string) error {
-	s.T.Helper()
 	// Avoid accidental shell injection / option smuggling.
 	if !regexp.MustCompile(`^[A-Za-z0-9_.@:-]+$`).MatchString(service) {
 		return fmt.Errorf("invalid systemd unit name: %q", service)

--- a/e2e/validators_kata.go
+++ b/e2e/validators_kata.go
@@ -49,8 +49,6 @@ var kataRuntimeHandlers = []string{kataRuntimeHandler, kataPreviewRuntimeHandler
 // emit. If Kata is ever promoted to the V2 templates, this validator should fail loudly rather
 // than silently pass, which is why the plugin paths are asserted explicitly.
 func ValidateKataContainerdConfig(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-
 	if err := assert.Equal(s.VHD.Distro.IsKataDistro(), true,
 		"ValidateKataContainerdConfig requires a Kata distro, got %q", s.VHD.Distro); err != nil {
 		return err
@@ -71,8 +69,6 @@ func ValidateKataContainerdConfig(ctx context.Context, s *Scenario) error {
 // ValidateKataErofsContainerdConfig checks that the EROFS snapshotter is configured and that
 // containerd loaded all of its EROFS plugins successfully.
 func ValidateKataErofsContainerdConfig(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-
 	errs := []error{
 		ValidateFileHasContent(ctx, s, containerdConfigPath, `[plugins."io.containerd.snapshotter.v1.erofs"]`),
 	}
@@ -114,8 +110,6 @@ func ValidateKataErofsContainerdConfig(ctx context.Context, s *Scenario) error {
 // the Kata handlers are present in the effective configuration and containerd raised no
 // warnings while getting there.
 func ValidateKataContainerdConfigDump(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-
 	// This must run on the node itself, not in a debug pod. The "debugnonhost" daemonset pods
 	// used by execOnVMForScenarioOnUnprivilegedPod run a bare CBL-Mariner base image with no
 	// volume mounts, so the host's containerd binary is not reachable from them and the command
@@ -162,8 +156,6 @@ func ValidateKataContainerdConfigDump(ctx context.Context, s *Scenario) error {
 // ship and that the containerd config references. Without these, the containerd config would be
 // syntactically valid but the kata shim would fail at pod sandbox creation time.
 func ValidateKataHostReadiness(ctx context.Context, s *Scenario) error {
-	s.T.Helper()
-
 	var errs []error
 
 	// The kata shim binary that runtime_type = "io.containerd.kata.v2" resolves to.
@@ -205,8 +197,6 @@ func ValidateKataHostReadiness(ctx context.Context, s *Scenario) error {
 // interfere with other scenarios running in parallel against the same cluster, and is named
 // after the handler so that several handlers can be validated on one node.
 func ValidateKataPodIsIsolated(ctx context.Context, s *Scenario, handler string) error {
-	s.T.Helper()
-
 	hostKernelResult, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, "uname -r", 0, "unable to read host kernel release")
 	if err != nil {
 		return err
@@ -234,7 +224,7 @@ func ValidateKataPodIsIsolated(ctx context.Context, s *Scenario, handler string)
 		return err
 	}
 
-	s.T.Logf("host kernel: %q, kata guest kernel: %q", hostKernel, guestKernel)
+	s.Logger.Logf("host kernel: %q, kata guest kernel: %q", hostKernel, guestKernel)
 	return assert.NotEqual(guestKernel, hostKernel,
 		"pod running under the %q RuntimeClass reported the same kernel release as the host, "+
 			"which means it was not launched inside a Kata VM", handler)
@@ -243,8 +233,6 @@ func ValidateKataPodIsIsolated(ctx context.Context, s *Scenario, handler string)
 // createKataRuntimeClass creates a RuntimeClass for the given handler scoped to the scenario's
 // node and registers its cleanup. It returns the RuntimeClass name.
 func createKataRuntimeClass(ctx context.Context, s *Scenario, handler string) (string, error) {
-	s.T.Helper()
-
 	kube := s.Runtime.Kube
 	name := truncateKataResourceName(fmt.Sprintf("%s-%s", handler, s.Runtime.VM.KubeName))
 
@@ -274,8 +262,6 @@ func createKataRuntimeClass(ctx context.Context, s *Scenario, handler string) (s
 // node, waits for it to reach Running, and registers its cleanup. Unlike ValidatePodRunning the
 // pod is kept alive after this returns so callers can exec into it.
 func createKataPod(ctx context.Context, s *Scenario, runtimeClassName, handler string) (*corev1.Pod, error) {
-	s.T.Helper()
-
 	kube := s.Runtime.Kube
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -298,7 +284,7 @@ func createKataPod(ctx context.Context, s *Scenario, runtimeClassName, handler s
 		},
 	}
 
-	s.T.Logf("creating pod %q under RuntimeClass %q", pod.Name, runtimeClassName)
+	s.Logger.Logf("creating pod %q under RuntimeClass %q", pod.Name, runtimeClassName)
 	if _, err := kube.Typed.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
 		return nil, fmt.Errorf("failed to create kata pod %q: %w", pod.Name, err)
 	}

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -197,11 +197,11 @@ func deleteVMSSAndWait(ctx context.Context, s *Scenario) {
 		ForceDeletion: to.Ptr(true),
 	})
 	if err != nil {
-		s.T.Logf("failed to begin delete of vmss %q for retry: %s", s.Runtime.VMSSName, err)
+		s.Logger.Logf("failed to begin delete of vmss %q for retry: %s", s.Runtime.VMSSName, err)
 		return
 	}
 	if _, err := poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions); err != nil {
-		s.T.Logf("failed to wait for delete of vmss %q for retry: %s", s.Runtime.VMSSName, err)
+		s.Logger.Logf("failed to wait for delete of vmss %q for retry: %s", s.Runtime.VMSSName, err)
 	}
 }
 
@@ -303,13 +303,13 @@ func createVMSSModel(ctx context.Context, s *Scenario) (armcompute.VirtualMachin
 
 	// These two links are really for local development
 	if config.Config.IsLocalBuild() {
-		s.T.Logf(
+		s.Logger.Logf(
 			"VMSS portal link: https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s/overview",
 			config.Config.SubscriptionID,
 			*cluster.Model.Properties.NodeResourceGroup,
 			s.Runtime.VMSSName,
 		)
-		s.T.Logf(
+		s.Logger.Logf(
 			"Managed cluster portal link: https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s/overview",
 			config.Config.SubscriptionID,
 			*cluster.Model.Properties.NodeResourceGroup,
@@ -461,13 +461,13 @@ func CreateVMSS(ctx context.Context, s *Scenario, resourceGroupName string) (*Sc
 
 	result := "SSH Instructions: (may take a few minutes for the VM to be ready for SSH)\n========================\n"
 	if config.Config.KeepVMSS {
-		s.T.Logf("VM will be preserved after the test finishes, PLEASE MANUALLY DELETE THE VMSS. Set KEEP_VMSS=false to delete it automatically after the test finishes\n")
+		s.Logger.Logf("VM will be preserved after the test finishes, PLEASE MANUALLY DELETE THE VMSS. Set KEEP_VMSS=false to delete it automatically after the test finishes\n")
 	} else {
-		s.T.Logf("VM will be automatically deleted after the test finishes, to preserve it for debugging purposes set KEEP_VMSS=true or pause the test with a breakpoint before the test finishes or failed\n")
+		s.Logger.Logf("VM will be automatically deleted after the test finishes, to preserve it for debugging purposes set KEEP_VMSS=true or pause the test with a breakpoint before the test finishes or failed\n")
 	}
 	// We combine the az aks get credentials in the same line so we don't overwrite the user's kubeconfig.
 	result += fmt.Sprintf(`az network bastion ssh --target-resource-id "%s" --name "%s" --resource-group %s --auth-type ssh-key --username azureuser --ssh-key %s`, *vm.VM.ID, SharedBastionName, config.ResourceGroupName(*s.Runtime.Cluster.Model.Location), config.VMSSHPrivateKeyFileName) + "\n"
-	s.T.Log(result)
+	s.Logger.Log(result)
 
 	vmssResp, err := operation.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
 
@@ -522,10 +522,10 @@ const rcv1pTagKey = "platformsettings.host_environment.service.platform_optedin_
 // were copied from a parent resource (true for VM instance tags inherited from VMSS).
 func logRCV1PAwareTags(s *Scenario, resourceKind, timingVerb, name, id string, tags map[string]*string, weSetTag, inherited bool) {
 	if tags == nil {
-		s.T.Logf("%s %s (id: %s) has no tags after %s", resourceKind, name, id, timingVerb)
+		s.Logger.Logf("%s %s (id: %s) has no tags after %s", resourceKind, name, id, timingVerb)
 		return
 	}
-	s.T.Logf("%s %s (id: %s) tags after %s (%d):", resourceKind, name, id, timingVerb, len(tags))
+	s.Logger.Logf("%s %s (id: %s) tags after %s (%d):", resourceKind, name, id, timingVerb, len(tags))
 	inheritedNote := ""
 	if inherited {
 		inheritedNote = "inherited from VMSS, "
@@ -537,16 +537,16 @@ func logRCV1PAwareTags(s *Scenario, resourceKind, timingVerb, name, id string, t
 		}
 		if k == rcv1pTagKey {
 			if weSetTag {
-				s.T.Logf("  tag: %s = %s [RCV1P opt-in tag — %sset by us]", k, val, inheritedNote)
+				s.Logger.Logf("  tag: %s = %s [RCV1P opt-in tag — %sset by us]", k, val, inheritedNote)
 			} else {
-				s.T.Logf("  tag: %s = %s [RCV1P opt-in tag — %splatform-injected]", k, val, inheritedNote)
+				s.Logger.Logf("  tag: %s = %s [RCV1P opt-in tag — %splatform-injected]", k, val, inheritedNote)
 			}
 		} else {
-			s.T.Logf("  tag: %s = %s", k, val)
+			s.Logger.Logf("  tag: %s = %s", k, val)
 		}
 	}
 	if _, hasTag := tags[rcv1pTagKey]; !hasTag && s.Tags.RCV1PCertMode {
-		s.T.Logf("  [RCV1P opt-in tag %q NOT present on %s — this is expected for negative tests]", rcv1pTagKey, resourceKind)
+		s.Logger.Logf("  [RCV1P opt-in tag %q NOT present on %s — this is expected for negative tests]", rcv1pTagKey, resourceKind)
 	}
 }
 
@@ -702,14 +702,14 @@ func extractLogsFromVM(ctx context.Context, s *Scenario, vm *ScenarioVM) {
 	// errors that would otherwise obscure the real provisioning failure. Boot diagnostics are
 	// still collected best-effort below, and VMSS deletion is handled by the caller.
 	if vm == nil || vm.SSHClient == nil {
-		s.T.Logf("skipping SSH log extraction for VMSS %q: no SSH connection (provisioning likely failed before SSH was established)", s.Runtime.VMSSName)
+		s.Logger.Logf("skipping SSH log extraction for VMSS %q: no SSH connection (provisioning likely failed before SSH was established)", s.Runtime.VMSSName)
 	} else if err := extractLogsFromVMLinux(ctx, s, vm); err != nil {
-		s.T.Logf("failed to extract logs from VM: %s", err)
+		s.Logger.Logf("failed to extract logs from VM: %s", err)
 	} else {
-		s.T.Logf("extracted VM logs to %s", testDir(s.T))
+		s.Logger.Logf("extracted VM logs to %s", testDir(s.testName))
 	}
 	if err := extractBootDiagnostics(ctx, s); err != nil {
-		s.T.Logf("failed to extract boot diagnostics from VM: %s", err)
+		s.Logger.Logf("failed to extract boot diagnostics from VM: %s", err)
 	}
 }
 
@@ -744,7 +744,7 @@ func extractBootDiagnostics(ctx context.Context, s *Scenario) error {
 			attempts := 0
 			for {
 				if attempts >= 3 {
-					s.T.Logf("failed to download serial console log for VM %s after 3 attempts", *vmInstance.InstanceID)
+					s.Logger.Logf("failed to download serial console log for VM %s after 3 attempts", *vmInstance.InstanceID)
 					break
 				}
 				attempts++
@@ -752,7 +752,7 @@ func extractBootDiagnostics(ctx context.Context, s *Scenario) error {
 				httpClient := config.NewHttpClient()
 				resp, err := httpClient.Get(*bootDiagResp.SerialConsoleLogBlobURI)
 				if err != nil {
-					s.T.Logf("failed to download serial console log for VM %s: %v", *vmInstance.InstanceID, err)
+					s.Logger.Logf("failed to download serial console log for VM %s: %v", *vmInstance.InstanceID, err)
 					continue
 				}
 				body := resp.Body
@@ -760,11 +760,11 @@ func extractBootDiagnostics(ctx context.Context, s *Scenario) error {
 
 				contents, err := io.ReadAll(body)
 				if err != nil {
-					s.T.Logf("failed to read serial console log for VM %s: %v", *vmInstance.InstanceID, err)
+					s.Logger.Logf("failed to read serial console log for VM %s: %v", *vmInstance.InstanceID, err)
 					continue
 				}
-				if err := writeToFile(s.T, logFile, string(contents)); err != nil {
-					s.T.Logf("failed to write serial console log for VM %s: %v", *vmInstance.InstanceID, err)
+				if err := writeToFile(s.testName, logFile, string(contents)); err != nil {
+					s.Logger.Logf("failed to write serial console log for VM %s: %v", *vmInstance.InstanceID, err)
 					continue
 				}
 				break
@@ -815,12 +815,12 @@ func extractLogsFromVMLinux(ctx context.Context, s *Scenario, vm *ScenarioVM) er
 	for file, sourceCmd := range commandList {
 		execResult, err := execScriptOnVm(ctx, s, vm, sourceCmd)
 		if err != nil {
-			s.T.Logf("error executing %s: %s", sourceCmd, err)
+			s.Logger.Logf("error executing %s: %s", sourceCmd, err)
 			continue
 		}
 		logFiles[file] = execResult.String()
 	}
-	err = dumpFileMapToDir(s.T, logFiles)
+	err = dumpFileMapToDir(s.testName, logFiles)
 	if err != nil {
 		return fmt.Errorf("failed to dump log files: %w", err)
 	}
@@ -872,11 +872,11 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 	pager := config.Azure.VMSSVM.NewListPager(*s.Runtime.Cluster.Model.Properties.NodeResourceGroup, s.Runtime.VMSSName, nil)
 	page, err := pager.NextPage(ctx)
 	if err != nil {
-		s.T.Logf("failed to list VMSS instances: %s", err)
+		s.Logger.Logf("failed to list VMSS instances: %s", err)
 		return
 	}
 	if len(page.Value) == 0 {
-		s.T.Logf("no VMSS instances found")
+		s.Logger.Logf("no VMSS instances found")
 		return
 	}
 
@@ -887,7 +887,7 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 	client := config.Azure.VMSSVMRunCommands
 
 	// Invoke the RunCommand on the VMSS instance
-	s.T.Logf("uploading windows logs to blob storage at %s, may take a few minutes", blobUrl)
+	s.Logger.Logf("uploading windows logs to blob storage at %s, may take a few minutes", blobUrl)
 
 	azurePortalURL := fmt.Sprintf(
 		"https://portal.azure.com/?feature.customportal=false#@microsoft.onmicrosoft.com/resource/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/containersList",
@@ -896,7 +896,7 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 		config.Config.BlobStorageAccount(),
 	)
 
-	s.T.Logf("##vso[task.logissue type=warning;]Storage account %s (%s) in Azure portal: %s", config.Config.BlobStorageAccount(), blobPrefix, azurePortalURL)
+	s.Logger.Logf("##vso[task.logissue type=warning;]Storage account %s (%s) in Azure portal: %s", config.Config.BlobStorageAccount(), blobPrefix, azurePortalURL)
 
 	runCommandTimeout := int32((20 * time.Minute).Seconds())
 
@@ -932,41 +932,41 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 		nil,
 	)
 	if err != nil {
-		s.T.Logf("failed to initiate run command on VMSS instance %s: %s", instanceID, err)
+		s.Logger.Logf("failed to initiate run command on VMSS instance %s: %s", instanceID, err)
 		return
 	}
 
 	// Poll the result until the operation is completed
 	runCommandResp, err := pollerResp.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
 	if err != nil {
-		s.T.Logf("failed to poll run command on VMSS instance %s: %s", instanceID, err)
+		s.Logger.Logf("failed to poll run command on VMSS instance %s: %s", instanceID, err)
 		return
 	}
 
 	respJSON, _ := json.MarshalIndent(runCommandResp, "", "  ")
-	s.T.Logf("run command executed successfully:\n%s", respJSON)
+	s.Logger.Logf("run command executed successfully:\n%s", respJSON)
 
-	s.T.Logf("uploaded logs to %s", blobUrl)
+	s.Logger.Logf("uploaded logs to %s", blobUrl)
 
 	downloadBlob := func(blobSuffix string) {
-		fileName := filepath.Join(testDir(s.T), blobSuffix)
-		err := os.MkdirAll(testDir(s.T), 0755)
+		fileName := filepath.Join(testDir(s.testName), blobSuffix)
+		err := os.MkdirAll(testDir(s.testName), 0755)
 		if err != nil {
-			s.T.Logf("failed to create directory %q: %s", testDir(s.T), err)
+			s.Logger.Logf("failed to create directory %q: %s", testDir(s.testName), err)
 			return
 		}
 		file, err := os.Create(fileName)
 		if err != nil {
-			s.T.Logf("failed to create file %q: %s", fileName, err)
+			s.Logger.Logf("failed to create file %q: %s", fileName, err)
 			return
 		}
 		// NOTE, read after write is possible, list blobs is eventually consistent and may fail
 		_, err = config.Azure.Blob.DownloadFile(ctx, config.Config.BlobContainer, blobPrefix+"/"+blobSuffix, file, nil)
 		if err != nil {
-			s.T.Logf("failed to download collected logs: %s", err)
+			s.Logger.Logf("failed to download collected logs: %s", err)
 			err = os.Remove(file.Name())
 			if err != nil {
-				s.T.Logf("failed to remove file: %s", err)
+				s.Logger.Logf("failed to remove file: %s", err)
 			}
 			return
 		}
@@ -975,14 +975,14 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 	downloadBlob("cse.log")
 	downloadBlob("provision.complete")
 	downloadBlob("network_config.txt")
-	s.T.Logf("logs collected to %s", testDir(s.T))
+	s.Logger.Logf("logs collected to %s", testDir(s.testName))
 }
 
 func deleteVMSS(ctx context.Context, s *Scenario) error {
 	if config.Config.KeepVMSS {
-		s.T.Logf("vmss %q will be retained for debugging purposes, please make sure to manually delete it later", s.Runtime.VMSSName)
-		if err := writeToFile(s.T, "sshkey", string(config.VMSSHPrivateKey)); err != nil {
-			s.T.Logf("failed to write retained vmss %s private ssh key to disk: %s", s.Runtime.VMSSName, err)
+		s.Logger.Logf("vmss %q will be retained for debugging purposes, please make sure to manually delete it later", s.Runtime.VMSSName)
+		if err := writeToFile(s.testName, "sshkey", string(config.VMSSHPrivateKey)); err != nil {
+			s.Logger.Logf("failed to write retained vmss %s private ssh key to disk: %s", s.Runtime.VMSSName, err)
 		}
 		return nil
 	}
@@ -996,7 +996,7 @@ func deleteVMSS(ctx context.Context, s *Scenario) error {
 		}
 		return fmt.Errorf("begin deleting vmss %q: %w", s.Runtime.VMSSName, err)
 	}
-	s.T.Logf("vmss %q deletion started", s.Runtime.VMSSName)
+	s.Logger.Logf("vmss %q deletion started", s.Runtime.VMSSName)
 	return nil
 }
 
@@ -1129,8 +1129,8 @@ func addDualStackSecondaryNIC(vmss *armcompute.VirtualMachineScaleSet) {
 	)
 }
 
-func generateVMSSNameLinux(t testing.TB) string {
-	name := fmt.Sprintf("%s-%s-%s", randomLowercaseString(4), time.Now().Format(time.DateOnly), t.Name())
+func generateVMSSNameLinux(testName string) string {
+	name := fmt.Sprintf("%s-%s-%s", randomLowercaseString(4), time.Now().Format(time.DateOnly), testName)
 	name = strings.ReplaceAll(name, "_", "")
 	name = strings.ReplaceAll(name, "/", "")
 	name = strings.ReplaceAll(name, "Test", "")
@@ -1151,7 +1151,7 @@ func generateVMSSName(s *Scenario) string {
 	if s.IsWindows() {
 		return generateVMSSNameWindows()
 	}
-	return generateVMSSNameLinux(s.T)
+	return generateVMSSNameLinux(s.testName)
 }
 
 func injectWriteFilesEntriesToCustomData(customData string, entries []CustomDataWriteFile) (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove explicit calls to *testing.T for logging. Preparation to move away from go testing for E2E.