### PR TITLE
fix: remove internal ADO backlog link from linux-vhd-content-test.sh

### DIFF
--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -2721,7 +2721,7 @@ testAppArmorInstalled $OS_SKU $OS_VERSION
 # Commenting out testImagesRetagged because at present it fails, but writes errors to stdout
 # which means the test failures haven't been caught. It also calles exit 1 on a failure,
 # which means the rest of the tests aren't being run.
-# See https://msazure.visualstudio.com/CloudNativeCompute/_backlogs/backlog/Node%20Lifecycle/Features/?workitem=24246232
+# Tracked internally (Node Lifecycle backlog item #24246232)
 # testImagesRetagged $CONTAINER_RUNTIME
 testCustomCAScriptExecutable
 testCustomCATimerNotStarted


### PR DESCRIPTION
## Summary

Removes an internal-only link from a shell script comment. This is a comment-only change; no test logic was modified.

## Changes

- Removed a literal internal work-tracking URL from the comment above the disabled `testImagesRetagged` call.
- Kept a hostname-free reference to the internal tracking item number so context isn't lost.

## Testing

- Confirmed no internal hostnames remain in the file.
- `git diff --stat` confirms a single-line comment change only.

## Related

- Companion PR (separate file, same cleanup): #9330
