### PR TITLE
refactor(anc): extract parseLinuxPlatformInfo for os-release dedup and add OS field for future Windows support

### DIFF
--- a/aks-node-controller/hotfix.go
+++ b/aks-node-controller/hotfix.go
@@ -215,6 +215,40 @@ func readHotfixConfig(path string) (*hotfixConfig, error) {
 	return &cfg, nil
 }
 
+// platformInfo holds the parsed OS identity and architecture for the current host.
+type platformInfo struct {
+	ID        string // e.g. "ubuntu", "azurelinux", "mariner"
+	VersionID string // e.g. "22.04", "3.0"
+	Arch      string // e.g. "amd64", "arm64"
+}
+
+// parsePlatformInfo reads /etc/os-release (or a.osReleasePath override for testing)
+// and combines it with the build architecture to describe the current platform.
+func (a *App) parsePlatformInfo() (platformInfo, error) {
+	osReleasePath := a.osReleasePath
+	if osReleasePath == "" {
+		osReleasePath = "/etc/os-release"
+	}
+	data, err := os.ReadFile(osReleasePath)
+	if err != nil {
+		return platformInfo{}, fmt.Errorf("reading %s: %w", osReleasePath, err)
+	}
+	info := platformInfo{Arch: runtime.GOARCH}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "ID=") {
+			info.ID = strings.ToLower(strings.Trim(strings.TrimPrefix(line, "ID="), `"`))
+		}
+		if strings.HasPrefix(line, "VERSION_ID=") {
+			info.VersionID = strings.Trim(strings.TrimPrefix(line, "VERSION_ID="), `"`)
+		}
+	}
+	if info.ID == "" {
+		return platformInfo{}, fmt.Errorf("ID not found in %s", osReleasePath)
+	}
+	return info, nil
+}
+
 // packageManager represents a supported system package manager.
 type packageManager string
 
@@ -225,34 +259,19 @@ const (
 )
 
 // detectPackageManager returns the package manager for the current OS.
-// It reads /etc/os-release (or a.osReleasePath override, for testing) to determine
-// whether to use apt-get (Ubuntu) or dnf/tdnf (AzureLinux/Mariner).
 func (a *App) detectPackageManager() (packageManager, error) {
-	osReleasePath := a.osReleasePath
-	if osReleasePath == "" {
-		osReleasePath = "/etc/os-release"
-	}
-	data, err := os.ReadFile(osReleasePath)
+	info, err := a.parsePlatformInfo()
 	if err != nil {
-		return "", fmt.Errorf("reading %s: %w", osReleasePath, err)
+		return "", err
 	}
-	content := string(data)
-	for _, line := range strings.Split(content, "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "ID=") {
-			id := strings.Trim(strings.TrimPrefix(line, "ID="), `"`)
-			id = strings.ToLower(id)
-			switch id {
-			case "ubuntu":
-				return pkgMgrApt, nil
-			case "azurelinux", "mariner":
-				return preferredRpmManager(), nil
-			default:
-				return "", fmt.Errorf("unsupported OS: %s", id)
-			}
-		}
+	switch info.ID {
+	case "ubuntu":
+		return pkgMgrApt, nil
+	case "azurelinux", "mariner":
+		return preferredRpmManager(), nil
+	default:
+		return "", fmt.Errorf("unsupported OS: %s", info.ID)
 	}
-	return "", fmt.Errorf("ID not found in %s", osReleasePath)
 }
 
 // preferredRpmManager returns dnf if available, falling back to tdnf (used by OS Guard).
@@ -492,29 +511,14 @@ func (a *App) resolveArtifact(cfg *hotfixConfig, hotfixVersion string) (*artifac
 // buildArtifactKey constructs the OS/arch lookup key for the artifacts map.
 // Format: "ID-VERSION_ID-GOARCH" (e.g. "ubuntu-22.04-amd64").
 func (a *App) buildArtifactKey() (string, error) {
-	osReleasePath := a.osReleasePath
-	if osReleasePath == "" {
-		osReleasePath = "/etc/os-release"
-	}
-	data, err := os.ReadFile(osReleasePath)
+	info, err := a.parsePlatformInfo()
 	if err != nil {
-		return "", fmt.Errorf("reading %s: %w", osReleasePath, err)
+		return "", err
 	}
-	var id, versionID string
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "ID=") {
-			id = strings.Trim(strings.TrimPrefix(line, "ID="), `"`)
-			id = strings.ToLower(id)
-		}
-		if strings.HasPrefix(line, "VERSION_ID=") {
-			versionID = strings.Trim(strings.TrimPrefix(line, "VERSION_ID="), `"`)
-		}
+	if info.VersionID == "" {
+		return "", fmt.Errorf("VERSION_ID not found in os-release")
 	}
-	if id == "" || versionID == "" {
-		return "", fmt.Errorf("ID or VERSION_ID not found in %s", osReleasePath)
-	}
-	return fmt.Sprintf("%s-%s-%s", id, versionID, runtime.GOARCH), nil
+	return fmt.Sprintf("%s-%s-%s", info.ID, info.VersionID, info.Arch), nil
 }
 
 // validateArtifactURL ensures the URL is HTTPS and the host is in the PMC allowlist.

