### PR TITLE
test: disable multi-GPU MIG scenario

### DIFF
--- a/e2e/scenario_gpu_managed_experience_test.go
+++ b/e2e/scenario_gpu_managed_experience_test.go
@@ -762,6 +762,8 @@ func runUbuntu2404NvidiaDevicePluginMIGSingle(
 }
 
 func Test_Ubuntu2404_NvidiaDevicePluginRunning_MIG_MultiGPU(t *testing.T) {
+	t.Skip("disabled to save on GPU quota")
+
 	const (
 		gpuCount           = 2
 		migInstancesPerGPU = 3

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -527,9 +527,7 @@ function nodePrep {
             # this will not be required per nvidia for next gen H100.
             REBOOTREQUIRED=true
 
-            # This service applies the partitioning scheme with nvidia-smi.
-            # We have looked into NVIDIA's mig-parted as an alternative, but it does not work well with our mixed MIG model
-            # because it would require us to deliberately define all possible MIG profile combinations.
+            # this service applies the partitioning scheme with nvidia-smi.
             logs_to_events "AKS.CSE.ensureMigPartition" ensureMigPartition
         fi
 

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -527,9 +527,9 @@ function nodePrep {
             # this will not be required per nvidia for next gen H100.
             REBOOTREQUIRED=true
 
-            # this service applies the partitioning scheme with nvidia-smi.
-            # we should consider moving to mig-parted which is simpler/newer.
-            # we couldn't because of old drivers but that has long been fixed.
+            # This service applies the partitioning scheme with nvidia-smi.
+            # We have looked into NVIDIA's mig-parted as an alternative, but it does not work well with our mixed MIG model
+            # because it would require us to deliberately define all possible MIG profile combinations.
             logs_to_events "AKS.CSE.ensureMigPartition" ensureMigPartition
         fi
 

--- a/parts/linux/cloud-init/artifacts/mig-partition.sh
+++ b/parts/linux/cloud-init/artifacts/mig-partition.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-#NOTE: Currently, Nvidia library mig-parted (https://github.com/NVIDIA/mig-parted) cannot work properly because of the outdated GPU driver version
-#TODO: Use mig-parted library to do the partition after the above issue is fixed 
+#NOTE: we have looked into Nvidia library mig-parted (https://github.com/NVIDIA/mig-parted) as an alternative but it doesn't work well with our mixed MIG model, since it would require us to deliberately define all possible MIG profile combinations.
 
 mig_profile_id() {
     case "$1" in
@@ -27,7 +26,7 @@ mig_profile_id() {
     esac
 }
 
-# TODO: Support GPU models with fewer than seven total partitions.
+#NOTE: The legacy uniform_mig_profile_layout only support GPU models with exactly 7 total partitions
 uniform_mig_profile_layout() {
     case "$1" in
         "MIG1g")


### PR DESCRIPTION
**What this PR does / why we need it**:

- Disables `Test_Ubuntu2404_NvidiaDevicePluginRunning_MIG_MultiGPU` before scenario setup to save GPU quota.
- Clarifies why `mig-parted` is not suitable for the mixed MIG model.
- Documents that the legacy uniform MIG layout supports GPU models with exactly seven total partitions.

**Testing done**:

- `go test -run '^Test_Ubuntu2404_NvidiaDevicePluginRunning_MIG_MultiGPU$' -count=1 -v` from `e2e/` (passes with the expected skip)
- `bash -n parts/linux/cloud-init/artifacts/mig-partition.sh`
- `shellcheck parts/linux/cloud-init/artifacts/mig-partition.sh`
- `git diff --check origin/main...HEAD`

**Which issue(s) this PR fixes**:

None.
