### PR TITLE
fix: preserve CIS module denylist (incl. SCTP) on AzureLinux 3.0

### DIFF
--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -3975,9 +3975,11 @@ func ValidateCollectWindowsLogsScript(ctx context.Context, s *Scenario) error {
 //   - AzureLinux 3.0: assert ABSENCE of the four modprobe blacklist entries. AzL3 is
 //     descoped from the mitigation because kernel 6.6.139.1-1.azl3 and later fix all
 //     three CVEs upstream, AND customer workloads on AzL3 require those modules (the
-//     blacklist actively blocks legitimate use cases). Newly-built AzL3 VHDs therefore
-//     no longer ship the modprobe-CIS.conf entries, and E2E runs against freshly-built
-//     VHDs. See https://github.com/Azure/AKS/issues/5753.
+//     blacklist actively blocks legitimate use cases). Only those four lines are stripped
+//     from modprobe-CIS.conf on newly-built AzL3 VHDs — the rest of the CIS module denylist
+//     (dccp/sctp/rds/tipc/cramfs/etc.) is still baked in and asserted present below, so
+//     AzL3 keeps the same CIS hardening as every other OS stream. E2E runs against
+//     freshly-built VHDs. See https://github.com/Azure/AKS/issues/5753.
 //
 // To add a new CVE mitigation, append the module name to BOTH lists below —
 // the absence-check list AND the default presence + load-refusal list.
@@ -3988,25 +3990,36 @@ func ValidateVulnerableKernelModulesDisabled(ctx context.Context, s *Scenario) e
 	}
 
 	// AzureLinux 3.0 (regular, NOT OSGuard): kernel 6.6.139.1-1.azl3+ supersedes the modprobe
-	// blacklist and the bake-in has been removed because customers need those modules. Assert
-	// the blacklist entries are NOT present on freshly-built AzL3 VHDs. AzureLinux OSGuard is
-	// intentionally kept in-scope (falls through to the full presence + load-refusal check below).
+	// blacklist for algif_aead/esp4/esp6/rxrpc, so only those four lines are stripped because
+	// customers need those modules. Assert the four CVE-related entries are NOT present, but
+	// the rest of the CIS module denylist (e.g. sctp, which AKS documents as a supported
+	// service protocol) must remain intact — it was previously lost entirely because the
+	// whole modprobe-CIS.conf file was skipped on AzL3. AzureLinux OSGuard is intentionally
+	// kept in-scope (falls through to the full presence + load-refusal check below).
 	if s.VHD.OS == config.OSAzureLinux && !s.VHD.Distro.IsAzureLinuxOSGuardDistro() && s.VHD.Distro != datamodel.AKSAzureLinuxV2Gen2 {
 		script := strings.Join([]string{
 			`failed=0`,
 			`for mod in algif_aead esp4 esp6 rxrpc; do`,
 			`  if grep -qsE "^(install ${mod} /bin/false|blacklist ${mod})" /etc/modprobe.d/*.conf 2>/dev/null; then`,
-			`    echo "FAIL: ${mod} blacklist entry unexpectedly present on AzureLinux 3.0 (bake-in removed; kernel 6.6.139.1-1.azl3+ supersedes)"`,
+			`    echo "FAIL: ${mod} blacklist entry unexpectedly present on AzureLinux 3.0 (only these four CVE-related lines should be stripped; kernel 6.6.139.1-1.azl3+ supersedes)"`,
 			`    failed=1`,
 			`  else`,
 			`    echo "PASS: ${mod} blacklist correctly absent on AzureLinux 3.0"`,
 			`  fi`,
 			`done`,
+			`for mod in dccp sctp rds tipc; do`,
+			`  if ! grep -qsE "^install ${mod} /bin/true" /etc/modprobe.d/*.conf 2>/dev/null; then`,
+			`    echo "FAIL: ${mod} CIS disable rule unexpectedly missing on AzureLinux 3.0 (only algif_aead/esp4/esp6/rxrpc should be stripped from modprobe-CIS.conf)"`,
+			`    failed=1`,
+			`  else`,
+			`    echo "PASS: ${mod} CIS modprobe denylist correctly retained on AzureLinux 3.0"`,
+			`  fi`,
+			`done`,
 			`exit $failed`,
 		}, "\n")
 		if _, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, script, 0,
-			"AzureLinux 3.0 modprobe blacklist should be absent (kernel fix 6.6.139.1-1.azl3+ supersedes; bake-in removed; no `install` or `blacklist` directive should remain)"); err != nil {
-			return fmt.Errorf("check that the AzureLinux 3.0 modprobe blacklist is absent: %w", err)
+			"AzureLinux 3.0 modprobe blacklist should only omit algif_aead/esp4/esp6/rxrpc while retaining the rest of the CIS module denylist (dccp/sctp/rds/tipc/etc.)"); err != nil {
+			return fmt.Errorf("check that the AzureLinux 3.0 modprobe blacklist is correctly scoped: %w", err)
 		}
 		return nil
 	}