--- a/aks-node-controller/hotfix.go
+++ b/aks-node-controller/hotfix.go
@@ -112,7 +112,10 @@ func (a *App) downloadBinaryHotfixIfNeeded(ctx context.Context, cfg *hotfixConfi
 
 	slog.Info("downloading ANC hotfix", "current", Version, "target", hotfixVersion)
 
-	// Try direct HTTP download if an artifact descriptor is available for this version + OS/arch.
+	// Prefer direct HTTP download when an artifact descriptor is available. This avoids the
+	// package manager's repository refresh, version resolution, and package installation,
+	// reducing hotfix latency while retaining SHA-256 verification. Transient download
+	// failures fall back to the package manager below.
 	if err := a.tryDirectDownload(ctx, cfg, hotfixVersion); err == nil {
 		return nil
 	} else if isIntegrityError(err) {
@@ -155,10 +158,10 @@ type hotfixConfig struct {
 	// takes precedence over Version.
 	Hotfixes map[string]string `json:"hotfixes,omitempty"`
 
-	// Artifacts maps a hotfix version to per-OS/arch artifact descriptors for direct
+	// Artifacts maps a hotfix version to per-platform/architecture artifact descriptors for direct
 	// HTTP download. When present and matching, the download path bypasses the package
 	// manager entirely. The outer key is the hotfix version (e.g. "202607.02.2"), the
-	// inner key is "ID-VERSION_ID-GOARCH" (e.g. "ubuntu-22.04-amd64").
+	// inner key is "GOOS-ID-VERSION_ID-GOARCH" (e.g. "linux-ubuntu-22.04-amd64").
 	Artifacts map[string]map[string]artifactInfo `json:"artifacts,omitempty"`
 }
 
@@ -215,15 +218,16 @@ func readHotfixConfig(path string) (*hotfixConfig, error) {
 	return &cfg, nil
 }
 
-// platformInfo holds the parsed OS identity and architecture for the current host.
+// platformInfo holds the OS family, platform identity, and architecture for the current host.
 type platformInfo struct {
+	OS        string // e.g. "linux", "windows"
 	ID        string // e.g. "ubuntu", "azurelinux", "mariner"
 	VersionID string // e.g. "22.04", "3.0"
 	Arch      string // e.g. "amd64", "arm64"
 }
 
-// parsePlatformInfo reads /etc/os-release (or a.osReleasePath override for testing)
-// and combines it with the build architecture to describe the current platform.
+// parsePlatformInfo currently reads Linux /etc/os-release (or a.osReleasePath override
+// for testing) and combines it with the build architecture to describe the platform.
 func (a *App) parsePlatformInfo() (platformInfo, error) {
 	osReleasePath := a.osReleasePath
 	if osReleasePath == "" {
@@ -233,7 +237,7 @@ func (a *App) parsePlatformInfo() (platformInfo, error) {
 	if err != nil {
 		return platformInfo{}, fmt.Errorf("reading %s: %w", osReleasePath, err)
 	}
-	info := platformInfo{Arch: runtime.GOARCH}
+	info := platformInfo{OS: "linux", Arch: runtime.GOARCH}
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "ID=") {
@@ -487,7 +491,7 @@ func isIntegrityError(err error) bool {
 }
 
 // resolveArtifact looks up the artifact descriptor for the given hotfix version and current
-// OS/architecture. Returns nil if no artifact is available (caller should fallback to pkg mgr).
+// platform/architecture. Returns nil if no artifact is available (caller should fallback to pkg mgr).
 func (a *App) resolveArtifact(cfg *hotfixConfig, hotfixVersion string) (*artifactInfo, string) {
 	if len(cfg.Artifacts) == 0 {
 		return nil, ""
@@ -508,8 +512,8 @@ func (a *App) resolveArtifact(cfg *hotfixConfig, hotfixVersion string) (*artifac
 	return &ai, key
 }
 
-// buildArtifactKey constructs the OS/arch lookup key for the artifacts map.
-// Format: "ID-VERSION_ID-GOARCH" (e.g. "ubuntu-22.04-amd64").
+// buildArtifactKey constructs the platform/architecture lookup key for the artifacts map.
+// Format: "GOOS-ID-VERSION_ID-GOARCH" (e.g. "linux-ubuntu-22.04-amd64").
 func (a *App) buildArtifactKey() (string, error) {
 	info, err := a.parsePlatformInfo()
 	if err != nil {
@@ -518,7 +522,7 @@ func (a *App) buildArtifactKey() (string, error) {
 	if info.VersionID == "" {
 		return "", fmt.Errorf("VERSION_ID not found in os-release")
 	}
-	return fmt.Sprintf("%s-%s-%s", info.ID, info.VersionID, info.Arch), nil
+	return fmt.Sprintf("%s-%s-%s-%s", info.OS, info.ID, info.VersionID, info.Arch), nil
 }
 
 // validateArtifactURL ensures the URL is HTTPS and the host is in the PMC allowlist.

--- a/aks-node-controller/hotfix.go
+++ b/aks-node-controller/hotfix.go
@@ -226,9 +226,9 @@ type platformInfo struct {
 	Arch      string // e.g. "amd64", "arm64"
 }
 
-// parsePlatformInfo currently reads Linux /etc/os-release (or a.osReleasePath override
+// parseLinuxPlatformInfo currently reads Linux /etc/os-release (or a.osReleasePath override
 // for testing) and combines it with the build architecture to describe the platform.
-func (a *App) parsePlatformInfo() (platformInfo, error) {
+func (a *App) parseLinuxPlatformInfo() (platformInfo, error) {
 	osReleasePath := a.osReleasePath
 	if osReleasePath == "" {
 		osReleasePath = "/etc/os-release"
@@ -264,7 +264,7 @@ const (
 
 // detectPackageManager returns the package manager for the current OS.
 func (a *App) detectPackageManager() (packageManager, error) {
-	info, err := a.parsePlatformInfo()
+	info, err := a.parseLinuxPlatformInfo()
 	if err != nil {
 		return "", err
 	}
@@ -515,7 +515,7 @@ func (a *App) resolveArtifact(cfg *hotfixConfig, hotfixVersion string) (*artifac
 // buildArtifactKey constructs the platform/architecture lookup key for the artifacts map.
 // Format: "GOOS-ID-VERSION_ID-GOARCH" (e.g. "linux-ubuntu-22.04-amd64").
 func (a *App) buildArtifactKey() (string, error) {
-	info, err := a.parsePlatformInfo()
+	info, err := a.parseLinuxPlatformInfo()
 	if err != nil {
 		return "", err
 	}

--- a/aks-node-controller/hotfix_test.go
+++ b/aks-node-controller/hotfix_test.go
@@ -658,7 +658,7 @@ func TestReadHotfixConfig_ParsesArtifacts(t *testing.T) {
 		"hotfixes": {"202607.02": "202607.02.2"},
 		"artifacts": {
 			"202607.02.2": {
-				"ubuntu-22.04-amd64": {
+				"linux-ubuntu-22.04-amd64": {
 					"url": "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/a/aks-node-controller/aks-node-controller_0.202607.02.2_amd64.deb",
 					"sha256": "abc123"
 				}
@@ -668,8 +668,8 @@ func TestReadHotfixConfig_ParsesArtifacts(t *testing.T) {
 	cfg, err := readHotfixConfig(path)
 	require.NoError(t, err)
 	require.Contains(t, cfg.Artifacts, "202607.02.2")
-	require.Contains(t, cfg.Artifacts["202607.02.2"], "ubuntu-22.04-amd64")
-	assert.Equal(t, "abc123", cfg.Artifacts["202607.02.2"]["ubuntu-22.04-amd64"].SHA256)
+	require.Contains(t, cfg.Artifacts["202607.02.2"], "linux-ubuntu-22.04-amd64")
+	assert.Equal(t, "abc123", cfg.Artifacts["202607.02.2"]["linux-ubuntu-22.04-amd64"].SHA256)
 }
 
 func TestReadHotfixConfig_NoArtifactsFieldBackwardCompat(t *testing.T) {
@@ -689,7 +689,7 @@ func TestBuildArtifactKey(t *testing.T) {
 		a := &App{osReleasePath: path}
 		key, err := a.buildArtifactKey()
 		require.NoError(t, err)
-		assert.Equal(t, fmt.Sprintf("ubuntu-22.04-%s", runtime.GOARCH), key)
+		assert.Equal(t, fmt.Sprintf("linux-ubuntu-22.04-%s", runtime.GOARCH), key)
 	})
 
 	t.Run("azurelinux", func(t *testing.T) {
@@ -699,7 +699,7 @@ func TestBuildArtifactKey(t *testing.T) {
 		a := &App{osReleasePath: path}
 		key, err := a.buildArtifactKey()
 		require.NoError(t, err)
-		assert.Equal(t, fmt.Sprintf("azurelinux-3.0-%s", runtime.GOARCH), key)
+		assert.Equal(t, fmt.Sprintf("linux-azurelinux-3.0-%s", runtime.GOARCH), key)
 	})
 
 	t.Run("missing VERSION_ID errors", func(t *testing.T) {
@@ -748,7 +748,7 @@ func TestDownloadHotfix_ArtifactHTTPSuccess(t *testing.T) {
 	sha := "3ab698426c19090c43a48950dcd94d196122b11149423f230b1234cda75e3293"
 
 	path := filepath.Join(dir, "hotfix-config.json")
-	artifactKey := fmt.Sprintf("ubuntu-22.04-%s", runtime.GOARCH)
+	artifactKey := fmt.Sprintf("linux-ubuntu-22.04-%s", runtime.GOARCH)
 	configJSON := fmt.Sprintf(`{
 		"hotfixes": {"202607.02": "202607.02.2"},
 		"artifacts": {
@@ -797,7 +797,7 @@ func TestDownloadHotfix_ArtifactSHAMismatchHardFail(t *testing.T) {
 	defer func() { Version = origVersion }()
 
 	dir := t.TempDir()
-	artifactKey := fmt.Sprintf("ubuntu-22.04-%s", runtime.GOARCH)
+	artifactKey := fmt.Sprintf("linux-ubuntu-22.04-%s", runtime.GOARCH)
 
 	path := filepath.Join(dir, "hotfix-config.json")
 	configJSON := fmt.Sprintf(`{
@@ -842,7 +842,7 @@ func TestDownloadHotfix_ArtifactHTTPErrorFallsBackToApt(t *testing.T) {
 	defer func() { Version = origVersion }()
 
 	dir := t.TempDir()
-	artifactKey := fmt.Sprintf("ubuntu-22.04-%s", runtime.GOARCH)
+	artifactKey := fmt.Sprintf("linux-ubuntu-22.04-%s", runtime.GOARCH)
 
 	path := filepath.Join(dir, "hotfix-config.json")
 	configJSON := fmt.Sprintf(`{
@@ -926,7 +926,7 @@ func TestDownloadHotfix_ArtifactInvalidURLHardFail(t *testing.T) {
 	defer func() { Version = origVersion }()
 
 	dir := t.TempDir()
-	artifactKey := fmt.Sprintf("ubuntu-22.04-%s", runtime.GOARCH)
+	artifactKey := fmt.Sprintf("linux-ubuntu-22.04-%s", runtime.GOARCH)
 
 	path := filepath.Join(dir, "hotfix-config.json")
 	configJSON := fmt.Sprintf(`{

--- a/aks-node-controller/hotfix_test.go
+++ b/aks-node-controller/hotfix_test.go
@@ -709,7 +709,7 @@ func TestBuildArtifactKey(t *testing.T) {
 		a := &App{osReleasePath: path}
 		_, err := a.buildArtifactKey()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "ID or VERSION_ID not found")
+		assert.Contains(t, err.Error(), "VERSION_ID not found")
 	})
 }
 


### PR DESCRIPTION
## Summary

Two changes in this PR:

### 1. Refactor: deduplicate os-release parsing
`detectPackageManager` and `buildArtifactKey` both independently read and parsed `/etc/os-release` with duplicated logic. Extract a single `parsePlatformInfo()` method returning a `platformInfo` struct and rewrite both consumers to reuse it.

### 2. Add `OS` field to `platformInfo` for future Windows support
Before the hotfix JSON format is officially onboarded, add an `OS` field to `platformInfo` (hardcoded to `"linux"` for now) and update the artifact key format from `ID-VERSION_ID-GOARCH` to `GOOS-ID-VERSION_ID-GOARCH`. This reserves cross-platform capability in the data format.

**Why not make the implementation generic too:** It's not just `/etc/os-release` that's Linux-dependent — the entire install path is Linux-only:
- `apt-get`, `dnf`, `tdnf`
- `/usr/bin/aks-node-controller`, `/opt/azure/containers/...`
- File permissions and binary staging behavior
- Windows version detection and install fallback are not yet defined

Making only the platform parsing look generic would create a false impression of Windows support when none actually exists.

## Test plan
- [x] All existing `aks-node-controller` tests pass