### PR TITLE
fix(windows): avoid false CSE failure during kubelet recovery

### DIFF
--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -838,52 +838,30 @@ param(
     [string]$arg3
 )
 
-$workDir = Join-Path $env:TEMP ("aks-e2e-logs-" + [guid]::NewGuid())
-$azCopyArchive = Join-Path $workDir "azcopy.zip"
-$azCopyDir = Join-Path $workDir "azcopy"
-New-Item -ItemType Directory -Path $workDir -Force | Out-Null
-Invoke-WebRequest -UseBasicParsing https://aka.ms/downloadazcopy-v10-windows -OutFile $azCopyArchive
-Expand-Archive -Path $azCopyArchive -DestinationPath $azCopyDir
-$azCopyPath = (Get-ChildItem -Path $azCopyDir -Filter "azcopy.exe" -Recurse -File | Select-Object -First 1).FullName
-if (-not $azCopyPath) {
-    throw "azcopy.exe was not found after extracting $azCopyArchive"
-}
-
+Invoke-WebRequest -UseBasicParsing https://aka.ms/downloadazcopy-v10-windows -OutFile azcopy.zip
+Expand-Archive azcopy.zip
+cd .\azcopy\*
+$azCopyPath = (Resolve-Path .\azcopy.exe).Path
 $env:AZCOPY_AUTO_LOGIN_TYPE="MSI"
 $env:AZCOPY_MSI_RESOURCE_STRING=$arg3
 $script:uploadFailures = @()
