### PR TITLE
fix: use base64 encoding for SSH key literals in PowerShell template

### DIFF
--- a/e2e/scenario_win_test.go
+++ b/e2e/scenario_win_test.go
@@ -57,13 +57,23 @@ func DualStackVMConfigMutator(set *armcompute.VirtualMachineScaleSet) {
 }
 
 func Test_Windows2022_AzureNetwork(t *testing.T) {
+	// Key comment contains a PowerShell subexpression that would be expanded
+	// if rendered inside a double-quoted string. The base64 encoding must
+	// ensure it is preserved literally in authorized_keys.
+	const sshKeyInterpolationComment = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDIs9weXqhc498AY/775zoJAO+bsmgBx2/V2KTaQgbU1I9ePbquox6r1idf1hcyR+wo9bqlMErLlSGdDCZqTfRmZS9gBbicxPuaIDnIvzfNBH/4Eqq6YVcwjkFeHWqL4ABPq/VNzbLr7JkkCVw9Widh3K/HTsfaDx13qOUwzcm2F7FN/+zvrRyz9RDwkzdeOVhG6JwHdQAjLM40z49BP4yPyHl4rxvDmGUcOYRy+zCf4Sz75Nw+7wOph3X8KUY8EcHqptXMtk+6f17tasZNaiK0sGY+Hq/Craz2ryO3cDtDn+8Kw2Mpwox8qmdKTCVHPkHgh9OwiFPPWcnld4kNg/+V9ONlsJLUTAwOVezqsCWWU/+NpTWhKqLp682FOZ1fhI+jRlMp0Sa6uEXdw9U56J4IbgzXa1RXYmmq8xceMRIRWC9dxVjcv8F1KrpJoCORtrZDQDaF3Kw789dX09MawfdCZscKSVDXRqvV7TWO2hndliQq3BW385ZkiephlrmpUVM= $(hostname)-literal-test`
+
 	RunScenario(t, &Scenario{
 		Description: "Windows Server 2022 Azure Network",
 		Config: Config{
-			Cluster:                ClusterAzureNetwork,
-			VHD:                    config.VHDWindows2022Containerd,
-			VMConfigMutator:        EmptyVMConfigMutator,
-			BootstrapConfigMutator: EmptyBootstrapConfigMutator,
+			Cluster:         ClusterAzureNetwork,
+			VHD:             config.VHDWindows2022Containerd,
+			VMConfigMutator: EmptyVMConfigMutator,
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.ContainerService.Properties.LinuxProfile.SSH.PublicKeys = append(
+					nbc.ContainerService.Properties.LinuxProfile.SSH.PublicKeys,
+					datamodel.PublicKey{KeyData: sshKeyInterpolationComment},
+				)
+			},
 			Validator: func(ctx context.Context, s *Scenario) error {
 				return errors.Join(
 					ValidateWindowsVersionFromWindowsSettings(ctx, s, "2022-containerd"),
@@ -76,6 +86,7 @@ func Test_Windows2022_AzureNetwork(t *testing.T) {
 					ValidateDotnetNotInstalledWindows(ctx, s),
 					ValidateWindowsSystemServicesRestartConfiguration(ctx, s),
 					ValidateCollectWindowsLogsScript(ctx, s),
+					ValidateSSHKeyLiteralPreservation(ctx, s, sshKeyInterpolationComment),
 				)
 			},
 		},
@@ -638,3 +649,4 @@ func Test_NetworkIsolatedCluster_Windows_OrasDownload(t *testing.T) {
 		},
 	})
 }
+

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -4382,3 +4382,18 @@ func ValidateServiceInSlice(ctx context.Context, s *Scenario, service, expectedS
 	return assert.Equal(actual, expectedSlice,
 		"expected %s to be in %s, but got %s", service, expectedSlice, actual)
 }
+
+// ValidateSSHKeyLiteralPreservation reads the Windows authorized_keys file and
+// checks that the expected key string appears literally. This does the comparison
+// in Go rather than in PowerShell to avoid the validator itself interpreting
+// special characters like $() in the key comment.
+func ValidateSSHKeyLiteralPreservation(ctx context.Context, s *Scenario, expectedKey string) error {
+	content, err := getFileContent(ctx, s, `C:\ProgramData\ssh\administrators_authorized_keys`)
+	if err != nil {
+		return fmt.Errorf("reading authorized_keys: %w", err)
+	}
+	if !strings.Contains(content, expectedKey) {
+		return fmt.Errorf("authorized_keys does not contain the expected literal key.\nExpected substring: %s\nActual content: %s", expectedKey, content)
+	}
+	return nil
+}

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -306,13 +306,22 @@ func getSSHPublicKeysPowerShell(linuxProfile *datamodel.LinuxProfile) string {
 	if linuxProfile != nil {
 		lastItem := len(linuxProfile.SSH.PublicKeys) - 1
 		for i, publicKey := range linuxProfile.SSH.PublicKeys {
-			str += `"` + strings.TrimSpace(publicKey.KeyData) + `"`
+			str += encodePowerShellBase64Literal(strings.TrimSpace(publicKey.KeyData))
 			if i < lastItem {
 				str += ", "
 			}
 		}
 	}
 	return str
+}
+
+// encodePowerShellBase64Literal returns a PowerShell expression that decodes
+// the given string from base64 at runtime. The base64 alphabet (A-Za-z0-9+/=)
+// contains no PowerShell delimiters, interpolation characters, or command
+// syntax, making the output safe by construction regardless of input content.
+func encodePowerShellBase64Literal(value string) string {
+	encoded := base64.StdEncoding.EncodeToString([]byte(value))
+	return "[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('" + encoded + "'))"
 }
 
 // IsSgxEnabledSKU determines if an VM SKU has SGX driver support.

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -316,9 +316,9 @@ func getSSHPublicKeysPowerShell(linuxProfile *datamodel.LinuxProfile) string {
 }
 
 // encodePowerShellBase64Literal returns a PowerShell expression that decodes
-// the given string from base64 at runtime. The base64 alphabet (A-Za-z0-9+/=)
-// contains no PowerShell delimiters, interpolation characters, or command
-// syntax, making the output safe by construction regardless of input content.
+// the given string from base64 at runtime. Standard base64 cannot contain a
+// single quote, so the encoded payload can be safely embedded in the
+// single-quoted argument without escaping.
 func encodePowerShellBase64Literal(value string) string {
 	encoded := base64.StdEncoding.EncodeToString([]byte(value))
 	return "[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('" + encoded + "'))"

--- a/pkg/agent/utils.go
+++ b/pkg/agent/utils.go
@@ -316,9 +316,10 @@ func getSSHPublicKeysPowerShell(linuxProfile *datamodel.LinuxProfile) string {
 }
 
 // encodePowerShellBase64Literal returns a PowerShell expression that decodes
-// the given string from base64 at runtime. Standard base64 cannot contain a
-// single quote, so the encoded payload can be safely embedded in the
-// single-quoted argument without escaping.
+// the given string from base64 at runtime. The encoded payload is placed inside
+// a single-quoted PowerShell literal; since the base64 alphabet (A-Za-z0-9+/=)
+// cannot contain a single quote, the literal cannot be terminated early,
+// making the output safe by construction regardless of input content.
 func encodePowerShellBase64Literal(value string) string {
 	encoded := base64.StdEncoding.EncodeToString([]byte(value))
 	return "[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('" + encoded + "'))"

--- a/pkg/agent/utils_test.go
+++ b/pkg/agent/utils_test.go
@@ -1671,3 +1671,107 @@ func TestValidateAndSetLinuxNodeBootstrappingConfiguration_TransparentHugePageVa
 		})
 	}
 }
+
+func TestEncodePowerShellBase64Literal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"plain key", "ssh-rsa AAAAB3 user@host",
+			"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('c3NoLXJzYSBBQUFBQjMgdXNlckBob3N0'))"},
+		{"embedded apostrophe", "ssh-rsa AAAAB3 user's key",
+			"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('c3NoLXJzYSBBQUFBQjMgdXNlcidzIGtleQ=='))"},
+		{"subexpression and semicolon", "ssh-rsa AAAAB3 ;$(cmd)",
+			"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('c3NoLXJzYSBBQUFBQjMgOyQoY21kKQ=='))"},
+		{"unicode right single quote U+2019", "ssh-rsa AAAAB3 user\u2019s key",
+			"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('c3NoLXJzYSBBQUFBQjMgdXNlcuKAmXMga2V5'))"},
+		{"empty string", "",
+			"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String(''))"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := encodePowerShellBase64Literal(tc.input)
+			if got != tc.expected {
+				t.Errorf("encodePowerShellBase64Literal(%q)\ngot:  %s\nwant: %s", tc.input, got, tc.expected)
+			}
+			// Round-trip: extract payload and decode back to original.
+			const prefix = "[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('"
+			const suffix = "'))"
+			if !strings.HasPrefix(got, prefix) || !strings.HasSuffix(got, suffix) {
+				t.Fatalf("output does not match expected format")
+			}
+			payload := got[len(prefix) : len(got)-len(suffix)]
+			decoded, err := base64.StdEncoding.DecodeString(payload)
+			if err != nil {
+				t.Fatalf("base64 decode failed: %v", err)
+			}
+			if string(decoded) != tc.input {
+				t.Errorf("round-trip mismatch: got %q, want %q", string(decoded), tc.input)
+			}
+		})
+	}
+}
+
+func TestGetSSHPublicKeysPowerShell(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  *datamodel.LinuxProfile
+		expected string
+	}{
+		{
+			name:     "nil profile",
+			profile:  nil,
+			expected: "",
+		},
+		{
+			name: "single key with whitespace trimmed",
+			profile: &datamodel.LinuxProfile{
+				SSH: struct {
+					PublicKeys []datamodel.PublicKey `json:"publicKeys"`
+				}{
+					PublicKeys: []datamodel.PublicKey{
+						{KeyData: "  ssh-rsa AAAAB3 user@host  "},
+					},
+				},
+			},
+			expected: "[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('c3NoLXJzYSBBQUFBQjMgdXNlckBob3N0'))",
+		},
+		{
+			name: "multiple keys",
+			profile: &datamodel.LinuxProfile{
+				SSH: struct {
+					PublicKeys []datamodel.PublicKey `json:"publicKeys"`
+				}{
+					PublicKeys: []datamodel.PublicKey{
+						{KeyData: "ssh-rsa AAAAB3 key1"},
+						{KeyData: "ssh-rsa AAAAC4 key2"},
+					},
+				},
+			},
+			expected: "[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('c3NoLXJzYSBBQUFBQjMga2V5MQ=='))" +
+				", " + "[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('c3NoLXJzYSBBQUFBQzQga2V5Mg=='))",
+		},
+		{
+			name: "key with special chars preserved",
+			profile: &datamodel.LinuxProfile{
+				SSH: struct {
+					PublicKeys []datamodel.PublicKey `json:"publicKeys"`
+				}{
+					PublicKeys: []datamodel.PublicKey{
+						{KeyData: "ssh-rsa AAAAB3 user's $(key)"},
+					},
+				},
+			},
+			expected: "[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('c3NoLXJzYSBBQUFBQjMgdXNlcidzICQoa2V5KQ=='))",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getSSHPublicKeysPowerShell(tc.profile)
+			if got != tc.expected {
+				t.Errorf("getSSHPublicKeysPowerShell()\ngot:  %s\nwant: %s", got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Switch `getSSHPublicKeysPowerShell` from rendering key data inside double-quoted PowerShell strings to base64-encoding each value and emitting a decode expression. The base64 alphabet (`A-Za-z0-9+/=`) contains no PowerShell delimiters or interpolation characters, ensuring key comments are preserved as literal data regardless of content.

### Changes
- `pkg/agent/utils.go` — new `encodePowerShellBase64Literal` helper, called from `getSSHPublicKeysPowerShell`
- `pkg/agent/utils_test.go` — unit tests covering various key comment contents, whitespace trimming, multiple keys, and round-trip decoding