### PR TITLE
ci: fix zizmor ref-version-mismatch on azure/login pin

### DIFF
--- a/.github/workflows/hotfix-generate.yml
+++ b/.github/workflows/hotfix-generate.yml
@@ -45,7 +45,7 @@ jobs:
     environment: test
     steps:
       - name: Azure login
-        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ secrets.AZURE_KV_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_KV_TENANT_ID }}

--- a/.github/workflows/tidy.yaml
+++ b/.github/workflows/tidy.yaml
@@ -23,7 +23,7 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.head.repo.full_name == 'Azure/AgentBaker'
     environment: test
     steps:
-      - uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
+      - uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ secrets.AZURE_KV_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_KV_TENANT_ID }}


### PR DESCRIPTION
## Summary

Fixes a pre-existing `zizmor` `ref-version-mismatch` finding that fails on every PR touching workflow files, unrelated to the PR's actual content.

## Changes

- `azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca` is pinned in both `.github/workflows/hotfix-generate.yml` and `.github/workflows/tidy.yaml` with a `# v3` comment, but that commit SHA is actually tagged `v3.0.1` on Azure/login.
- Updated both comments to `# v3.0.1` to match. Comment-only change, no functional impact.

## Testing

- Confirmed via GitHub API that the pinned SHA resolves to tag `v3.0.1`.
- Verified both workflow files still parse as valid YAML.

## Related

- AB#39457324
