### PR TITLE
refactor(e2e): decouple scenarios from test control

### DIFF
--- a/e2e/aks_model.go
+++ b/e2e/aks_model.go
@@ -359,7 +359,7 @@ func addFirewallRules(
 		if err != nil {
 			return fmt.Errorf("failed to start adding route %q: %w", *route.Name, err)
 		}
-		_, err = poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+		_, err = poller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 		if err != nil {
 			return fmt.Errorf("failed to add route %q to AKS route table: %w", *route.Name, err)
 		}
@@ -409,7 +409,7 @@ func ensureFirewallRouteTable(
 		if err != nil {
 			return fmt.Errorf("failed to start creating firewall route table %q: %w", routeTableName, err)
 		}
-		routeTableResp, err := poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+		routeTableResp, err := poller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 		if err != nil {
 			return fmt.Errorf("failed to create firewall route table %q: %w", routeTableName, err)
 		}
@@ -1150,7 +1150,7 @@ func createNetworkIsolatedSecurityGroup(ctx context.Context, cluster *armcontain
 	if err != nil {
 		return nil, err
 	}
-	nsg, err := poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	nsg, err := poller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 	if err != nil {
 		return nil, err
 	}
@@ -1175,7 +1175,7 @@ func updateSubnet(ctx context.Context, cluster *armcontainerservice.ManagedClust
 		if err != nil {
 			return err
 		}
-		_, err = poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+		_, err = poller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 		return err
 	})
 }

--- a/e2e/cache.go
+++ b/e2e/cache.go
@@ -68,7 +68,7 @@ func createGallery(ctx context.Context, request CreateGalleryRequest) (armcomput
 	if err != nil {
 		return armcompute.Gallery{}, fmt.Errorf("failed to create gallery: %w", err)
 	}
-	resp, err := poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	resp, err := poller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 	if err != nil {
 		return armcompute.Gallery{}, fmt.Errorf("failed to poll gallery creation: %w", err)
 	}
@@ -129,7 +129,7 @@ func createGalleryImage(ctx context.Context, request CreateGalleryImageRequest) 
 	if err != nil {
 		return armcompute.GalleryImage{}, fmt.Errorf("failed to create gallery image: %w", err)
 	}
-	resp, err := poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	resp, err := poller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 	if err != nil {
 		return armcompute.GalleryImage{}, fmt.Errorf("failed to poll gallery image creation: %w", err)
 	}

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -482,7 +482,7 @@ func deleteCluster(ctx context.Context, clusterName, resourceGroupName string) e
 	if err != nil {
 		return fmt.Errorf("failed to delete cluster %q: %w", clusterName, err)
 	}
-	_, err = pollerResp.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	_, err = pollerResp.PollUntilDone(ctx, config.PollUntilDoneOptions())
 	if err != nil {
 		return fmt.Errorf("failed to wait for cluster deletion %w", err)
 	}
@@ -613,7 +613,7 @@ func createNewAKSCluster(ctx context.Context, cluster *armcontainerservice.Manag
 		return nil, fmt.Errorf("failed to begin aks cluster creation: %w", err)
 	}
 
-	clusterResp, err := pollerResp.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	clusterResp, err := pollerResp.PollUntilDone(ctx, config.PollUntilDoneOptions())
 	if err != nil {
 		return nil, fmt.Errorf("failed to wait for aks cluster creation %w", err)
 	}

--- a/e2e/config/azure.go
+++ b/e2e/config/azure.go
@@ -448,7 +448,7 @@ func (a *AzureClient) createBlobStorageAccount(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("create storage account: %w", err)
 	}
-	_, err = poller.PollUntilDone(ctx, DefaultPollUntilDoneOptions)
+	_, err = poller.PollUntilDone(ctx, PollUntilDoneOptions())
 	if err != nil {
 		return fmt.Errorf("create storage account: %w", err)
 	}
@@ -747,7 +747,7 @@ func (a *AzureClient) replicateImageVersionToCurrentRegion(ctx context.Context, 
 	if err != nil {
 		return fmt.Errorf("begin updating image version target regions: %w", err)
 	}
-	if _, err := resp.PollUntilDone(ctx, DefaultPollUntilDoneOptions); err != nil {
+	if _, err := resp.PollUntilDone(ctx, PollUntilDoneOptions()); err != nil {
 		return fmt.Errorf("updating image version target regions: %w", err)
 	}
 
@@ -833,7 +833,7 @@ func (a *AzureClient) DeleteDisk(ctx context.Context, resourceGroupName, diskNam
 		return fmt.Errorf("failed to delete disk: %w", err)
 	}
 
-	_, err = deleteOp.PollUntilDone(ctx, DefaultPollUntilDoneOptions)
+	_, err = deleteOp.PollUntilDone(ctx, PollUntilDoneOptions())
 	if err != nil {
 		return fmt.Errorf("failed to complete disk deletion: %w", err)
 	}
@@ -848,7 +848,7 @@ func (a *AzureClient) DeleteSnapshot(ctx context.Context, resourceGroupName, sna
 		return fmt.Errorf("failed to delete snapshot: %w", err)
 	}
 
-	_, err = deleteOp.PollUntilDone(ctx, DefaultPollUntilDoneOptions)
+	_, err = deleteOp.PollUntilDone(ctx, PollUntilDoneOptions())
 	if err != nil {
 		return fmt.Errorf("failed to complete snapshot deletion: %w", err)
 	}

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -22,6 +22,9 @@ import (
 
 const (
 	DefaultV5VMSKU = "Standard_D2ds_v5"
+
+	// defaultPollUntilDoneFrequency is how often a long-running ARM operation is polled.
+	defaultPollUntilDoneFrequency = 15 * time.Second
 )
 
 var (
@@ -29,17 +32,24 @@ var (
 	Azure          = mustNewAzureClient()
 	VMIdentityName = "abe2e-vm-identity"
 
-	// Poll long-running ARM operations every 15s rather than every 1s. The E2E suite runs
-	// with -parallel 60, so a 1s cadence across dozens of concurrent VMSS create/delete
-	// operations floods ARM and triggers ResourceCollectionRequestsThrottled (429), which
-	// stalls provisioning past TestTimeoutVMSS and surfaces as "context deadline exceeded".
-	// These operations take minutes, so 15s polling is ample and cuts ARM request volume ~15x.
-	DefaultPollUntilDoneOptions = &runtime.PollUntilDoneOptions{
-		Frequency: 15 * time.Second,
-	}
 	VMSSHPublicKey, VMSSHPrivateKey, SysSSHPublicKey, SysSSHPrivateKey []byte
 	VMSSHPrivateKeyFileName, SysSSHPrivateKeyFileName                  string
 )
+
+// PollUntilDoneOptions returns fresh polling options for a single ARM long-running
+// operation. Options are returned per call so no mutable pointer is shared between
+// concurrently running scenarios.
+//
+// Poll long-running ARM operations every 15s rather than every 1s. The E2E suite runs
+// with -parallel 60, so a 1s cadence across dozens of concurrent VMSS create/delete
+// operations floods ARM and triggers ResourceCollectionRequestsThrottled (429), which
+// stalls provisioning past TestTimeoutVMSS and surfaces as "context deadline exceeded".
+// These operations take minutes, so 15s polling is ample and cuts ARM request volume ~15x.
+func PollUntilDoneOptions() *runtime.PollUntilDoneOptions {
+	return &runtime.PollUntilDoneOptions{
+		Frequency: defaultPollUntilDoneFrequency,
+	}
+}
 
 func ResourceGroupName(location string) string {
 	return "abe2e-" + location

--- a/e2e/config/config_poll_test.go
+++ b/e2e/config/config_poll_test.go
@@ -1,0 +1,18 @@
+package config
+
+import "testing"
+
+func TestPollUntilDoneOptionsAreNotShared(t *testing.T) {
+	first := PollUntilDoneOptions()
+	second := PollUntilDoneOptions()
+	if first == second {
+		t.Fatal("expected independent options per operation, got the same pointer")
+	}
+	if first.Frequency != defaultPollUntilDoneFrequency {
+		t.Errorf("expected the fixed poll frequency %s, got %s", defaultPollUntilDoneFrequency, first.Frequency)
+	}
+	first.Frequency = 0
+	if second.Frequency != defaultPollUntilDoneFrequency {
+		t.Error("mutating one set of options must not affect another")
+	}
+}

--- a/e2e/cse_timing.go
+++ b/e2e/cse_timing.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/Azure/agentbaker/e2e/toolkit"
@@ -252,14 +251,10 @@ type CSETimingThresholds struct {
 }
 
 // ValidateCSETimings extracts, logs, and validates CSE task timings.
-// It emits one subtest per threshold so ADO can track each timing check.
+// It records one check per threshold so the runner can report each timing check
+// separately.
 func ValidateCSETimings(ctx context.Context, s *Scenario, thresholds CSETimingThresholds) (*CSETimingReport, error) {
 	defer toolkit.LogStep(s.Logger, "validating CSE task timings")()
-
-	tRunner := toolkit.UnwrapTestingT(s.T)
-	if tRunner == nil {
-		return nil, fmt.Errorf("ValidateCSETimings requires *testing.T for sub-test support, got %T", s.T)
-	}
 
 	report := s.Runtime.CSETimingReport
 	if report == nil {
@@ -289,12 +284,8 @@ func ValidateCSETimings(ctx context.Context, s *Scenario, thresholds CSETimingTh
 			checkErr = fmt.Errorf("CSE total duration %s exceeds threshold %s", totalDuration, thresholds.TotalCSEThreshold)
 			errs = append(errs, checkErr)
 		}
-		tRunner.Run("TotalCSEDuration", func(t *testing.T) {
-			t.Logf("total CSE duration: %s (threshold: %s)", totalDuration, thresholds.TotalCSEThreshold)
-			if checkErr != nil {
-				t.Error(checkErr)
-			}
-		})
+		s.Logger.Logf("total CSE duration: %s (threshold: %s)", totalDuration, thresholds.TotalCSEThreshold)
+		s.recordCheck("TotalCSEDuration", totalDuration, checkErr)
 	}
 
 	sortedSuffixes := make([]string, 0, len(thresholds.TaskThresholds))
@@ -331,12 +322,8 @@ func ValidateCSETimings(ctx context.Context, s *Scenario, thresholds CSETimingTh
 					checkErr = fmt.Errorf("CSE task %s took %s, exceeds threshold %s", task.TaskName, task.Duration, maxDuration)
 					errs = append(errs, checkErr)
 				}
-				tRunner.Run(fmt.Sprintf("Task_%s", testName), func(t *testing.T) {
-					t.Logf("task %s duration: %s (threshold: %s)", task.TaskName, task.Duration, maxDuration)
-					if checkErr != nil {
-						t.Error(checkErr)
-					}
-				})
+				s.Logger.Logf("task %s duration: %s (threshold: %s)", task.TaskName, task.Duration, maxDuration)
+				s.recordCheck("Task_"+testName, task.Duration, checkErr)
 				break
 			}
 		}
@@ -374,13 +361,9 @@ func ValidateCSETimings(ctx context.Context, s *Scenario, thresholds CSETimingTh
 					task.TaskName, task.Duration, defaultThreshold)
 				errs = append(errs, checkErr)
 			}
-			tRunner.Run(fmt.Sprintf("Task_%s", shortName), func(t *testing.T) {
-				t.Logf("task %s duration: %s (default threshold: %s — no specific threshold configured)",
-					task.TaskName, task.Duration, defaultThreshold)
-				if checkErr != nil {
-					t.Error(checkErr)
-				}
-			})
+			s.Logger.Logf("task %s duration: %s (default threshold: %s — no specific threshold configured)",
+				task.TaskName, task.Duration, defaultThreshold)
+			s.recordCheck("Task_"+shortName, task.Duration, checkErr)
 		}
 	}
 

--- a/e2e/scenario_control_test.go
+++ b/e2e/scenario_control_test.go
@@ -1,0 +1,92 @@
+package e2e
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/agentbaker/e2e/config"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+func TestRecordCheckCapturesFailureMessage(t *testing.T) {
+	s := &Scenario{}
+	s.recordCheck("TotalCSEDuration", 3*time.Second, nil)
+	s.recordCheck("Task_cse_start", 5*time.Second, errors.New("too slow"))
+
+	if len(s.checks) != 2 {
+		t.Fatalf("expected 2 recorded checks, got %d", len(s.checks))
+	}
+	if s.checks[0].Message != "" {
+		t.Errorf("expected a passing check to have no message, got %q", s.checks[0].Message)
+	}
+	if s.checks[1].Message != "too slow" {
+		t.Errorf("expected the failure message, got %q", s.checks[1].Message)
+	}
+	if s.checks[1].Duration != 5*time.Second {
+		t.Errorf("expected the recorded duration, got %s", s.checks[1].Duration)
+	}
+}
+
+func TestMarkScenarioOutcomeTreatsSkipAsNotFailed(t *testing.T) {
+	failing := &Scenario{}
+	markScenarioOutcome(failing, errors.New("boom"), nil)
+	if !failing.failed {
+		t.Error("expected an error to mark the scenario failed")
+	}
+
+	skipped := &Scenario{}
+	markScenarioOutcome(skipped, fmt.Errorf("wrapped: %w", &skipError{message: "no capacity"}), nil)
+	if skipped.failed {
+		t.Error("expected a skip not to mark the scenario failed")
+	}
+
+	passing := &Scenario{}
+	markScenarioOutcome(passing, nil, nil)
+	if passing.failed {
+		t.Error("expected a successful scenario not to be marked failed")
+	}
+}
+
+func TestSkipIfSKUNotAvailableErr(t *testing.T) {
+	original := config.Config.SkipTestsWithSKUCapacityIssue
+	config.Config.SkipTestsWithSKUCapacityIssue = true
+	t.Cleanup(func() { config.Config.SkipTestsWithSKUCapacityIssue = original })
+
+	notAvailable := &azcore.ResponseError{StatusCode: http.StatusConflict, ErrorCode: "SkuNotAvailable"}
+	var skip *skipError
+	if err := skipIfSKUNotAvailableErr(fmt.Errorf("create vmss: %w", notAvailable)); !errors.As(err, &skip) {
+		t.Errorf("expected a skip for an unavailable SKU, got %v", err)
+	}
+
+	other := &azcore.ResponseError{StatusCode: http.StatusConflict, ErrorCode: "Conflict"}
+	if err := skipIfSKUNotAvailableErr(other); err != nil {
+		t.Errorf("expected no skip for an unrelated conflict, got %v", err)
+	}
+	if err := skipIfSKUNotAvailableErr(nil); err != nil {
+		t.Errorf("expected no skip without an error, got %v", err)
+	}
+
+	config.Config.SkipTestsWithSKUCapacityIssue = false
+	if err := skipIfSKUNotAvailableErr(notAvailable); err != nil {
+		t.Errorf("expected no skip when the option is disabled, got %v", err)
+	}
+}
+
+func TestScenarioVMSizeIsScenarioLocal(t *testing.T) {
+	if got := scenarioVMSize(&Scenario{}); got != config.Config.DefaultVMSKU {
+		t.Errorf("expected the configured default before runtime state exists, got %q", got)
+	}
+	s := &Scenario{Runtime: &ScenarioRuntime{VMSize: config.DefaultV5VMSKU}}
+	if got := scenarioVMSize(s); got != config.DefaultV5VMSKU {
+		t.Errorf("expected the scenario-local VM size, got %q", got)
+	}
+	if config.Config.DefaultVMSKU == config.DefaultV5VMSKU {
+		return
+	}
+	if scenarioVMSize(&Scenario{}) != config.Config.DefaultVMSKU {
+		t.Error("a scenario-local fallback must not change the configured default")
+	}
+}

--- a/e2e/scenario_runner_test.go
+++ b/e2e/scenario_runner_test.go
@@ -1,0 +1,219 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	aksnodeconfigv1 "github.com/Azure/agentbaker/aks-node-controller/pkg/gen/aksnodeconfig/v1"
+	"github.com/Azure/agentbaker/e2e/config"
+	"github.com/Azure/agentbaker/e2e/toolkit"
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
+)
+
+// This file is the compatibility adapter between the `go test` runner and the
+// test-control-free scenario implementation. Everything that reads or writes
+// test state - skipping, failing, sub-tests, parallelism, test cleanup - lives
+// here. Implementation code only returns errors and records checks.
+
+// RunScenario runs s as a Go test. Scenario definitions keep calling it, so the
+// existing Test_* functions, their names and their sub-test layout are unchanged.
+func RunScenario(t *testing.T, s *Scenario) {
+	t.Parallel()
+	// Special case for testing VHD caching. Not used by default.
+	if config.Config.TestPreProvision || s.VHDCaching {
+		t.Run("VHDCreation", func(t *testing.T) {
+			t.Parallel()
+			runScenarioWithPreProvision(t, s)
+		})
+		return
+	}
+	if config.Config.DisableScriptless || scriptlessUnsupported(s) {
+		runScenarioForTest(t, s)
+		return
+	}
+
+	if s.Runtime == nil {
+		s.Runtime = &ScenarioRuntime{}
+	}
+	s.Runtime.EnableScriptlessNBCCSECmd = true
+	runScenarioForTest(t, s)
+}
+
+// runScenarioForTest attaches a test-backed logger and cleanup stack to s, runs
+// the scenario, mirrors the checks it recorded into sub-tests, and reports the
+// outcome to t. It returns the scenario error so staged runs can decide whether
+// to continue. It does not return when the scenario is skipped, because
+// testing.T.Skip ends the goroutine.
+func runScenarioForTest(t *testing.T, s *Scenario) error {
+	t.Helper()
+	tb := toolkit.WithFailureFormatting(t)
+	logger := toolkit.NewTestLogger(tb)
+	ctx := newTestCtx(tb, logger)
+	if s.cleanup != nil {
+		panic("Scenario.Cleanup called outside of a scenario run")
+	}
+	cleanup := &scenarioCleanup{}
+	s.cleanup = cleanup
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), scenarioCleanupTimeout)
+		defer cancel()
+		if err := cleanup.runCleanups(cleanupCtx); err != nil {
+			tb.Errorf("scenario cleanup failed: %v", err)
+		}
+	})
+
+	err := runScenario(ctx, t.Name(), logger, s)
+	reportScenarioChecks(t, s)
+
+	var skip *skipError
+	if errors.As(err, &skip) {
+		t.Skip(skip.Error())
+	}
+	if err != nil {
+		tb.Error(err)
+	}
+	return err
+}
+
+// reportScenarioChecks turns the checks a scenario recorded into child test
+// results, so ADO keeps per-check history for CSE timings.
+func reportScenarioChecks(t *testing.T, s *Scenario) {
+	t.Helper()
+	for _, check := range s.checks {
+		t.Run(check.Name, func(t *testing.T) {
+			t.Logf("%s: %s", check.Name, check.Duration)
+			if check.Message != "" {
+				t.Error(check.Message)
+			}
+		})
+	}
+}
+
+func newTestCtx(t testing.TB, logger toolkit.Logger) context.Context {
+	if testCtx.Err() != nil {
+		t.Skip("test suite is shutting down")
+	}
+	ctx, cancel := context.WithTimeout(testCtx, config.Config.TestTimeout)
+	t.Cleanup(cancel)
+	// only a logger is put in the context, implementation code must not be able
+	// to control the test through it
+	ctx = toolkit.ContextWithLogger(ctx, logger)
+	return ctx
+}
+
+func runScenarioWithPreProvision(t *testing.T, original *Scenario) {
+	// This is hard to understand. Some functional magic is used to run the original scenario in two stages.
+	// 1. Stage 1: Run the original scenario with pre-provisioning enabled, but skip the main validation and validate only pre-provisioning.
+	// 2. Create a new Image from the VMSS created in Stage 1
+	// 3. Stage 2: Run the original scenario again, but this time using the custom VHD created in a previous step, with validators,
+	// The goal here is to test pre-provisioning logic on the variety of existing scenarios
+	firstStage := copyScenario(original)
+	var customVHD *config.Image
+
+	// Mutate the copy for pre-provisioning
+	firstStage.Config.SkipDefaultValidation = true
+	firstStage.Config.Validator = func(ctx context.Context, stage1 *Scenario) error {
+		var validationErr error
+		if stage1.IsWindows() {
+			validationErr = errors.Join(
+				ValidateFileExists(ctx, stage1, "C:\\AzureData\\base_prep.complete"),
+				ValidateFileDoesNotExist(ctx, stage1, "C:\\AzureData\\provision.complete"),
+				ValidateWindowsServiceIsNotRunning(ctx, stage1, "kubelet"),
+				ValidateWindowsServiceIsRunning(ctx, stage1, "containerd"),
+			)
+		} else {
+			validationErr = errors.Join(
+				ValidateFileExists(ctx, stage1, "/etc/containerd/config.toml"),
+				ValidateFileExists(ctx, stage1, "/opt/azure/containers/base_prep.complete"),
+				ValidateFileDoesNotExist(ctx, stage1, "/opt/azure/containers/provision.complete"),
+				ValidateSystemdUnitIsRunning(ctx, stage1, "containerd"),
+				ValidateSystemdUnitIsNotRunning(ctx, stage1, "kubelet"),
+			)
+		}
+		if validationErr != nil {
+			return validationErr
+		}
+		toolkit.Log(ctx, "=== Creating VHD Image ===")
+		var err error
+		customVHD, err = CreateImage(ctx, stage1)
+		if err != nil {
+			return err
+		}
+		customVHDJSON, _ := json.MarshalIndent(customVHD, "", "  ")
+		toolkit.Logf(ctx, "Created custom VHD image: %s", string(customVHDJSON))
+		cleanupBastionTunnel(firstStage.Runtime.VM.SSHClient)
+		firstStage.Runtime.VM.SSHClient = nil
+		return nil
+	}
+	firstStage.Config.VMConfigMutator = func(vmss *armcompute.VirtualMachineScaleSet) {
+		if original.VMConfigMutator != nil {
+			original.VMConfigMutator(vmss)
+		}
+		if vmss.Properties.VirtualMachineProfile.StorageProfile.OSDisk != nil {
+			vmss.Properties.VirtualMachineProfile.StorageProfile.OSDisk.DiffDiskSettings = nil
+		}
+	}
+	if original.BootstrapConfigMutator != nil || original.BootstrapConfigMutatorWithError != nil || original.PreProvisionBootstrapConfigMutator != nil {
+		firstStage.BootstrapConfigMutator = nil
+		firstStage.BootstrapConfigMutatorWithError = func(ctx context.Context, cluster *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) error {
+			if original.BootstrapConfigMutator != nil {
+				original.BootstrapConfigMutator(cluster, nbc)
+			}
+			if original.BootstrapConfigMutatorWithError != nil {
+				if err := original.BootstrapConfigMutatorWithError(ctx, cluster, nbc); err != nil {
+					return err
+				}
+			}
+			nbc.PreProvisionOnly = true
+			nbc.EnableScriptlessNBCCSECmd = false
+			// Bake-stage-only mutation: lets a scenario deliberately diverge bake-time
+			// state from provision-time state (e.g. a stale sentinel bootstrap token).
+			if original.PreProvisionBootstrapConfigMutator != nil {
+				original.PreProvisionBootstrapConfigMutator(cluster, nbc)
+			}
+			return nil
+		}
+	}
+	if original.AKSNodeConfigMutator != nil {
+		firstStage.AKSNodeConfigMutator = func(cluster *Cluster, nodeconfig *aksnodeconfigv1.Configuration) {
+			original.AKSNodeConfigMutator(cluster, nodeconfig)
+			nodeconfig.PreProvisionOnly = true
+		}
+	}
+
+	if err := runScenarioForTest(t, firstStage); err != nil {
+		return
+	}
+
+	if t.Failed() {
+		return
+	}
+
+	// Create a new subtest to avoid conflicts with previous steps (log output folder is based on the test name)
+	t.Run("VMProvision", func(t *testing.T) {
+		t.Parallel()
+		secondStageScenario := copyScenario(original)
+		secondStageScenario.Description = "Stage 2: Create VMSS from captured VHD via SIG"
+		secondStageScenario.Config.VHD = customVHD
+		secondStageScenario.Config.Validator = func(ctx context.Context, s *Scenario) error {
+			// This validators are used when running all scenarios in "VHD Caching" mode, which is usually done manually
+			var markerErr error
+			if s.IsWindows() {
+				markerErr = ValidateFileExists(ctx, s, "C:\\AzureData\\provision.complete")
+			} else {
+				markerErr = ValidateFileExists(ctx, s, "/opt/azure/containers/provision.complete")
+			}
+			if markerErr != nil {
+				return markerErr
+			}
+			if original.Config.Validator != nil {
+				return original.Config.Validator(ctx, s)
+			}
+			return nil
+		}
+		runScenarioForTest(t, secondStageScenario)
+	})
+}