--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -62,6 +62,35 @@ ubuntuKernelIncludesVulnerableModuleFixes() {
   kernelVersionGe "$kernel_release" "$fixed_kernel"
 }
 
+bakeModprobeCISWithoutVulnerableModules() {
+  local context_message="$1"
+
+  MODPROBE_CIS_WITHOUT_VULNERABLE_MODULES_SRC=/home/packer/modprobe-CIS-without-vulnerable-kernel-modules.conf
+  sed -E \
+    -e '/^# CVE-2026-31431 \(Copy Fail\):/d' \
+    -e '/^# until kernel fix is available\. See https:\/\/ubuntu\.com\/blog\/copy-fail-vulnerability-fixes-available$/d' \
+    -e '/^# DirtyFrag \/ CopyFail2:/d' \
+    -e '/^# write LPE vulnerabilities\. rxrpc path bypasses AppArmor userns restrictions\.$/d' \
+    -e '/^# AKS platform components do not require kernel IPsec ESP\/XFRM or AFS\/RxRPC\.$/d' \
+    -e '/^# Disabling these modules prevents workloads that rely on those protocols from working$/d' \
+    -e '/^# on the node\. See https:\/\/github\.com\/V4bel\/dirtyfrag$/d' \
+    -e "/$VULNERABLE_KERNEL_MODULE_DENY_PATTERN/d" \
+    "$MODPROBE_CIS_SRC" > "$MODPROBE_CIS_WITHOUT_VULNERABLE_MODULES_SRC" || exit "$ERR_PACKER_COPY_FILE"
+  if grep -qE "$VULNERABLE_KERNEL_MODULE_DENY_PATTERN" "$MODPROBE_CIS_WITHOUT_VULNERABLE_MODULES_SRC"; then
+    echo "Failed to remove vulnerable module deny rules from $MODPROBE_CIS_WITHOUT_VULNERABLE_MODULES_SRC"
+    exit "$ERR_PACKER_COPY_FILE"
+  fi
+  echo "Copying modprobe-CIS.conf without algif_aead / esp4 / esp6 / rxrpc ${context_message}"
+  cpAndMode "$MODPROBE_CIS_WITHOUT_VULNERABLE_MODULES_SRC" "$MODPROBE_CIS_DEST" 644
+  rm -f "$MODPROBE_CIS_WITHOUT_VULNERABLE_MODULES_SRC" || exit "$ERR_PACKER_COPY_FILE"
+  removeVulnerableKernelModuleDenyRulesFromModprobeDirectory || exit "$ERR_PACKER_COPY_FILE"
+  if grep -qsE "$VULNERABLE_KERNEL_MODULE_DENY_PATTERN" /etc/modprobe.d/*.conf 2>/dev/null; then
+    echo "Failed to remove vulnerable module deny rules from /etc/modprobe.d/*.conf"
+    grep -nE "$VULNERABLE_KERNEL_MODULE_DENY_PATTERN" /etc/modprobe.d/*.conf || true
+    exit "$ERR_PACKER_COPY_FILE"
+  fi
+}
+
 removeVulnerableKernelModuleDenyRulesFromModprobeDirectory() {
   local modprobe_conf
   local tmp_modprobe_conf
@@ -520,47 +549,29 @@ copyPackerFiles() {
   cpAndMode $SSHD_CONFIG_SRC $SSHD_CONFIG_DEST 600
   # CVE-2026-31431 (Copy Fail), DirtyFrag, Fragnesia mitigation: bake modprobe blacklist
   # for algif_aead / esp4 / esp6 / rxrpc into the VHD only for OS streams that still need it.
-  # Keep the rest of the CIS module deny list on fixed Ubuntu VHDs; those entries are
-  # unrelated to the 2026 kernel CVEs and are required for the CIS baseline.
+  # Keep the rest of the CIS module deny list (dccp/sctp/rds/tipc/cramfs/etc.) intact on
+  # every OS stream; those entries are unrelated to the 2026 kernel CVEs and are required
+  # for the CIS baseline.
   #
   # The vulnerable-module block is omitted on fixed Ubuntu 22.04 / 24.04 kernels,
-  # and by default on future Ubuntu releases that are not explicitly in mitigation scope.
-  # the whole file is skipped on AzureLinux 3.0 because:
+  # and by default on future Ubuntu releases that are not explicitly in mitigation scope,
+  # and on AzureLinux 3.0 (non-OSGuard) because:
   #   1. Ubuntu 22.04 linux-azure 5.15.0-1116-azure and Ubuntu 24.04 linux-azure
   #      6.8.0-1058-azure include the fixes. The CSE still applies the deny rules
   #      at runtime if it detects an older vulnerable Ubuntu kernel.
   #   2. The upstream kernel fix in 6.6.139.1-1.azl3+ supersedes the modprobe blacklist.
   #   3. Customer workloads require those kernel modules; the bake-in actively blocks
   #      legitimate use cases on fixed kernels.
-  # Ubuntu 20.04, Mariner / AzureLinux 2.0, and AzureLinux OSGuard still get the bake-in. See
+  # In both cases only the algif_aead/esp4/esp6/rxrpc lines are stripped — the rest of
+  # modprobe-CIS.conf (including the SCTP/DCCP/RDS/TIPC/cramfs/etc. CIS baseline denylist)
+  # is still baked in, so AzureLinux 3.0 keeps the same CIS module hardening as every other
+  # OS stream instead of silently losing the whole file. See
   # https://github.com/Azure/AKS/issues/5753.
+  # Ubuntu 20.04, Mariner / AzureLinux 2.0, and AzureLinux OSGuard still get the unmodified bake-in.
   if isUbuntu "$OS" && ubuntuKernelIncludesVulnerableModuleFixes; then
-    MODPROBE_CIS_WITHOUT_VULNERABLE_MODULES_SRC=/home/packer/modprobe-CIS-without-vulnerable-kernel-modules.conf
-    sed -E \
-      -e '/^# CVE-2026-31431 \(Copy Fail\):/d' \
-      -e '/^# until kernel fix is available\. See https:\/\/ubuntu\.com\/blog\/copy-fail-vulnerability-fixes-available$/d' \
-      -e '/^# DirtyFrag \/ CopyFail2:/d' \
-      -e '/^# write LPE vulnerabilities\. rxrpc path bypasses AppArmor userns restrictions\.$/d' \
-      -e '/^# AKS platform components do not require kernel IPsec ESP\/XFRM or AFS\/RxRPC\.$/d' \
-      -e '/^# Disabling these modules prevents workloads that rely on those protocols from working$/d' \
-      -e '/^# on the node\. See https:\/\/github\.com\/V4bel\/dirtyfrag$/d' \
-      -e "/$VULNERABLE_KERNEL_MODULE_DENY_PATTERN/d" \
-      "$MODPROBE_CIS_SRC" > "$MODPROBE_CIS_WITHOUT_VULNERABLE_MODULES_SRC" || exit "$ERR_PACKER_COPY_FILE"
-    if grep -qE "$VULNERABLE_KERNEL_MODULE_DENY_PATTERN" "$MODPROBE_CIS_WITHOUT_VULNERABLE_MODULES_SRC"; then
-      echo "Failed to remove vulnerable module deny rules from $MODPROBE_CIS_WITHOUT_VULNERABLE_MODULES_SRC"
-      exit "$ERR_PACKER_COPY_FILE"
-    fi
-    echo "Copying modprobe-CIS.conf without algif_aead / esp4 / esp6 / rxrpc on Ubuntu ${OS_VERSION} (fixed or future Ubuntu kernels are not in mitigation scope)"
-    cpAndMode "$MODPROBE_CIS_WITHOUT_VULNERABLE_MODULES_SRC" "$MODPROBE_CIS_DEST" 644
-    rm -f "$MODPROBE_CIS_WITHOUT_VULNERABLE_MODULES_SRC" || exit "$ERR_PACKER_COPY_FILE"
-    removeVulnerableKernelModuleDenyRulesFromModprobeDirectory || exit "$ERR_PACKER_COPY_FILE"
-    if grep -qsE "$VULNERABLE_KERNEL_MODULE_DENY_PATTERN" /etc/modprobe.d/*.conf 2>/dev/null; then
-      echo "Failed to remove vulnerable module deny rules from /etc/modprobe.d/*.conf"
-      grep -nE "$VULNERABLE_KERNEL_MODULE_DENY_PATTERN" /etc/modprobe.d/*.conf || true
-      exit "$ERR_PACKER_COPY_FILE"
-    fi
+    bakeModprobeCISWithoutVulnerableModules "on Ubuntu ${OS_VERSION} (fixed or future Ubuntu kernels are not in mitigation scope)"
   elif isAzureLinux "$OS" "$OS_VARIANT" && [ "${OS_VERSION}" = "3.0" ] && ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then
-    echo "Skipping modprobe-CIS.conf bake-in on AzureLinux 3.0 (kernel 6.6.139.1-1.azl3+ has upstream fix; OSGuard intentionally retains the bake-in)"
+    bakeModprobeCISWithoutVulnerableModules "on AzureLinux 3.0 (kernel 6.6.139.1-1.azl3+ has upstream fix; OSGuard intentionally retains the full bake-in; the SCTP/DCCP/RDS/TIPC/cramfs/etc. CIS baseline denylist is preserved)"
   else
     cpAndMode $MODPROBE_CIS_SRC $MODPROBE_CIS_DEST 644
   fi

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1480,9 +1480,10 @@ testNfsServerService() {
 # To add a new CVE mitigation, append the module to BOTH loops below — the
 # absence loop AND the default presence + load-refusal loop.
 #
-# AzureLinux 3.0 is descoped: kernel 6.6.139.1-1.azl3+ fixes the CVEs upstream and
-# the modprobe blacklist is NOT baked into newly-built AzL3 VHDs (customer workloads
-# require those modules). Ubuntu 22.04 linux-azure 5.15.0-1116-azure and Ubuntu
+# AzureLinux 3.0 is descoped: kernel 6.6.139.1-1.azl3+ fixes the CVEs upstream, so only the
+# algif_aead/esp4/esp6/rxrpc lines are stripped from newly-built AzL3 VHDs (customer workloads
+# require those modules); the rest of the CIS module denylist (dccp/sctp/rds/tipc/cramfs/etc.)
+# is still baked in and asserted below. Ubuntu 22.04 linux-azure 5.15.0-1116-azure and Ubuntu
 # 24.04 linux-azure 6.8.0-1058-azure include the fixes, so newly-built Ubuntu
 # 22.04/24.04 VHDs with a fixed running kernel also stop baking the vulnerable-module
 # blacklist while keeping the baseline CIS module deny list. Ubuntu 20.04 and vulnerable
@@ -1553,19 +1554,29 @@ testVulnerableKernelModulesDisabled() {
       fi
     done
 
-    if [ "$os_sku" = "Ubuntu" ]; then
-      for mod in cramfs freevxfs jffs2 hfs hfsplus usb-storage; do
-        if ! grep -qsE "^install ${mod} /bin/true" /etc/modprobe.d/*.conf 2>/dev/null; then
-          err "$test" "${mod} CIS disable rule not found in /etc/modprobe.d/*.conf"
-          failed=1
-        elif ! grep -qsE "^blacklist ${mod}" /etc/modprobe.d/*.conf 2>/dev/null; then
-          err "$test" "${mod} CIS blacklist rule not found in /etc/modprobe.d/*.conf"
-          failed=1
-        else
-          echo "$test: CIS modprobe config correctly blocks ${mod}"
-        fi
-      done
-    fi
+    # Only the algif_aead/esp4/esp6/rxrpc lines above are stripped for the CVE mitigation;
+    # the rest of the CIS 3.5.x / 1.1.1.x module denylist must remain intact on every OS
+    # stream (including AzureLinux 3.0, which used to skip the whole modprobe-CIS.conf file).
+    for mod in dccp sctp rds tipc; do
+      if ! grep -qsE "^install ${mod} /bin/true" /etc/modprobe.d/*.conf 2>/dev/null; then
+        err "$test" "${mod} CIS disable rule not found in /etc/modprobe.d/*.conf on ${os_sku} ${os_version}"
+        failed=1
+      else
+        echo "$test: CIS modprobe config correctly blocks ${mod} on ${os_sku} ${os_version}"
+      fi
+    done
+
+    for mod in cramfs freevxfs jffs2 hfs hfsplus usb-storage; do
+      if ! grep -qsE "^install ${mod} /bin/true" /etc/modprobe.d/*.conf 2>/dev/null; then
+        err "$test" "${mod} CIS disable rule not found in /etc/modprobe.d/*.conf on ${os_sku} ${os_version}"
+        failed=1
+      elif ! grep -qsE "^blacklist ${mod}" /etc/modprobe.d/*.conf 2>/dev/null; then
+        err "$test" "${mod} CIS blacklist rule not found in /etc/modprobe.d/*.conf on ${os_sku} ${os_version}"
+        failed=1
+      else
+        echo "$test: CIS modprobe config correctly blocks ${mod} on ${os_sku} ${os_version}"
+      fi
+    done
 
     if [ "$failed" -ne 0 ]; then
       return 1


### PR DESCRIPTION
## Summary

Customer report ("AKS STCP Support" email thread) found that SCTP works on AzureLinux V3 node pools but is blocked on Ubuntu node pools. Traced to `/etc/modprobe.d/CIS.conf` containing `install sctp /bin/true`.

## Root Cause

`parts/linux/cloud-init/artifacts/modprobe-CIS.conf` is the single shared source for both Ubuntu and AzureLinux and blocks SCTP/DCCP/RDS/TIPC/cramfs/freevxfs/jffs2/hfs/hfsplus/usb-storage per CIS 3.5.x/1.1.1.x.

In `vhdbuilder/packer/packer_source.sh` (`copyPackerFiles`):
- **Ubuntu:** the file is always baked in. Only 4 unrelated lines (`algif_aead`/`esp4`/`esp6`/`rxrpc`, a 2026 LPE CVE mitigation) are surgically stripped on fixed 22.04/24.04 kernels (#9054).
- **AzureLinux 3.0 (non-OSGuard):** the *entire file* was skipped (#8546), not just the 4 CVE lines — silently unblocking SCTP and the rest of the CIS baseline as a side effect.

#8546 intended only to unblock the 4 CVE-related modules on AzL3 once its kernel had the upstream fix, but took the blunt "skip whole file" approach instead of the surgical per-line removal later implemented correctly for Ubuntu in #9054.

## Changes

- `vhdbuilder/packer/packer_source.sh`: extracted the Ubuntu surgical-stripping logic into a reusable `bakeModprobeCISWithoutVulnerableModules()` helper and applied it to the AzureLinux 3.0 path instead of skipping the whole `modprobe-CIS.conf` file. Only `algif_aead`/`esp4`/`esp6`/`rxrpc` are stripped; the rest of the CIS denylist (`dccp`/`sctp`/`rds`/`tipc`/`cramfs`/etc.) is now baked in consistently across OS streams.
- `vhdbuilder/packer/test/linux-vhd-content-test.sh`: extended `testVulnerableKernelModulesDisabled` to assert the CIS baseline denylist (including `sctp`) is present on AzureLinux 3.0, not just Ubuntu.
- `e2e/validators.go`: updated `ValidateVulnerableKernelModulesDisabled` comments/assertions for AzureLinux 3.0 to also assert `dccp`/`sctp`/`rds`/`tipc` remain blocked, alongside the existing CVE-module absence checks.

## Testing

- `bash -n` + `shellcheck` on both modified shell scripts (no new warnings).
- `go build ./e2e/...` compiles cleanly.
- Simulated the `sed` transformation against the real `modprobe-CIS.conf` locally — confirmed the 4 CVE lines are removed while `dccp`/`sctp`/`rds`/`tipc`/`cramfs`/etc. all remain (see PR discussion/commit for output).

## Related

- AB#39442583
- Follows up on #8546 / #9054

🤖 *Generated by GitHub Copilot*