### PR TITLE
fix: lps tls verification to accept san-less certificates, validate full chain against the cluster ca

### DIFF
--- a/aks-node-controller/checkhotfix_grpc.go
+++ b/aks-node-controller/checkhotfix_grpc.go
@@ -36,19 +36,6 @@ const (
 	// the "authorization" metadata header (per the live-patching client example / contract),
 	// mirroring the embargoed HTTP service's header-based auth.
 	lpsAttestedMetadataKey = "authorization"
-
-	// lpsServerName is the DNS name the live-patching service's serving certificate is issued for.
-	// The service mints its leaf cert with this exact value in both Subject.CN and the SAN
-	// (aks-rp: ccp/live-patching-controller/internal/server/cert.go sets CommonName/DNSNames =
-	// s.ServerName), and the chart hard-codes the flag "--server-name=aks-security-patch.data.mcr.microsoft.com".
-	// We pin it here to verify the presented cert by hostname. It must track that chart value.
-	//
-	// NOTE: this is used ONLY as the name we verify the cert against -- it is deliberately NOT set as
-	// tls.Config.ServerName. Go would put ServerName on the wire as the SNI, which would collide with
-	// the kube-api-proxy legacy SNI filter chain (server_names: [aks-security-patch...], no ALPN
-	// guard) and misroute the gRPC stream to the legacy embargo cluster. Leaving ServerName empty
-	// keeps the wire SNI at the apiserver authority so envoy routes on ALPN to the gRPC chain.
-	lpsServerName = "aks-security-patch.data.mcr.microsoft.com"
 )
 
 // lpsGRPCStatusError is a non-benign gRPC failure from the live-patching service. fallbackAllowed
