### PR TITLE
fix(workflows): compare Windows packages against PR base

### DIFF
--- a/.github/workflows/check-windows-packages-change.yml
+++ b/.github/workflows/check-windows-packages-change.yml
@@ -11,8 +11,8 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
-          path: main
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
           fetch-depth: 1
           persist-credentials: false
 
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Produce vhd files - main
+      - name: Produce vhd files - base
         id: makeDiff
         shell: pwsh
         run: |
@@ -32,12 +32,12 @@ jobs:
 
           mkdir -Force "${DIFF_DIR}"
 
-          pwsh -c vhdbuilder/scripts/windows/generate_cached_stuff_list.ps1 "${DIFF_DIR}" vhdbuilder/packer/windows/components_json_helpers.ps1 ../main/vhdbuilder/packer/windows/windows_settings.json ../main/parts/common/components.json
+          pwsh -c vhdbuilder/scripts/windows/generate_cached_stuff_list.ps1 "${DIFF_DIR}" vhdbuilder/packer/windows/components_json_helpers.ps1 ../base/vhdbuilder/packer/windows/windows_settings.json ../base/parts/common/components.json
 
           git add "${DIFF_DIR}"
           git config user.email "you@example.com"
           git config user.name "Your Name"
-          git commit -m "versions of files from main"
+          git commit -m "versions of files from PR base"
 
           pwsh -c vhdbuilder/scripts/windows/generate_cached_stuff_list.ps1 "${DIFF_DIR}" vhdbuilder/packer/windows/components_json_helpers.ps1 vhdbuilder/packer/windows/windows_settings.json parts/common/components.json
 


### PR DESCRIPTION
# fix(workflows): compare Windows packages against PR base

**What this PR does / why we need it**:

Updated the Windows package comparison workflow to check out the pull request's exact base commit instead of always checking out `main`. The baseline checkout, generated package-list paths, step name, and temporary comparison commit message now consistently use `base`.

This ensures pull requests targeting release or other non-`main` branches are compared against their actual target commit.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None
