### PR TITLE
chore: remove former AKS code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @AbelHu @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @sulixu @SriHarsha001 @runzhen @karenychen @xuexu6666 @titilambert @benjamin-brady @fcher @sinmentis @aboodasfari @janenotjung-hue @abigailliang-aks-sig-node
+* @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @sulixu @SriHarsha001 @runzhen @karenychen @titilambert @benjamin-brady @fcher @sinmentis @aboodasfari @janenotjung-hue @abigailliang-aks-sig-node
 
 # Code owners for cse_cmd.sh and nodecustomdata.yml. This is to ensure that the scriptless v-team is aware of the changes in order to sync with AKSNodeConfig
 
@@ -9,11 +9,11 @@ nodecustomdata.yml @Devinwong @lilypan26 @r2k1 @timmy-wright @cameronmeissner @a
 
 # These include security patch owners since security patch script changes will cause the related custom data snapshots to change
 
-pkg/agent/testdata/ @yewmsft @YaoC @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @AbelHu @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @SriHarsha001 @fcher @sinmentis @aboodasfari @janenotjung-hue @abigailliang-aks-sig-node
+pkg/agent/testdata/ @yewmsft @YaoC @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @SriHarsha001 @fcher @sinmentis @aboodasfari @janenotjung-hue @abigailliang-aks-sig-node
 
 # Code owners for the security patch release notes
 
-vhdbuilder/release-notes/security-patch/ @yagmurbaydogan @yewmsft @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @AbelHu @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @SriHarsha001 @fcher
+vhdbuilder/release-notes/security-patch/ @yagmurbaydogan @yewmsft @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @SriHarsha001 @fcher
 
 # Code owners for security patching
 
@@ -40,9 +40,9 @@ vhdbuilder/packer/windows/windows_settings.json
 
 # Code owners for localdns exporter
 
-parts/linux/cloud-init/artifacts/localdns_exporter.sh @saewoni @yewmsft @jingwenw15
-spec/parts/linux/cloud-init/artifacts/localdns_exporter_spec.sh @saewoni @yewmsft @jingwenw15
-e2e/localdns/validate-localdns-exporter-metrics.sh @saewoni @yewmsft @jingwenw15
+parts/linux/cloud-init/artifacts/localdns_exporter.sh @saewoni @yewmsft
+spec/parts/linux/cloud-init/artifacts/localdns_exporter_spec.sh @saewoni @yewmsft
+e2e/localdns/validate-localdns-exporter-metrics.sh @saewoni @yewmsft
 
 # Code owners for Windows CSE files
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @sulixu @SriHarsha001 @runzhen @karenychen @titilambert @benjamin-brady @fcher @sinmentis @aboodasfari @janenotjung-hue @abigailliang-aks-sig-node
+* @cameronmeissner @ganeshkumarashok @Devinwong @lilypan26 @djsly @phealy @r2k1 @timmy-wright @zachary-bailey @awesomenix @mxj220 @pdamianov-dev @calvin197 @sulixu @SriHarsha001 @runzhen @karenychen @xuexu6666 @titilambert @benjamin-brady @fcher @sinmentis @aboodasfari @janenotjung-hue @abigailliang-aks-sig-node
 
 # Code owners for cse_cmd.sh and nodecustomdata.yml. This is to ensure that the scriptless v-team is aware of the changes in order to sync with AKSNodeConfig
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes @AbelHu and @jingwenw15 from CODEOWNERS because they no longer work in AKS. Existing ownership coverage remains in place for every affected path.

**Which issue(s) this PR fixes**:

N/A

> 🤖 *Generated by GitHub Copilot*