@@ -106,13 +93,11 @@ func (a *App) fetchHotfixOverGRPC(ctx context.Context) ([]byte, error) {
 
 // dialLPSGRPC builds the gRPC client connection to the live-patching service: it dials the cluster
 // apiserver FQDN:443 (riding the existing apiserver egress rule) and advertises the live-patching
-// ALPN protocol so the kube-api-proxy envoy routes the stream to the LPS backend. The server
-// certificate is issued for lpsServerName (with a real SAN), but tls.Config.ServerName is left
-// EMPTY so the wire SNI stays the apiserver authority and envoy routes on ALPN (setting it would
-// collide with the legacy SNI filter chain). We therefore disable Go's default name check and
-// verify the presented chain against the cluster CA AND the hostname ourselves (see
-// verifyChainAgainstPool). The connection is lazy; the per-RPC context deadline bounds connect +
-// call. Tests inject grpcDialContext to reach an in-process (bufconn) server.
+// ALPN protocol so the kube-api-proxy envoy routes the stream to the LPS backend. The LPS serving
+// certificate has no SAN/CN, so Go's default hostname verification cannot be used. Instead, the
+// presented chain is verified against the cluster CA, matching the LPS client contract. The
+// connection is lazy; the per-RPC context deadline bounds connect + call. Tests inject
+// grpcDialContext to reach an in-process (bufconn) server.
 //
 // The cluster CA is REQUIRED: without it the server certificate cannot be verified, so rather than
 // weaken TLS we return an error and the caller fails open (nothing staged).
@@ -138,21 +123,18 @@ func (a *App) dialLPSGRPC(fqdn string, caPEM []byte) (*grpc.ClientConn, error) {
 		host = h
 	}
 
-	// The live-patching serving cert is issued for lpsServerName (real SAN), but we do NOT set
-	// tls.Config.ServerName: Go would send it as the wire SNI, colliding with kube-api-proxy's legacy
-	// SNI filter chain and misrouting the gRPC stream. So we advertise the live-patching ALPN protocol
-	// (the value envoy's kube-api-proxy filter chain matches to route the stream to LPS) plus "h2" for
-	// the gRPC HTTP/2 handshake. grpc-go's credentials.NewTLS appends "h2" to NextProtos on its own,
-	// but we list it explicitly so the on-wire ALPN set (["aks-live-patching", "h2"]) is unambiguous:
-	// envoy routes on the custom proto while gRPC negotiates h2. We then disable Go's default
-	// name-based verification and verify the presented chain against the cluster CA AND the hostname
-	// (lpsServerName) ourselves.
+	// Advertise the live-patching ALPN protocol (the value envoy's kube-api-proxy filter chain
+	// matches to route the stream to LPS) plus "h2" for the gRPC HTTP/2 handshake. grpc-go's
+	// credentials.NewTLS appends "h2" to NextProtos on its own, but we list it explicitly so the
+	// on-wire ALPN set (["aks-live-patching", "h2"]) is unambiguous: envoy routes on the custom proto
+	// while gRPC negotiates h2. The LPS certificate intentionally has no SAN/CN, so disable Go's
+	// default name check and verify the presented chain against the cluster CA ourselves.
 	tlsConfig := &tls.Config{
 		MinVersion:            tls.VersionTLS12,
 		RootCAs:               pool,
 		NextProtos:            []string{lpsALPNProto, alpnH2Proto},
-		InsecureSkipVerify:    true, //nolint:gosec // default SNI-name check disabled to avoid the legacy-SNI routing collision; chain AND hostname verified in verifyChainAgainstPool
-		VerifyPeerCertificate: verifyChainAgainstPool(pool, lpsServerName),
+		InsecureSkipVerify:    true, //nolint:gosec // default name check cannot validate LPS's SAN-less certificate; the chain is verified below
+		VerifyPeerCertificate: verifyChainAgainstPool(pool),
 	}
 
 	target := net.JoinHostPort(host, lpsAPIServerPort)
@@ -160,11 +142,9 @@ func (a *App) dialLPSGRPC(fqdn string, caPEM []byte) (*grpc.ClientConn, error) {
 }
 
 // verifyChainAgainstPool verifies that the server's presented certificate chains up to the trusted
-// pool AND is valid for serverName. The default TLS name check is disabled (see dialLPSGRPC) so we
-// re-implement full verification here: passing DNSName to x509.VerifyOptions makes leaf.Verify
-// enforce both the chain-to-CA and the hostname, giving standard-strength verification without
-// putting serverName on the wire as the SNI.
-func verifyChainAgainstPool(pool *x509.CertPool, serverName string) func([][]byte, [][]*x509.Certificate) error {
+// cluster CA. Hostname verification is intentionally omitted because the LPS serving certificate
+// has no SAN/CN.
+func verifyChainAgainstPool(pool *x509.CertPool) func([][]byte, [][]*x509.Certificate) error {
 	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 		if len(rawCerts) == 0 {
 			return fmt.Errorf("server presented no certificates")
@@ -181,7 +161,7 @@ func verifyChainAgainstPool(pool *x509.CertPool, serverName string) func([][]byt
 			}
 			intermediates.AddCert(cert)
 		}
-		if _, err := leaf.Verify(x509.VerifyOptions{Roots: pool, Intermediates: intermediates, DNSName: serverName}); err != nil {
+		if _, err := leaf.Verify(x509.VerifyOptions{Roots: pool, Intermediates: intermediates}); err != nil {
 			return fmt.Errorf("server certificate verification failed: %w", err)
 		}
 		return nil

--- a/aks-node-controller/checkhotfix_grpc_verify_test.go
+++ b/aks-node-controller/checkhotfix_grpc_verify_test.go
@@ -35,61 +35,47 @@ func mintCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
 	return caCert, key
 }
 
-// mintLeaf creates a leaf certificate with the given SAN DNS name, signed by the CA.
-func mintLeaf(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.PrivateKey, dnsName string) []byte {
+// mintLeaf creates a leaf certificate without a SAN/CN, matching the LPS serving certificate.
+func mintLeaf(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.PrivateKey) []byte {
 	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	tmpl := &x509.Certificate{
 		SerialNumber: big.NewInt(2),
-		Subject:      pkix.Name{CommonName: dnsName},
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames:     []string{dnsName},
 	}
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
 	require.NoError(t, err)
 	return der
 }
 
-// TestVerifyChainAgainstPool asserts the strengthened verifier enforces BOTH the chain-to-CA and
-// the hostname, mirroring the standard TLS name check without putting the name on the wire as SNI.
+// TestVerifyChainAgainstPool asserts that a SAN-less LPS certificate is accepted only when it
+// chains to the trusted cluster CA.
 func TestVerifyChainAgainstPool(t *testing.T) {
 	caCert, caKey := mintCA(t)
 	pool := x509.NewCertPool()
 	pool.AddCert(caCert)
 
-	leaf := mintLeaf(t, caCert, caKey, lpsServerName)
+	leaf := mintLeaf(t, caCert, caKey)
 
-	t.Run("valid chain and matching hostname passes", func(t *testing.T) {
-		err := verifyChainAgainstPool(pool, lpsServerName)([][]byte{leaf}, nil)
+	t.Run("valid SAN-less chain passes", func(t *testing.T) {
+		err := verifyChainAgainstPool(pool)([][]byte{leaf}, nil)
 		assert.NoError(t, err)
-	})
-
-	t.Run("hostname mismatch is rejected", func(t *testing.T) {
-		err := verifyChainAgainstPool(pool, "wrong.example.com")([][]byte{leaf}, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "verification failed")
-	})
-
-	t.Run("cert issued for a different name is rejected", func(t *testing.T) {
-		otherLeaf := mintLeaf(t, caCert, caKey, "attacker.example.com")
-		err := verifyChainAgainstPool(pool, lpsServerName)([][]byte{otherLeaf}, nil)
-		require.Error(t, err)
 	})
 
 	t.Run("chain to an untrusted CA is rejected", func(t *testing.T) {
 		otherCA, _ := mintCA(t)
 		untrusted := x509.NewCertPool()
 		untrusted.AddCert(otherCA)
-		err := verifyChainAgainstPool(untrusted, lpsServerName)([][]byte{leaf}, nil)
+		err := verifyChainAgainstPool(untrusted)([][]byte{leaf}, nil)
 		require.Error(t, err)
 	})
 
 	t.Run("no certificates presented is rejected", func(t *testing.T) {
-		err := verifyChainAgainstPool(pool, lpsServerName)(nil, nil)
+		err := verifyChainAgainstPool(pool)(nil, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no certificates")
 	})


### PR DESCRIPTION
Fixed ANC’s LPS TLS verification to accept SAN-less certificates while still validating the full chain against the cluster CA.