### PR TITLE
perf: reduce initial WALinuxAgent goal state period

### DIFF
--- a/parts/linux/cloud-init/nodecustomdata.yml
+++ b/parts/linux/cloud-init/nodecustomdata.yml
@@ -8,6 +8,11 @@ bootcmd:
     [ -e /usr/local/bin/${bin} ] || continue
     ln -s /usr/local/bin/${bin} /opt/bin/
   done
+  if grep -q '^Extensions.InitialGoalStatePeriod=' /etc/waagent.conf; then
+    sed -i 's/^Extensions.InitialGoalStatePeriod=.*/Extensions.InitialGoalStatePeriod=2/' /etc/waagent.conf
+  else
+    printf '\nExtensions.InitialGoalStatePeriod=2\n' >> /etc/waagent.conf
+  fi
 
 write_files:
 # IMPORTANT: OSGuard images have /usr/ mounted read-only (dm-verity).

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -1637,6 +1637,15 @@ var _ = Describe("getLinuxNodeBootstrappingPayload", func() {
 		Expect(string(decodedPayload)).To(ContainSubstring("/opt/azure/containers/provision_preload.sh"))
 	})
 
+	It("should configure a shorter initial goal state period", func() {
+		templateGenerator := InitializeTemplateGenerator()
+		config := newConfig(false)
+
+		nodeCustomData := getCustomDataFromJSON(templateGenerator.getLinuxNodeCustomDataJSONObject(config))
+
+		Expect(nodeCustomData).To(ContainSubstring("Extensions.InitialGoalStatePeriod=2"))
+	})
+
 	It("should embed the encoded AKSNodeConfig in the scriptless NBC boothook when provided", func() {
 		templateGenerator := InitializeTemplateGenerator()
 		config := newConfig(false)


### PR DESCRIPTION
**What this PR does / why we need it**:

Configures `Extensions.InitialGoalStatePeriod=2` in AKS Linux CustomData before WALinuxAgent starts. WALinuxAgent uses the shorter period only until the initial extension goal state reaches a terminal state, then returns to the regular six-second period.

Production telemetry modeling indicates this reduces CSE terminal-status reporting latency by approximately 2 seconds at p50 and 4 seconds at p95. The narrower initial-only setting avoids changing steady-state polling for the lifetime of the VM.

The boot command updates an existing setting or appends it when the distro configuration omits the property. A rendering test verifies the generated node CustomData contains the setting.

Changing the initial period from six seconds to two seconds increases goal-state checks and status uploads during initial provisioning. This PR intentionally leaves `Extensions.GoalStatePeriod` unchanged so the additional load stops after convergence.

**Which issue(s) this PR fixes**:

N/A