### PR TITLE
fix(windows): retry kubelet start check after NodeResetScriptTask

### DIFF
--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -333,8 +333,45 @@ function Start-NodeResetScriptTask {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "NodeResetScriptTask failed with result $($taskInfo.LastTaskResult)"
     }
 
+    # windowsnodereset.ps1 (run by NodeResetScriptTask) issues Start-Service kubelet, but the
+    # service can still be in StartPending immediately after the task reports success, especially
+    # on slower first boots such as sysprepped/cached (golden) images. Asserting Running exactly
+    # once here caused intermittent CSE failures, so poll with bounded retries and re-nudge the
+    # service, matching the containerd start pattern in containerdfunc.ps1 (Start-Containerd).
     $kubeletService=Get-Service -Name "kubelet" -ErrorAction SilentlyContinue
-    if ($null -eq $kubeletService -or $kubeletService.Status -ne "Running") {
+    if ($null -eq $kubeletService) {
+        Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not installed after NodeResetScriptTask completed"
+    }
+
+    $retryCount=0
+    $maxRetryCount=6 # 1 minute
+    do {
+        $kubeletService=Get-Service -Name "kubelet" -ErrorAction SilentlyContinue
+        if ($kubeletService.Status -eq "Running") {
+            Write-Log -Message "kubelet service is running after NodeResetScriptTask"
+            break
+        }
+
+        $retryCount++
+        Write-Log -Message "kubelet service is not running after NodeResetScriptTask (attempt $retryCount of $maxRetryCount), current status: $($kubeletService.Status)"
+
+        try {
+            Start-Service kubelet -ErrorAction Stop
+            $kubeletService=Get-Service -Name "kubelet"
+            $kubeletService.WaitForStatus('Running', [timespan]::FromSeconds(5))
+            Write-Log -Message "kubelet service started successfully after NodeResetScriptTask"
+            break
+        }
+        catch {
+            Write-Log -Message "Failed to start kubelet service after NodeResetScriptTask: $_"
+        }
+
+        if ($retryCount -lt $maxRetryCount) {
+            Start-Sleep -Seconds 5
+        }
+    } while ($retryCount -lt $maxRetryCount)
+
+    if ($kubeletService.Status -ne "Running") {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not running after NodeResetScriptTask completed"
     }
 

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -669,13 +669,16 @@ Describe "Start-NodeResetScriptTask" {
   }
 
   It "recovers when kubelet reaches running after a retry" {
+    # Calls 1 (presence check) and 2 (first loop check) report StartPending so the loop
+    # enters the recovery branch and invokes Start-Service; the Get-Service after Start-Service
+    # returns Running with a no-op WaitForStatus so the loop breaks via the recovery path.
     $script:kubeletCallCount = 0
     Mock Get-Service -MockWith {
       $script:kubeletCallCount++
-      if ($script:kubeletCallCount -eq 1) {
-        return [pscustomobject]@{ Status = "StartPending" }
-      }
-      return [pscustomobject]@{ Status = "Running" }
+      $status = if ($script:kubeletCallCount -le 2) { "StartPending" } else { "Running" }
+      $svc = [pscustomobject]@{ Status = $status }
+      $svc | Add-Member -MemberType ScriptMethod -Name WaitForStatus -Value { param($desiredStatus, $timeout) } -Force
+      return $svc
     }
 
     Start-NodeResetScriptTask

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -603,6 +603,7 @@ Describe "Start-NodeResetScriptTask" {
       return [pscustomobject]@{ LastRunTime = [datetime]"2026-01-02"; LastTaskResult = 0 }
     }
     Mock Get-Service -MockWith { return [pscustomobject]@{ Status = "Running" } }
+    Mock Start-Service -MockWith {}
     Mock Start-Sleep -MockWith {}
     Mock Write-Log -MockWith {}
     Mock Set-ExitCode -MockWith {
@@ -665,5 +666,21 @@ Describe "Start-NodeResetScriptTask" {
     Mock Get-Service -MockWith { return [pscustomobject]@{ Status = "Stopped" } }
 
     { Start-NodeResetScriptTask } | Should -Throw "*kubelet service is not running*"
+  }
+
+  It "recovers when kubelet reaches running after a retry" {
+    $script:kubeletCallCount = 0
+    Mock Get-Service -MockWith {
+      $script:kubeletCallCount++
+      if ($script:kubeletCallCount -eq 1) {
+        return [pscustomobject]@{ Status = "StartPending" }
+      }
+      return [pscustomobject]@{ Status = "Running" }
+    }
+
+    Start-NodeResetScriptTask
+
+    Assert-MockCalled -CommandName Start-Service -Exactly -Times 1
+    Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
   }
 }


### PR DESCRIPTION
## What

`Start-NodeResetScriptTask` (in `parts/windows/windowscsehelper.ps1`) asserted the `kubelet` service was `Running` **exactly once**, immediately after the `k8s-restart-job` reset task reported success. `windowsnodereset.ps1` issues `Start-Service kubelet`, but on slower first boots — notably **sysprepped/cached (golden) images** provisioned in the Windows VHDCaching e2e scenario — kubelet can still be in `StartPending` at that instant, so CSE failed intermittently with `WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK` ("kubelet service is not running after NodeResetScriptTask completed").

## Fix

Poll for kubelet to reach `Running` with bounded retries (6 × ~5s) and re-nudge `Start-Service` on each attempt, mirroring the existing `Start-Containerd` pattern in `staging/cse/windows/containerdfunc.ps1`. A genuinely failed kubelet still exits with the same code/message after the timeout, so the intent of #8970 (validate the reset result) is preserved — this only absorbs start-latency.

## Evidence

`Agentbaker Windows E2E` is flaky on this exact scenario on **unchanged `main`** (green some days, red others). The failing case is always `Test_Windows2022_VHDCaching_LegacyTLSBootstrap/VHDCreation/VMProvision`: the base node comes up and validates, but the node provisioned from the sysprepped/captured image fails the reset kubelet check. Within a run, the faster base node passes while the slower cached node fails — consistent with a start-latency race, not a deterministic break.

## Testing

Adds a Pester case in `windowscsehelper.tests.ps1` covering kubelet reaching `Running` after a retry; existing cases (including "fails when kubelet is not running") still hold. Windows E2E triggered on this PR.
