### PR TITLE
Fix LPS apiserver front port to 9443

### DIFF
--- a/aks-node-controller/checkhotfix.go
+++ b/aks-node-controller/checkhotfix.go
@@ -48,7 +48,7 @@ const (
 	// lpsAPIServerPort is the HTTPS port the apiserver front (and thus the LPS path) listens on.
 	// Envoy forwards the matched ALPN stream to the LPS backend internally; the client only ever
 	// dials the apiserver front here.
-	lpsAPIServerPort = "443"
+	lpsAPIServerPort = "9443"
 
 	// imdsAttestedDocURL returns the IMDS attested-data document, whose signature is used as
 	// the LPS Authorization token. IMDS is reachable pre-kubelet (the same primitive Secure

--- a/aks-node-controller/checkhotfix_grpc.go
+++ b/aks-node-controller/checkhotfix_grpc.go
@@ -105,7 +105,7 @@ func (a *App) fetchHotfixOverGRPC(ctx context.Context) ([]byte, error) {
 }
 
 // dialLPSGRPC builds the gRPC client connection to the live-patching service: it dials the cluster
-// apiserver FQDN:443 (riding the existing apiserver egress rule) and advertises the live-patching
+// apiserver FQDN:9443 (riding the existing apiserver egress rule) and advertises the live-patching
 // ALPN protocol so the kube-api-proxy envoy routes the stream to the LPS backend. The server
 // certificate is issued for lpsServerName (with a real SAN), but tls.Config.ServerName is left
 // EMPTY so the wire SNI stays the apiserver authority and envoy routes on ALPN (setting it would


### PR DESCRIPTION
## What

`lpsAPIServerPort` in `aks-node-controller/checkhotfix.go` was `"443"`; it should be `"9443"` — the port the apiserver front (and thus the LPS/live-patching path) actually listens on.

## Changes
- `checkhotfix.go`: `lpsAPIServerPort` `"443"` → `"9443"`.
- `checkhotfix_grpc.go`: updated the `dialLPSGRPC` doc comment (`apiserver FQDN:443` → `:9443`) to match.

## Notes
- `net.JoinHostPort(host, lpsAPIServerPort)` is the only consumer, so the dial target is now `host:9443`.
- The `"host:443"` example in the `net.SplitHostPort` comment was intentionally left as-is: it refers to a port that may already be carried in `api_server_name` (which is stripped before rejoining with `lpsAPIServerPort`), not to the LPS dial port.
- No tests referenced the port. `go build ./...` passes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>