### PR TITLE
feat(vhdbuilder): configure the Trident ACL Agent on ACL images

### DIFF
--- a/parts/linux/cloud-init/artifacts/acl/trident-acl-agent-override.conf
+++ b/parts/linux/cloud-init/artifacts/acl/trident-acl-agent-override.conf
@@ -1,0 +1,33 @@
+[Service]
+# The Trident ACL Agent ships with no Environment= lines, so every
+# deployment-specific setting is supplied here. Only the settings whose
+# defaults are wrong for AKS are overridden; kubeconfig path, node name, API
+# server, trident socket, orchestration mode, state path, timeouts and
+# heartbeat interval are all correct by default.
+
+# The agent defaults to the "acl.microsoft.com" prefix, but the AKS-RP
+# annotation contract specifies "acl.azure.com". A mismatch is silent: the
+# resource provider writes an annotation key the agent never watches, and no
+# update ever runs.
+Environment="TRIDENT_ACL_AGENT_KUBERNETES_ANNOTATION_PREFIX=acl.azure.com"
+
+# The agent compares the node's running version against the target version in
+# an update request to decide whether the node is already at target. It reads
+# an os-release-formatted KEY=VALUE file. The default of VERSION_ID in
+# /etc/os-release is not usable here: it carries the OS release (3.0.YYYYMMDD)
+# rather than the node image version (YYYYMM.DD.PATCH) that the request
+# specifies, so the two are not comparable. Point the agent at the node image
+# version written during the image build instead.
+Environment="TRIDENT_ACL_AGENT_CURRENT_VERSION_PATH=/opt/azure/containers/image-version"
+Environment="TRIDENT_ACL_AGENT_CURRENT_VERSION_KEY=IMAGE_VERSION"
+
+# Fail at startup if that file or key is missing. The default behaviour is to
+# log a warning and report version 0.0.0, which parses and compares cleanly
+# but is always wrong: the node would never be recognised as already at
+# target, and would report a bogus source version on every update.
+Environment="TRIDENT_ACL_AGENT_CURRENT_VERSION_FALLBACK=error"
+
+# Create /var/lib/trident-acl-agent before the agent starts, so its state file
+# has a directory to live in. The state file is what carries an in-flight
+# operation across the reboot.
+StateDirectory=trident-acl-agent

--- a/parts/linux/cloud-init/artifacts/acl/trident-acl-agent-override.conf
+++ b/parts/linux/cloud-init/artifacts/acl/trident-acl-agent-override.conf
@@ -1,33 +1,84 @@
 [Service]
-# The Trident ACL Agent ships with no Environment= lines, so every
-# deployment-specific setting is supplied here. Only the settings whose
-# defaults are wrong for AKS are overridden; kubeconfig path, node name, API
-# server, trident socket, orchestration mode, state path, timeouts and
-# heartbeat interval are all correct by default.
+# Configuration for the Trident ACL Agent on AKS nodes.
+#
+# Every setting the agent reads from the environment is set explicitly, including
+# those whose current upstream default already matches. The agent applies its own
+# defaults for anything unset, so relying on them would let an upstream default
+# change silently alter node behaviour on an image rebuild. Pinning them means
+# this file, rather than the agent's defaults, defines how AKS nodes update.
+#
+# The trade is that a deliberate upstream default change, such as a timeout that
+# proves too short in practice, does not reach AKS until this file is updated.
+# These values should therefore be reviewed against the agent's defaults when the
+# Trident version in the base image moves.
+#
+# Settings that cannot be pinned here, and why, are listed at the end.
 
-# The agent defaults to the "acl.microsoft.com" prefix, but the AKS-RP
-# annotation contract specifies "acl.azure.com". A mismatch is silent: the
-# resource provider writes an annotation key the agent never watches, and no
-# update ever runs.
+# --- Kubernetes ------------------------------------------------------------
+# The agent defaults to the "acl.microsoft.com" prefix, but the AKS annotation
+# contract uses "acl.azure.com". A mismatch is silent: the resource provider
+# writes an annotation key the agent never watches, and no update ever runs.
 Environment="TRIDENT_ACL_AGENT_KUBERNETES_ANNOTATION_PREFIX=acl.azure.com"
 