--- a/e2e/shared_infra.go
+++ b/e2e/shared_infra.go
@@ -121,7 +121,7 @@ func ensureSharedVNet(ctx context.Context, rg, location string) error {
 			if updateErr != nil {
 				return fmt.Errorf("adding IPv6 to shared VNet: %w", updateErr)
 			}
-			if _, updateErr = poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions); updateErr != nil {
+			if _, updateErr = poller.PollUntilDone(ctx, config.PollUntilDoneOptions()); updateErr != nil {
 				return fmt.Errorf("waiting for IPv6 VNet update: %w", updateErr)
 			}
 		}
@@ -143,7 +143,7 @@ func ensureSharedVNet(ctx context.Context, rg, location string) error {
 	if err != nil {
 		return fmt.Errorf("creating shared VNet: %w", err)
 	}
-	_, err = poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	_, err = poller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 	if err != nil {
 		return fmt.Errorf("waiting for shared VNet creation: %w", err)
 	}
@@ -168,7 +168,7 @@ func ensurePESubnet(ctx context.Context, rg string) error {
 	if err != nil {
 		return fmt.Errorf("creating PE subnet: %w", err)
 	}
-	_, err = poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	_, err = poller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 	if err != nil {
 		return fmt.Errorf("waiting for PE subnet creation: %w", err)
 	}
@@ -210,7 +210,7 @@ func cleanupOrphanedSubnets(ctx context.Context, rg string) {
 				toolkit.Logf(ctx, "warning: failed to start deleting subnet %s: %v", name, err)
 				continue
 			}
-			if _, err := poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions); err != nil {
+			if _, err := poller.PollUntilDone(ctx, config.PollUntilDoneOptions()); err != nil {
 				toolkit.Logf(ctx, "warning: failed to delete subnet %s: %v", name, err)
 			}
 		}
@@ -247,7 +247,7 @@ func ensureSubnet(ctx context.Context, rg, vnetName, subnetName, cidr string) er
 		if err != nil {
 			return fmt.Errorf("creating subnet %s: %w", subnetName, err)
 		}
-		_, err = poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+		_, err = poller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 		if err != nil {
 			return fmt.Errorf("waiting for subnet %s: %w", subnetName, err)
 		}
@@ -276,7 +276,7 @@ func ensureDualStackSubnet(ctx context.Context, rg, vnetName, subnetName, ipv4CI
 		if err != nil {
 			return fmt.Errorf("creating dual-stack subnet %s: %w", subnetName, err)
 		}
-		_, err = poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+		_, err = poller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 		if err != nil {
 			return fmt.Errorf("waiting for dual-stack subnet %s: %w", subnetName, err)
 		}
@@ -297,7 +297,7 @@ func ensureBastionIPConnect(ctx context.Context, rg string, bastion armnetwork.B
 	if err != nil {
 		return fmt.Errorf("enabling bastion IP connect: %w", err)
 	}
-	if _, err := poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions); err != nil {
+	if _, err := poller.PollUntilDone(ctx, config.PollUntilDoneOptions()); err != nil {
 		return fmt.Errorf("waiting for bastion IP connect: %w", err)
 	}
 	return nil
@@ -335,7 +335,7 @@ func ensureSharedBastion(ctx context.Context, rg, location string) (string, erro
 	if err != nil {
 		return "", fmt.Errorf("creating bastion public IP: %w", err)
 	}
-	pipResp, err := pipPoller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	pipResp, err := pipPoller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 	if err != nil {
 		return "", fmt.Errorf("waiting for bastion public IP: %w", err)
 	}
@@ -374,7 +374,7 @@ func ensureSharedBastion(ctx context.Context, rg, location string) (string, erro
 	if err != nil {
 		return "", fmt.Errorf("creating shared bastion: %w", err)
 	}
-	resp, err := bastionPoller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	resp, err := bastionPoller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 	if err != nil {
 		return "", fmt.Errorf("waiting for shared bastion: %w", err)
 	}
@@ -421,7 +421,7 @@ func ensureSharedFirewall(ctx context.Context, rg, location string) (string, err
 		if err != nil {
 			return "", fmt.Errorf("updating shared firewall app rules: %w", err)
 		}
-		fwResp, err := fwPoller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+		fwResp, err := fwPoller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 		if err != nil {
 			return "", fmt.Errorf("waiting for shared firewall update: %w", err)
 		}
@@ -455,7 +455,7 @@ func ensureSharedFirewall(ctx context.Context, rg, location string) (string, err
 	if err != nil {
 		return "", fmt.Errorf("creating firewall public IP: %w", err)
 	}
-	pipResp, err := pipPoller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	pipResp, err := pipPoller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 	if err != nil {
 		return "", fmt.Errorf("waiting for firewall public IP: %w", err)
 	}
@@ -467,7 +467,7 @@ func ensureSharedFirewall(ctx context.Context, rg, location string) (string, err
 	if err != nil {
 		return "", fmt.Errorf("creating shared firewall: %w", err)
 	}
-	fwResp, err := fwPoller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	fwResp, err := fwPoller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 	if err != nil {
 		return "", fmt.Errorf("waiting for shared firewall: %w", err)
 	}
@@ -674,7 +674,7 @@ func detachNodeResourceGroupReferencesFromClusterSubnet(ctx context.Context, loc
 		if err != nil {
 			return fmt.Errorf("detaching node resource group references from subnet %s: %w", subnetName, err)
 		}
-		_, err = poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+		_, err = poller.PollUntilDone(ctx, config.PollUntilDoneOptions())
 		return err
 	})
 }

--- a/e2e/skip.go
+++ b/e2e/skip.go
@@ -1,0 +1,11 @@
+package e2e
+
+// skipError reports that a scenario cannot run and must not be treated as a
+// failure. Implementation code returns it instead of calling into test control.
+type skipError struct {
+	message string
+}
+
+func (e *skipError) Error() string {
+	return e.message
+}

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -13,10 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-	"testing"
 	"time"
 
-	aksnodeconfigv1 "github.com/Azure/agentbaker/aks-node-controller/pkg/gen/aksnodeconfig/v1"
 	"github.com/Azure/agentbaker/aks-node-controller/pkg/nodeconfigutils"
 	"github.com/Azure/agentbaker/e2e/assert"
 	"github.com/Azure/agentbaker/e2e/components"
@@ -64,184 +62,37 @@ func constructErrorMessage(subscriptionID, location string) string {
 	return fmt.Sprintf("Received second cancellation signal, forcing exit.\nPlease check https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/%s/resourceGroups/%s/overview and delete any resources created by the test suite", subscriptionID, config.ResourceGroupName(location))
 }
 
-func newTestCtx(t testing.TB, logger toolkit.Logger) context.Context {
-	if testCtx.Err() != nil {
-		t.Skip("test suite is shutting down")
-	}
-	ctx, cancel := context.WithTimeout(testCtx, config.Config.TestTimeout)
-	t.Cleanup(cancel)
-	// only a logger is put in the context, implementation code must not be able
-	// to control the test through it
-	ctx = toolkit.ContextWithLogger(ctx, logger)
-	return ctx
-}
-
-func RunScenario(t *testing.T, s *Scenario) {
-	t.Parallel()
-	// Special case for testing VHD caching. Not used by default.
-	if config.Config.TestPreProvision || s.VHDCaching {
-		t.Run("VHDCreation", func(t *testing.T) {
-			t.Parallel()
-			if err := runScenarioWithPreProvision(t, s); err != nil {
-				s.T.Error(err)
-			}
-		})
-		return
-	}
-	if config.Config.DisableScriptless || scriptlessUnsupported(s) {
-		if err := runScenario(t, s); err != nil {
-			s.T.Error(err)
-		}
-		return
-	}
-
-	if s.Runtime == nil {
-		s.Runtime = &ScenarioRuntime{}
-	}
-	s.Runtime.EnableScriptlessNBCCSECmd = true
-	if err := runScenario(t, s); err != nil {
-		s.T.Error(err)
-	}
-}
-
 func scriptlessUnsupported(s *Scenario) bool {
 	return s.IsWindows() || len(s.Config.CustomDataWriteFiles) > 0 || s.VHDCaching || config.Config.TestPreProvision || s.VHD.Distro == datamodel.AKSAzureLinuxV2Gen2
-}
-
-func runScenarioWithPreProvision(t *testing.T, original *Scenario) error {
-	// This is hard to understand. Some functional magic is used to run the original scenario in two stages.
-	// 1. Stage 1: Run the original scenario with pre-provisioning enabled, but skip the main validation and validate only pre-provisioning.
-	// 2. Create a new Image from the VMSS created in Stage 1
-	// 3. Stage 2: Run the original scenario again, but this time using the custom VHD created in a previous step, with validators,
-	// The goal here is to test pre-provisioning logic on the variety of existing scenarios
-	firstStage := copyScenario(original)
-	var customVHD *config.Image
-
-	// Mutate the copy for pre-provisioning
-	firstStage.Config.SkipDefaultValidation = true
-	firstStage.Config.Validator = func(ctx context.Context, stage1 *Scenario) error {
-		var validationErr error
-		if stage1.IsWindows() {
-			validationErr = errors.Join(
-				ValidateFileExists(ctx, stage1, "C:\\AzureData\\base_prep.complete"),
-				ValidateFileDoesNotExist(ctx, stage1, "C:\\AzureData\\provision.complete"),
-				ValidateWindowsServiceIsNotRunning(ctx, stage1, "kubelet"),
-				ValidateWindowsServiceIsRunning(ctx, stage1, "containerd"),
-			)
-		} else {
-			validationErr = errors.Join(
-				ValidateFileExists(ctx, stage1, "/etc/containerd/config.toml"),
-				ValidateFileExists(ctx, stage1, "/opt/azure/containers/base_prep.complete"),
-				ValidateFileDoesNotExist(ctx, stage1, "/opt/azure/containers/provision.complete"),
-				ValidateSystemdUnitIsRunning(ctx, stage1, "containerd"),
-				ValidateSystemdUnitIsNotRunning(ctx, stage1, "kubelet"),
-			)
-		}
-		if validationErr != nil {
-			return validationErr
-		}
-		toolkit.Log(ctx, "=== Creating VHD Image ===")
-		var err error
-		customVHD, err = CreateImage(ctx, stage1)
-		if err != nil {
-			return err
-		}
-		customVHDJSON, _ := json.MarshalIndent(customVHD, "", "  ")
-		toolkit.Logf(ctx, "Created custom VHD image: %s", string(customVHDJSON))
-		cleanupBastionTunnel(firstStage.Runtime.VM.SSHClient)
-		firstStage.Runtime.VM.SSHClient = nil
-		return nil
-	}
-	firstStage.Config.VMConfigMutator = func(vmss *armcompute.VirtualMachineScaleSet) {
-		if original.VMConfigMutator != nil {
-			original.VMConfigMutator(vmss)
-		}
-		if vmss.Properties.VirtualMachineProfile.StorageProfile.OSDisk != nil {
-			vmss.Properties.VirtualMachineProfile.StorageProfile.OSDisk.DiffDiskSettings = nil
-		}
-	}
-	if original.BootstrapConfigMutator != nil || original.BootstrapConfigMutatorWithError != nil || original.PreProvisionBootstrapConfigMutator != nil {
-		firstStage.BootstrapConfigMutator = nil
-		firstStage.BootstrapConfigMutatorWithError = func(ctx context.Context, cluster *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) error {
-			if original.BootstrapConfigMutator != nil {
-				original.BootstrapConfigMutator(cluster, nbc)
-			}
-			if original.BootstrapConfigMutatorWithError != nil {
-				if err := original.BootstrapConfigMutatorWithError(ctx, cluster, nbc); err != nil {
-					return err
-				}
-			}
-			nbc.PreProvisionOnly = true
-			nbc.EnableScriptlessNBCCSECmd = false
-			// Bake-stage-only mutation: lets a scenario deliberately diverge bake-time
-			// state from provision-time state (e.g. a stale sentinel bootstrap token).
-			if original.PreProvisionBootstrapConfigMutator != nil {
-				original.PreProvisionBootstrapConfigMutator(cluster, nbc)
-			}
-			return nil
-		}
-	}
-	if original.AKSNodeConfigMutator != nil {
-		firstStage.AKSNodeConfigMutator = func(cluster *Cluster, nodeconfig *aksnodeconfigv1.Configuration) {
-			original.AKSNodeConfigMutator(cluster, nodeconfig)
-			nodeconfig.PreProvisionOnly = true
-		}
-	}
-
-	err := runScenario(t, firstStage)
-	original.T = firstStage.T
-	if err != nil {
-		return err
-	}
-
-	if t.Failed() {
-		return nil
-	}
-
-	// Create a new subtest to avoid conflicts with previous steps (log output folder is based on the test name)
-	t.Run("VMProvision", func(t *testing.T) {
-		t.Parallel()
-		secondStageScenario := copyScenario(original)
-		secondStageScenario.Description = "Stage 2: Create VMSS from captured VHD via SIG"
-		secondStageScenario.Config.VHD = customVHD
-		secondStageScenario.Config.Validator = func(ctx context.Context, s *Scenario) error {
-			// This validators are used when running all scenarios in "VHD Caching" mode, which is usually done manually
-			var markerErr error
-			if s.IsWindows() {
-				markerErr = ValidateFileExists(ctx, s, "C:\\AzureData\\provision.complete")
-			} else {
-				markerErr = ValidateFileExists(ctx, s, "/opt/azure/containers/provision.complete")
-			}
-			if markerErr != nil {
-				return markerErr
-			}
-			if original.Config.Validator != nil {
-				return original.Config.Validator(ctx, s)
-			}
-			return nil
-		}
-		if err := runScenario(t, secondStageScenario); err != nil {
-			secondStageScenario.T.Error(err)
-		}
-	})
-	return nil
 }
 
 func copyScenario(s *Scenario) *Scenario {
 	copied := *s
 	copied.Config = s.Config
 	copied.cleanup = nil
+	copied.failed = false
+	copied.checks = nil
 	return &copied
 }
 
-func runScenario(t testing.TB, s *Scenario) error {
-	t = toolkit.WithFailureFormatting(t)
-	s.T = t
-	s.testName = t.Name()
-	s.Logger = toolkit.NewTestLogger(t)
-	if s.cleanup != nil {
-		panic("Scenario.Cleanup called outside of a scenario run")
+// markScenarioOutcome records whether the scenario run ended in a failure so
+// cleanup handlers can branch on it. A skip is not a failure.
+func markScenarioOutcome(s *Scenario, runErr error, recovered any) {
+	if recovered != nil {
+		s.failed = true
+		panic(recovered)
 	}
+	var skip *skipError
+	s.failed = runErr != nil && !errors.As(runErr, &skip)
+}
+
+// runScenario executes a scenario end to end. It never controls a test: it
+// reports problems by returning an error, and a *skipError when the scenario
+// cannot run at all. The caller owns the cleanup stack in s.cleanup and is
+// responsible for running it once the scenario and any staged runs finish.
+func runScenario(ctx context.Context, name string, logger toolkit.Logger, s *Scenario) (runErr error) {
+	s.testName = name
+	s.Logger = logger
 	if s.Location == "" {
 		s.Location = config.Config.DefaultLocation
 	}
@@ -252,17 +103,11 @@ func runScenario(t testing.TB, s *Scenario) error {
 		s.K8sSystemPoolSKU = config.Config.DefaultVMSKU
 	}
 
-	ctx := newTestCtx(t, s.Logger)
-	cleanup := &scenarioCleanup{}
-	s.cleanup = cleanup
-	t.Cleanup(func() {
-		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), scenarioCleanupTimeout)
-		defer cancel()
-		if err := cleanup.runCleanups(cleanupCtx); err != nil {
-			t.Errorf("scenario cleanup failed: %v", err)
-		}
-	})
-	if err := maybeSkipScenario(ctx, t, s); err != nil {
+	ctx = toolkit.ContextWithLogger(ctx, s.Logger)
+	defer func() {
+		markScenarioOutcome(s, runErr, recover())
+	}()
+	if err := maybeSkipScenario(ctx, name, s); err != nil {
 		return err
 	}
 
@@ -303,6 +148,7 @@ func runScenario(t testing.TB, s *Scenario) error {
 		s.Runtime = &ScenarioRuntime{}
 	}
 	s.Runtime.Cluster = cluster
+	s.Runtime.VMSize = config.Config.DefaultVMSKU
 	s.Runtime.VMSSName = generateVMSSName(s)
 
 	testKube, err := cluster.NewKubeclientForTest()
@@ -315,7 +161,9 @@ func runScenario(t testing.TB, s *Scenario) error {
 	vmssCtx, cancel := context.WithTimeout(ctx, config.Config.TestTimeoutVMSS)
 	defer cancel()
 	s.Runtime.VM, err = prepareAKSNode(vmssCtx, s)
-	if s.ExpectedError != "" {
+	// A skip means the scenario never ran, so it cannot confirm an expected error.
+	var skip *skipError
+	if s.ExpectedError != "" && !errors.As(err, &skip) {
 		return assert.ErrorContains(err, s.ExpectedError)
 	}
 	if err != nil {
@@ -394,26 +242,26 @@ func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 
 	gen2Only, err := CachedIsVMSizeGen2Only(ctx, VMSizeSKURequest{
 		Location: s.Location,
-		VMSize:   config.Config.DefaultVMSKU,
+		VMSize:   s.Runtime.VMSize,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("checking if VM size %q supports only Gen2: %w", config.Config.DefaultVMSKU, err)
+		return nil, fmt.Errorf("checking if VM size %q supports only Gen2: %w", s.Runtime.VMSize, err)
 	}
 	if gen2Only && s.Config.VHD.UnsupportedGen2 {
-		s.Logger.Logf("VM size %q only supports Gen2 hypervisor but image does not, falling back to vm size that supported gen 1 %q", config.Config.DefaultVMSKU, config.DefaultV5VMSKU)
-		config.Config.DefaultVMSKU = config.DefaultV5VMSKU
+		s.Logger.Logf("VM size %q only supports Gen2 hypervisor but image does not, falling back to vm size that supported gen 1 %q", s.Runtime.VMSize, config.DefaultV5VMSKU)
+		s.Runtime.VMSize = config.DefaultV5VMSKU
 	}
 	supportsNVMe, err := CachedVMSizeSupportsNVMe(ctx, VMSizeSKURequest{
 		Location: s.Location,
-		VMSize:   config.Config.DefaultVMSKU,
+		VMSize:   s.Runtime.VMSize,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("checking if VM size %q supports only NVMe: %w", config.Config.DefaultVMSKU, err)
+		return nil, fmt.Errorf("checking if VM size %q supports only NVMe: %w", s.Runtime.VMSize, err)
 	}
 	if supportsNVMe {
 		if s.Config.VHD.UnsupportedNVMe {
-			s.Logger.Logf("VM size %q supports NVMe disk controller but image does not support NVMe, falling back to vm size that supports SCSI %q", config.Config.DefaultVMSKU, config.DefaultV5VMSKU)
-			config.Config.DefaultVMSKU = config.DefaultV5VMSKU
+			s.Logger.Logf("VM size %q supports NVMe disk controller but image does not support NVMe, falling back to vm size that supports SCSI %q", s.Runtime.VMSize, config.DefaultV5VMSKU)
+			s.Runtime.VMSize = config.DefaultV5VMSKU
 		} else {
 			s.Config.UseNVMe = true
 		}
@@ -451,8 +299,8 @@ func prepareAKSNode(ctx context.Context, s *Scenario) (*ScenarioVM, error) {
 	return scenarioVM, nil
 }
 
-func maybeSkipScenario(ctx context.Context, t testing.TB, s *Scenario) error {
-	s.Tags.Name = t.Name()
+func maybeSkipScenario(ctx context.Context, name string, s *Scenario) error {
+	s.Tags.Name = name
 	s.Tags.OS = string(s.VHD.OS)
 	s.Tags.Arch = s.VHD.Arch
 	s.Tags.ImageName = s.VHD.Name
@@ -461,20 +309,20 @@ func maybeSkipScenario(ctx context.Context, t testing.TB, s *Scenario) error {
 	if config.Config.TagsToRun != "" {
 		matches, err := s.Tags.MatchesFilters(config.Config.TagsToRun)
 		if err != nil {
-			return fmt.Errorf("could not match tags for %q: %w", t.Name(), err)
+			return fmt.Errorf("could not match tags for %q: %w", name, err)
 		}
 		if !matches {
-			t.Skipf("skipping scenario %q: scenario tags %+v does not match filter %q", t.Name(), s.Tags, config.Config.TagsToRun)
+			return &skipError{message: fmt.Sprintf("skipping scenario %q: scenario tags %+v does not match filter %q", name, s.Tags, config.Config.TagsToRun)}
 		}
 	}
 
 	if config.Config.TagsToSkip != "" {
 		matches, err := s.Tags.MatchesAnyFilter(config.Config.TagsToSkip)
 		if err != nil {
-			return fmt.Errorf("could not match tags for %q: %w", t.Name(), err)
+			return fmt.Errorf("could not match tags for %q: %w", name, err)
 		}
 		if matches {
-			t.Skipf("skipping scenario %q: scenario tags %+v matches filter %q", t.Name(), s.Tags, config.Config.TagsToSkip)
+			return &skipError{message: fmt.Sprintf("skipping scenario %q: scenario tags %+v matches filter %q", name, s.Tags, config.Config.TagsToSkip)}
 		}
 	}
 
@@ -484,9 +332,9 @@ func maybeSkipScenario(ctx context.Context, t testing.TB, s *Scenario) error {
 	})
 	if err != nil {
 		if config.Config.IgnoreScenariosWithMissingVHD && errors.Is(err, config.ErrNotFound) {
-			t.Skipf("skipping scenario %q: could not find image for VHD %s due to %s", t.Name(), s.VHD.Distro, err)
+			return &skipError{message: fmt.Sprintf("skipping scenario %q: could not find image for VHD %s due to %s", name, s.VHD.Distro, err)}
 		}
-		return fmt.Errorf("failing scenario %q: could not find image for VHD %s: %w", t.Name(), s.VHD.Distro, err)
+		return fmt.Errorf("failing scenario %q: could not find image for VHD %s: %w", name, s.VHD.Distro, err)
 	}
 	s.Logger.Logf("TAGS %+v", s.Tags)
 	return nil
@@ -1057,7 +905,7 @@ func CreateSIGImageVersionFromDisk(ctx context.Context, s *Scenario, version str
 		return nil, fmt.Errorf("Failed to create gallery image version: %w", err)
 	}
 
-	_, err = createVersionOp.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	_, err = createVersionOp.PollUntilDone(ctx, config.PollUntilDoneOptions())
 	if err != nil {
 		return nil, fmt.Errorf("Failed to complete gallery image version creation: %w", err)
 	}

--- a/e2e/toolkit/log.go
+++ b/e2e/toolkit/log.go
@@ -182,20 +182,6 @@ func (t *failureFormatter) Fail() {
 	t.TB.Fail()
 }
 
-// UnwrapTestingT extracts the underlying *testing.T from a testing.TB,
-// unwrapping runner decorators if needed. Returns nil if the
-// underlying type is not *testing.T (e.g. *testing.B).
-func UnwrapTestingT(tb testing.TB) *testing.T {
-	switch v := tb.(type) {
-	case *testing.T:
-		return v
-	case *failureFormatter:
-		return UnwrapTestingT(v.TB)
-	default:
-		return nil
-	}
-}
-
 // LogStep logs "→ msg..." at the start and "✓ msg done (Xs)" or "✗ msg failed (Xs)"
 // when the returned function is called. Intended for use with defer:
 //

--- a/e2e/toolkit/log_test.go
+++ b/e2e/toolkit/log_test.go
@@ -199,15 +199,3 @@ func TestFailureFormattingDecoratesFailures(t *testing.T) {
 		}
 	}
 }
-
-func TestUnwrapTestingT(t *testing.T) {
-	if got := UnwrapTestingT(t); got != t {
-		t.Errorf("expected the testing.T itself, got %v", got)
-	}
-	if got := UnwrapTestingT(WithFailureFormatting(t)); got != t {
-		t.Errorf("expected the decorator to unwrap to the testing.T, got %v", got)
-	}
-	if got := UnwrapTestingT(&recordingTB{}); got != nil {
-		t.Errorf("expected nil for a testing.TB that is not a *testing.T, got %v", got)
-	}
-}

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"testing"
 	"time"
 
 	aksnodeconfigv1 "github.com/Azure/agentbaker/aks-node-controller/pkg/gen/aksnodeconfig/v1"
@@ -152,10 +151,6 @@ type Scenario struct {
 	// Runtime contains the runtime state of the scenario. It's populated in the beginning of the test run
 	Runtime *ScenarioRuntime
 
-	// T is reserved for test control only: reporting failures, skipping and
-	// creating sub-tests. Use Logger for logging, never T.
-	T testing.TB
-
 	// Logger writes the scenario log. It is set by the test runner before the
 	// scenario starts and carries no test-control capability.
 	Logger toolkit.Logger
@@ -165,14 +160,45 @@ type Scenario struct {
 	testName string
 
 	cleanup *scenarioCleanup
+
+	// failed reports whether the scenario run ended in a failure. It is set by
+	// the runner once the scenario flow returns, so cleanup handlers can decide
+	// how much diagnostic data to collect.
+	failed bool
+
+	// checks holds the named sub-results a scenario records while it runs. The
+	// runner turns them into per-check test results.
+	checks []scenarioCheck
+}
+
+// scenarioCheck is a named sub-result recorded by a scenario, such as a single
+// CSE task duration measured against its threshold.
+type scenarioCheck struct {
+	Name     string
+	Duration time.Duration
+	Message  string
+}
+
+// recordCheck stores a named check result. A non-nil err marks the check failed.
+func (s *Scenario) recordCheck(name string, duration time.Duration, err error) {
+	check := scenarioCheck{Name: name, Duration: duration}
+	if err != nil {
+		check.Message = err.Error()
+	}
+	s.checks = append(s.checks, check)
 }
 
 type ScenarioRuntime struct {
-	NBC                       *datamodel.NodeBootstrappingConfiguration
-	AKSNodeConfig             *aksnodeconfigv1.Configuration
-	Cluster                   *Cluster
-	Kube                      *Kubeclient // per-test client with independent rate limiter
-	VM                        *ScenarioVM
+	NBC           *datamodel.NodeBootstrappingConfiguration
+	AKSNodeConfig *aksnodeconfigv1.Configuration
+	Cluster       *Cluster
+	Kube          *Kubeclient // per-test client with independent rate limiter
+	VM            *ScenarioVM
+	// VMSize is the effective VM size of the scenario node. It starts from the
+	// configured default and may fall back to another size when the image does
+	// not support the default. It is scenario-local so concurrent scenarios
+	// cannot observe each other's fallback.
+	VMSize                    string
 	VMSSName                  string
 	EnableScriptlessNBCCSECmd bool
 	CSETimingReport           *CSETimingReport // eagerly extracted before GA can sweep events

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -2979,7 +2979,6 @@ func ValidateNvidiaDevicePluginServiceRunning(ctx context.Context, s *Scenario) 
 }
 
 func ValidateNvidiaDevicePluginMIGStrategy(ctx context.Context, s *Scenario, strategy string) error {
-	s.T.Helper()
 	command := fmt.Sprintf("systemctl cat nvidia-device-plugin.service | grep -F -- '--mig-strategy %s'", strategy)
 	if _, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, command, 0, "NVIDIA device plugin is not configured with MIG strategy "+strategy); err != nil {
 		return fmt.Errorf("validate NVIDIA device plugin MIG strategy %q: %w", strategy, err)
@@ -3017,8 +3016,7 @@ func ValidateNodeAdvertisesGPUResources(ctx context.Context, s *Scenario, gpuCou
 }
 
 func ValidateNodeAdvertisesExactGPUResources(ctx context.Context, s *Scenario, expected map[string]int64) error {
-	s.T.Helper()
-	s.T.Logf("validating that node advertises exactly the expected NVIDIA GPU resources")
+	s.Logger.Logf("validating that node advertises exactly the expected NVIDIA GPU resources")
 
 	for resourceName := range expected {
 		if err := waitUntilResourceAvailable(ctx, s, resourceName); err != nil {
@@ -3255,8 +3253,7 @@ func ValidateMIGModeEnabled(ctx context.Context, s *Scenario, gpuCountExpected i
 }
 
 func ValidateMIGInstanceProfileCounts(ctx context.Context, s *Scenario, expected map[string]int) error {
-	s.T.Helper()
-	s.T.Logf("validating exact MIG instance profile counts")
+	s.Logger.Logf("validating exact MIG instance profile counts")
 
 	command := []string{
 		"set -ex",

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -15,7 +15,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/Azure/agentbaker/aks-node-controller/pkg/nodeconfigutils"
@@ -99,7 +98,9 @@ func ConfigureAndCreateVMSS(ctx context.Context, s *Scenario) (*ScenarioVM, erro
 		return nil
 	})
 
-	skipTestIfSKUNotAvailableErr(s.T, err)
+	if skipErr := skipIfSKUNotAvailableErr(err); skipErr != nil {
+		return vm, skipErr
+	}
 
 	return vm, err
 }
@@ -200,7 +201,7 @@ func deleteVMSSAndWait(ctx context.Context, s *Scenario) {
 		s.Logger.Logf("failed to begin delete of vmss %q for retry: %s", s.Runtime.VMSSName, err)
 		return
 	}
-	if _, err := poller.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions); err != nil {
+	if _, err := poller.PollUntilDone(ctx, config.PollUntilDoneOptions()); err != nil {
 		s.Logger.Logf("failed to wait for delete of vmss %q for retry: %s", s.Runtime.VMSSName, err)
 	}
 }
@@ -469,7 +470,7 @@ func CreateVMSS(ctx context.Context, s *Scenario, resourceGroupName string) (*Sc
 	result += fmt.Sprintf(`az network bastion ssh --target-resource-id "%s" --name "%s" --resource-group %s --auth-type ssh-key --username azureuser --ssh-key %s`, *vm.VM.ID, SharedBastionName, config.ResourceGroupName(*s.Runtime.Cluster.Model.Location), config.VMSSHPrivateKeyFileName) + "\n"
 	s.Logger.Log(result)
 
-	vmssResp, err := operation.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	vmssResp, err := operation.PollUntilDone(ctx, config.PollUntilDoneOptions())
 
 	// Log VMSS tags for diagnostics (visible in test-log.json via gotestsum --jsonfile).
 	// For RCV1P tests, annotates the opt-in tag to help distinguish our tags from platform-injected ones.
@@ -669,24 +670,27 @@ func getPrivateIPFromVMSSVM(ctx context.Context, resourceGroup, vmssName, instan
 	return *ipConfig.Properties.PrivateIPAddress, nil
 }
 
-func skipTestIfSKUNotAvailableErr(t testing.TB, err error) {
+// skipIfSKUNotAvailableErr returns a skip reason when the scenario cannot run
+// because Azure has no capacity for the SKU. It returns nil otherwise.
+func skipIfSKUNotAvailableErr(err error) error {
 	if !config.Config.SkipTestsWithSKUCapacityIssue {
-		return
+		return nil
 	}
 	var respErr *azcore.ResponseError
 	if !errors.As(err, &respErr) || respErr.StatusCode != 409 {
-		return
+		return nil
 	}
 	// sometimes the SKU is not available and we can't do anything. Skip the test in this case.
 	if respErr.ErrorCode == "SkuNotAvailable" {
-		t.Skip("skipping scenario SKU not available", t.Name(), err)
+		return &skipError{message: fmt.Sprintf("skipping scenario, SKU not available: %v", err)}
 	}
 	// sometimes the SKU quota is exceeded and we can't do anything. Skip the test in this case.
 	if respErr.ErrorCode == "OperationNotAllowed" &&
 		strings.Contains(respErr.Error(), "exceeding approved") &&
 		strings.Contains(respErr.Error(), "quota") {
-		t.Skip("skipping scenario SKU quota exceeded", t.Name(), err)
+		return &skipError{message: fmt.Sprintf("skipping scenario, SKU quota exceeded: %v", err)}
 	}
+	return nil
 }
 
 func extractLogsFromVM(ctx context.Context, s *Scenario, vm *ScenarioVM) {
@@ -869,7 +873,7 @@ hnsdiag list endpoints >> network_config.txt
 // extractLogsFromVMWindows runs a script on windows VM to collect logs and upload them to a blob storage
 // it then lists the blobs in the container and prints the content of each blob
 func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
-	if !s.T.Failed() {
+	if !s.failed {
 		return
 	}
 
@@ -941,7 +945,7 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 	}
 
 	// Poll the result until the operation is completed
-	runCommandResp, err := pollerResp.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
+	runCommandResp, err := pollerResp.PollUntilDone(ctx, config.PollUntilDoneOptions())
 	if err != nil {
 		s.Logger.Logf("failed to poll run command on VMSS instance %s: %s", instanceID, err)
 		return
@@ -1319,7 +1323,7 @@ func getBaseVMSSModel(s *Scenario, customData, cseCmd string) armcompute.Virtual
 	model := armcompute.VirtualMachineScaleSet{
 		Location: to.Ptr(s.Location),
 		SKU: &armcompute.SKU{
-			Name:     to.Ptr(config.Config.DefaultVMSKU),
+			Name:     to.Ptr(scenarioVMSize(s)),
 			Capacity: to.Ptr[int64](1),
 		},
 		Properties: &armcompute.VirtualMachineScaleSetProperties{
@@ -1433,6 +1437,15 @@ func getBaseVMSSModel(s *Scenario, customData, cseCmd string) armcompute.Virtual
 		model.Properties.VirtualMachineProfile.OSProfile.AdminPassword = to.Ptr(generateWindowsPassword())
 	}
 	return model
+}
+
+// scenarioVMSize returns the effective VM size of the scenario node, falling
+// back to the configured default before the runtime state exists.
+func scenarioVMSize(s *Scenario) string {
+	if s.Runtime != nil && s.Runtime.VMSize != "" {
+		return s.Runtime.VMSize
+	}
+	return config.Config.DefaultVMSKU
 }
 
 func generateWindowsPassword() string {


### PR DESCRIPTION
**What this PR does / why we need it**:

Stack layer 1, on top of #9323 (base branch `r2k1-ci-fix-azure-login-comment`). It decouples the E2E scenario implementation from `testing.TB` and fixes two shared-state races, without changing how scenarios are defined or run.

`Scenario` no longer carries a `testing.TB`. Implementation code logs through `toolkit.Logger` and records named check results (`Scenario.recordCheck`) instead of creating sub-tests, so no file under `e2e/` outside `_test.go` depends on test control any more.

`RunScenario(t, s)` stays as a compatibility adapter, moved to `e2e/scenario_runner_test.go`. It:
- attaches a test-backed logger and the test context,
- owns the cleanup stack and its `t.Cleanup` registration, keeping the existing `VHDCreation` / `VMProvision` staging and cleanup ordering,
- maps recorded checks back into `t.Run` child results, so ADO keeps per-check CSE timing history under the same names (`TotalCSEDuration`, `Task_<name>`),
- turns a returned `*skipError` into `t.Skip`, preserving skip semantics that previously came from `t.Skipf` inside implementation code.

Every current scenario `_test.go` definition, scenario name, tag filter, retry, pipeline, `TestMain`, environment parsing, config initialization, signal handling and gotestsum behavior are unchanged.

**Race fixes**

1. Effective VM size is now per scenario. The Gen1 and NVMe→SCSI fallbacks used to assign `config.Config.DefaultVMSKU`, a process-global read by every concurrently running scenario, so one image's fallback silently changed the VM size of unrelated scenarios. The effective size now lives in `ScenarioRuntime.VMSize`, and VMSS construction reads it through `scenarioVMSize(s)`.
2. ARM poll options are per operation. `config.DefaultPollUntilDoneOptions` was a single mutable `*runtime.PollUntilDoneOptions` handed to every long-running ARM call across all scenarios. It is replaced by `config.PollUntilDoneOptions()`, which returns a fresh value per call; all call sites are updated. The 15s frequency is unchanged.

**Out of scope for this layer**: standalone CLI, scenario registry, executor, JUnit writer, urfave config migration, scenario file moves, pipeline changes, docs.

**Validation**

- `gofmt` clean on all changed Go files.
- `go build ./...` and `go vet ./...` clean in `e2e/`.
- `go test` and `go test -race` pass for every unit test in `e2e/` and in `e2e/assert`, `e2e/components`, `e2e/config`, `e2e/nodeexporter`, `e2e/toolkit`. The live scenario `Test_*` functions need real Azure infrastructure and were not run locally; the E2E gate covers them.
- New unit tests cover `recordCheck`, `markScenarioOutcome` skip-vs-failure classification, `skipIfSKUNotAvailableErr`, scenario-local VM sizing, and that `PollUntilDoneOptions()` returns independent values.
- Verified repo-wide that no `e2e` implementation file imports `testing` and that no `s.T` reference remains; `testing` survives only in `_test.go` files and in `e2e/toolkit/log.go`, which provides the runner-boundary test logger.

**Behavior caveats**

- A scenario that both declares `ExpectedError` and hits an Azure SKU capacity skip now skips instead of asserting the expected error. Previously `t.Skip` ended the goroutine before the assertion; the new code checks for `*skipError` explicitly to keep that outcome.
- `extractLogsFromVMWindows` now branches on `Scenario.failed`, set when the scenario flow returns, rather than on `t.Failed()`. Failures reported outside the scenario flow (for example a cleanup error) no longer flip it.
- The dead `toolkit.UnwrapTestingT` helper and its test are removed; its only caller was the CSE timing sub-test code replaced here.

**Which issue(s) this PR fixes**:

None.