### PR TITLE
chore(ci): correct azure login version comments

### DIFF
--- a/.github/workflows/hotfix-generate.yml
+++ b/.github/workflows/hotfix-generate.yml
@@ -45,7 +45,7 @@ jobs:
     environment: test
     steps:
       - name: Azure login
-        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ secrets.AZURE_KV_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_KV_TENANT_ID }}

--- a/.github/workflows/tidy.yaml
+++ b/.github/workflows/tidy.yaml
@@ -23,7 +23,7 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.head.repo.full_name == 'Azure/AgentBaker'
     environment: test
     steps:
-      - uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
+      - uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ secrets.AZURE_KV_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_KV_TENANT_ID }}


### PR DESCRIPTION
## What
Updates the trailing version comment on the pinned `azure/login` action from `# v3` to `# v3.0.1` in two workflow files:
- `.github/workflows/hotfix-generate.yml`
- `.github/workflows/tidy.yaml`

The pinned SHA (`f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca`) is **unchanged**. This is a comment-only fix — no runtime action version changes.

## Why
`zizmor` resolves that SHA to `v3.0.1`, but `main` currently has a stale `# v3` comment next to it. This triggers zizmor's `ref-version-mismatch` finding and fails any PR that touches these workflow files, even unrelated ones.

## Scope
This is layer **L0** (base = `main`) — a minimal prerequisite fix, intended to supersede/replace the workflow-comment portion of #9321. It contains **no E2E migration code**.

## Validation
- Confirmed `main` had `# v3` in both files before editing.
- Diff limited to exactly these two comment lines (verified with `git diff`).
- YAML syntax validated (Ruby's YAML parser; PyYAML/zizmor/actionlint not installed locally, so no new tooling was installed per task constraints).