-# The agent compares the node's running version against the target version in
-# an update request to decide whether the node is already at target. It reads
-# an os-release-formatted KEY=VALUE file. The default of VERSION_ID in
-# /etc/os-release is not usable here: it carries the OS release (3.0.YYYYMMDD)
-# rather than the node image version (YYYYMM.DD.PATCH) that the request
-# specifies, so the two are not comparable. Point the agent at the node image
-# version written during the image build instead.
+# The agent authenticates to the API server as this node, using the kubeconfig
+# kubelet writes when it completes TLS bootstrapping.
+Environment="TRIDENT_ACL_AGENT_KUBERNETES_KUBECONFIG=/var/lib/kubelet/kubeconfig"
+
+# --- Trident ---------------------------------------------------------------
+# The gRPC socket served by tridentd. The agent needs the daemon rather than the
+# Trident CLI: the CLI reboots on finalize before a terminal status can be
+# written back, so an update would complete with the orchestrator never learning
+# the outcome.
+Environment="TRIDENT_ACL_AGENT_TRIDENT_SOCKET=unix:///run/trident/trident.sock"
+
+# --- Orchestration ---------------------------------------------------------
+# Drive updates from node annotations. The alternative mode polls an Omaha
+# endpoint directly, which does not apply here: AKS decides when a node updates.
+Environment="TRIDENT_ACL_AGENT_ORCHESTRATION_MODE=annotations"
+
+# State that carries an in-flight operation across the reboot, so the agent can
+# report the outcome of a finalize once the new image has booted. This lives on
+# the root partition, which an A/B update of /usr does not replace.
+Environment="TRIDENT_ACL_AGENT_ORCHESTRATION_STATE_PATH=/var/lib/trident-acl-agent/state.json"
+
+# How long the agent waits for each phase before reporting failure, and how
+# often it refreshes the status annotation while an operation is in progress.
+# The heartbeat interval must stay well below the orchestrator's staleness
+# threshold, since that is how a silently stalled node is detected.
+Environment="TRIDENT_ACL_AGENT_ORCHESTRATION_STAGE_TIMEOUT=20m"
+Environment="TRIDENT_ACL_AGENT_ORCHESTRATION_FINALIZE_TIMEOUT=10m"
+Environment="TRIDENT_ACL_AGENT_ORCHESTRATION_HEARTBEAT_INTERVAL=60s"
+
+# --- Current version -------------------------------------------------------
+# The agent compares the node's running version against the target version in an
+# update request, reading an os-release-formatted KEY=VALUE file. The VERSION_ID
+# in /etc/os-release cannot serve: it carries the OS release (3.0.YYYYMMDD)
+# rather than the node image version (YYYYMM.DD.PATCH) that update requests
+# specify, so the two are not comparable.
 Environment="TRIDENT_ACL_AGENT_CURRENT_VERSION_PATH=/opt/azure/containers/image-version"
 Environment="TRIDENT_ACL_AGENT_CURRENT_VERSION_KEY=IMAGE_VERSION"
 
-# Fail at startup if that file or key is missing. The default behaviour is to
-# log a warning and report version 0.0.0, which parses and compares cleanly
-# but is always wrong: the node would never be recognised as already at
-# target, and would report a bogus source version on every update.
+# Fail at startup if that file or key is missing. The default is to log a warning
+# and report version 0.0.0, which parses and compares cleanly but is always
+# wrong: the node would never be recognised as already at target, and would
+# report a bogus source version on every update.
 Environment="TRIDENT_ACL_AGENT_CURRENT_VERSION_FALLBACK=error"
 
-# Create /var/lib/trident-acl-agent before the agent starts, so its state file
-# has a directory to live in. The state file is what carries an in-flight
-# operation across the reboot.
+# --- Deliberately not set --------------------------------------------------
+# TRIDENT_ACL_AGENT_KUBERNETES_NODE_NAME
+#   Per node. Defaults to the lowercased hostname, which is what kubelet
+#   registers the Node object as.
+# TRIDENT_ACL_AGENT_KUBERNETES_API_SERVER
+#   Per cluster. When unset the agent uses the server embedded in the kubeconfig
+#   above, which is already correct for this node.
+# TRIDENT_ACL_AGENT_NEBRASKA_*
+#   Unused in annotation mode: an update request carries its own server details,
+#   with no fallback to configuration. Setting them here would imply an update
+#   source that is not consulted.
+#
+# The Kubernetes watch poll interval has no environment variable and is fixed by
+# the agent.
+
+# Create /var/lib/trident-acl-agent before the agent starts, so the state file
+# above has a directory to live in.
 StateDirectory=trident-acl-agent

