### PR TITLE
fix: remove go.mod replacements causing issues

### DIFF
--- a/aks-node-controller/go.mod
+++ b/aks-node-controller/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/agentbaker/aks-node-controller
 go 1.25.11
 
 require (
-	github.com/Azure/agentbaker/aks-live-patching v0.0.0-00010101000000-000000000000
+	github.com/Azure/agentbaker/aks-live-patching v0.20260831.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/fsnotify/fsnotify v1.8.0
@@ -26,9 +26,3 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
-
-replace github.com/Azure/agentbaker => ../
-
-replace github.com/Azure/agentbaker/aks-live-patching => ../aks-live-patching
-
-replace github.com/coreos/ignition/v2 => github.com/flatcar/ignition/v2 v2.0.0-20250903113522-05b8a773288c

--- a/aks-node-controller/go.sum
+++ b/aks-node-controller/go.sum
@@ -1,3 +1,5 @@
+github.com/Azure/agentbaker/aks-live-patching v0.20260831.0 h1:nKQaxhJUTsZQuKt73fhgmuRKf8/bP+NadZgeMkoEF6c=
+github.com/Azure/agentbaker/aks-live-patching v0.20260831.0/go.mod h1:+sEaCL2ZNsq3HFM2ScKuOH84K6RwPJIA6NBcyZanhZk=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1 h1:Wc1ml6QlJs2BHQ/9Bqu1jiyggbsSjramq2oUmp5WeIo=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1/go.mod h1:Ot/6aikWnKWi4l9QB7qVSwa8iMphQNqkWALMoNT3rzM=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=


### PR DESCRIPTION
Stop using replace directives, i tagged latest commit from aks-live-patching, but we need to start tagging commits from now on, will change VHD build for it.