-$collectionStartedAt = Get-Date
-Push-Location $workDir
-try {
-    & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "C:\k\debug\collect-windows-logs.ps1"
-    if ($LASTEXITCODE -ne 0) {
-        $script:uploadFailures += "collect-windows-logs.ps1 exited with code $LASTEXITCODE"
-    }
-} finally {
-    Pop-Location
-}
-$collectionSearchPaths = @($workDir, "C:\k\debug")
-$collectedLogs = (Get-ChildItem -Path $collectionSearchPaths -Filter "*_logs.zip" -File -Recurse -ErrorAction SilentlyContinue |
-    Where-Object { $_.LastWriteTime -ge $collectionStartedAt } |
+C:\k\debug\collect-windows-logs.ps1
+$collectedLogs = (Get-ChildItem . -Filter "*_logs.zip" -File |
     Sort-Object LastWriteTime -Descending |
     Select-Object -First 1).FullName
-if (-not $collectedLogs) {
-    $script:uploadFailures += "collect-windows-logs.ps1 did not create a diagnostics archive"
-}
 
 # Collect network configuration information
-$networkConfigPath = Join-Path $workDir "network_config.txt"
-ipconfig /all > $networkConfigPath
-Get-NetIPConfiguration -Detailed >> $networkConfigPath
-Get-NetAdapter | Format-Table -AutoSize >> $networkConfigPath
-Get-DnsClientServerAddress >> $networkConfigPath
-Get-NetRoute >> $networkConfigPath
-Get-NetNat >> $networkConfigPath
-Get-NetIPAddress >> $networkConfigPath
-Get-NetNeighbor >> $networkConfigPath
-Get-NetConnectionProfile >> $networkConfigPath
-hnsdiag list networks >> $networkConfigPath
-hnsdiag list endpoints >> $networkConfigPath
+ipconfig /all > network_config.txt
+Get-NetIPConfiguration -Detailed >> network_config.txt
+Get-NetAdapter | Format-Table -AutoSize >> network_config.txt
+Get-DnsClientServerAddress >> network_config.txt
+Get-NetRoute >> network_config.txt
+Get-NetNat >> network_config.txt
+Get-NetIPAddress >> network_config.txt
+Get-NetNeighbor >> network_config.txt
+Get-NetConnectionProfile >> network_config.txt
+hnsdiag list networks >> network_config.txt
+hnsdiag list endpoints >> network_config.txt
 
 function Upload-Log {
     param(
@@ -909,7 +887,7 @@ Upload-Log "C:\azuredata\CustomDataSetupScript.log" "$arg1/cse.log"
 Upload-Log "C:\AzureData\provision.complete" "$arg1/provision.complete"
 Upload-Log "C:\k\kubelet.err.log" "$arg1/kubelet.err.log"
 Upload-Log "C:\k\containerd.err.log" "$arg1/containerd.err.log"
-Upload-Log $networkConfigPath "$arg1/network_config.txt"
+Upload-Log "network_config.txt" "$arg1/network_config.txt"
 
 if ($script:uploadFailures.Count -gt 0) {
     throw "failed to upload Windows diagnostics: $($script:uploadFailures -join '; ')"

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -838,32 +838,82 @@ param(
     [string]$arg3
 )
 
-Invoke-WebRequest -UseBasicParsing https://aka.ms/downloadazcopy-v10-windows -OutFile azcopy.zip
-Expand-Archive azcopy.zip
-cd .\azcopy\*
+$workDir = Join-Path $env:TEMP ("aks-e2e-logs-" + [guid]::NewGuid())
+$azCopyArchive = Join-Path $workDir "azcopy.zip"
+$azCopyDir = Join-Path $workDir "azcopy"
+New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+Invoke-WebRequest -UseBasicParsing https://aka.ms/downloadazcopy-v10-windows -OutFile $azCopyArchive
+Expand-Archive -Path $azCopyArchive -DestinationPath $azCopyDir
+$azCopyPath = (Get-ChildItem -Path $azCopyDir -Filter "azcopy.exe" -Recurse -File | Select-Object -First 1).FullName
+if (-not $azCopyPath) {
+    throw "azcopy.exe was not found after extracting $azCopyArchive"
+}
+
 $env:AZCOPY_AUTO_LOGIN_TYPE="MSI"
 $env:AZCOPY_MSI_RESOURCE_STRING=$arg3
-C:\k\debug\collect-windows-logs.ps1
-$CollectedLogs=(Get-ChildItem . -Filter "*_logs.zip" -File)[0].Name
-.\azcopy.exe copy $CollectedLogs "$arg1/collected-node-logs.zip"
-.\azcopy.exe copy "C:\azuredata\CustomDataSetupScript.log" "$arg1/cse.log"
-.\azcopy.exe copy "C:\AzureData\provision.complete" "$arg1/provision.complete"
-.\azcopy.exe copy "C:\k\kubelet.err.log" "$arg1/kubelet.err.log"
-.\azcopy.exe copy "C:\k\containerd.err.log" "$arg1/containerd.err.log"
+$script:uploadFailures = @()
+$collectionStartedAt = Get-Date
+Push-Location $workDir
+try {
+    & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "C:\k\debug\collect-windows-logs.ps1"
+    if ($LASTEXITCODE -ne 0) {
+        $script:uploadFailures += "collect-windows-logs.ps1 exited with code $LASTEXITCODE"
+    }
+} finally {
+    Pop-Location
+}
+$collectionSearchPaths = @($workDir, "C:\k\debug")
+$collectedLogs = (Get-ChildItem -Path $collectionSearchPaths -Filter "*_logs.zip" -File -Recurse -ErrorAction SilentlyContinue |
+    Where-Object { $_.LastWriteTime -ge $collectionStartedAt } |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1).FullName
+if (-not $collectedLogs) {
+    $script:uploadFailures += "collect-windows-logs.ps1 did not create a diagnostics archive"
+}
 
 # Collect network configuration information
-ipconfig /all > network_config.txt
-Get-NetIPConfiguration -Detailed >> network_config.txt
-Get-NetAdapter | Format-Table -AutoSize >> network_config.txt
-Get-DnsClientServerAddress >> network_config.txt
-Get-NetRoute >> network_config.txt
-Get-NetNat >> network_config.txt
-Get-NetIPAddress >> network_config.txt
-Get-NetNeighbor >> network_config.txt
-Get-NetConnectionProfile >> network_config.txt
-hnsdiag list networks >> network_config.txt
-hnsdiag list endpoints >> network_config.txt
-.\azcopy.exe copy "network_config.txt" "$arg1/network_config.txt"
+$networkConfigPath = Join-Path $workDir "network_config.txt"
+ipconfig /all > $networkConfigPath
+Get-NetIPConfiguration -Detailed >> $networkConfigPath
+Get-NetAdapter | Format-Table -AutoSize >> $networkConfigPath
+Get-DnsClientServerAddress >> $networkConfigPath
+Get-NetRoute >> $networkConfigPath
+Get-NetNat >> $networkConfigPath
+Get-NetIPAddress >> $networkConfigPath
+Get-NetNeighbor >> $networkConfigPath
+Get-NetConnectionProfile >> $networkConfigPath
+hnsdiag list networks >> $networkConfigPath
+hnsdiag list endpoints >> $networkConfigPath
+
+function Upload-Log {
+    param(
+        [string]$source,
+        [string]$destination
+    )
+
+    if (-not (Test-Path -LiteralPath $source)) {
+        $script:uploadFailures += "source file does not exist: $source"
+        return
+    }
+
+    & $azCopyPath copy $source $destination
+    if ($LASTEXITCODE -ne 0) {
+        $script:uploadFailures += "azcopy exited with code $LASTEXITCODE while uploading $source"
+    }
+}
+
+if ($collectedLogs) {
+    Upload-Log $collectedLogs "$arg1/collected-node-logs.zip"
+}
+Upload-Log "C:\azuredata\CustomDataSetupScript.log" "$arg1/cse.log"
+Upload-Log "C:\AzureData\provision.complete" "$arg1/provision.complete"
+Upload-Log "C:\k\kubelet.err.log" "$arg1/kubelet.err.log"
+Upload-Log "C:\k\containerd.err.log" "$arg1/containerd.err.log"
+Upload-Log $networkConfigPath "$arg1/network_config.txt"
+
+if ($script:uploadFailures.Count -gt 0) {
+    throw "failed to upload Windows diagnostics: $($script:uploadFailures -join '; ')"
+}
 `
 
 // extractLogsFromVMWindows runs a script on windows VM to collect logs and upload them to a blob storage
@@ -944,13 +994,12 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 	runCommandResp, err := pollerResp.PollUntilDone(ctx, config.DefaultPollUntilDoneOptions)
 	if err != nil {
 		s.Logger.Logf("failed to poll run command on VMSS instance %s: %s", instanceID, err)
-		return
+	} else {
+		respJSON, _ := json.MarshalIndent(runCommandResp, "", "  ")
+		s.Logger.Logf("run command executed successfully:\n%s", respJSON)
 	}
 
-	respJSON, _ := json.MarshalIndent(runCommandResp, "", "  ")
-	s.Logger.Logf("run command executed successfully:\n%s", respJSON)
-
-	s.Logger.Logf("uploaded logs to %s", blobUrl)
+	s.Logger.Logf("downloading any logs uploaded to %s", blobUrl)
 
 	downloadBlob := func(blobSuffix string) {
 		fileName := filepath.Join(testDir(s.testName), blobSuffix)
@@ -978,6 +1027,8 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 	downloadBlob("collected-node-logs.zip")
 	downloadBlob("cse.log")
 	downloadBlob("provision.complete")
+	downloadBlob("kubelet.err.log")
+	downloadBlob("containerd.err.log")
 	downloadBlob("network_config.txt")
 	s.Logger.Logf("logs collected to %s", testDir(s.testName))
 }

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -1004,12 +1004,12 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 			return
 		}
 	}
-	downloadBlob("collected-node-logs.zip")
 	downloadBlob("cse.log")
 	downloadBlob("provision.complete")
 	downloadBlob("kubelet.err.log")
 	downloadBlob("containerd.err.log")
 	downloadBlob("network_config.txt")
+	downloadBlob("collected-node-logs.zip")
 	s.Logger.Logf("logs collected to %s", testDir(s.testName))
 }
 

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -892,7 +892,7 @@ function Upload-Log {
     )
 
     if (-not (Test-Path -LiteralPath $source)) {
-        $script:uploadFailures += "source file does not exist: $source"
+        Write-Warning "skipping missing log file: $source"
         return
     }
 
@@ -1000,6 +1000,8 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 	}
 
 	s.Logger.Logf("downloading any logs uploaded to %s", blobUrl)
+	downloadCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
+	defer cancel()
 
 	downloadBlob := func(blobSuffix string) {
 		fileName := filepath.Join(testDir(s.testName), blobSuffix)
@@ -1014,7 +1016,7 @@ func extractLogsFromVMWindows(ctx context.Context, s *Scenario) {
 			return
 		}
 		// NOTE, read after write is possible, list blobs is eventually consistent and may fail
-		_, err = config.Azure.Blob.DownloadFile(ctx, config.Config.BlobContainer, blobPrefix+"/"+blobSuffix, file, nil)
+		_, err = config.Azure.Blob.DownloadFile(downloadCtx, config.Config.BlobContainer, blobPrefix+"/"+blobSuffix, file, nil)
 		if err != nil {
 			s.Logger.Logf("failed to download collected logs: %s", err)
 			err = os.Remove(file.Name())

--- a/e2e/vmss.go
+++ b/e2e/vmss.go
@@ -880,14 +880,14 @@ function Upload-Log {
     }
 }
 
-if ($collectedLogs) {
-    Upload-Log $collectedLogs "$arg1/collected-node-logs.zip"
-}
 Upload-Log "C:\azuredata\CustomDataSetupScript.log" "$arg1/cse.log"
 Upload-Log "C:\AzureData\provision.complete" "$arg1/provision.complete"
 Upload-Log "C:\k\kubelet.err.log" "$arg1/kubelet.err.log"
 Upload-Log "C:\k\containerd.err.log" "$arg1/containerd.err.log"
 Upload-Log "network_config.txt" "$arg1/network_config.txt"
+if ($collectedLogs) {
+    Upload-Log $collectedLogs "$arg1/collected-node-logs.zip"
+}
 
 if ($script:uploadFailures.Count -gt 0) {
     throw "failed to upload Windows diagnostics: $($script:uploadFailures -join '; ')"

--- a/parts/windows/kuberneteswindowssetup.ps1.template
+++ b/parts/windows/kuberneteswindowssetup.ps1.template
@@ -110,6 +110,7 @@ $global:KubeletNodeLabels="{{GetAgentKubernetesLabels .}}"
 $global:KubeletNodeLabels="{{GetAgentKubernetesLabelsDeprecated .}}"
 {{end}}
 $global:KubeletConfigArgs=@( {{GetKubeletConfigKeyValsPsh}} )
+$global:KubeletHealthzEndpoint="{{GetKubeletHealthzEndpoint}}"
 $global:KubeproxyConfigArgs=@( {{GetKubeproxyConfigKeyValsPsh}} )
 
 $global:KubeproxyFeatureGates=@( {{GetKubeProxyFeatureGatesPsh}} )

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -333,19 +333,49 @@ function Start-NodeResetScriptTask {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "NodeResetScriptTask failed with result $($taskInfo.LastTaskResult)"
     }
 
-    $healthCheckArgs=@{
-        Uri="http://127.0.0.1:10248/healthz"
-        UseBasicParsing=$true
-        TimeoutSec=1
-        ErrorAction="Stop"
-    }
     try {
+        $healthCheckArgs=@{
+            Uri=Get-KubeletHealthCheckUri
+            UseBasicParsing=$true
+            TimeoutSec=1
+            ErrorAction="Stop"
+        }
         Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 23 -RetryDelaySeconds 1 | Out-Null
     } catch {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not become healthy after NodeResetScriptTask completed. Error: $($_.Exception.Message)"
     }
 
     Write-Log -Message "We waited [$($timer.Elapsed.TotalSeconds)] seconds on NodeResetScriptTask"
+}
+
+function Get-KubeletHealthCheckUri {
+    $healthzBindAddress="127.0.0.1"
+    $healthzPort=10248
+
+    foreach ($arg in $global:KubeletConfigArgs) {
+        $name, $value=$arg -split "=", 2
+        if ($name -eq "--healthz-bind-address") {
+            $healthzBindAddress=$value
+        } elseif ($name -eq "--healthz-port") {
+            if (-not [int]::TryParse($value, [ref]$healthzPort) -or $healthzPort -lt 0 -or $healthzPort -gt 65535) {
+                throw "invalid kubelet healthz port: $value"
+            }
+        }
+    }
+
+    if ($healthzPort -eq 0) {
+        throw "kubelet healthz endpoint is disabled"
+    }
+    if ($healthzBindAddress -eq "0.0.0.0") {
+        $healthzBindAddress="127.0.0.1"
+    } elseif ($healthzBindAddress -eq "::") {
+        $healthzBindAddress="::1"
+    }
+    if ($healthzBindAddress.Contains(":")) {
+        $healthzBindAddress="[$healthzBindAddress]"
+    }
+
+    return "http://${healthzBindAddress}:${healthzPort}/healthz"
 }
 
 function Postpone-RestartComputer {

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -346,7 +346,7 @@ function Start-NodeResetScriptTask {
                 TimeoutSec=1
                 ErrorAction="Stop"
             }
-            # NSSM recovery took 13 seconds in the observed failure; allow 30 attempts for slower hosts.
+            # Observed NSSM recovery took over 12 seconds; allow 30 attempts for slower hosts.
             Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 30 -RetryDelaySeconds 1 | Out-Null
         } catch {
             Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not become healthy after NodeResetScriptTask completed. Error: $($_.Exception.Message)"

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -340,7 +340,7 @@ function Start-NodeResetScriptTask {
         ErrorAction="Stop"
     }
     try {
-        Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 45 -RetryDelaySeconds 0.5 | Out-Null
+        Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 45 -RetryDelayMilliseconds 500 | Out-Null
     } catch {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not become healthy after NodeResetScriptTask completed. Error: $($_.Exception.Message)"
     }
@@ -400,6 +400,7 @@ function AKS-Expand-Archive {
 }
 
 function Retry-Command {
+    [CmdletBinding(DefaultParameterSetName="Seconds")]
     Param(
         [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][string]
         $Command,
@@ -407,8 +408,10 @@ function Retry-Command {
         $Args,
         [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][int]
         $Retries,
-        [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][double]
-        $RetryDelaySeconds
+        [Parameter(Mandatory=$true, ParameterSetName="Seconds")][ValidateNotNullOrEmpty()][int]
+        $RetryDelaySeconds,
+        [Parameter(Mandatory=$true, ParameterSetName="Milliseconds")][ValidateNotNullOrEmpty()][int]
+        $RetryDelayMilliseconds
     )
 
     for ($i=0; ; ) {
@@ -421,7 +424,11 @@ function Retry-Command {
             if ($i -ge $Retries) {
                 throw $_
             }
-            Start-Sleep -Milliseconds ([int]($RetryDelaySeconds * 1000))
+            if ($PSCmdlet.ParameterSetName -eq "Milliseconds") {
+                Start-Sleep -Milliseconds $RetryDelayMilliseconds
+            } else {
+                Start-Sleep -Seconds $RetryDelaySeconds
+            }
         }
     }
 }

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -327,15 +327,37 @@ function Start-NodeResetScriptTask {
         Write-Log -Message "Waiting on NodeResetScriptTask..."
         Start-Sleep -Seconds 3
     } while ($true)
-    $timer.Stop()
 
     if ($taskInfo.LastTaskResult -ne 0) {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "NodeResetScriptTask failed with result $($taskInfo.LastTaskResult)"
     }
 
     $kubeletService=Get-Service -Name "kubelet" -ErrorAction SilentlyContinue
+    if ($null -eq $kubeletService) {
+        Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not running after NodeResetScriptTask completed. The service was not found"
+    }
+
+    if ($kubeletService.Status -ne "Running") {
+        # NSSM restarts kubelet, so only wait out the remaining budget instead of starting it here.
+        $remainingSeconds=$TimeoutSeconds - $timer.Elapsed.TotalSeconds
+        if ($remainingSeconds -le 0) {
+            Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not running after NodeResetScriptTask completed. Status: $($kubeletService.Status). No time left in the [$TimeoutSeconds] seconds budget"
+        }
+
+        Write-Log -Message "kubelet service status is [$($kubeletService.Status)]. Waiting up to [$remainingSeconds] seconds for it to reach Running"
+        try {
+            $kubeletService.WaitForStatus("Running", [TimeSpan]::FromSeconds($remainingSeconds))
+        } catch {
+            Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not running after NodeResetScriptTask completed. Status: $($kubeletService.Status). Error: $($_.Exception.Message)"
+        }
+
+        $kubeletService=Get-Service -Name "kubelet" -ErrorAction SilentlyContinue
+    }
+
+    $timer.Stop()
+
     if ($null -eq $kubeletService -or $kubeletService.Status -ne "Running") {
-        Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not running after NodeResetScriptTask completed"
+        Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not running after NodeResetScriptTask completed. Status: $($kubeletService.Status)"
     }
 
     Write-Log -Message "We waited [$($timer.Elapsed.TotalSeconds)] seconds on NodeResetScriptTask"

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -346,6 +346,7 @@ function Start-NodeResetScriptTask {
                 TimeoutSec=1
                 ErrorAction="Stop"
             }
+            # NSSM recovery took 13 seconds in the observed failure; allow 30 attempts for slower hosts.
             Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 30 -RetryDelaySeconds 1 | Out-Null
         } catch {
             Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not become healthy after NodeResetScriptTask completed. Error: $($_.Exception.Message)"

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -340,7 +340,7 @@ function Start-NodeResetScriptTask {
         ErrorAction="Stop"
     }
     try {
-        Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 45 -RetryDelayMilliseconds 500 | Out-Null
+        Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 23 -RetryDelaySeconds 1 | Out-Null
     } catch {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not become healthy after NodeResetScriptTask completed. Error: $($_.Exception.Message)"
     }
@@ -400,7 +400,6 @@ function AKS-Expand-Archive {
 }
 
 function Retry-Command {
-    [CmdletBinding(DefaultParameterSetName="Seconds")]
     Param(
         [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][string]
         $Command,
@@ -408,10 +407,8 @@ function Retry-Command {
         $Args,
         [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][int]
         $Retries,
-        [Parameter(Mandatory=$true, ParameterSetName="Seconds")][ValidateNotNullOrEmpty()][int]
-        $RetryDelaySeconds,
-        [Parameter(Mandatory=$true, ParameterSetName="Milliseconds")][ValidateNotNullOrEmpty()][int]
-        $RetryDelayMilliseconds
+        [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][int]
+        $RetryDelaySeconds
     )
 
     for ($i=0; ; ) {
@@ -424,11 +421,7 @@ function Retry-Command {
             if ($i -ge $Retries) {
                 throw $_
             }
-            if ($PSCmdlet.ParameterSetName -eq "Milliseconds") {
-                Start-Sleep -Milliseconds $RetryDelayMilliseconds
-            } else {
-                Start-Sleep -Seconds $RetryDelaySeconds
-            }
+            Start-Sleep -Seconds $RetryDelaySeconds
         }
     }
 }

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -333,6 +333,18 @@ function Start-NodeResetScriptTask {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "NodeResetScriptTask failed with result $($taskInfo.LastTaskResult)"
     }
 
+    $healthCheckArgs=@{
+        Uri="http://127.0.0.1:10248/healthz"
+        UseBasicParsing=$true
+        TimeoutSec=5
+        ErrorAction="Stop"
+    }
+    try {
+        Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 12 -RetryDelaySeconds 5 | Out-Null
+    } catch {
+        Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not become healthy after NodeResetScriptTask completed. Error: $($_.Exception.Message)"
+    }
+
     Write-Log -Message "We waited [$($timer.Elapsed.TotalSeconds)] seconds on NodeResetScriptTask"
 }
 

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -334,7 +334,10 @@ function Start-NodeResetScriptTask {
     }
 
     if ([string]::IsNullOrEmpty($global:KubeletHealthzEndpoint)) {
-        Write-Log -Message "Skipping kubelet health check because the health endpoint is disabled"
+        $kubeletService=Get-Service -Name "kubelet" -ErrorAction SilentlyContinue
+        if ($null -eq $kubeletService -or $kubeletService.Status -ne "Running") {
+            Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not running after NodeResetScriptTask completed"
+        }
     } else {
         try {
             $healthCheckArgs=@{

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -339,27 +339,17 @@ function Start-NodeResetScriptTask {
 
     if ($kubeletService.Status -ne "Running") {
         # NSSM restarts kubelet, so only wait out the remaining budget instead of starting it here.
-        $remainingSeconds=$TimeoutSeconds - $timer.Elapsed.TotalSeconds
-        if ($remainingSeconds -le 0) {
-            Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not running after NodeResetScriptTask completed. Status: $($kubeletService.Status). No time left in the [$TimeoutSeconds] seconds budget"
-        }
-
+        $remainingSeconds=[Math]::Max(0.0, $TimeoutSeconds - $timer.Elapsed.TotalSeconds)
         Write-Log -Message "kubelet service status is [$($kubeletService.Status)]. Waiting up to [$remainingSeconds] seconds for it to reach Running"
         try {
             $kubeletService.WaitForStatus("Running", [TimeSpan]::FromSeconds($remainingSeconds))
         } catch {
-            Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not running after NodeResetScriptTask completed. Status: $($kubeletService.Status). Error: $($_.Exception.Message)"
+            $waitError=$_.Exception.GetBaseException().Message
+            Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service did not reach Running after NodeResetScriptTask completed. Status: $($kubeletService.Status). Error: $waitError"
         }
-
-        $kubeletService=Get-Service -Name "kubelet" -ErrorAction SilentlyContinue
     }
 
     $timer.Stop()
-
-    if ($null -eq $kubeletService -or $kubeletService.Status -ne "Running") {
-        Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not running after NodeResetScriptTask completed. Status: $($kubeletService.Status)"
-    }
-
     Write-Log -Message "We waited [$($timer.Elapsed.TotalSeconds)] seconds on NodeResetScriptTask"
 }
 

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -333,16 +333,20 @@ function Start-NodeResetScriptTask {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "NodeResetScriptTask failed with result $($taskInfo.LastTaskResult)"
     }
 
-    try {
-        $healthCheckArgs=@{
-            Uri="http://127.0.0.1:10248/healthz"
-            UseBasicParsing=$true
-            TimeoutSec=1
-            ErrorAction="Stop"
+    if ([string]::IsNullOrEmpty($global:KubeletHealthzEndpoint)) {
+        Write-Log -Message "Skipping kubelet health check because the health endpoint is disabled"
+    } else {
+        try {
+            $healthCheckArgs=@{
+                Uri=$global:KubeletHealthzEndpoint
+                UseBasicParsing=$true
+                TimeoutSec=1
+                ErrorAction="Stop"
+            }
+            Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 23 -RetryDelaySeconds 1 | Out-Null
+        } catch {
+            Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not become healthy after NodeResetScriptTask completed. Error: $($_.Exception.Message)"
         }
-        Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 23 -RetryDelaySeconds 1 | Out-Null
-    } catch {
-        Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not become healthy after NodeResetScriptTask completed. Error: $($_.Exception.Message)"
     }
 
     Write-Log -Message "We waited [$($timer.Elapsed.TotalSeconds)] seconds on NodeResetScriptTask"

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -327,29 +327,12 @@ function Start-NodeResetScriptTask {
         Write-Log -Message "Waiting on NodeResetScriptTask..."
         Start-Sleep -Seconds 3
     } while ($true)
+    $timer.Stop()
 
     if ($taskInfo.LastTaskResult -ne 0) {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "NodeResetScriptTask failed with result $($taskInfo.LastTaskResult)"
     }
 
-    $kubeletService=Get-Service -Name "kubelet" -ErrorAction SilentlyContinue
-    if ($null -eq $kubeletService) {
-        Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not running after NodeResetScriptTask completed. The service was not found"
-    }
-
-    if ($kubeletService.Status -ne "Running") {
-        # NSSM restarts kubelet, so only wait out the remaining budget instead of starting it here.
-        $remainingSeconds=[Math]::Max(0.0, $TimeoutSeconds - $timer.Elapsed.TotalSeconds)
-        Write-Log -Message "kubelet service status is [$($kubeletService.Status)]. Waiting up to [$remainingSeconds] seconds for it to reach Running"
-        try {
-            $kubeletService.WaitForStatus("Running", [TimeSpan]::FromSeconds($remainingSeconds))
-        } catch {
-            $waitError=$_.Exception.GetBaseException().Message
-            Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service did not reach Running after NodeResetScriptTask completed. Status: $($kubeletService.Status). Error: $waitError"
-        }
-    }
-
-    $timer.Stop()
     Write-Log -Message "We waited [$($timer.Elapsed.TotalSeconds)] seconds on NodeResetScriptTask"
 }
 

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -335,7 +335,7 @@ function Start-NodeResetScriptTask {
 
     try {
         $healthCheckArgs=@{
-            Uri=Get-KubeletHealthCheckUri
+            Uri="http://127.0.0.1:10248/healthz"
             UseBasicParsing=$true
             TimeoutSec=1
             ErrorAction="Stop"
@@ -346,36 +346,6 @@ function Start-NodeResetScriptTask {
     }
 
     Write-Log -Message "We waited [$($timer.Elapsed.TotalSeconds)] seconds on NodeResetScriptTask"
-}
-
-function Get-KubeletHealthCheckUri {
-    $healthzBindAddress="127.0.0.1"
-    $healthzPort=10248
-
-    foreach ($arg in $global:KubeletConfigArgs) {
-        $name, $value=$arg -split "=", 2
-        if ($name -eq "--healthz-bind-address") {
-            $healthzBindAddress=$value
-        } elseif ($name -eq "--healthz-port") {
-            if (-not [int]::TryParse($value, [ref]$healthzPort) -or $healthzPort -lt 0 -or $healthzPort -gt 65535) {
-                throw "invalid kubelet healthz port: $value"
-            }
-        }
-    }
-
-    if ($healthzPort -eq 0) {
-        throw "kubelet healthz endpoint is disabled"
-    }
-    if ($healthzBindAddress -eq "0.0.0.0") {
-        $healthzBindAddress="127.0.0.1"
-    } elseif ($healthzBindAddress -eq "::") {
-        $healthzBindAddress="::1"
-    }
-    if ($healthzBindAddress.Contains(":")) {
-        $healthzBindAddress="[$healthzBindAddress]"
-    }
-
-    return "http://${healthzBindAddress}:${healthzPort}/healthz"
 }
 
 function Postpone-RestartComputer {

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -336,11 +336,11 @@ function Start-NodeResetScriptTask {
     $healthCheckArgs=@{
         Uri="http://127.0.0.1:10248/healthz"
         UseBasicParsing=$true
-        TimeoutSec=2
+        TimeoutSec=1
         ErrorAction="Stop"
     }
     try {
-        Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 12 -RetryDelaySeconds 2 | Out-Null
+        Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 45 -RetryDelaySeconds 0.5 | Out-Null
     } catch {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not become healthy after NodeResetScriptTask completed. Error: $($_.Exception.Message)"
     }
@@ -407,7 +407,7 @@ function Retry-Command {
         $Args,
         [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][int]
         $Retries,
-        [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][int]
+        [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][double]
         $RetryDelaySeconds
     )
 
@@ -421,7 +421,7 @@ function Retry-Command {
             if ($i -ge $Retries) {
                 throw $_
             }
-            Start-Sleep $RetryDelaySeconds
+            Start-Sleep -Milliseconds ([int]($RetryDelaySeconds * 1000))
         }
     }
 }

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -343,7 +343,7 @@ function Start-NodeResetScriptTask {
                 TimeoutSec=1
                 ErrorAction="Stop"
             }
-            Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 23 -RetryDelaySeconds 1 | Out-Null
+            Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 30 -RetryDelaySeconds 1 | Out-Null
         } catch {
             Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not become healthy after NodeResetScriptTask completed. Error: $($_.Exception.Message)"
         }

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -336,11 +336,11 @@ function Start-NodeResetScriptTask {
     $healthCheckArgs=@{
         Uri="http://127.0.0.1:10248/healthz"
         UseBasicParsing=$true
-        TimeoutSec=5
+        TimeoutSec=2
         ErrorAction="Stop"
     }
     try {
-        Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 12 -RetryDelaySeconds 5 | Out-Null
+        Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 12 -RetryDelaySeconds 2 | Out-Null
     } catch {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not become healthy after NodeResetScriptTask completed. Error: $($_.Exception.Message)"
     }

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -593,7 +593,6 @@ Describe "Update-BaseUrl" {
 Describe "Start-NodeResetScriptTask" {
   BeforeEach {
     $script:taskInfoCallCount = 0
-    $global:KubeletConfigArgs = @()
     Mock Start-ScheduledTask -MockWith {}
     Mock Get-ScheduledTask -MockWith { return [pscustomobject]@{ State = "Ready" } }
     Mock Get-ScheduledTaskInfo -MockWith {
@@ -619,23 +618,6 @@ Describe "Start-NodeResetScriptTask" {
       $Uri -eq "http://127.0.0.1:10248/healthz" -and $TimeoutSec -eq 1 -and $ErrorAction -eq "Stop"
     }
     Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
-  }
-
-  It "uses the configured kubelet health endpoint" {
-    $global:KubeletConfigArgs = @("--healthz-bind-address=0.0.0.0", "--healthz-port=10249")
-
-    Start-NodeResetScriptTask
-
-    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 1 -ParameterFilter {
-      $Uri -eq "http://127.0.0.1:10249/healthz"
-    }
-  }
-
-  It "fails immediately when the kubelet health endpoint is disabled" {
-    $global:KubeletConfigArgs = @("--healthz-port=0")
-
-    { Start-NodeResetScriptTask } | Should -Throw "*kubelet healthz endpoint is disabled*"
-    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 0
   }
 
   It "does not accept Ready before the new run starts" {

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -604,6 +604,7 @@ Describe "Start-NodeResetScriptTask" {
       return [pscustomobject]@{ LastRunTime = [datetime]"2026-01-02"; LastTaskResult = 0 }
     }
     Mock Invoke-WebRequest -MockWith { return [pscustomobject]@{ StatusCode = 200 } }
+    Mock Get-Service -MockWith { return [pscustomobject]@{ Status = "Running" } }
     Mock Start-Sleep -MockWith {}
     Mock Write-Log -MockWith {}
     Mock Set-ExitCode -MockWith {
@@ -688,14 +689,20 @@ Describe "Start-NodeResetScriptTask" {
     Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 30
   }
 
-  It "skips the health check when the endpoint is disabled" {
+  It "checks the service state when the health endpoint is disabled" {
     $global:KubeletHealthzEndpoint = ""
 
     Start-NodeResetScriptTask
 
     Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 0
-    Assert-MockCalled -CommandName Write-Log -Exactly -Times 1 -ParameterFilter {
-      $Message -eq "Skipping kubelet health check because the health endpoint is disabled"
-    }
+    Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
+  }
+
+  It "fails when the health endpoint is disabled and kubelet is not running" {
+    $global:KubeletHealthzEndpoint = ""
+    Mock Get-Service -MockWith { return [pscustomobject]@{ Status = "Stopped" } }
+
+    { Start-NodeResetScriptTask } | Should -Throw "*kubelet service is not running*"
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 0
   }
 }

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -677,13 +677,13 @@ Describe "Start-NodeResetScriptTask" {
     Start-NodeResetScriptTask
 
     Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 3
-    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 2 -ParameterFilter { $Milliseconds -eq 500 }
+    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 2 -ParameterFilter { $Seconds -eq 1 }
   }
 
   It "fails when kubelet does not become healthy" {
     Mock Invoke-WebRequest -MockWith { throw "connection refused" }
 
     { Start-NodeResetScriptTask } | Should -Throw "*kubelet did not become healthy*connection refused*"
-    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 45
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 23
   }
 }

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -602,6 +602,7 @@ Describe "Start-NodeResetScriptTask" {
       }
       return [pscustomobject]@{ LastRunTime = [datetime]"2026-01-02"; LastTaskResult = 0 }
     }
+    Mock Invoke-WebRequest -MockWith { return [pscustomobject]@{ StatusCode = 200 } }
     Mock Start-Sleep -MockWith {}
     Mock Write-Log -MockWith {}
     Mock Set-ExitCode -MockWith {
@@ -610,9 +611,12 @@ Describe "Start-NodeResetScriptTask" {
     }
   }
 
-  It "waits for a new successful run" {
+  It "waits for a new successful run and healthy kubelet" {
     Start-NodeResetScriptTask
     Assert-MockCalled -CommandName Start-ScheduledTask -Exactly -Times 1
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 1 -ParameterFilter {
+      $Uri -eq "http://127.0.0.1:10248/healthz" -and $TimeoutSec -eq 5 -and $ErrorAction -eq "Stop"
+    }
     Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
   }
 
@@ -657,5 +661,29 @@ Describe "Start-NodeResetScriptTask" {
     }
 
     { Start-NodeResetScriptTask } | Should -Throw "*failed with result 1*"
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 0
+  }
+
+  It "retries until kubelet becomes healthy" {
+    $script:healthCheckCallCount = 0
+    Mock Invoke-WebRequest -MockWith {
+      $script:healthCheckCallCount++
+      if ($script:healthCheckCallCount -lt 3) {
+        throw "connection refused"
+      }
+      return [pscustomobject]@{ StatusCode = 200 }
+    }
+
+    Start-NodeResetScriptTask
+
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 3
+    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 2 -ParameterFilter { $Seconds -eq 5 }
+  }
+
+  It "fails when kubelet does not become healthy" {
+    Mock Invoke-WebRequest -MockWith { throw "connection refused" }
+
+    { Start-NodeResetScriptTask } | Should -Throw "*kubelet did not become healthy*connection refused*"
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 12
   }
 }

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -615,7 +615,7 @@ Describe "Start-NodeResetScriptTask" {
     Start-NodeResetScriptTask
     Assert-MockCalled -CommandName Start-ScheduledTask -Exactly -Times 1
     Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 1 -ParameterFilter {
-      $Uri -eq "http://127.0.0.1:10248/healthz" -and $TimeoutSec -eq 5 -and $ErrorAction -eq "Stop"
+      $Uri -eq "http://127.0.0.1:10248/healthz" -and $TimeoutSec -eq 2 -and $ErrorAction -eq "Stop"
     }
     Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
   }
@@ -677,7 +677,7 @@ Describe "Start-NodeResetScriptTask" {
     Start-NodeResetScriptTask
 
     Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 3
-    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 2 -ParameterFilter { $Seconds -eq 5 }
+    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 2 -ParameterFilter { $Seconds -eq 2 }
   }
 
   It "fails when kubelet does not become healthy" {

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -685,7 +685,7 @@ Describe "Start-NodeResetScriptTask" {
     Mock Invoke-WebRequest -MockWith { throw "connection refused" }
 
     { Start-NodeResetScriptTask } | Should -Throw "*kubelet did not become healthy*connection refused*"
-    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 23
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 30
   }
 
   It "skips the health check when the endpoint is disabled" {

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -593,6 +593,7 @@ Describe "Update-BaseUrl" {
 Describe "Start-NodeResetScriptTask" {
   BeforeEach {
     $script:taskInfoCallCount = 0
+    $global:KubeletHealthzEndpoint = "http://127.0.0.1:10248/healthz"
     Mock Start-ScheduledTask -MockWith {}
     Mock Get-ScheduledTask -MockWith { return [pscustomobject]@{ State = "Ready" } }
     Mock Get-ScheduledTaskInfo -MockWith {
@@ -685,5 +686,16 @@ Describe "Start-NodeResetScriptTask" {
 
     { Start-NodeResetScriptTask } | Should -Throw "*kubelet did not become healthy*connection refused*"
     Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 23
+  }
+
+  It "skips the health check when the endpoint is disabled" {
+    $global:KubeletHealthzEndpoint = ""
+
+    Start-NodeResetScriptTask
+
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 0
+    Assert-MockCalled -CommandName Write-Log -Exactly -Times 1 -ParameterFilter {
+      $Message -eq "Skipping kubelet health check because the health endpoint is disabled"
+    }
   }
 }

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -591,34 +591,8 @@ Describe "Update-BaseUrl" {
 }
 
 Describe "Start-NodeResetScriptTask" {
-  BeforeAll {
-    function New-MockKubeletService {
-      Param(
-        [string]$InitialStatus,
-        [switch]$ThrowOnWait
-      )
-      $service = [pscustomobject]@{
-        Status = $InitialStatus
-        ThrowOnWait = [bool]$ThrowOnWait
-        WaitCallCount = 0
-        WaitTimeouts = @()
-      }
-      $service | Add-Member -MemberType ScriptMethod -Name WaitForStatus -Value {
-        Param($DesiredStatus, $Timeout)
-        $this.WaitCallCount++
-        $this.WaitTimeouts += $Timeout
-        if ($this.ThrowOnWait -or $Timeout -le [TimeSpan]::Zero) {
-          throw "Time out has expired and the operation has not been completed."
-        }
-        $this.Status = $DesiredStatus
-      }
-      return $service
-    }
-  }
-
   BeforeEach {
     $script:taskInfoCallCount = 0
-    $script:kubeletService = New-MockKubeletService -InitialStatus "Running"
     Mock Start-ScheduledTask -MockWith {}
     Mock Get-ScheduledTask -MockWith { return [pscustomobject]@{ State = "Ready" } }
     Mock Get-ScheduledTaskInfo -MockWith {
@@ -628,9 +602,6 @@ Describe "Start-NodeResetScriptTask" {
       }
       return [pscustomobject]@{ LastRunTime = [datetime]"2026-01-02"; LastTaskResult = 0 }
     }
-    Mock Get-Service -MockWith { return $script:kubeletService }
-    Mock Start-Service -MockWith {}
-    Mock Resume-Service -MockWith {}
     Mock Start-Sleep -MockWith {}
     Mock Write-Log -MockWith {}
     Mock Set-ExitCode -MockWith {
@@ -639,12 +610,10 @@ Describe "Start-NodeResetScriptTask" {
     }
   }
 
-  It "waits for a new successful run and running kubelet" {
+  It "waits for a new successful run" {
     Start-NodeResetScriptTask
-
     Assert-MockCalled -CommandName Start-ScheduledTask -Exactly -Times 1
     Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
-    $script:kubeletService.WaitCallCount | Should -Be 0
   }
 
   It "does not accept Ready before the new run starts" {
@@ -688,68 +657,5 @@ Describe "Start-NodeResetScriptTask" {
     }
 
     { Start-NodeResetScriptTask } | Should -Throw "*failed with result 1*"
-  }
-
-  It "waits for kubelet to leave Paused without restarting it" {
-    $script:kubeletService = New-MockKubeletService -InitialStatus "Paused"
-
-    Start-NodeResetScriptTask
-
-    Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
-    Assert-MockCalled -CommandName Start-Service -Exactly -Times 0
-    Assert-MockCalled -CommandName Resume-Service -Exactly -Times 0
-    $script:kubeletService.WaitCallCount | Should -Be 1
-    $script:kubeletService.Status | Should -Be "Running"
-  }
-
-  It "waits for kubelet to leave StartPending without restarting it" {
-    $script:kubeletService = New-MockKubeletService -InitialStatus "StartPending"
-
-    Start-NodeResetScriptTask
-
-    Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
-    Assert-MockCalled -CommandName Start-Service -Exactly -Times 0
-    Assert-MockCalled -CommandName Resume-Service -Exactly -Times 0
-    $script:kubeletService.WaitCallCount | Should -Be 1
-    $script:kubeletService.Status | Should -Be "Running"
-  }
-
-  It "waits with the time remaining in the task timeout budget" {
-    $script:kubeletService = New-MockKubeletService -InitialStatus "Stopped"
-
-    Start-NodeResetScriptTask -TimeoutSeconds 180
-
-    $script:kubeletService.WaitTimeouts.Count | Should -Be 1
-    $timeout = $script:kubeletService.WaitTimeouts[0]
-    $timeout | Should -BeOfType [TimeSpan]
-    $timeout.TotalSeconds | Should -BeGreaterThan 0
-    $timeout.TotalSeconds | Should -BeLessThan 180
-  }
-
-  It "fails when kubelet does not reach Running before the wait times out" {
-    $script:kubeletService = New-MockKubeletService -InitialStatus "Stopped" -ThrowOnWait
-
-    { Start-NodeResetScriptTask } | Should -Throw "*kubelet service did not reach Running*Status: Stopped*Time out has expired*"
-    Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 1 -ParameterFilter {
-      $ExitCode -eq $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK
-    }
-    Assert-MockCalled -CommandName Start-Service -Exactly -Times 0
-    Assert-MockCalled -CommandName Resume-Service -Exactly -Times 0
-  }
-
-  It "fails immediately when no time is left in the budget" {
-    $script:kubeletService = New-MockKubeletService -InitialStatus "Stopped"
-
-    { Start-NodeResetScriptTask -TimeoutSeconds 0 } | Should -Throw "*kubelet service did not reach Running*Status: Stopped*Time out has expired*"
-    Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 1 -ParameterFilter {
-      $ExitCode -eq $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK
-    }
-    $script:kubeletService.WaitCallCount | Should -Be 1
-  }
-
-  It "fails when the kubelet service is missing" {
-    Mock Get-Service -MockWith { return $null }
-
-    { Start-NodeResetScriptTask } | Should -Throw "*kubelet service is not running*was not found*"
   }
 }

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -595,12 +595,10 @@ Describe "Start-NodeResetScriptTask" {
     function New-MockKubeletService {
       Param(
         [string]$InitialStatus,
-        [string]$StatusAfterWait = "Running",
         [switch]$ThrowOnWait
       )
       $service = [pscustomobject]@{
         Status = $InitialStatus
-        StatusAfterWait = $StatusAfterWait
         ThrowOnWait = [bool]$ThrowOnWait
         WaitCallCount = 0
         WaitTimeouts = @()
@@ -609,10 +607,10 @@ Describe "Start-NodeResetScriptTask" {
         Param($DesiredStatus, $Timeout)
         $this.WaitCallCount++
         $this.WaitTimeouts += $Timeout
-        if ($this.ThrowOnWait) {
+        if ($this.ThrowOnWait -or $Timeout -le [TimeSpan]::Zero) {
           throw "Time out has expired and the operation has not been completed."
         }
-        $this.Status = $this.StatusAfterWait
+        $this.Status = $DesiredStatus
       }
       return $service
     }
@@ -731,7 +729,7 @@ Describe "Start-NodeResetScriptTask" {
   It "fails when kubelet does not reach Running before the wait times out" {
     $script:kubeletService = New-MockKubeletService -InitialStatus "Stopped" -ThrowOnWait
 
-    { Start-NodeResetScriptTask } | Should -Throw "*kubelet service is not running*Status: Stopped*Time out has expired*"
+    { Start-NodeResetScriptTask } | Should -Throw "*kubelet service did not reach Running*Status: Stopped*Time out has expired*"
     Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 1 -ParameterFilter {
       $ExitCode -eq $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK
     }
@@ -739,20 +737,13 @@ Describe "Start-NodeResetScriptTask" {
     Assert-MockCalled -CommandName Resume-Service -Exactly -Times 0
   }
 
-  It "fails without waiting when no time is left in the budget" {
+  It "fails immediately when no time is left in the budget" {
     $script:kubeletService = New-MockKubeletService -InitialStatus "Stopped"
 
-    { Start-NodeResetScriptTask -TimeoutSeconds 0 } | Should -Throw "*kubelet service is not running*No time left*"
+    { Start-NodeResetScriptTask -TimeoutSeconds 0 } | Should -Throw "*kubelet service did not reach Running*Status: Stopped*Time out has expired*"
     Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 1 -ParameterFilter {
       $ExitCode -eq $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK
     }
-    $script:kubeletService.WaitCallCount | Should -Be 0
-  }
-
-  It "fails when kubelet never reaches Running after the wait" {
-    $script:kubeletService = New-MockKubeletService -InitialStatus "Stopped" -StatusAfterWait "Stopped"
-
-    { Start-NodeResetScriptTask } | Should -Throw "*kubelet service is not running*Status: Stopped*"
     $script:kubeletService.WaitCallCount | Should -Be 1
   }
 

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -593,6 +593,7 @@ Describe "Update-BaseUrl" {
 Describe "Start-NodeResetScriptTask" {
   BeforeEach {
     $script:taskInfoCallCount = 0
+    $global:KubeletConfigArgs = @()
     Mock Start-ScheduledTask -MockWith {}
     Mock Get-ScheduledTask -MockWith { return [pscustomobject]@{ State = "Ready" } }
     Mock Get-ScheduledTaskInfo -MockWith {
@@ -618,6 +619,23 @@ Describe "Start-NodeResetScriptTask" {
       $Uri -eq "http://127.0.0.1:10248/healthz" -and $TimeoutSec -eq 1 -and $ErrorAction -eq "Stop"
     }
     Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
+  }
+
+  It "uses the configured kubelet health endpoint" {
+    $global:KubeletConfigArgs = @("--healthz-bind-address=0.0.0.0", "--healthz-port=10249")
+
+    Start-NodeResetScriptTask
+
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 1 -ParameterFilter {
+      $Uri -eq "http://127.0.0.1:10249/healthz"
+    }
+  }
+
+  It "fails immediately when the kubelet health endpoint is disabled" {
+    $global:KubeletConfigArgs = @("--healthz-port=0")
+
+    { Start-NodeResetScriptTask } | Should -Throw "*kubelet healthz endpoint is disabled*"
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 0
   }
 
   It "does not accept Ready before the new run starts" {

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -615,7 +615,7 @@ Describe "Start-NodeResetScriptTask" {
     Start-NodeResetScriptTask
     Assert-MockCalled -CommandName Start-ScheduledTask -Exactly -Times 1
     Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 1 -ParameterFilter {
-      $Uri -eq "http://127.0.0.1:10248/healthz" -and $TimeoutSec -eq 2 -and $ErrorAction -eq "Stop"
+      $Uri -eq "http://127.0.0.1:10248/healthz" -and $TimeoutSec -eq 1 -and $ErrorAction -eq "Stop"
     }
     Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
   }
@@ -677,13 +677,13 @@ Describe "Start-NodeResetScriptTask" {
     Start-NodeResetScriptTask
 
     Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 3
-    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 2 -ParameterFilter { $Seconds -eq 2 }
+    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 2 -ParameterFilter { $Milliseconds -eq 500 }
   }
 
   It "fails when kubelet does not become healthy" {
     Mock Invoke-WebRequest -MockWith { throw "connection refused" }
 
     { Start-NodeResetScriptTask } | Should -Throw "*kubelet did not become healthy*connection refused*"
-    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 12
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 45
   }
 }

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -591,8 +591,36 @@ Describe "Update-BaseUrl" {
 }
 
 Describe "Start-NodeResetScriptTask" {
+  BeforeAll {
+    function New-MockKubeletService {
+      Param(
+        [string]$InitialStatus,
+        [string]$StatusAfterWait = "Running",
+        [switch]$ThrowOnWait
+      )
+      $service = [pscustomobject]@{
+        Status = $InitialStatus
+        StatusAfterWait = $StatusAfterWait
+        ThrowOnWait = [bool]$ThrowOnWait
+        WaitCallCount = 0
+        WaitTimeouts = @()
+      }
+      $service | Add-Member -MemberType ScriptMethod -Name WaitForStatus -Value {
+        Param($DesiredStatus, $Timeout)
+        $this.WaitCallCount++
+        $this.WaitTimeouts += $Timeout
+        if ($this.ThrowOnWait) {
+          throw "Time out has expired and the operation has not been completed."
+        }
+        $this.Status = $this.StatusAfterWait
+      }
+      return $service
+    }
+  }
+
   BeforeEach {
     $script:taskInfoCallCount = 0
+    $script:kubeletService = New-MockKubeletService -InitialStatus "Running"
     Mock Start-ScheduledTask -MockWith {}
     Mock Get-ScheduledTask -MockWith { return [pscustomobject]@{ State = "Ready" } }
     Mock Get-ScheduledTaskInfo -MockWith {
@@ -602,7 +630,9 @@ Describe "Start-NodeResetScriptTask" {
       }
       return [pscustomobject]@{ LastRunTime = [datetime]"2026-01-02"; LastTaskResult = 0 }
     }
-    Mock Get-Service -MockWith { return [pscustomobject]@{ Status = "Running" } }
+    Mock Get-Service -MockWith { return $script:kubeletService }
+    Mock Start-Service -MockWith {}
+    Mock Resume-Service -MockWith {}
     Mock Start-Sleep -MockWith {}
     Mock Write-Log -MockWith {}
     Mock Set-ExitCode -MockWith {
@@ -616,6 +646,7 @@ Describe "Start-NodeResetScriptTask" {
 
     Assert-MockCalled -CommandName Start-ScheduledTask -Exactly -Times 1
     Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
+    $script:kubeletService.WaitCallCount | Should -Be 0
   }
 
   It "does not accept Ready before the new run starts" {
@@ -661,9 +692,73 @@ Describe "Start-NodeResetScriptTask" {
     { Start-NodeResetScriptTask } | Should -Throw "*failed with result 1*"
   }
 
-  It "fails when kubelet is not running" {
-    Mock Get-Service -MockWith { return [pscustomobject]@{ Status = "Stopped" } }
+  It "waits for kubelet to leave Paused without restarting it" {
+    $script:kubeletService = New-MockKubeletService -InitialStatus "Paused"
 
-    { Start-NodeResetScriptTask } | Should -Throw "*kubelet service is not running*"
+    Start-NodeResetScriptTask
+
+    Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
+    Assert-MockCalled -CommandName Start-Service -Exactly -Times 0
+    Assert-MockCalled -CommandName Resume-Service -Exactly -Times 0
+    $script:kubeletService.WaitCallCount | Should -Be 1
+    $script:kubeletService.Status | Should -Be "Running"
+  }
+
+  It "waits for kubelet to leave StartPending without restarting it" {
+    $script:kubeletService = New-MockKubeletService -InitialStatus "StartPending"
+
+    Start-NodeResetScriptTask
+
+    Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
+    Assert-MockCalled -CommandName Start-Service -Exactly -Times 0
+    Assert-MockCalled -CommandName Resume-Service -Exactly -Times 0
+    $script:kubeletService.WaitCallCount | Should -Be 1
+    $script:kubeletService.Status | Should -Be "Running"
+  }
+
+  It "waits with the time remaining in the task timeout budget" {
+    $script:kubeletService = New-MockKubeletService -InitialStatus "Stopped"
+
+    Start-NodeResetScriptTask -TimeoutSeconds 180
+
+    $script:kubeletService.WaitTimeouts.Count | Should -Be 1
+    $timeout = $script:kubeletService.WaitTimeouts[0]
+    $timeout | Should -BeOfType [TimeSpan]
+    $timeout.TotalSeconds | Should -BeGreaterThan 0
+    $timeout.TotalSeconds | Should -BeLessThan 180
+  }
+
+  It "fails when kubelet does not reach Running before the wait times out" {
+    $script:kubeletService = New-MockKubeletService -InitialStatus "Stopped" -ThrowOnWait
+
+    { Start-NodeResetScriptTask } | Should -Throw "*kubelet service is not running*Status: Stopped*Time out has expired*"
+    Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 1 -ParameterFilter {
+      $ExitCode -eq $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK
+    }
+    Assert-MockCalled -CommandName Start-Service -Exactly -Times 0
+    Assert-MockCalled -CommandName Resume-Service -Exactly -Times 0
+  }
+
+  It "fails without waiting when no time is left in the budget" {
+    $script:kubeletService = New-MockKubeletService -InitialStatus "Stopped"
+
+    { Start-NodeResetScriptTask -TimeoutSeconds 0 } | Should -Throw "*kubelet service is not running*No time left*"
+    Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 1 -ParameterFilter {
+      $ExitCode -eq $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK
+    }
+    $script:kubeletService.WaitCallCount | Should -Be 0
+  }
+
+  It "fails when kubelet never reaches Running after the wait" {
+    $script:kubeletService = New-MockKubeletService -InitialStatus "Stopped" -StatusAfterWait "Stopped"
+
+    { Start-NodeResetScriptTask } | Should -Throw "*kubelet service is not running*Status: Stopped*"
+    $script:kubeletService.WaitCallCount | Should -Be 1
+  }
+
+  It "fails when the kubelet service is missing" {
+    Mock Get-Service -MockWith { return $null }
+
+    { Start-NodeResetScriptTask } | Should -Throw "*kubelet service is not running*was not found*"
   }
 }

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -950,6 +950,9 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 		"GetKubeletConfigKeyValsPsh": func() string {
 			return config.GetOrderedKubeletConfigStringForPowershell(profile.CustomKubeletConfig)
 		},
+		"GetKubeletHealthzEndpoint": func() string {
+			return config.GetKubeletHealthzEndpoint(profile.CustomKubeletConfig)
+		},
 		"GetKubeproxyConfigKeyValsPsh": func() string {
 			return config.GetOrderedKubeproxyConfigStringForPowershell()
 		},

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -1597,9 +1597,9 @@ func (config *NodeBootstrappingConfiguration) GetOrderedKubeletConfigStringForPo
 	// Settings from customKubeletConfig, only take if it's set.
 	kubeletConfig = setCustomKubletConfigFromSettings(customKc, kubeletConfig)
 
-	if len(kubeletConfig) == 0 {
-		return ""
-	}
+	// CSE uses this endpoint as the Windows kubelet readiness contract.
+	kubeletConfig["--healthz-bind-address"] = "127.0.0.1"
+	kubeletConfig["--healthz-port"] = "10248"
 
 	commandLineOmmittedKubeletConfigFlags := GetCommandLineOmittedKubeletConfigFlags()
 	keys := []string{}

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -1620,10 +1620,6 @@ func (config *NodeBootstrappingConfiguration) GetKubeletHealthzEndpoint(customKc
 	kubeletConfig := config.getWindowsKubeletConfig(customKc)
 
 	address := kubeletConfig["--healthz-bind-address"]
-	if address == "" {
-		address = "127.0.0.1"
-	}
-
 	port := kubeletConfig["--healthz-port"]
 	if port == "" {
 		port = "10248"
@@ -1633,7 +1629,7 @@ func (config *NodeBootstrappingConfiguration) GetKubeletHealthzEndpoint(customKc
 	}
 
 	switch address {
-	case "0.0.0.0":
+	case "", "0.0.0.0":
 		address = "127.0.0.1"
 	case "::":
 		address = "::1"

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math/rand"
+	"net"
 	neturl "net/url"
 	"slices"
 	"sort"
@@ -1573,33 +1574,30 @@ func setCustomKubletConfigFromSettings(customKc *CustomKubeletConfig, kubeletCon
 	return kubeletConfig
 }
 
-/*
-GetOrderedKubeletConfigStringForPowershell returns an ordered string of key/val pairs for Powershell
-script consumption.
-*/
-func (config *NodeBootstrappingConfiguration) GetOrderedKubeletConfigStringForPowershell(customKc *CustomKubeletConfig) string {
+func (config *NodeBootstrappingConfiguration) getWindowsKubeletConfig(customKc *CustomKubeletConfig) map[string]string {
 	kubeletConfig := config.KubeletConfig
 	if kubeletConfig == nil {
 		kubeletConfig = map[string]string{}
 	}
 
-	// override default kubelet configuration with customzied ones.
 	if config.ContainerService != nil && config.ContainerService.Properties != nil {
 		kubeletCustomConfiguration := config.ContainerService.Properties.GetComponentWindowsKubernetesConfiguration(Componentkubelet)
 		if kubeletCustomConfiguration != nil {
-			config := kubeletCustomConfiguration.Config
-			for k, v := range config {
+			for k, v := range kubeletCustomConfiguration.Config {
 				kubeletConfig[k] = v
 			}
 		}
 	}
 
-	// Settings from customKubeletConfig, only take if it's set.
-	kubeletConfig = setCustomKubletConfigFromSettings(customKc, kubeletConfig)
+	return setCustomKubletConfigFromSettings(customKc, kubeletConfig)
+}
 
-	// CSE uses this endpoint as the Windows kubelet readiness contract.
-	kubeletConfig["--healthz-bind-address"] = "127.0.0.1"
-	kubeletConfig["--healthz-port"] = "10248"
+/*
+GetOrderedKubeletConfigStringForPowershell returns an ordered string of key/val pairs for Powershell
+script consumption.
+*/
+func (config *NodeBootstrappingConfiguration) GetOrderedKubeletConfigStringForPowershell(customKc *CustomKubeletConfig) string {
+	kubeletConfig := config.getWindowsKubeletConfig(customKc)
 
 	commandLineOmmittedKubeletConfigFlags := GetCommandLineOmittedKubeletConfigFlags()
 	keys := []string{}
@@ -1615,6 +1613,33 @@ func (config *NodeBootstrappingConfiguration) GetOrderedKubeletConfigStringForPo
 		buf.WriteString(fmt.Sprintf("\"%s=%s\", ", key, kubeletConfig[key]))
 	}
 	return strings.TrimSuffix(buf.String(), ", ")
+}
+
+// GetKubeletHealthzEndpoint returns the local URL matching the effective Windows kubelet configuration.
+func (config *NodeBootstrappingConfiguration) GetKubeletHealthzEndpoint(customKc *CustomKubeletConfig) string {
+	kubeletConfig := config.getWindowsKubeletConfig(customKc)
+
+	address := kubeletConfig["--healthz-bind-address"]
+	if address == "" {
+		address = "127.0.0.1"
+	}
+
+	port := kubeletConfig["--healthz-port"]
+	if port == "" {
+		port = "10248"
+	}
+	if port == "0" {
+		return ""
+	}
+
+	switch address {
+	case "0.0.0.0":
+		address = "127.0.0.1"
+	case "::":
+		address = "::1"
+	}
+
+	return fmt.Sprintf("http://%s/healthz", net.JoinHostPort(address, port))
 }
 
 /*

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -2711,7 +2711,7 @@ func TestKubernetesConfigIsAddonDisabled(t *testing.T) {
 }
 
 func TestKubernetesConfigGetOrderedKubeletConfigString(t *testing.T) {
-	alphabetizedStringForPowershell := `"--address=0.0.0.0", "--allow-privileged=true", "--anonymous-auth=false", "--authorization-mode=Webhook", "--cgroups-per-qos=true", "--client-ca-file=/etc/kubernetes/certs/ca.crt", "--container-log-max-files=20", "--container-log-max-size=1024Mi", "--healthz-bind-address=127.0.0.1", "--healthz-port=10248", "--image-gc-high-threshold=80", "--image-gc-low-threshold=60", "--kubeconfig=/var/lib/kubelet/kubeconfig", "--pod-manifest-path=/etc/kubernetes/manifests"` //nolint:lll
+	alphabetizedStringForPowershell := `"--address=0.0.0.0", "--allow-privileged=true", "--anonymous-auth=false", "--authorization-mode=Webhook", "--cgroups-per-qos=true", "--client-ca-file=/etc/kubernetes/certs/ca.crt", "--container-log-max-files=20", "--container-log-max-size=1024Mi", "--image-gc-high-threshold=80", "--image-gc-low-threshold=60", "--kubeconfig=/var/lib/kubelet/kubeconfig", "--pod-manifest-path=/etc/kubernetes/manifests"` //nolint:lll
 	cases := []struct {
 		name                  string
 		config                *NodeBootstrappingConfiguration
@@ -2722,7 +2722,7 @@ func TestKubernetesConfigGetOrderedKubeletConfigString(t *testing.T) {
 			name:                  "zero value kubernetesConfig",
 			config:                &NodeBootstrappingConfiguration{},
 			CustomKubeletConfig:   nil,
-			expectedForPowershell: `"--healthz-bind-address=127.0.0.1", "--healthz-port=10248"`,
+			expectedForPowershell: "",
 		},
 		// Some values
 		{
@@ -2988,7 +2988,7 @@ func TestGetOrderedKubeletConfigStringForPowershell(t *testing.T) {
 				},
 			},
 			CustomKubeletConfig: nil,
-			expected:            `"--healthz-bind-address=127.0.0.1", "--healthz-port=10248"`,
+			expected:            "",
 		},
 		{
 			name: "KubeletConfig is not empty",
@@ -3007,7 +3007,7 @@ func TestGetOrderedKubeletConfigStringForPowershell(t *testing.T) {
 				ImageGcLowThreshold:  to.Int32Ptr(60),
 				ImageGcHighThreshold: to.Int32Ptr(80),
 			},
-			expected: `"--address=0.0.0.0", "--allow-privileged=true", "--cloud-config=c:\k\azure.json", "--healthz-bind-address=127.0.0.1", "--healthz-port=10248", "--image-gc-high-threshold=80", "--image-gc-low-threshold=60"`,
+			expected: `"--address=0.0.0.0", "--allow-privileged=true", "--cloud-config=c:\k\azure.json", "--image-gc-high-threshold=80", "--image-gc-low-threshold=60"`,
 		},
 		{
 			name: "custom configuration overrides default KubeletConfig",
@@ -3038,7 +3038,7 @@ func TestGetOrderedKubeletConfigStringForPowershell(t *testing.T) {
 				ContainerLogMaxSizeMB: to.Int32Ptr(1024),
 				ContainerLogMaxFiles:  to.Int32Ptr(20),
 			},
-			expected: `"--address=127.0.0.1", "--allow-privileged=true", "--cloud-config=c:\k\azure.json", "--container-log-max-files=20", "--container-log-max-size=1024Mi", "--healthz-bind-address=127.0.0.1", "--healthz-port=10248"`,
+			expected: `"--address=127.0.0.1", "--allow-privileged=true", "--cloud-config=c:\k\azure.json", "--container-log-max-files=20", "--container-log-max-size=1024Mi", "--healthz-bind-address=0.0.0.0", "--healthz-port=0"`,
 		},
 		{
 			name: "custom configuration does not override default KubeletConfig",
@@ -3071,7 +3071,7 @@ func TestGetOrderedKubeletConfigStringForPowershell(t *testing.T) {
 				ContainerLogMaxSizeMB: to.Int32Ptr(1024),
 				ContainerLogMaxFiles:  to.Int32Ptr(20),
 			},
-			expected: `"--address=0.0.0.0", "--allow-privileged=true", "--cloud-config=c:\k\azure.json", "--container-log-max-files=20", "--container-log-max-size=1024Mi", "--event-qps=100", "--healthz-bind-address=127.0.0.1", "--healthz-port=10248", "--image-gc-high-threshold=80", "--image-gc-low-threshold=60"`, //nolint:lll
+			expected: `"--address=0.0.0.0", "--allow-privileged=true", "--cloud-config=c:\k\azure.json", "--container-log-max-files=20", "--container-log-max-size=1024Mi", "--event-qps=100", "--image-gc-high-threshold=80", "--image-gc-low-threshold=60"`, //nolint:lll
 		},
 	}
 
@@ -3081,6 +3081,81 @@ func TestGetOrderedKubeletConfigStringForPowershell(t *testing.T) {
 			actual := c.config.GetOrderedKubeletConfigStringForPowershell(c.CustomKubeletConfig)
 			if c.expected != actual {
 				t.Fatalf("test case: %s, expected: %s. Got: %s.", c.name, c.expected, actual)
+			}
+		})
+	}
+}
+
+func TestGetKubeletHealthzEndpoint(t *testing.T) {
+	cases := []struct {
+		name     string
+		config   *NodeBootstrappingConfiguration
+		expected string
+	}{
+		{
+			name:     "uses kubelet defaults",
+			config:   &NodeBootstrappingConfiguration{},
+			expected: "http://127.0.0.1:10248/healthz",
+		},
+		{
+			name: "uses configured endpoint",
+			config: &NodeBootstrappingConfiguration{
+				KubeletConfig: map[string]string{
+					"--healthz-bind-address": "10.0.0.4",
+					"--healthz-port":         "10255",
+				},
+			},
+			expected: "http://10.0.0.4:10255/healthz",
+		},
+		{
+			name: "uses loopback for IPv4 wildcard",
+			config: &NodeBootstrappingConfiguration{
+				KubeletConfig: map[string]string{"--healthz-bind-address": "0.0.0.0"},
+			},
+			expected: "http://127.0.0.1:10248/healthz",
+		},
+		{
+			name: "uses loopback for IPv6 wildcard",
+			config: &NodeBootstrappingConfiguration{
+				KubeletConfig: map[string]string{"--healthz-bind-address": "::"},
+			},
+			expected: "http://[::1]:10248/healthz",
+		},
+		{
+			name: "returns empty endpoint when disabled",
+			config: &NodeBootstrappingConfiguration{
+				KubeletConfig: map[string]string{"--healthz-port": "0"},
+			},
+			expected: "",
+		},
+		{
+			name: "uses Windows component configuration",
+			config: &NodeBootstrappingConfiguration{
+				ContainerService: &ContainerService{
+					Properties: &Properties{
+						CustomConfiguration: &CustomConfiguration{
+							WindowsKubernetesConfigurations: map[string]*ComponentConfiguration{
+								string(Componentkubelet): {
+									Config: map[string]string{
+										"--healthz-bind-address": "0.0.0.0",
+										"--healthz-port":         "10255",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "http://127.0.0.1:10255/healthz",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			actual := c.config.GetKubeletHealthzEndpoint(nil)
+			if c.expected != actual {
+				t.Fatalf("expected %q, got %q", c.expected, actual)
 			}
 		})
 	}

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -3038,7 +3038,7 @@ func TestGetOrderedKubeletConfigStringForPowershell(t *testing.T) {
 				ContainerLogMaxSizeMB: to.Int32Ptr(1024),
 				ContainerLogMaxFiles:  to.Int32Ptr(20),
 			},
-			expected: `"--address=127.0.0.1", "--allow-privileged=true", "--cloud-config=c:\k\azure.json", "--container-log-max-files=20", "--container-log-max-size=1024Mi", "--healthz-bind-address=0.0.0.0", "--healthz-port=0"`,
+			expected: `"--address=127.0.0.1", "--allow-privileged=true", "--cloud-config=c:\k\azure.json", "--container-log-max-files=20", "--container-log-max-size=1024Mi", "--healthz-bind-address=0.0.0.0", "--healthz-port=0"`, //nolint:lll
 		},
 		{
 			name: "custom configuration does not override default KubeletConfig",

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -2711,7 +2711,7 @@ func TestKubernetesConfigIsAddonDisabled(t *testing.T) {
 }
 
 func TestKubernetesConfigGetOrderedKubeletConfigString(t *testing.T) {
-	alphabetizedStringForPowershell := `"--address=0.0.0.0", "--allow-privileged=true", "--anonymous-auth=false", "--authorization-mode=Webhook", "--cgroups-per-qos=true", "--client-ca-file=/etc/kubernetes/certs/ca.crt", "--container-log-max-files=20", "--container-log-max-size=1024Mi", "--image-gc-high-threshold=80", "--image-gc-low-threshold=60", "--kubeconfig=/var/lib/kubelet/kubeconfig", "--pod-manifest-path=/etc/kubernetes/manifests"` //nolint:lll
+	alphabetizedStringForPowershell := `"--address=0.0.0.0", "--allow-privileged=true", "--anonymous-auth=false", "--authorization-mode=Webhook", "--cgroups-per-qos=true", "--client-ca-file=/etc/kubernetes/certs/ca.crt", "--container-log-max-files=20", "--container-log-max-size=1024Mi", "--healthz-bind-address=127.0.0.1", "--healthz-port=10248", "--image-gc-high-threshold=80", "--image-gc-low-threshold=60", "--kubeconfig=/var/lib/kubelet/kubeconfig", "--pod-manifest-path=/etc/kubernetes/manifests"` //nolint:lll
 	cases := []struct {
 		name                  string
 		config                *NodeBootstrappingConfiguration
@@ -2722,7 +2722,7 @@ func TestKubernetesConfigGetOrderedKubeletConfigString(t *testing.T) {
 			name:                  "zero value kubernetesConfig",
 			config:                &NodeBootstrappingConfiguration{},
 			CustomKubeletConfig:   nil,
-			expectedForPowershell: "",
+			expectedForPowershell: `"--healthz-bind-address=127.0.0.1", "--healthz-port=10248"`,
 		},
 		// Some values
 		{
@@ -2988,7 +2988,7 @@ func TestGetOrderedKubeletConfigStringForPowershell(t *testing.T) {
 				},
 			},
 			CustomKubeletConfig: nil,
-			expected:            "",
+			expected:            `"--healthz-bind-address=127.0.0.1", "--healthz-port=10248"`,
 		},
 		{
 			name: "KubeletConfig is not empty",
@@ -3007,7 +3007,7 @@ func TestGetOrderedKubeletConfigStringForPowershell(t *testing.T) {
 				ImageGcLowThreshold:  to.Int32Ptr(60),
 				ImageGcHighThreshold: to.Int32Ptr(80),
 			},
-			expected: `"--address=0.0.0.0", "--allow-privileged=true", "--cloud-config=c:\k\azure.json", "--image-gc-high-threshold=80", "--image-gc-low-threshold=60"`,
+			expected: `"--address=0.0.0.0", "--allow-privileged=true", "--cloud-config=c:\k\azure.json", "--healthz-bind-address=127.0.0.1", "--healthz-port=10248", "--image-gc-high-threshold=80", "--image-gc-low-threshold=60"`,
 		},
 		{
 			name: "custom configuration overrides default KubeletConfig",
@@ -3017,7 +3017,11 @@ func TestGetOrderedKubeletConfigStringForPowershell(t *testing.T) {
 						CustomConfiguration: &CustomConfiguration{
 							WindowsKubernetesConfigurations: map[string]*ComponentConfiguration{
 								string(Componentkubelet): {
-									Config: map[string]string{"--address": "127.0.0.1"},
+									Config: map[string]string{
+										"--address":              "127.0.0.1",
+										"--healthz-bind-address": "0.0.0.0",
+										"--healthz-port":         "0",
+									},
 								},
 							},
 						},
@@ -3034,7 +3038,7 @@ func TestGetOrderedKubeletConfigStringForPowershell(t *testing.T) {
 				ContainerLogMaxSizeMB: to.Int32Ptr(1024),
 				ContainerLogMaxFiles:  to.Int32Ptr(20),
 			},
-			expected: `"--address=127.0.0.1", "--allow-privileged=true", "--cloud-config=c:\k\azure.json", "--container-log-max-files=20", "--container-log-max-size=1024Mi"`,
+			expected: `"--address=127.0.0.1", "--allow-privileged=true", "--cloud-config=c:\k\azure.json", "--container-log-max-files=20", "--container-log-max-size=1024Mi", "--healthz-bind-address=127.0.0.1", "--healthz-port=10248"`,
 		},
 		{
 			name: "custom configuration does not override default KubeletConfig",
@@ -3067,7 +3071,7 @@ func TestGetOrderedKubeletConfigStringForPowershell(t *testing.T) {
 				ContainerLogMaxSizeMB: to.Int32Ptr(1024),
 				ContainerLogMaxFiles:  to.Int32Ptr(20),
 			},
-			expected: `"--address=0.0.0.0", "--allow-privileged=true", "--cloud-config=c:\k\azure.json", "--container-log-max-files=20", "--container-log-max-size=1024Mi", "--event-qps=100", "--image-gc-high-threshold=80", "--image-gc-low-threshold=60"`, //nolint:lll
+			expected: `"--address=0.0.0.0", "--allow-privileged=true", "--cloud-config=c:\k\azure.json", "--container-log-max-files=20", "--container-log-max-size=1024Mi", "--event-qps=100", "--healthz-bind-address=127.0.0.1", "--healthz-port=10248", "--image-gc-high-threshold=80", "--image-gc-low-threshold=60"`, //nolint:lll
 		},
 	}
 

--- a/staging/cse/windows/debug/collect-windows-logs.ps1
+++ b/staging/cse/windows/debug/collect-windows-logs.ps1
@@ -43,6 +43,7 @@ $lockedFiles = @(
   "kubeproxy.err.log",
   "azure-vnet-telemetry.log",
   "azure-vnet.log",
+  "azure-vnet-ipam.log",
   "csi-proxy.log",
   "csi-proxy.err.log",
   "containerd.log",

--- a/staging/cse/windows/provisioningscripts/loggenerator.ps1
+++ b/staging/cse/windows/provisioningscripts/loggenerator.ps1
@@ -76,6 +76,7 @@ $kLogFiles = @(
     "kubeproxy.err.log",
     "azure-vnet-telemetry.log",
     "azure-vnet.log",
+    "azure-vnet-ipam.log",
     "csi-proxy.log",
     "csi-proxy.err.log",
     "containerd.log",

--- a/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
+++ b/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
@@ -142,6 +142,9 @@ Write-Log "Starting kubelet service"
 try {
     Start-Service kubelet -ErrorAction Stop
     Write-Log "Do not start kubeproxy service since kubelet will restart kubeproxy"
+} catch {
+    Write-Log "Failed to start kubelet service: $_"
+    throw
 } finally {
     Register-HNSRemediatorScriptTask
     Write-Log "Exiting windowsnodereset.ps1"

--- a/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
+++ b/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
@@ -139,7 +139,7 @@ if ($global:CsiProxyEnabled) {
 }
 
 Write-Log "Starting kubelet service"
-Start-Service kubelet
+Start-Service kubelet -ErrorAction Stop
 
 Write-Log "Do not start kubeproxy service since kubelet will restart kubeproxy"
 

--- a/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
+++ b/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
@@ -139,10 +139,10 @@ if ($global:CsiProxyEnabled) {
 }
 
 Write-Log "Starting kubelet service"
-Start-Service kubelet -ErrorAction Stop
-
-Write-Log "Do not start kubeproxy service since kubelet will restart kubeproxy"
-
-Register-HNSRemediatorScriptTask
-
-Write-Log "Exiting windowsnodereset.ps1"
+try {
+    Start-Service kubelet -ErrorAction Stop
+    Write-Log "Do not start kubeproxy service since kubelet will restart kubeproxy"
+} finally {
+    Register-HNSRemediatorScriptTask
+    Write-Log "Exiting windowsnodereset.ps1"
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Windows CSE can fail after node reset because NSSM reports kubelet as running before it is healthy. Kubelet may exit while containerd creates its pipe, then recover on the next NSSM attempt.

This PR:
- waits for the reset task, then polls kubelet's effective `/healthz` endpoint;
- preserves the service-state fallback when healthz is disabled;
- surfaces direct kubelet startup errors and restores HNS remediation after kubelet startup;
- preserves Windows E2E diagnostics across AzCopy timeouts and locked logs.

The endpoint and helper ship together in CustomData, including for old and PIS-cached VHDs.

**Which issue(s) this PR fixes**:

N/A. Related: #8970, #9344

**Testing**:

- 53 Windows CSE helper tests passed
- `go test ./pkg/agent/datamodel ./pkg/agent`
- Windows Server 2025 Gen2 VHD E2E passed