--- a/parts/linux/cloud-init/artifacts/acl/trident-acl-agent.path
+++ b/parts/linux/cloud-init/artifacts/acl/trident-acl-agent.path
@@ -1,0 +1,17 @@
+[Unit]
+Description=Start the Trident ACL Agent once kubelet's kubeconfig exists
+Documentation=https://microsoft.github.io/trident/
+
+[Path]
+# The agent authenticates to the API server as this node using kubelet's
+# kubeconfig, and fails to start if the file is absent. On a new node that file
+# does not appear until kubelet completes TLS bootstrapping, so trigger on the
+# file itself rather than on a unit or target that only approximates it.
+#
+# On later boots the file already exists, and systemd activates the unit
+# immediately when the path unit starts, so no special case is needed.
+PathExists=/var/lib/kubelet/kubeconfig
+Unit=trident-acl-agent.service
+
+[Install]
+WantedBy=multi-user.target

--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -619,6 +619,19 @@ copyPackerFiles() {
     # not Debian-style common-auth/common-password.
     cpAndMode $PAM_D_SYSTEM_AUTH_SRC $PAM_D_SYSTEM_AUTH_DEST 644
     cpAndMode $PAM_D_SYSTEM_PASSWORD_SRC $PAM_D_SYSTEM_PASSWORD_DEST 644
+
+    # Configuration for the Trident ACL Agent, which drives A/B OS updates on
+    # ACL nodes. The agent itself and its unit come from the trident-acl-agent
+    # package in the ACL base image; only its configuration and its start
+    # trigger are supplied here.
+    # cpAndMode creates the .service.d directory, so no mkdir is needed.
+    TAA_OVERRIDE_SRC=/home/packer/trident-acl-agent-override.conf
+    TAA_OVERRIDE_DEST=/etc/systemd/system/trident-acl-agent.service.d/10-aks.conf
+    cpAndMode $TAA_OVERRIDE_SRC $TAA_OVERRIDE_DEST 600
+
+    TAA_PATH_UNIT_SRC=/home/packer/trident-acl-agent.path
+    TAA_PATH_UNIT_DEST=/etc/systemd/system/trident-acl-agent.path
+    cpAndMode $TAA_PATH_UNIT_SRC $TAA_PATH_UNIT_DEST 600
   else
     cpAndMode $DOCKER_CLEAR_MOUNT_PROPAGATION_FLAGS_SRC $DOCKER_CLEAR_MOUNT_PROPAGATION_FLAGS_DEST 644
     cpAndMode $NVIDIA_MODPROBE_SERVICE_SRC $NVIDIA_MODPROBE_SERVICE_DEST 644

--- a/vhdbuilder/packer/post-install-dependencies.sh
+++ b/vhdbuilder/packer/post-install-dependencies.sh
@@ -103,6 +103,31 @@ echo -e "=== os-release Begin" >> ${VHD_LOGS_FILEPATH}
 cat /etc/os-release >> ${VHD_LOGS_FILEPATH}
 echo -e "=== os-release End" >> ${VHD_LOGS_FILEPATH}
 
+# Record the node image version where the Trident ACL Agent can read it.
+#
+# The agent compares the node's running version against the target version in
+# an A/B update request, and reads an os-release-formatted KEY=VALUE file to do
+# so. /etc/os-release cannot serve: its VERSION_ID is the ACL OS release
+# (3.0.YYYYMMDD), while the update request carries the node image version
+# (YYYYMM.DD.PATCH). The same value is already recorded in image-bom.json, but
+# the agent does not parse JSON.
+#
+# This file lives on the root partition, so it describes the node image the
+# node was provisioned from and is not replaced by an A/B update of /usr.
+if isACL "$OS" "$OS_VARIANT"; then
+  if [ -z "${IMAGE_VERSION:-}" ]; then
+    echo "ERROR: IMAGE_VERSION must be set to record the node image version for the Trident ACL Agent"
+    exit 1
+  fi
+  IMAGE_VERSION_FILEPATH=/opt/azure/containers/image-version
+  mkdir -p "$(dirname ${IMAGE_VERSION_FILEPATH})"
+  echo "IMAGE_VERSION=${IMAGE_VERSION}" > ${IMAGE_VERSION_FILEPATH}
+  chmod 0644 ${IMAGE_VERSION_FILEPATH}
+  echo -e "=== image-version Begin" >> ${VHD_LOGS_FILEPATH}
+  cat ${IMAGE_VERSION_FILEPATH} >> ${VHD_LOGS_FILEPATH}
+  echo -e "=== image-version End" >> ${VHD_LOGS_FILEPATH}
+fi
+
 if [ "$OS" = "$UBUNTU_OS_NAME" ]; then
   echo -e "PUUID: $(efibootmgr -v)" >> ${VHD_LOGS_FILEPATH}
 fi

--- a/vhdbuilder/packer/pre-install-dependencies.sh
+++ b/vhdbuilder/packer/pre-install-dependencies.sh
@@ -66,6 +66,19 @@ capture_benchmark "${SCRIPT_NAME}_make_certs_directory_and_update_certs"
 systemctlEnableAndStart ci-syslog-watcher.path 30 || exit 1
 systemctlEnableAndStart ci-syslog-watcher.service 30 || exit 1
 
+if isACL "$OS" "$OS_VARIANT"; then
+    # Arm the Trident ACL Agent, which drives A/B OS updates on ACL nodes.
+    #
+    # Only the path unit is enabled, not the service. The agent authenticates
+    # to the API server with kubelet's kubeconfig and exits if that file is
+    # absent, which on a new node it is until kubelet finishes TLS
+    # bootstrapping. Enabling the service directly would start it at every boot
+    # before kubelet and leave it restarting until the file appeared. The path
+    # unit waits for the file instead, and starts the agent when it appears.
+    systemctlEnableAndStart trident-acl-agent.path 30 || exit 1
+    capture_benchmark "${SCRIPT_NAME}_enable_trident_acl_agent"
+fi
+
 if isFlatcar "$OS" || isACL "$OS" "$OS_VARIANT"; then
     # "copy-on-write"; this starts out as a symlink to a R/O location
     cp /etc/waagent.conf{,.new}

--- a/vhdbuilder/packer/vhd-image-builder-acl.json
+++ b/vhdbuilder/packer/vhd-image-builder-acl.json
@@ -494,6 +494,16 @@
     },
     {
       "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/acl/trident-acl-agent-override.conf",
+      "destination": "/home/packer/trident-acl-agent-override.conf"
+    },
+    {
+      "type": "file",
+      "source": "parts/linux/cloud-init/artifacts/acl/trident-acl-agent.path",
+      "destination": "/home/packer/trident-acl-agent.path"
+    },
+    {
+      "type": "file",
       "source": "parts/linux/cloud-init/artifacts/update_certs.path",
       "destination": "/home/packer/update_certs.path"
     },
