### PR TITLE
fix(windows): import WireServer certs into trust stores

### DIFF
--- a/e2e/scenario_rcv1p_win_test.go
+++ b/e2e/scenario_rcv1p_win_test.go
@@ -3,8 +3,8 @@
 //
 // scenario_rcv1p_win_test.go contains end-to-end tests for the RCV1P cert mode on Windows.
 // Windows uses a different cert installation path than Linux: certificates are downloaded to
-// C:\ca and imported into the Windows certificate store (Cert:\LocalMachine\Root) via
-// Import-Certificate. A scheduled task (aks-ca-certs-refresh-task) is registered to
+// C:\ca and imported into the Windows root or intermediate LocalMachine certificate store.
+// A scheduled task (aks-ca-certs-refresh-task) is registered to
 // periodically refresh the certificates.
 package e2e
 

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -4339,21 +4339,27 @@ func rcv1pTrustStoreDir(s *Scenario) string {
 // ValidateRCV1PCertModeWindows validates that the rcv1p certificate endpoint mode was used during
 // Windows node provisioning, certificates were downloaded and installed, and a refresh task was scheduled.
 func ValidateRCV1PCertModeWindows(ctx context.Context, s *Scenario) error {
-	// Validate CA certificates were downloaded to C:\ca (matches Windows Get-CACertificates
-	// behavior; import into Cert:\LocalMachine\Root is handled out-of-band by the platform/
-	// refresh task, not by CSE).
+	// Validate every downloaded certificate can be parsed and was installed system-wide.
 	command := []string{
 		"$ErrorActionPreference = 'Stop'",
 		"$caFolder = 'C:\\ca'",
 		"if (-not (Test-Path $caFolder)) { throw 'CA certificates folder C:\\ca does not exist' }",
 		"$certs = Get-ChildItem -Path $caFolder -File",
 		"if ($certs.Count -eq 0) { throw 'No certificates found in C:\\ca folder' }",
-		"Write-Host \"Found $($certs.Count) certificate(s) in $caFolder\"",
+		"$certStorePaths = @('Cert:\\LocalMachine\\Root', 'Cert:\\LocalMachine\\CA')",
+		"$installedCerts = Get-ChildItem -Path $certStorePaths",
+		"foreach ($cert in $certs) {",
+		"    $downloadedCert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($cert.FullName)",
+		"    if (-not ($installedCerts | Where-Object Thumbprint -eq $downloadedCert.Thumbprint)) {",
+		"        throw \"Certificate $($cert.Name) with thumbprint $($downloadedCert.Thumbprint) is not installed in the LocalMachine Root or CA store\"",
+		"    }",
+		"}",
+		"Write-Host \"Found and validated $($certs.Count) certificate(s) in $caFolder\"",
 	}
 	var errs []error
 	if _, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, strings.Join(command, "\n"), 0,
-		"expected certificates in C:\\ca"); err != nil {
-		errs = append(errs, fmt.Errorf(`check certificates in C:\ca: %w`, err))
+		"expected certificates in C:\\ca to be installed in LocalMachine trust stores"); err != nil {
+		errs = append(errs, fmt.Errorf(`check certificates in C:\ca are installed in LocalMachine trust stores: %w`, err))
 	}
 
 	// Validate the refresh scheduled task exists

--- a/staging/cse/windows/kubernetesfunc.ps1
+++ b/staging/cse/windows/kubernetesfunc.ps1
@@ -356,8 +356,9 @@ function Get-CACertificates {
         Write-Log "Get CA certificates. Location: $Location. EndpointMode: $certEndpointMode"
     }
 
-    # Get-CACertificates downloads Azure root CA certificates from wireserver and writes them
-    # to the local certificate folder. When called with -FailOnError, wireserver unreachable
+    # C:\ca is a staging location; installing WireServer certificates into LocalMachine trust
+    # stores is intentional and matches the system-wide trust behavior on Linux.
+    # When called with -FailOnError, wireserver unreachable
     # after retries is fatal — silently falling back to the OS default trust store would be a
     # security hole if the customer intended hardened root certs. This matches the Linux
     # behavior in init-aks-cloud.sh (is_opted_in_for_root_certs return code 2 = fatal).
@@ -379,7 +380,7 @@ function Get-CACertificates {
                 $name = $certificate.Name
                 $certFilePath = Join-Path $caFolder $name
                 Write-Log "Write certificate $name to $certFilePath"
-                $certificate.CertBody > $certFilePath
+                $certificate.CertBody | Out-File -Encoding ascii -FilePath $certFilePath
                 # The legacy endpoint returns trusted root certificates only.
                 Write-Log "Import certificate $name to the LocalMachine Root certificate store"
                 Import-Certificate -FilePath $certFilePath -CertStoreLocation 'Cert:\LocalMachine\Root' -ErrorAction Stop | Out-Null
@@ -445,7 +446,7 @@ function Get-CACertificates {
 
                 $certFilePath = Join-Path $caFolder $resourceFileName
                 Write-Log "Write certificate $resourceFileName to $certFilePath"
-                $certContentResponse.Content > $certFilePath
+                $certContentResponse.Content | Out-File -Encoding ascii -FilePath $certFilePath
                 Write-Log "Import certificate $resourceFileName to $certStoreLocation"
                 Import-Certificate -FilePath $certFilePath -CertStoreLocation $certStoreLocation -ErrorAction Stop | Out-Null
                 $downloadedAny = $true

--- a/staging/cse/windows/kubernetesfunc.ps1
+++ b/staging/cse/windows/kubernetesfunc.ps1
@@ -380,6 +380,9 @@ function Get-CACertificates {
                 $certFilePath = Join-Path $caFolder $name
                 Write-Log "Write certificate $name to $certFilePath"
                 $certificate.CertBody > $certFilePath
+                # The legacy endpoint returns trusted root certificates only.
+                Write-Log "Import certificate $name to the LocalMachine Root certificate store"
+                Import-Certificate -FilePath $certFilePath -CertStoreLocation 'Cert:\LocalMachine\Root' -ErrorAction Stop | Out-Null
             }
 
             return $true
@@ -400,6 +403,12 @@ function Get-CACertificates {
         $downloadedAny = $false
 
         foreach ($requestType in $operationRequestTypes) {
+            # Keep intermediates out of the trusted root store while making both chains system-wide.
+            $certStoreLocation = if ($requestType -eq "operationrequestsroot") {
+                'Cert:\LocalMachine\Root'
+            } else {
+                'Cert:\LocalMachine\CA'
+            }
             $operationRequestUri = "http://168.63.129.16/machine?comp=acmspackage&type=$requestType&ext=json"
             $operationResponse = Retry-Command -Command 'Invoke-WebRequest' -Args @{Uri=$operationRequestUri; UseBasicParsing=$true; TimeoutSec=30} -Retries 10 -RetryDelaySeconds 10
             $operationJson = ($operationResponse.Content) | ConvertFrom-Json
@@ -437,6 +446,8 @@ function Get-CACertificates {
                 $certFilePath = Join-Path $caFolder $resourceFileName
                 Write-Log "Write certificate $resourceFileName to $certFilePath"
                 $certContentResponse.Content > $certFilePath
+                Write-Log "Import certificate $resourceFileName to $certStoreLocation"
+                Import-Certificate -FilePath $certFilePath -CertStoreLocation $certStoreLocation -ErrorAction Stop | Out-Null
                 $downloadedAny = $true
             }
         }

--- a/staging/cse/windows/kubernetesfunc.ps1
+++ b/staging/cse/windows/kubernetesfunc.ps1
@@ -383,7 +383,11 @@ function Get-CACertificates {
                 $certificate.CertBody | Out-File -Encoding ascii -FilePath $certFilePath
                 # The legacy endpoint returns trusted root certificates only.
                 Write-Log "Import certificate $name to the LocalMachine Root certificate store"
-                Import-Certificate -FilePath $certFilePath -CertStoreLocation 'Cert:\LocalMachine\Root' -ErrorAction Stop | Out-Null
+                try {
+                    Import-Certificate -FilePath $certFilePath -CertStoreLocation 'Cert:\LocalMachine\Root' -ErrorAction Stop | Out-Null
+                } catch {
+                    throw "Failed to import CA certificate '$name' into Cert:\LocalMachine\Root. Error: $_"
+                }
             }
 
             return $true
@@ -448,7 +452,11 @@ function Get-CACertificates {
                 Write-Log "Write certificate $resourceFileName to $certFilePath"
                 $certContentResponse.Content | Out-File -Encoding ascii -FilePath $certFilePath
                 Write-Log "Import certificate $resourceFileName to $certStoreLocation"
-                Import-Certificate -FilePath $certFilePath -CertStoreLocation $certStoreLocation -ErrorAction Stop | Out-Null
+                try {
+                    Import-Certificate -FilePath $certFilePath -CertStoreLocation $certStoreLocation -ErrorAction Stop | Out-Null
+                } catch {
+                    throw "Failed to import CA certificate '$resourceFileName' into $certStoreLocation. Error: $_"
+                }
                 $downloadedAny = $true
             }
         }
@@ -477,9 +485,9 @@ function Get-CACertificates {
             Write-Log "Wireserver error response body: $responseBody"
         }
         if ($FailOnError) {
-            throw "Failed to retrieve CA certificates (HTTP $statusCode). Error: $_"
+            throw "Failed to process CA certificates (HTTP $statusCode). Error: $_"
         }
-        Write-Log "Warning: failed to retrieve CA certificates (HTTP $statusCode). Error: $_"
+        Write-Log "Warning: failed to process CA certificates (HTTP $statusCode). Error: $_"
         return $false
     }
 }

--- a/staging/cse/windows/kubernetesfunc.tests.ps1
+++ b/staging/cse/windows/kubernetesfunc.tests.ps1
@@ -168,6 +168,7 @@ Describe 'Get-CACertificates' {
         if (Test-Path 'C:\ca') {
             Remove-Item -Path 'C:\ca' -Recurse -Force
         }
+        Mock Import-Certificate
     }
 
     It 'uses the legacy endpoint when location is a ussec/usnat region' {
@@ -186,6 +187,42 @@ Describe 'Get-CACertificates' {
         Assert-MockCalled -CommandName Retry-Command -Exactly -Times 1
         $script:retryUris | Should -Contain 'http://168.63.129.16/machine?comp=acmspackage&type=cacertificates&ext=json'
         $script:retryUris | Should -Not -Contain 'http://168.63.129.16/acms/isOptedInForRootCerts'
+        Assert-MockCalled -CommandName Import-Certificate -Exactly -Times 1 -ParameterFilter {
+            $FilePath -eq 'C:\ca\legacy.crt' -and
+            $CertStoreLocation -eq 'Cert:\LocalMachine\Root' -and
+            $ErrorAction -eq 'Stop'
+        }
+    }
+
+    It 'imports rcv1p root and intermediate certificates into their LocalMachine stores' {
+        Mock Retry-Command -MockWith {
+            param($Command, $Args, $Retries, $RetryDelaySeconds)
+            $uri = $PSBoundParameters['Args'].Uri
+            if ($uri -eq 'http://168.63.129.16/acms/isOptedInForRootCerts') {
+                return [PSCustomObject]@{ Content = '{"IsOptedInForRootCerts":true}' }
+            }
+            if ($uri -like '*type=operationrequestsroot&*') {
+                return [PSCustomObject]@{ Content = '{"OperationsInfo":[{"ResouceFileName":"root.crt"}]}' }
+            }
+            if ($uri -like '*type=operationrequestsintermediate&*') {
+                return [PSCustomObject]@{ Content = '{"OperationsInfo":[{"ResouceFileName":"intermediate.crt"}]}' }
+            }
+            return [PSCustomObject]@{ Content = 'certificate-body' }
+        }
+
+        $result = Get-CACertificates -Location 'southcentralus'
+
+        $result | Should -Be $true
+        Assert-MockCalled -CommandName Import-Certificate -Exactly -Times 1 -ParameterFilter {
+            $FilePath -eq 'C:\ca\root.crt' -and
+            $CertStoreLocation -eq 'Cert:\LocalMachine\Root' -and
+            $ErrorAction -eq 'Stop'
+        }
+        Assert-MockCalled -CommandName Import-Certificate -Exactly -Times 1 -ParameterFilter {
+            $FilePath -eq 'C:\ca\intermediate.crt' -and
+            $CertStoreLocation -eq 'Cert:\LocalMachine\CA' -and
+            $ErrorAction -eq 'Stop'
+        }
     }
 
     It 'returns false when certificate retrieval throws' {

--- a/staging/cse/windows/kubernetesfunc.tests.ps1
+++ b/staging/cse/windows/kubernetesfunc.tests.ps1
@@ -243,7 +243,22 @@ Describe 'Get-CACertificates' {
             throw 'simulated retrieval failure'
         }
 
-        { Get-CACertificates -Location 'southcentralus' -FailOnError } | Should -Throw '*Failed to retrieve CA certificates*'
+        { Get-CACertificates -Location 'southcentralus' -FailOnError } | Should -Throw '*Failed to process CA certificates*simulated retrieval failure*'
+    }
+
+    It 'identifies the certificate and store when import fails with -FailOnError' {
+        Mock Retry-Command -MockWith {
+            return [PSCustomObject]@{
+                Content = '{"Certificates":[{"Name":"broken.crt","CertBody":"invalid-body"}]}'
+            }
+        }
+        Mock Import-Certificate -MockWith {
+            throw 'simulated import failure'
+        }
+
+        {
+            Get-CACertificates -Location 'ussecwest' -FailOnError
+        } | Should -Throw "*Failed to import CA certificate 'broken.crt' into Cert:\LocalMachine\Root*simulated import failure*"
     }
 
     It 'throws when legacy endpoint returns empty data with -FailOnError' {

--- a/staging/cse/windows/kubernetesfunc.tests.ps1
+++ b/staging/cse/windows/kubernetesfunc.tests.ps1
@@ -187,6 +187,7 @@ Describe 'Get-CACertificates' {
         Assert-MockCalled -CommandName Retry-Command -Exactly -Times 1
         $script:retryUris | Should -Contain 'http://168.63.129.16/machine?comp=acmspackage&type=cacertificates&ext=json'
         $script:retryUris | Should -Not -Contain 'http://168.63.129.16/acms/isOptedInForRootCerts'
+        [IO.File]::ReadAllBytes('C:\ca\legacy.crt') | Should -Not -Contain 0
         Assert-MockCalled -CommandName Import-Certificate -Exactly -Times 1 -ParameterFilter {
             $FilePath -eq 'C:\ca\legacy.crt' -and
             $CertStoreLocation -eq 'Cert:\LocalMachine\Root' -and
@@ -213,6 +214,8 @@ Describe 'Get-CACertificates' {
         $result = Get-CACertificates -Location 'southcentralus'
 
         $result | Should -Be $true
+        [IO.File]::ReadAllBytes('C:\ca\root.crt') | Should -Not -Contain 0
+        [IO.File]::ReadAllBytes('C:\ca\intermediate.crt') | Should -Not -Contain 0
         Assert-MockCalled -CommandName Import-Certificate -Exactly -Times 1 -ParameterFilter {
             $FilePath -eq 'C:\ca\root.crt' -and
             $CertStoreLocation -eq 'Cert:\LocalMachine\Root' -and


### PR DESCRIPTION
Install certificates downloaded by Get-CACertificates into the LocalMachine certificate stores instead of leaving them only under C:\ca. Legacy endpoint certificates and rcv1p root certificates are added to the Root store, while rcv1p intermediate certificates are added to the CA store to preserve the correct trust-chain semantics.

Use ErrorAction Stop so import failures follow the existing Get-CACertificates error handling and fail provisioning when FailOnError is requested. Extend the focused Pester coverage to verify the file paths, destination stores, and terminating error behavior passed to Import-Certificate.

<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
