### PR TITLE
fix(windows): wait for kubelet healthz after node reset

### DIFF
--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -333,9 +333,16 @@ function Start-NodeResetScriptTask {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "NodeResetScriptTask failed with result $($taskInfo.LastTaskResult)"
     }
 
-    $kubeletService=Get-Service -Name "kubelet" -ErrorAction SilentlyContinue
-    if ($null -eq $kubeletService -or $kubeletService.Status -ne "Running") {
-        Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not running after NodeResetScriptTask completed"
+    $healthCheckArgs=@{
+        Uri="http://127.0.0.1:10248/healthz"
+        UseBasicParsing=$true
+        TimeoutSec=2
+        ErrorAction="Stop"
+    }
+    try {
+        Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 12 -RetryDelaySeconds 2 | Out-Null
+    } catch {
+        Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not become healthy after NodeResetScriptTask completed. Error: $($_.Exception.Message)"
     }
 
     Write-Log -Message "We waited [$($timer.Elapsed.TotalSeconds)] seconds on NodeResetScriptTask"

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -602,7 +602,7 @@ Describe "Start-NodeResetScriptTask" {
       }
       return [pscustomobject]@{ LastRunTime = [datetime]"2026-01-02"; LastTaskResult = 0 }
     }
-    Mock Get-Service -MockWith { return [pscustomobject]@{ Status = "Running" } }
+    Mock Invoke-WebRequest -MockWith { return [pscustomobject]@{ StatusCode = 200 } }
     Mock Start-Sleep -MockWith {}
     Mock Write-Log -MockWith {}
     Mock Set-ExitCode -MockWith {
@@ -611,10 +611,12 @@ Describe "Start-NodeResetScriptTask" {
     }
   }
 
-  It "waits for a new successful run and running kubelet" {
+  It "waits for a new successful run and healthy kubelet" {
     Start-NodeResetScriptTask
-
     Assert-MockCalled -CommandName Start-ScheduledTask -Exactly -Times 1
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 1 -ParameterFilter {
+      $Uri -eq "http://127.0.0.1:10248/healthz" -and $TimeoutSec -eq 2 -and $ErrorAction -eq "Stop"
+    }
     Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
   }
 
@@ -659,11 +661,29 @@ Describe "Start-NodeResetScriptTask" {
     }
 
     { Start-NodeResetScriptTask } | Should -Throw "*failed with result 1*"
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 0
   }
 
-  It "fails when kubelet is not running" {
-    Mock Get-Service -MockWith { return [pscustomobject]@{ Status = "Stopped" } }
+  It "retries until kubelet becomes healthy" {
+    $script:healthCheckCallCount = 0
+    Mock Invoke-WebRequest -MockWith {
+      $script:healthCheckCallCount++
+      if ($script:healthCheckCallCount -lt 3) {
+        throw "connection refused"
+      }
+      return [pscustomobject]@{ StatusCode = 200 }
+    }
 
-    { Start-NodeResetScriptTask } | Should -Throw "*kubelet service is not running*"
+    Start-NodeResetScriptTask
+
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 3
+    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 2 -ParameterFilter { $Seconds -eq 2 }
+  }
+
+  It "fails when kubelet does not become healthy" {
+    Mock Invoke-WebRequest -MockWith { throw "connection refused" }
+
+    { Start-NodeResetScriptTask } | Should -Throw "*kubelet did not become healthy*connection refused*"
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 12
   }
 }

--- a/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
+++ b/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
@@ -139,10 +139,13 @@ if ($global:CsiProxyEnabled) {
 }
 
 Write-Log "Starting kubelet service"
-Start-Service kubelet
-
-Write-Log "Do not start kubeproxy service since kubelet will restart kubeproxy"
-
-Register-HNSRemediatorScriptTask
-
-Write-Log "Exiting windowsnodereset.ps1"
+try {
+    Start-Service kubelet -ErrorAction Stop
+    Write-Log "Do not start kubeproxy service since kubelet will restart kubeproxy"
+} catch {
+    Write-Log "Failed to start kubelet service: $_"
+    throw
+} finally {
+    Register-HNSRemediatorScriptTask
+    Write-Log "Exiting windowsnodereset.ps1"
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Windows CSE cannot use NSSM service state to decide whether kubelet is healthy. NSSM reports `Running` after it launches the process and `Paused` during restart delay. A healthy recovery after the containerd named-pipe race can fail a one-time service check, while a kubelet that is about to crash can pass it.

RP node readiness eventually replaces the node, but only after extra time and API calls.

This PR:
- waits for `k8s-restart-job` to succeed, then polls kubelet's local `http://127.0.0.1:10248/healthz`
- completes immediately on the first HTTP 200 (no added delay on the healthy path)
- retries up to 12 times with a 2s delay and 2s request timeout to cover the expected NSSM restart
- fails CSE with `WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK` if kubelet never becomes healthy
- makes `Start-Service kubelet` terminating and logs direct SCM failures
- restores the HNS remediator task in `finally`, including when kubelet startup fails

The health check runs from current CustomData and works with old VHDs. The stricter `Start-Service` handling is VHD-baked and applies to updated VHDs.

`/healthz` proves local kubelet health. It does not prove node registration or Kubernetes `Ready`. RP still owns that check.

Validated that AKS does not override kubelet `--healthz-port` / `--healthz-bind-address` for Windows:
- RP `defaults_kubelet.go` leaves the kubelet defaults (`127.0.0.1:10248`)
- `CustomKubeletConfig` does not expose healthz settings
- kubelet still serves `/healthz` by default through current supported versions

Related: #9354, #8970, #9344

**Which issue(s) this PR fixes**:

N/A

**Testing**:

- PowerShell parsing passed for `windowscsehelper.ps1`, `windowscsehelper.tests.ps1`, and `windowsnodereset.ps1`
- Added Pester coverage for immediate `/healthz` success, retry through transient failures, exhausted retries, and skipping the health check when the reset task itself fails