@@ -775,7 +785,7 @@
     {
       "type": "shell",
       "inline": [
-        "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} HYPERV_GENERATION={{user `hyperv_generation`}} CONTAINER_RUNTIME={{user `container_runtime`}} ENABLE_FIPS={{user `enable_fips`}} IMG_SKU={{user `img_sku`}} /bin/bash -eux /home/packer/post-install-dependencies.sh"
+        "sudo FEATURE_FLAGS={{user `feature_flags`}} BUILD_NUMBER={{user `build_number`}} BUILD_ID={{user `build_id`}} COMMIT={{user `commit`}} HYPERV_GENERATION={{user `hyperv_generation`}} CONTAINER_RUNTIME={{user `container_runtime`}} ENABLE_FIPS={{user `enable_fips`}} IMG_SKU={{user `img_sku`}} IMAGE_VERSION={{user `image_version`}} /bin/bash -eux /home/packer/post-install-dependencies.sh"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Configures the Trident ACL Agent on Azure Container Linux node images. The agent drives A/B OS updates, replacing the OS image in place rather than reprovisioning the node.

The agent binary and its systemd unit ship in the ACL base image, but the packaged unit deliberately carries no configuration and is not enabled, so a deployment supplies both. This adds the AKS-specific half.

## What this changes

**Configuration**, as a systemd drop-in at `/etc/systemd/system/trident-acl-agent.service.d/10-aks.conf`.

**Every** setting the agent reads from the environment is set explicitly, including those whose current default already matches. Relying on the agent's defaults would make node behaviour depend on whatever those defaults were when the image was built, so an upstream change could silently alter how AKS nodes update on the next rebuild. Pinning them means this file, rather than the agent's defaults, defines the behaviour.

The trade is recorded in the file: a deliberate upstream change, such as a timeout that proves too short, no longer reaches AKS until the file is updated, so these values need reviewing when the Trident version in the base image moves. All pinned values were verified against the agent's current defaults; only the annotation prefix deliberately differs.

Four settings are deliberately left unset, listed in the file with reasons: node name and API server are per-node and per-cluster, the Nebraska settings are unused in annotation mode, and the Kubernetes watch poll interval has no environment variable at all.

| Setting | Reason |
|---|---|
| `..._KUBERNETES_ANNOTATION_PREFIX` | The agent defaults to `acl.microsoft.com`; the AKS annotation contract uses `acl.azure.com`. A mismatch is silent: the resource provider writes a key the agent never watches, and no update runs. |
| `..._CURRENT_VERSION_PATH` / `_KEY` | Point the agent at the node image version. See below. |
| `..._CURRENT_VERSION_FALLBACK=error` | Fail at startup rather than reporting `0.0.0`, which parses cleanly but is always wrong. |
| `StateDirectory=` | Create `/var/lib/trident-acl-agent` before the agent starts. |

**A node image version stamp** at `/opt/azure/containers/image-version`.

The agent compares the node's running version against the target version in an update request, reading an os-release-formatted `KEY=VALUE` file. `VERSION_ID` in `/etc/os-release` cannot serve: it carries the OS release (`3.0.YYYYMMDD`) rather than the node image version (`YYYYMM.DD.PATCH`) that update requests specify, so the two are not comparable.

The correct value is already recorded in `image-bom.json`, but that is JSON and the agent parses `KEY=VALUE`, so the same value is now also written in the format the agent can read. The build fails if the version is unavailable rather than inheriting the date-derived fallback used elsewhere, since a plausible-but-wrong version would not be caught by `FALLBACK=error`.

**Enablement**, via a path unit rather than by enabling the service.

The agent authenticates to the API server with kubelet's kubeconfig and exits if that file is absent, which on a new node it is until kubelet finishes TLS bootstrapping. Enabling the service directly would start it on every boot before kubelet and leave it restarting until the file appeared.

The path unit waits for the file itself, which is the actual precondition rather than a proxy for it. On later boots the file already exists and systemd activates the service immediately when the path unit starts, so first boot and subsequent boots take the same code path. This follows the existing `update_certs.path` pattern.

## Dependency, and why this is a draft

This configures a package that is not yet in the ACL base image. It should not merge until:

1. The ACL base image installs the `trident-acl-agent` package. Note that installing `trident` alone is not sufficient: `trident-acl-agent` is a separate subpackage whose `Requires` points at `trident`, not the reverse.
2. That package resolves to a Trident release containing the annotation-protocol agent.

Merging earlier would break ACL VHD builds, because `systemctlEnableAndStart trident-acl-agent.path` would reference a service unit that does not exist.

## Scope

- ACL only. Every change is behind `isACL` or lives in the ACL packer template.
- `vhd-image-builder-acl-arm64.json` is **not** updated. If the agent is in scope for arm64, that template needs the same two provisioner entries.
- No CSE changes. Enablement happens entirely in the image build.

## Testing

- `bash -n` clean on all modified shell scripts; the packer template parses as JSON.
- Not yet validated on a built image, pending the base image dependency above.

