### PR TITLE
feat: add Azure Container Linux CVM SIG config

### DIFF
--- a/pkg/agent/bakerapi_test.go
+++ b/pkg/agent/bakerapi_test.go
@@ -417,6 +417,7 @@ var _ = Describe("AgentBaker API implementation tests", func() {
 				datamodel.AKSACLArm64Gen2TL,
 				datamodel.AKSACLGen2FIPSTL,
 				datamodel.AKSACLArm64Gen2FIPSTL,
+				datamodel.AKSACLCVMGen2,
 			}
 
 			ubuntuEdgeZoneDistros = []datamodel.Distro{

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -830,7 +830,7 @@ var (
 	SIGACLCVMGen2ImageConfigTemplate = SigImageConfigTemplate{
 		ResourceGroup: AKSAzureLinuxResourceGroup,
 		Gallery:       AKSAzureLinuxGalleryName,
-		Definition:    "aclgen2CVM",
+		Definition:    "aclgen2CVMSpecialized",
 		Version:       LinuxSIGImageVersion,
 	}
 

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -128,6 +128,7 @@ var AvailableContainerdDistros = []Distro{
 	AKSACLArm64Gen2TL,
 	AKSACLGen2FIPSTL,
 	AKSACLArm64Gen2FIPSTL,
+	AKSACLCVMGen2,
 	AKSCBLMarinerV1,
 	AKSCBLMarinerV2,
 	AKSAzureLinuxV2,
@@ -200,6 +201,7 @@ var AvailableGen2Distros = []Distro{
 	AKSACLArm64Gen2TL,
 	AKSACLGen2FIPSTL,
 	AKSACLArm64Gen2FIPSTL,
+	AKSACLCVMGen2,
 	AKSCBLMarinerV2Gen2,
 	AKSAzureLinuxV2Gen2,
 	AKSAzureLinuxV3Gen2,
@@ -310,6 +312,7 @@ var AvailableACLDistros = []Distro{
 	AKSACLArm64Gen2TL,
 	AKSACLGen2FIPSTL,
 	AKSACLArm64Gen2FIPSTL,
+	AKSACLCVMGen2,
 }
 
 // IsContainerdSKU returns true if distro type is containerd-enabled.
@@ -824,6 +827,15 @@ var (
 		Version:       LinuxSIGImageVersion,
 	}
 
+	// Definition name pending confirmation of the AKSAzureLinux gallery import name for the generalized
+	// TrustedLaunchAndConfidentialVmSupported ACL CVM image (mariner-aks-pipelines PR 28925).
+	SIGACLCVMGen2ImageConfigTemplate = SigImageConfigTemplate{
+		ResourceGroup: AKSAzureLinuxResourceGroup,
+		Gallery:       AKSAzureLinuxGalleryName,
+		Definition:    "aclcvmgen2",
+		Version:       LinuxSIGImageVersion,
+	}
+
 	SIGWindows2019ImageConfigTemplate = SigImageConfigTemplate{
 		ResourceGroup: AKSWindowsResourceGroup,
 		Gallery:       AKSWindowsGalleryName,
@@ -987,6 +999,7 @@ func getSigAzureLinuxImageConfigMapWithOpts(opts ...SigImageConfigOpt) map[Distr
 		AKSACLArm64Gen2TL:                SIGACLArm64Gen2TLImageConfigTemplate.WithOptions(opts...),
 		AKSACLGen2FIPSTL:                 SIGACLGen2FIPSTLImageConfigTemplate.WithOptions(opts...),
 		AKSACLArm64Gen2FIPSTL:            SIGACLArm64Gen2FIPSTLImageConfigTemplate.WithOptions(opts...),
+		AKSACLCVMGen2:                    SIGACLCVMGen2ImageConfigTemplate.WithOptions(opts...),
 	}
 }
 

--- a/pkg/agent/datamodel/sig_config.go
+++ b/pkg/agent/datamodel/sig_config.go
@@ -827,12 +827,10 @@ var (
 		Version:       LinuxSIGImageVersion,
 	}
 
-	// Definition name pending confirmation of the AKSAzureLinux gallery import name for the generalized
-	// TrustedLaunchAndConfidentialVmSupported ACL CVM image (mariner-aks-pipelines PR 28925).
 	SIGACLCVMGen2ImageConfigTemplate = SigImageConfigTemplate{
 		ResourceGroup: AKSAzureLinuxResourceGroup,
 		Gallery:       AKSAzureLinuxGalleryName,
-		Definition:    "aclcvmgen2",
+		Definition:    "aclgen2CVM",
 		Version:       LinuxSIGImageVersion,
 	}
 

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -436,7 +436,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		aclCVMGen2 := sigConfig.SigAzureLinuxImageConfig[AKSACLCVMGen2]
 		Expect(aclCVMGen2.ResourceGroup).To(Equal("resourcegroup"))
 		Expect(aclCVMGen2.Gallery).To(Equal("aksazurelinux"))
-		Expect(aclCVMGen2.Definition).To(Equal("aclgen2CVM"))
+		Expect(aclCVMGen2.Definition).To(Equal("aclgen2CVMSpecialized"))
 		Expect(aclCVMGen2.Version).To(Equal(LinuxSIGImageVersion))
 	})
 })

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -39,6 +39,7 @@ var _ = Describe("GetMaintainedLinuxSIGImageConfigMap", func() {
 			AKSACLArm64Gen2TL:                       SIGACLArm64Gen2TLImageConfigTemplate.WithOptions(),
 			AKSACLGen2FIPSTL:                        SIGACLGen2FIPSTLImageConfigTemplate.WithOptions(),
 			AKSACLArm64Gen2FIPSTL:                   SIGACLArm64Gen2FIPSTLImageConfigTemplate.WithOptions(),
+			AKSACLCVMGen2:                           SIGACLCVMGen2ImageConfigTemplate.WithOptions(),
 		}
 		actual := GetMaintainedLinuxSIGImageConfigMap()
 		for distro, config := range expected {
@@ -106,7 +107,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(mariner.Definition).To(Equal("V1"))
 		Expect(mariner.Version).To(Equal(FrozenCBLMarinerV1SIGImageVersionForDeprecation))
 
-		Expect(len(sigConfig.SigAzureLinuxImageConfig)).To(Equal(21))
+		Expect(len(sigConfig.SigAzureLinuxImageConfig)).To(Equal(22))
 
 		azurelinuxV2 := sigConfig.SigAzureLinuxImageConfig[AKSAzureLinuxV2]
 		Expect(azurelinuxV2.ResourceGroup).To(Equal("resourcegroup"))
@@ -431,5 +432,11 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		Expect(aclArm64Gen2FIPS.Gallery).To(Equal("aksazurelinux"))
 		Expect(aclArm64Gen2FIPS.Definition).To(Equal("aclgen2arm64fipsTL"))
 		Expect(aclArm64Gen2FIPS.Version).To(Equal(LinuxSIGImageVersion))
+
+		aclCVMGen2 := sigConfig.SigAzureLinuxImageConfig[AKSACLCVMGen2]
+		Expect(aclCVMGen2.ResourceGroup).To(Equal("resourcegroup"))
+		Expect(aclCVMGen2.Gallery).To(Equal("aksazurelinux"))
+		Expect(aclCVMGen2.Definition).To(Equal("aclcvmgen2"))
+		Expect(aclCVMGen2.Version).To(Equal(LinuxSIGImageVersion))
 	})
 })

