### PR TITLE
fix: go experiment variable removal

### DIFF
--- a/hack/setup_golang.sh
+++ b/hack/setup_golang.sh
@@ -40,7 +40,7 @@ setup_pmc
 sudo apt-get -y install make
 
 # install msft-golang
-sudo apt-get -y install msft-golang
+sudo apt-get -y install "msft-golang=1.26.7-ubuntu${UBUNTU_RELEASE}u1"
 
 # make sure go is accessible from the command line
 go version

--- a/hack/setup_golang.sh
+++ b/hack/setup_golang.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 set -euxo pipefail
 
+go_version="1.26.7"
+
 # This script installs Microsoft's Go distribution via apt-get (Ubuntu).
 # On hosts without apt-get (e.g. Azure Linux build agents), the build environment
-# is expected to provide Go through its own package manager, so just verify that
-# `go` is on PATH and exit.
+# is expected to provide the required Go version through its own package manager,
+# so verify it is on PATH and matches before exiting.
 if ! command -v apt-get >/dev/null 2>&1; then
     echo "apt-get not found; skipping Ubuntu-specific Go setup."
     if ! command -v go >/dev/null 2>&1; then
         echo "ERROR: 'go' is not on PATH; the build environment must install Go before invoking setup_golang.sh." >&2
+        exit 1
+    fi
+    actual_go_version=$(go env GOVERSION)
+    if [[ "${actual_go_version}" != "go${go_version}" ]]; then
+        echo "ERROR: expected Go ${go_version}, found ${actual_go_version}; the build environment must provide the required version." >&2
         exit 1
     fi
     echo "Using Go provided by the build environment:"
@@ -23,24 +30,26 @@ purge_go() {
 }
 
 setup_pmc() {
+    local ubuntu_release="$1"
     # see: https://github.com/microsoft/go/blob/microsoft/main/README.md#ubuntu
-    UBUNTU_RELEASE=$(sudo lsb_release -r -s 2>/dev/null || echo "")
-    curl -sSL -O https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb
+    curl -sSL -O "https://packages.microsoft.com/config/ubuntu/${ubuntu_release}/packages-microsoft-prod.deb"
     sudo dpkg -i packages-microsoft-prod.deb
     sudo apt-get update
 }
+
+ubuntu_release=$(sudo lsb_release -r -s)
 
 # purge any existing go installation
 purge_go
 
 # setup access to packages.microsoft.com for the particular Ubuntu release
-setup_pmc
+setup_pmc "${ubuntu_release}"
 
 # install make
 sudo apt-get -y install make
 
 # install msft-golang
-sudo apt-get -y install "msft-golang=1.26.7-ubuntu${UBUNTU_RELEASE}u1"
+sudo apt-get -y install "msft-golang=${go_version}-ubuntu${ubuntu_release}u1"
 
 # make sure go is accessible from the command line
 go version

--- a/packer.mk
+++ b/packer.mk
@@ -141,19 +141,19 @@ build-aks-node-controller:
 	ANC_VERSION="$${IMAGE_VERSION:-$$(date +%Y%m.%d.0)}"; \
 	ANC_LDFLAGS="-X main.Version=$${ANC_VERSION}"; \
 	echo "Stamping ANC version: $${ANC_VERSION}"; \
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$${ANC_LDFLAGS}" -o bin/aks-node-controller-linux-amd64; \
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$${ANC_LDFLAGS}" -o bin/aks-node-controller-linux-arm64'
+	GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$${ANC_LDFLAGS}" -o bin/aks-node-controller-linux-amd64; \
+	GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$${ANC_LDFLAGS}" -o bin/aks-node-controller-linux-arm64'
 
 build-image-fetcher:
 	@echo "Building image-fetcher binaries"
 	@bash -c "pushd image-fetcher && \
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/image-fetcher-linux-amd64 && \
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/image-fetcher-linux-arm64 && \
+	GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/image-fetcher-linux-amd64 && \
+	GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/image-fetcher-linux-arm64 && \
 	popd"
 
 build-lister-binary:
 	@echo "Building lister binary for $(GOARCH)"
-	@bash -c "pushd vhdbuilder/lister && CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -o bin/lister main.go && popd"
+	@bash -c "pushd vhdbuilder/lister && GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -o bin/lister main.go && popd"
 
 generate-acl-customdata: vhdbuilder/packer/acl-customdata.json
 vhdbuilder/packer/acl-customdata.json: vhdbuilder/packer/acl-customdata.yaml | hack/tools/bin/butane

--- a/packer.mk
+++ b/packer.mk
@@ -141,19 +141,19 @@ build-aks-node-controller:
 	ANC_VERSION="$${IMAGE_VERSION:-$$(date +%Y%m.%d.0)}"; \
 	ANC_LDFLAGS="-X main.Version=$${ANC_VERSION}"; \
 	echo "Stamping ANC version: $${ANC_VERSION}"; \
-	GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$${ANC_LDFLAGS}" -o bin/aks-node-controller-linux-amd64; \
-	GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$${ANC_LDFLAGS}" -o bin/aks-node-controller-linux-arm64'
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$${ANC_LDFLAGS}" -o bin/aks-node-controller-linux-amd64; \
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$${ANC_LDFLAGS}" -o bin/aks-node-controller-linux-arm64'
 
 build-image-fetcher:
 	@echo "Building image-fetcher binaries"
 	@bash -c "pushd image-fetcher && \
-	GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/image-fetcher-linux-amd64 && \
-	GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/image-fetcher-linux-arm64 && \
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/image-fetcher-linux-amd64 && \
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/image-fetcher-linux-arm64 && \
 	popd"
 
 build-lister-binary:
 	@echo "Building lister binary for $(GOARCH)"
-	@bash -c "pushd vhdbuilder/lister && GOEXPERIMENT=ms_nocgo_opensslcrypto CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -o bin/lister main.go && popd"
+	@bash -c "pushd vhdbuilder/lister && CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -o bin/lister main.go && popd"
 
 generate-acl-customdata: vhdbuilder/packer/acl-customdata.json
 vhdbuilder/packer/acl-customdata.json: vhdbuilder/packer/acl-customdata.yaml | hack/tools/bin/butane


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a currently a regression that is blocking the VHD build from successfully completing due to a golang update.

**Which issue(s) this PR fixes**:

Failed VHD Builds

Fixes #
