### PR TITLE
fix: bound the systemctl retry budget in cse_helpers.sh

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1129,7 +1129,7 @@ EOF
     fi
 
     # start measure-tls-bootstrapping-latency.service without waiting for the main process to start, while ignoring any failures
-    if ! systemctlEnableAndStartNoBlock measure-tls-bootstrapping-latency 30; then
+    if ! systemctlEnableAndStartNoBlock measure-tls-bootstrapping-latency 30 $SYSTEMCTL_RESTART_OPTIONAL_RETRIES; then
         rm -f "${tls_bootstrapping_start_time_filepath}"
         echo "failed to start measure-tls-bootstrapping-latency.service"
     fi
@@ -1151,7 +1151,7 @@ EOF
     # it MAY succeed, only due to unreliability of systemd
     # service type=Simple, which does not exit non-zero
     # on failure if ExecStart failed to invoke.
-    systemctlEnableAndStart mig-partition 300
+    systemctlEnableAndStart mig-partition 300 $SYSTEMCTL_RESTART_OPTIONAL_RETRIES
 }
 
 configureNodeExporter() {
@@ -1162,11 +1162,11 @@ configureNodeExporter() {
         return 0
     fi
 
-    if ! systemctlEnableAndStart node-exporter 30; then
+    if ! systemctlEnableAndStart node-exporter 30 $SYSTEMCTL_RESTART_OPTIONAL_RETRIES; then
         echo "Failed to start node-exporter service"
         return $ERR_NODE_EXPORTER_START_FAIL
     fi
-    if ! systemctlEnableAndStart node-exporter-restart.path 30; then
+    if ! systemctlEnableAndStart node-exporter-restart.path 30 $SYSTEMCTL_RESTART_OPTIONAL_RETRIES; then
         echo "Failed to start node-exporter-restart.path"
         return $ERR_NODE_EXPORTER_START_FAIL
     fi
@@ -2054,7 +2054,7 @@ EOF
     # This is optional observability — don't block provisioning if it fails.
     # Note: the kubelet node label is added separately in cse_main.sh before ensureKubelet.
     echo "Enabling localdns-exporter.socket for metrics collection."
-    if systemctlEnableAndStartNoBlock localdns-exporter.socket 30; then
+    if systemctlEnableAndStartNoBlock localdns-exporter.socket 30 $SYSTEMCTL_RESTART_OPTIONAL_RETRIES; then
         echo "Enable localdns-exporter.socket succeeded."
     else
         echo "WARNING: Failed to enable localdns-exporter.socket. Metrics will not be available but continuing provisioning."
@@ -2183,7 +2183,7 @@ EOF
     # Enable the timer for periodic refresh.
     # This will update the hosts file with fresh IPs from live DNS.
     echo "Enabling aks-localdns-hosts-setup timer..."
-    if systemctlEnableAndStartNoBlock aks-localdns-hosts-setup.timer 30; then
+    if systemctlEnableAndStartNoBlock aks-localdns-hosts-setup.timer 30 $SYSTEMCTL_RESTART_OPTIONAL_RETRIES; then
         echo "aks-localdns-hosts-setup timer enabled successfully."
     else
         echo "Warning: Failed to enable aks-localdns-hosts-setup timer"
@@ -2325,7 +2325,7 @@ EOF
     # 2. Start the nvidia-dcgm service.
     # DCGM is monitoring/telemetry and does not gate GPU workload scheduling, so start it without
     # blocking node provisioning and treat a slow/failed start as non-fatal.
-    logs_to_events "AKS.CSE.start.nvidia-dcgm" "systemctlEnableAndStartNoBlock nvidia-dcgm 30" || echo "warning: nvidia-dcgm could not be enqueued; GPU monitoring will start asynchronously"
+    logs_to_events "AKS.CSE.start.nvidia-dcgm" "systemctlEnableAndStartNoBlock nvidia-dcgm 30 $SYSTEMCTL_RESTART_OPTIONAL_RETRIES" || echo "warning: nvidia-dcgm could not be enqueued; GPU monitoring will start asynchronously"
 
     # 3. Start the nvidia-dcgm-exporter service.
     # Create systemd drop-in directory for nvidia-dcgm-exporter service
@@ -2349,7 +2349,7 @@ EOF
     # Start the nvidia-dcgm-exporter service.
     # The exporter is telemetry only and does not gate scheduling, so start it off the critical
     # path and treat a slow/failed start as non-fatal.
-    logs_to_events "AKS.CSE.start.nvidia-dcgm-exporter" "systemctlEnableAndStartNoBlock nvidia-dcgm-exporter 30" || echo "warning: nvidia-dcgm-exporter could not be enqueued; GPU metrics will start asynchronously"
+    logs_to_events "AKS.CSE.start.nvidia-dcgm-exporter" "systemctlEnableAndStartNoBlock nvidia-dcgm-exporter 30 $SYSTEMCTL_RESTART_OPTIONAL_RETRIES" || echo "warning: nvidia-dcgm-exporter could not be enqueued; GPU metrics will start asynchronously"
 }
 
 get_compute_sku() {

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -220,6 +220,23 @@ ORAS_REGISTRY_CONFIG_FILE=/etc/oras/config.yaml # oras registry auth config file
 # more details: https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
 AKS_AAD_SERVER_APP_ID="6dae42f8-4368-4678-94ff-3960e28e3630"
 
+# Retry tuning for systemctlEnableAndStart/systemctlEnableAndStartNoBlock.
+# The retry count alone is not a time bound: a unit that fails fast burns
+# SYSTEMCTL_RESTART_MAX_RETRIES * 5s sleeping (~500s), and a unit that hangs burns
+# retries * per-attempt timeout, which can exceed the global CSE timeout on its own.
+# SYSTEMCTL_RESTART_MAX_BUDGET_SECONDS bounds the wall-clock time any single unit can
+# take, so one bad unit cannot consume the whole CSE window and mask later failures
+# behind a generic timeout instead of a specific error code.
+SYSTEMCTL_RESTART_MAX_RETRIES=100
+SYSTEMCTL_RESTART_MAX_BUDGET_SECONDS=120
+# Retry count for optional units whose failure is explicitly non-fatal to provisioning.
+# These are not worth a full budget each - there are enough of them that their combined
+# worst case would otherwise exceed the CSE window.
+SYSTEMCTL_RESTART_OPTIONAL_RETRIES=3
+# systemctl enable only writes symlinks on disk. If it fails, it is not a transient
+# condition that a long retry tail will fix.
+SYSTEMCTL_ENABLE_MAX_RETRIES=3
+
 # Checks if the elapsed time since CSEStartTime exceeds 13 minutes.
 # That value is based on the global CSE timeout which is set to 15 minutes - majority of CSE executions succeed or fail very fast, meaning we can exit slightly before the global timeout without affecting the overall CSE execution.
 # Global cse timeout is set in cse_start.sh: `timeout -k5s 15m /bin/bash /opt/azure/containers/provision.sh`
@@ -583,29 +600,56 @@ retrycmd_can_oras_ls_acr_anonymously() {
 }
 
 # base systemctl retry command, should not be called directly - use systemctl_restart, systemctl_stop, systemctl_disable
+# maxBudget (7th arg): if > 0, the total wall-clock seconds this operation is allowed to spend across all retries.
+# A value of 0 disables the per-operation budget (falls back to the global CSE timeout guard only).
+# returns 0 if successful, 1 if the operation kept failing, 2 if the operation budget or the global CSE timeout was hit.
 _systemctl_retry_svc_operation() {
-    retries=$1; wait_sleep=$2; timeout=$3 operation=$4 svcname=$5 shouldLogRetryInfo=${6:-false}
+    retries=$1; wait_sleep=$2; timeout=$3 operation=$4 svcname=$5 shouldLogRetryInfo=${6:-false} maxBudget=${7:-0}
+    opStartTime=$(date +%s)
     for i in $(seq 1 $retries); do
-        timeout $timeout systemctl daemon-reload
-        timeout $timeout systemctl $operation $svcname && break || \
+        # Check the per-operation budget if set, and cap the per-attempt timeout to whatever
+        # budget is left so a single hung systemctl call cannot overrun it.
+        effectiveTimeout=$timeout
+        if [ "${maxBudget}" -gt 0 ]; then
+            opElapsed=$(( $(date +%s) - opStartTime ))
+            if [ "$opElapsed" -ge "$maxBudget" ]; then
+                echo "$svcname: operation budget of ${maxBudget}s exceeded after ${opElapsed}s and $((i - 1)) attempt(s), giving up on \"systemctl $operation\"." >&2
+                return 2
+            fi
+            remainingBudget=$(( maxBudget - opElapsed ))
+            if [ "$effectiveTimeout" -gt "$remainingBudget" ]; then
+                effectiveTimeout=$remainingBudget
+            fi
+        fi
+
+        # check if global cse timeout is approaching (only in real CSE runs)
+        if [ -n "${CSE_STARTTIME_SECONDS:-}" ] && ! check_cse_timeout; then
+            echo "CSE timeout approaching, exiting early." >&2
+            return 2
+        fi
+
+        timeout $effectiveTimeout systemctl daemon-reload
+        timeout $effectiveTimeout systemctl $operation $svcname && return 0
+
         if [ $i -eq $retries ]; then
             return 1
-        else
-          if [ "$shouldLogRetryInfo" = "true" ]; then
-              systemctl status $svcname --no-pager -l
-              journalctl -u $svcname
-          fi
-            sleep $wait_sleep
         fi
+        if [ "$shouldLogRetryInfo" = "true" ]; then
+            systemctl status $svcname --no-pager -l
+            # bound the journal dump: this runs on every failed attempt, so an unbounded
+            # dump grows quadratically with the retry count.
+            journalctl -u $svcname --no-pager -n 50
+        fi
+        sleep $wait_sleep
     done
 }
 
 systemctl_restart() {
-    _systemctl_retry_svc_operation "$1" "$2" "$3" "restart" "$4" true
+    _systemctl_retry_svc_operation "$1" "$2" "$3" "restart" "$4" true "${5:-0}"
 }
 
 systemctl_restart_no_block() {
-    _systemctl_retry_svc_operation "$1" "$2" "$3" "restart --no-block" "$4" true
+    _systemctl_retry_svc_operation "$1" "$2" "$3" "restart --no-block" "$4" true "${5:-0}"
 }
 
 systemctl_stop() {
@@ -621,15 +665,15 @@ sysctl_reload() {
 }
 
 systemctlEnableAndStart() {
-    service=$1; timeout=$2
-    systemctl_restart 100 5 $timeout $service
+    service=$1; timeout=$2; retries=${3:-$SYSTEMCTL_RESTART_MAX_RETRIES}
+    systemctl_restart "$retries" 5 "$timeout" "$service" "$SYSTEMCTL_RESTART_MAX_BUDGET_SECONDS"
     RESTART_STATUS=$?
     if [ $RESTART_STATUS -ne 0 ]; then
         echo "$service could not be started"
         systemctl status $service --no-pager -l > /var/log/azure/$service-status.log || true
         return 1
     fi
-    if ! retrycmd_if_failure 120 5 25 systemctl enable $service; then
+    if ! retrycmd_if_failure $SYSTEMCTL_ENABLE_MAX_RETRIES 5 25 systemctl enable $service; then
         echo "$service could not be enabled by systemctl"
         systemctl status $service --no-pager -l > /var/log/azure/$service-status.log || true
         return 1
@@ -637,9 +681,9 @@ systemctlEnableAndStart() {
 }
 
 systemctlEnableAndStartNoBlock() {
-    service=$1; timeout=$2
+    service=$1; timeout=$2; retries=${3:-$SYSTEMCTL_RESTART_MAX_RETRIES}
 
-    systemctl_restart_no_block 100 5 $timeout $service
+    systemctl_restart_no_block "$retries" 5 "$timeout" "$service" "$SYSTEMCTL_RESTART_MAX_BUDGET_SECONDS"
     RESTART_STATUS=$?
     if [ $RESTART_STATUS -ne 0 ]; then
         echo "$service could not be enqueued for startup"
@@ -647,7 +691,7 @@ systemctlEnableAndStartNoBlock() {
         return 1
     fi
 
-    if ! retrycmd_if_failure 120 5 25 systemctl enable $service; then
+    if ! retrycmd_if_failure $SYSTEMCTL_ENABLE_MAX_RETRIES 5 25 systemctl enable $service; then
         echo "$service could not be enabled by systemctl"
         systemctl status $service --no-pager -l > /var/log/azure/$service-status.log || true
         return 1

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -650,7 +650,7 @@ function nodePrep {
     fi
 
     if systemctl cat aks-log-collector.timer &>/dev/null; then
-        systemctlEnableAndStartNoBlock aks-log-collector.timer 30 || echo "Warning: Could not start aks-log-collector.timer"
+        systemctlEnableAndStartNoBlock aks-log-collector.timer 30 $SYSTEMCTL_RESTART_OPTIONAL_RETRIES || echo "Warning: Could not start aks-log-collector.timer"
     else
         echo "aks-log-collector.timer not found on this VHD, skipping"
     fi

--- a/spec/parts/linux/cloud-init/artifacts/cse_retry_helpers_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_retry_helpers_spec.sh
@@ -74,6 +74,112 @@ Describe 'long running cse helper functions'
                 The stdout should not include "mock systemctl call"
                 The stdout should not include "mock journalctl call"
             End
+
+            It "bounds the journalctl dump so it does not grow with the retry count"
+                journalctl() {
+                    echo "journalctl args: $*"
+                }
+                When call _systemctl_retry_svc_operation 2 0 1 "restart" "nonexistent.service" "true"
+                The status should eq 1
+                The stdout should include "journalctl args: -u nonexistent.service --no-pager -n 50"
+            End
+        End
+
+        Describe '_systemctl_retry_svc_operation operation budget'
+            # the operation budget is a wall-clock bound, so let each attempt cost real time
+            timeout() {
+                sleep 1
+                return 124
+            }
+            systemctl() {
+                echo "mock systemctl call"
+            }
+            journalctl() {
+                echo "mock journalctl call"
+            }
+
+            budget_precheck() {
+                # exercise the operation budget in isolation from the global CSE timeout guard
+                unset CSE_STARTTIME_SECONDS
+            }
+            BeforeEach budget_precheck
+
+            It "gives up on the operation budget instead of exhausting all retries"
+                When call _systemctl_retry_svc_operation 100 1 5 "restart" "nonexistent.service" "false" 2
+                The status should eq 2
+                The stderr should include "nonexistent.service: operation budget of 2s exceeded"
+                The stderr should include "1 attempt(s)"
+                The stdout should be defined
+            End
+
+            It "keeps retrying until the retry count is exhausted when no budget is supplied"
+                When call _systemctl_retry_svc_operation 2 0 1 "restart" "nonexistent.service" "false"
+                The status should eq 1
+                The stdout should be defined
+                The stderr should be defined
+            End
+
+            It "returns 0 immediately when the operation succeeds"
+                timeout() {
+                    return 0
+                }
+                When call _systemctl_retry_svc_operation 100 5 30 "restart" "working.service" "false" 120
+                The status should eq 0
+                The stdout should be defined
+            End
+        End
+
+        Describe 'systemctl_restart budget passthrough'
+            _systemctl_retry_svc_operation() {
+                echo "_systemctl_retry_svc_operation args: $*"
+            }
+
+            It "defaults the budget to 0 when the caller omits it"
+                When call systemctl_restart 5 1 30 "some.service"
+                The status should eq 0
+                The stdout should include "_systemctl_retry_svc_operation args: 5 1 30 restart some.service true 0"
+            End
+
+            It "passes a caller-supplied budget through"
+                When call systemctl_restart 5 1 30 "some.service" 120
+                The status should eq 0
+                The stdout should include "_systemctl_retry_svc_operation args: 5 1 30 restart some.service true 120"
+            End
+        End
+
+        Describe 'systemctlEnableAndStart retry configuration'
+            systemctl_restart() {
+                echo "systemctl_restart args: $*"
+                return 1
+            }
+            systemctl_restart_no_block() {
+                echo "systemctl_restart_no_block args: $*"
+                return 1
+            }
+            systemctl() {
+                echo "mock systemctl call"
+            }
+
+            It "applies the default retry count and operation budget"
+                When call systemctlEnableAndStart some.service 30
+                The status should eq 1
+                The stdout should include "systemctl_restart args: 100 5 30 some.service 120"
+                The stderr should be defined
+            End
+
+            It "honors a caller-supplied retry count for optional units"
+                When call systemctlEnableAndStart some.service 30 3
+                The status should eq 1
+                The stdout should include "systemctl_restart args: 3 5 30 some.service 120"
+                The stderr should be defined
+            End
+
+            It "honors a caller-supplied retry count in the no-block variant"
+                When call systemctlEnableAndStartNoBlock some.service 30 3
+                The status should eq 1
+                The stdout should include "systemctl_restart_no_block args: 3 5 30 some.service 120"
+                The stderr should be defined
+            End
         End
     End
 


### PR DESCRIPTION
## What

`systemctlEnableAndStart` / `systemctlEnableAndStartNoBlock` hardcode `systemctl_restart 100 5 $timeout $service`.

The retry count is not a time bound, and the `30` / `300` a caller passes is only the **per-`systemctl`-call timeout**, not a retry budget. `systemctlEnableAndStart localdns 30` reads like "give up after 30s"; it can actually run for over an hour.

I measured this with a fast-failing unit:

| scenario | before | after |
|---|---|---|
| critical unit fails fast | **498s** (rc=1) | **122s** (rc=2, 24 attempts) |
| optional unit fails fast | **498s** | **10s** |

`DefaultCSETimeout` is 900s (`pkg/agent/datamodel/const.go`). A single bad unit eating 498s of that means downstream provisioning steps never run, and their specific error codes get replaced by a generic CSE timeout — which is strictly worse for diagnosis than failing fast.

This isn't hypothetical. `cse_config.sh::configureLocalDNSExporterSocket` already carries a per-caller workaround for exactly this problem:

```sh
# systemctlEnableAndStartNoBlock would hit its retry loop (~100 retries × 5s) for a missing unit.
```

The `100 5` values date to #7339 and were never deliberately tuned (#8105 only moved the status logging).

## Changes

**`_systemctl_retry_svc_operation`**
- Optional `maxBudget` (7th arg, default `0` = disabled) — the same convention `_retry_file_curl_internal` already uses in this file. Caps the per-attempt timeout to the remaining budget and returns `2` when exhausted.
- Adds the `check_cse_timeout` guard that every other retry helper here already has, so we exit with a specific code instead of running the CSE window to zero.
- Bounds the journal dump: `journalctl -u $svc --no-pager -n 50`. It previously ran unbounded on *every* failed attempt, so log volume grew quadratically with the retry count.

**`systemctlEnableAndStart` / `NoBlock`**
- Optional 3rd `retries` param; applies a 120s budget by default.
- `systemctl enable` retries `120 → 3`. It only writes symlinks on disk and runs immediately after a successful restart, so a 600s tail cannot help.

**Callers** — a small retry count for units whose failure is *already explicitly non-fatal*: `mig-partition`, `node-exporter`(+`.path`), `nvidia-dcgm`(+`-exporter`), `localdns-exporter.socket`, `aks-localdns-hosts-setup.timer`, `aks-log-collector.timer`, `measure-tls-bootstrapping-latency`. There are enough of these that a full 120s budget each would exceed the CSE window on its own.

Worth calling out: `ensureMigPartition` is documented as *"this is expected to fail and work only on next reboot"* — and is currently retried for ~500s.

`containerd`, `kubelet`, `localdns`, and `nvidia-gridd` keep the default budget.

## Compatibility

Every new parameter is optional and defaults to today's values, so old and new copies of these scripts interoperate in both directions. `systemctl_stop` / `systemctl_disable` are unchanged (budget defaults to `0`). `cse_helpers.sh` and `cse_config.sh` ship in the same CustomData blob, so the shared constants are versioned together.

## Testing

- `make shellspec` (docker): **939 examples, 0 failures**
- 9 new examples covering the retry loop, which previously had **no direct coverage** — every existing caller mocked the helper. Covers: budget trips before retry exhaustion, legacy behavior when no budget is passed, success path, bounded journalctl, arg passthrough, and caller-supplied retry counts.
- `make validate-shell`: shellcheck findings byte-identical to `main` (the gate has pre-existing failures in unrelated files).
- `go test ./pkg/agent/...`: ok
- Wall-clock numbers in the table above measured in the shellspec container.

No testdata regeneration needed — `cse_helpers.sh` is not embedded in the parser snapshots.