--- a/pkg/agent/datamodel/sig_config_test.go
+++ b/pkg/agent/datamodel/sig_config_test.go
@@ -436,7 +436,7 @@ var _ = Describe("GetSIGAzureCloudSpecConfig", func() {
 		aclCVMGen2 := sigConfig.SigAzureLinuxImageConfig[AKSACLCVMGen2]
 		Expect(aclCVMGen2.ResourceGroup).To(Equal("resourcegroup"))
 		Expect(aclCVMGen2.Gallery).To(Equal("aksazurelinux"))
-		Expect(aclCVMGen2.Definition).To(Equal("aclcvmgen2"))
+		Expect(aclCVMGen2.Definition).To(Equal("aclgen2CVM"))
 		Expect(aclCVMGen2.Version).To(Equal(LinuxSIGImageVersion))
 	})
 })

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -201,6 +201,7 @@ const (
 	AKSACLArm64Gen2TL                       Distro = "aks-acl-arm64-gen2-tl"
 	AKSACLGen2FIPSTL                        Distro = "aks-acl-gen2-fips-tl"
 	AKSACLArm64Gen2FIPSTL                   Distro = "aks-acl-arm64-gen2-fips-tl"
+	AKSACLCVMGen2                           Distro = "aks-acl-cvm-gen2"
 
 	// Windows string const.
 	// AKSWindows2019 stands for distro of windows server 2019 SIG image with docker.
@@ -292,6 +293,7 @@ var AKSDistrosAvailableOnVHD = []Distro{
 	AKSACLArm64Gen2TL,
 	AKSACLGen2FIPSTL,
 	AKSACLArm64Gen2FIPSTL,
+	AKSACLCVMGen2,
 }
 
 type CustomConfigurationComponent string

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -1342,6 +1342,13 @@ func TestAgentPoolProfileIsACL(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "ACL CVM distro",
+			ap: AgentPoolProfile{
+				Distro: AKSACLCVMGen2,
+			},
+			expected: true,
+		},
+		{
 			name: "Flatcar distro is not ACL",
 			ap: AgentPoolProfile{
 				Distro: AKSFlatcarGen2,


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds AgentBaker SIG configuration for the Azure Container Linux Confidential VM Gen2 distro, `aks-acl-cvm-gen2`, so AKS can resolve the distro to its Azure Linux gallery image.

Changes:
- Adds the `AKSACLCVMGen2` distro constant and includes it in `AKSDistrosAvailableOnVHD`.
- Registers the distro in the containerd, Gen2, and Azure Container Linux availability lists.
- Adds the `SIGACLCVMGen2ImageConfigTemplate` and Azure Linux SIG config-map entry.
- Uses the generated SIG definition `aclgen2CVM`. PR #9283 explicitly keeps ACL CVM generalized and suppresses the `Specialized` suffix for `AzureContainerLinux`.
- Adds unit-test coverage for maintained-image registration, cloud-specific SIG resolution, ACL classification, and version-override resolution.

Validation:
- `go test ./pkg/agent/...`

Related work and dependency:
- Depends on ACL CVM image-build support in #9283.
- This change must remain aligned with the AKS-RP distro constant `aks-acl-cvm-gen2`.

**Which issue(s) this PR fixes**:

Fixes #