### PR TITLE
feat: cache azure iptables monitor

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -300,6 +300,17 @@
       "windowsVersions": []
     },
     {
+      "downloadURL": "mcr.microsoft.com/containernetworking/azure-iptables-monitor:*",
+      "amd64OnlyVersions": [],
+      "multiArchVersionsV2": [
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/azure-iptables-monitor",
+          "latestVersion": "v0.0.5-0"
+        }
+      ],
+      "windowsVersions": []
+    },
+    {
       "downloadURL": "mcr.microsoft.com/containernetworking/azure-npm:*",
       "amd64OnlyVersions": [],
       "multiArchVersionsV2": [

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -305,7 +305,15 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=containernetworking/azure-iptables-monitor",
-          "latestVersion": "v0.0.5-0"
+          "latestVersion": "v0.0.5-0",
+          "containerImagePrefetch": {
+            "latestVersion": {
+              "binaries": [
+                "/azure-iptables-monitor",
+                "/azure-block-iptables"
+              ]
+            }
+          }
         }
       ],
       "windowsVersions": []


### PR DESCRIPTION
iptables blocker binary inside the monitor image is used during startup so should be cached

<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
azure-iptables-monitor was not cached, leading to startup latency

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA
