### PR TITLE
fix(windows): probe kubelet healthz after the node reset task

### DIFF
--- a/parts/windows/kuberneteswindowssetup.ps1.template
+++ b/parts/windows/kuberneteswindowssetup.ps1.template
@@ -110,6 +110,8 @@ $global:KubeletNodeLabels="{{GetAgentKubernetesLabels .}}"
 $global:KubeletNodeLabels="{{GetAgentKubernetesLabelsDeprecated .}}"
 {{end}}
 $global:KubeletConfigArgs=@( {{GetKubeletConfigKeyValsPsh}} )
+# Empty when kubelet serves no healthz endpoint, in which case CSE falls back to the service state.
+$global:KubeletHealthzUri="{{GetKubeletHealthzUriPsh}}"
 $global:KubeproxyConfigArgs=@( {{GetKubeproxyConfigKeyValsPsh}} )
 
 $global:KubeproxyFeatureGates=@( {{GetKubeProxyFeatureGatesPsh}} )

--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -333,16 +333,25 @@ function Start-NodeResetScriptTask {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "NodeResetScriptTask failed with result $($taskInfo.LastTaskResult)"
     }
 
-    $healthCheckArgs=@{
-        Uri="http://127.0.0.1:10248/healthz"
-        UseBasicParsing=$true
-        TimeoutSec=2
-        ErrorAction="Stop"
-    }
-    try {
-        Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 12 -RetryDelaySeconds 2 | Out-Null
-    } catch {
-        Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not become healthy after NodeResetScriptTask completed. Error: $($_.Exception.Message)"
+    if ([string]::IsNullOrWhiteSpace($global:KubeletHealthzUri)) {
+        # kubelet serves no healthz endpoint, so the service state is the only local signal left.
+        Write-Log -Message "kubelet healthz endpoint is disabled, checking the kubelet service state instead"
+        $kubeletService=Get-Service -Name "kubelet" -ErrorAction SilentlyContinue
+        if ($null -eq $kubeletService -or $kubeletService.Status -ne "Running") {
+            Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not running after NodeResetScriptTask completed"
+        }
+    } else {
+        $healthCheckArgs=@{
+            Uri=$global:KubeletHealthzUri
+            UseBasicParsing=$true
+            TimeoutSec=2
+            ErrorAction="Stop"
+        }
+        try {
+            Retry-Command -Command "Invoke-WebRequest" -Args $healthCheckArgs -Retries 12 -RetryDelaySeconds 2 | Out-Null
+        } catch {
+            Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not become healthy after NodeResetScriptTask completed. Error: $($_.Exception.Message)"
+        }
     }
 
     Write-Log -Message "We waited [$($timer.Elapsed.TotalSeconds)] seconds on NodeResetScriptTask"

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -593,6 +593,7 @@ Describe "Update-BaseUrl" {
 Describe "Start-NodeResetScriptTask" {
   BeforeEach {
     $script:taskInfoCallCount = 0
+    $global:KubeletHealthzUri = "http://127.0.0.1:10248/healthz"
     Mock Start-ScheduledTask -MockWith {}
     Mock Get-ScheduledTask -MockWith { return [pscustomobject]@{ State = "Ready" } }
     Mock Get-ScheduledTaskInfo -MockWith {
@@ -685,5 +686,32 @@ Describe "Start-NodeResetScriptTask" {
 
     { Start-NodeResetScriptTask } | Should -Throw "*kubelet did not become healthy*connection refused*"
     Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 12
+  }
+
+  It "probes the configured healthz endpoint" {
+    $global:KubeletHealthzUri = "http://127.0.0.2:10267/healthz"
+
+    Start-NodeResetScriptTask
+
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 1 -ParameterFilter {
+      $Uri -eq "http://127.0.0.2:10267/healthz"
+    }
+  }
+
+  It "checks the service state when the healthz server is disabled" {
+    $global:KubeletHealthzUri = ""
+    Mock Get-Service -MockWith { return [pscustomobject]@{ Status = "Running" } }
+
+    Start-NodeResetScriptTask
+
+    Assert-MockCalled -CommandName Invoke-WebRequest -Exactly -Times 0
+    Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
+  }
+
+  It "fails when the healthz server is disabled and kubelet is not running" {
+    $global:KubeletHealthzUri = ""
+    Mock Get-Service -MockWith { return [pscustomobject]@{ Status = "Stopped" } }
+
+    { Start-NodeResetScriptTask } | Should -Throw "*kubelet service is not running*"
   }
 }

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -950,6 +950,9 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 		"GetKubeletConfigKeyValsPsh": func() string {
 			return config.GetOrderedKubeletConfigStringForPowershell(profile.CustomKubeletConfig)
 		},
+		"GetKubeletHealthzUriPsh": func() string {
+			return config.GetKubeletHealthzURIForPowershell(profile.CustomKubeletConfig)
+		},
 		"GetKubeproxyConfigKeyValsPsh": func() string {
 			return config.GetOrderedKubeproxyConfigStringForPowershell()
 		},

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -951,7 +951,7 @@ func getContainerServiceFuncMap(config *datamodel.NodeBootstrappingConfiguration
 			return config.GetOrderedKubeletConfigStringForPowershell(profile.CustomKubeletConfig)
 		},
 		"GetKubeletHealthzUriPsh": func() string {
-			return config.GetKubeletHealthzURIForPowershell(profile.CustomKubeletConfig)
+			return config.GetKubeletHealthzURIForWindows(profile.CustomKubeletConfig)
 		},
 		"GetKubeproxyConfigKeyValsPsh": func() string {
 			return config.GetOrderedKubeproxyConfigStringForPowershell()

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math/rand"
+	"net"
 	neturl "net/url"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -100,6 +102,12 @@ type OSType string
 const (
 	Windows OSType = "Windows"
 	Linux   OSType = "Linux"
+)
+
+// kubelet's own defaults for --healthz-bind-address and --healthz-port.
+const (
+	defaultKubeletHealthzBindAddress = "127.0.0.1"
+	defaultKubeletHealthzPort        = 10248
 )
 
 // KubeletDiskType describes options for placement of the primary kubelet partition.
@@ -1574,10 +1582,11 @@ func setCustomKubletConfigFromSettings(customKc *CustomKubeletConfig, kubeletCon
 }
 
 /*
-GetOrderedKubeletConfigStringForPowershell returns an ordered string of key/val pairs for Powershell
-script consumption.
+getKubeletConfigForPowershell returns the merged kubelet configuration for a Windows node. Windows
+kubelet is configured through command line flags only, so this map is the single source of truth for
+every kubelet setting on the node.
 */
-func (config *NodeBootstrappingConfiguration) GetOrderedKubeletConfigStringForPowershell(customKc *CustomKubeletConfig) string {
+func (config *NodeBootstrappingConfiguration) getKubeletConfigForPowershell(customKc *CustomKubeletConfig) map[string]string {
 	kubeletConfig := config.KubeletConfig
 	if kubeletConfig == nil {
 		kubeletConfig = map[string]string{}
@@ -1587,15 +1596,59 @@ func (config *NodeBootstrappingConfiguration) GetOrderedKubeletConfigStringForPo
 	if config.ContainerService != nil && config.ContainerService.Properties != nil {
 		kubeletCustomConfiguration := config.ContainerService.Properties.GetComponentWindowsKubernetesConfiguration(Componentkubelet)
 		if kubeletCustomConfiguration != nil {
-			config := kubeletCustomConfiguration.Config
-			for k, v := range config {
+			for k, v := range kubeletCustomConfiguration.Config {
 				kubeletConfig[k] = v
 			}
 		}
 	}
 
 	// Settings from customKubeletConfig, only take if it's set.
-	kubeletConfig = setCustomKubletConfigFromSettings(customKc, kubeletConfig)
+	return setCustomKubletConfigFromSettings(customKc, kubeletConfig)
+}
+
+/*
+GetKubeletHealthzURIForPowershell returns the local URI that Windows CSE polls to confirm kubelet
+initialized after the node reset task started it. It returns an empty string when kubelet serves no
+healthz endpoint, which is the case when --healthz-port is not positive.
+*/
+func (config *NodeBootstrappingConfiguration) GetKubeletHealthzURIForPowershell(customKc *CustomKubeletConfig) string {
+	kubeletConfig := config.getKubeletConfigForPowershell(customKc)
+
+	// Defaults match kubelet's own defaults for --healthz-port and --healthz-bind-address.
+	port := defaultKubeletHealthzPort
+	if parsed, err := strconv.Atoi(unquoteKubeletConfigValue(kubeletConfig["--healthz-port"])); err == nil {
+		port = parsed
+	}
+	if port <= 0 {
+		return ""
+	}
+
+	host := defaultKubeletHealthzBindAddress
+	if bindAddress := unquoteKubeletConfigValue(kubeletConfig["--healthz-bind-address"]); bindAddress != "" {
+		host = bindAddress
+	}
+	// A wildcard bind address is still reachable over loopback.
+	if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
+		host = defaultKubeletHealthzBindAddress
+	}
+
+	return fmt.Sprintf("http://%s/healthz", net.JoinHostPort(host, strconv.Itoa(port)))
+}
+
+/*
+unquoteKubeletConfigValue strips the quoting used to pass empty or literal values through to the
+Windows kubelet command line, so that an explicitly emptied flag reads as unset.
+*/
+func unquoteKubeletConfigValue(value string) string {
+	return strings.Trim(strings.TrimSpace(value), `"`)
+}
+
+/*
+GetOrderedKubeletConfigStringForPowershell returns an ordered string of key/val pairs for Powershell
+script consumption.
+*/
+func (config *NodeBootstrappingConfiguration) GetOrderedKubeletConfigStringForPowershell(customKc *CustomKubeletConfig) string {
+	kubeletConfig := config.getKubeletConfigForPowershell(customKc)
 
 	if len(kubeletConfig) == 0 {
 		return ""

--- a/pkg/agent/datamodel/types.go
+++ b/pkg/agent/datamodel/types.go
@@ -1582,11 +1582,11 @@ func setCustomKubletConfigFromSettings(customKc *CustomKubeletConfig, kubeletCon
 }
 
 /*
-getKubeletConfigForPowershell returns the merged kubelet configuration for a Windows node. Windows
+getWindowsKubeletConfig returns the merged kubelet configuration for a Windows node. Windows
 kubelet is configured through command line flags only, so this map is the single source of truth for
 every kubelet setting on the node.
 */
-func (config *NodeBootstrappingConfiguration) getKubeletConfigForPowershell(customKc *CustomKubeletConfig) map[string]string {
+func (config *NodeBootstrappingConfiguration) getWindowsKubeletConfig(customKc *CustomKubeletConfig) map[string]string {
 	kubeletConfig := config.KubeletConfig
 	if kubeletConfig == nil {
 		kubeletConfig = map[string]string{}
@@ -1607,12 +1607,12 @@ func (config *NodeBootstrappingConfiguration) getKubeletConfigForPowershell(cust
 }
 
 /*
-GetKubeletHealthzURIForPowershell returns the local URI that Windows CSE polls to confirm kubelet
+GetKubeletHealthzURIForWindows returns the local URI that Windows CSE polls to confirm kubelet
 initialized after the node reset task started it. It returns an empty string when kubelet serves no
 healthz endpoint, which is the case when --healthz-port is not positive.
 */
-func (config *NodeBootstrappingConfiguration) GetKubeletHealthzURIForPowershell(customKc *CustomKubeletConfig) string {
-	kubeletConfig := config.getKubeletConfigForPowershell(customKc)
+func (config *NodeBootstrappingConfiguration) GetKubeletHealthzURIForWindows(customKc *CustomKubeletConfig) string {
+	kubeletConfig := config.getWindowsKubeletConfig(customKc)
 
 	// Defaults match kubelet's own defaults for --healthz-port and --healthz-bind-address.
 	port := defaultKubeletHealthzPort
@@ -1648,7 +1648,7 @@ GetOrderedKubeletConfigStringForPowershell returns an ordered string of key/val 
 script consumption.
 */
 func (config *NodeBootstrappingConfiguration) GetOrderedKubeletConfigStringForPowershell(customKc *CustomKubeletConfig) string {
-	kubeletConfig := config.getKubeletConfigForPowershell(customKc)
+	kubeletConfig := config.getWindowsKubeletConfig(customKc)
 
 	if len(kubeletConfig) == 0 {
 		return ""

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -3082,6 +3082,106 @@ func TestGetOrderedKubeletConfigStringForPowershell(t *testing.T) {
 	}
 }
 
+func TestGetKubeletHealthzURIForPowershell(t *testing.T) {
+	cases := []struct {
+		name          string
+		kubeletConfig map[string]string
+		expected      string
+	}{
+		{
+			name:          "no kubelet config at all",
+			kubeletConfig: nil,
+			expected:      "http://127.0.0.1:10248/healthz",
+		},
+		{
+			name:          "kubelet defaults when healthz is not configured",
+			kubeletConfig: map[string]string{"--anonymous-auth": "false"},
+			expected:      "http://127.0.0.1:10248/healthz",
+		},
+		{
+			name: "overridden port and bind address",
+			kubeletConfig: map[string]string{
+				"--healthz-port":         "10267",
+				"--healthz-bind-address": "10.0.0.4",
+			},
+			expected: "http://10.0.0.4:10267/healthz",
+		},
+		{
+			name:          "wildcard bind address is probed over loopback",
+			kubeletConfig: map[string]string{"--healthz-bind-address": "0.0.0.0"},
+			expected:      "http://127.0.0.1:10248/healthz",
+		},
+		{
+			name:          "IPv6 wildcard bind address is probed over loopback",
+			kubeletConfig: map[string]string{"--healthz-bind-address": "::"},
+			expected:      "http://127.0.0.1:10248/healthz",
+		},
+		{
+			name:          "IPv6 bind address is bracketed",
+			kubeletConfig: map[string]string{"--healthz-bind-address": "::1"},
+			expected:      "http://[::1]:10248/healthz",
+		},
+		{
+			name: "quoted empty values fall back to the kubelet defaults",
+			kubeletConfig: map[string]string{
+				"--healthz-bind-address": `""""`,
+				"--healthz-port":         "",
+			},
+			expected: "http://127.0.0.1:10248/healthz",
+		},
+		{
+			name:          "unparsable port falls back to the kubelet default",
+			kubeletConfig: map[string]string{"--healthz-port": "not-a-port"},
+			expected:      "http://127.0.0.1:10248/healthz",
+		},
+		{
+			name:          "healthz server disabled with port 0",
+			kubeletConfig: map[string]string{"--healthz-port": "0"},
+			expected:      "",
+		},
+		{
+			name:          "healthz server disabled with a negative port",
+			kubeletConfig: map[string]string{"--healthz-port": "-1"},
+			expected:      "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			config := &NodeBootstrappingConfiguration{
+				ContainerService: &ContainerService{Properties: &Properties{}},
+				KubeletConfig:    c.kubeletConfig,
+			}
+			if actual := config.GetKubeletHealthzURIForPowershell(nil); actual != c.expected {
+				t.Fatalf("expected: %q. Got: %q.", c.expected, actual)
+			}
+		})
+	}
+}
+
+func TestGetKubeletHealthzURIForPowershellHonorsWindowsCustomConfiguration(t *testing.T) {
+	config := &NodeBootstrappingConfiguration{
+		ContainerService: &ContainerService{
+			Properties: &Properties{
+				CustomConfiguration: &CustomConfiguration{
+					WindowsKubernetesConfigurations: map[string]*ComponentConfiguration{
+						string(Componentkubelet): {
+							Config: map[string]string{"--healthz-port": "10267"},
+						},
+					},
+				},
+			},
+		},
+		KubeletConfig: map[string]string{"--healthz-port": "10248"},
+	}
+
+	expected := "http://127.0.0.1:10267/healthz"
+	if actual := config.GetKubeletHealthzURIForPowershell(nil); actual != expected {
+		t.Fatalf("expected: %q. Got: %q.", expected, actual)
+	}
+}
+
 func TestSecurityProfileGetProxyAddress(t *testing.T) {
 	testProxyAddress := "https://test-private-egress-proxy"
 	cases := []struct {

--- a/pkg/agent/datamodel/types_test.go
+++ b/pkg/agent/datamodel/types_test.go
@@ -3082,7 +3082,7 @@ func TestGetOrderedKubeletConfigStringForPowershell(t *testing.T) {
 	}
 }
 
-func TestGetKubeletHealthzURIForPowershell(t *testing.T) {
+func TestGetKubeletHealthzURIForWindows(t *testing.T) {
 	cases := []struct {
 		name          string
 		kubeletConfig map[string]string
@@ -3153,14 +3153,14 @@ func TestGetKubeletHealthzURIForPowershell(t *testing.T) {
 				ContainerService: &ContainerService{Properties: &Properties{}},
 				KubeletConfig:    c.kubeletConfig,
 			}
-			if actual := config.GetKubeletHealthzURIForPowershell(nil); actual != c.expected {
+			if actual := config.GetKubeletHealthzURIForWindows(nil); actual != c.expected {
 				t.Fatalf("expected: %q. Got: %q.", c.expected, actual)
 			}
 		})
 	}
 }
 
-func TestGetKubeletHealthzURIForPowershellHonorsWindowsCustomConfiguration(t *testing.T) {
+func TestGetKubeletHealthzURIForWindowsHonorsCustomConfiguration(t *testing.T) {
 	config := &NodeBootstrappingConfiguration{
 		ContainerService: &ContainerService{
 			Properties: &Properties{
@@ -3177,7 +3177,7 @@ func TestGetKubeletHealthzURIForPowershellHonorsWindowsCustomConfiguration(t *te
 	}
 
 	expected := "http://127.0.0.1:10267/healthz"
-	if actual := config.GetKubeletHealthzURIForPowershell(nil); actual != expected {
+	if actual := config.GetKubeletHealthzURIForWindows(nil); actual != expected {
 		t.Fatalf("expected: %q. Got: %q.", expected, actual)
 	}
 }

--- a/pkg/agent/windows_kubelet_healthz_test.go
+++ b/pkg/agent/windows_kubelet_healthz_test.go
@@ -1,0 +1,64 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Azure/agentbaker/pkg/agent/datamodel"
+)
+
+// Windows CSE polls this URI to confirm kubelet initialized after the node reset task started it,
+// so the rendered value has to stay in sync with the kubelet flags rendered next to it.
+func TestWindowsCustomDataRendersKubeletHealthzUri(t *testing.T) {
+	cases := []struct {
+		name          string
+		kubeletConfig map[string]string
+		expected      string
+	}{
+		{
+			name:          "kubelet defaults when healthz is not configured",
+			kubeletConfig: map[string]string{"--address": "0.0.0.0"},
+			expected:      "http://127.0.0.1:10248/healthz",
+		},
+		{
+			name: "overridden port and bind address",
+			kubeletConfig: map[string]string{
+				"--healthz-port":         "10267",
+				"--healthz-bind-address": "127.0.0.2",
+			},
+			expected: "http://127.0.0.2:10267/healthz",
+		},
+		{
+			name:          "empty when the healthz server is disabled",
+			kubeletConfig: map[string]string{"--healthz-port": "0"},
+			expected:      "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			cs := &datamodel.ContainerService{
+				Location:   "eastus",
+				Properties: datamodel.GetK8sDefaultProperties(true),
+			}
+			cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.31.0"
+			config := &datamodel.NodeBootstrappingConfiguration{
+				ContainerService: cs,
+				AgentPoolProfile: cs.Properties.AgentPoolProfiles[0],
+				K8sComponents:    &datamodel.K8sComponents{},
+				CloudSpecConfig:  datamodel.AzurePublicCloudSpecForTest,
+				KubeletConfig:    c.kubeletConfig,
+			}
+
+			customData := InitializeTemplateGenerator().getWindowsNodeCustomDataJSONObject(config)
+
+			expected := fmt.Sprintf(`$global:KubeletHealthzUri=\"%s\"`, c.expected)
+			if !strings.Contains(customData, expected) {
+				t.Fatalf("rendered Windows CustomData does not contain %q", expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Stacked on #9354.

## What

Windows CSE cannot use the kubelet service state to decide whether kubelet is healthy. NSSM reports `Running` as soon as it launches the kubelet process, and `Paused` while it waits to restart a process that exited. A healthy recovery from the containerd startup race therefore fails a one-time service check, while a kubelet about to crash passes it.

After `k8s-restart-job` succeeds, CSE now polls kubelet's local healthz endpoint. The first HTTP 200 completes the check immediately, so a healthy kubelet adds no delay. Up to 12 attempts with a 2s delay and 2s timeout bound the failure case, which returns `WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK` before RP starts waiting on node readiness.

## Where the URI comes from

The endpoint is derived in Go, from the same merged kubelet config map that renders `$global:KubeletConfigArgs`, and rendered into CustomData as `$global:KubeletHealthzUri`:

```powershell
$global:KubeletConfigArgs=@( ... )
# Empty when kubelet serves no healthz endpoint, in which case CSE falls back to the service state.
$global:KubeletHealthzUri="http://127.0.0.1:10248/healthz"
```

Doing this in Go rather than PowerShell means reading a `map[string]string` instead of regex-parsing already-rendered flags — no quote stripping, no hand-rolled IPv6 bracketing (`net.JoinHostPort`), no wildcard-address string matching (`net.IP.IsUnspecified`). It reads the same merged map that produces the flags, so it stays correct if the flags change. An empty value means `--healthz-port` is not positive; CSE then falls back to the old service-state check.

Both `kuberneteswindowssetup.ps1.template` and `windowscsehelper.ps1` ship together in the same CustomData package, so this works on old VHDs. `Start-Service kubelet -ErrorAction Stop` still surfaces direct SCM failures.

## Why derive it at all

Today nothing sets healthz flags: RP's `defaults_kubelet.go` sets none, `CustomKubeletConfig` is a fixed struct with no healthz fields, and the Windows custom-config backdoor is closed — `AvailableWindowsCustomConfigComponents` is an empty slice, so every `WindowsKubernetesConfigurations` component is rejected at validation.

So this is not defending against a customer-reachable override. It is defending against an AgentBaker or RP code change adding a healthz flag and silently breaking CSE, which a hardcoded URI would not survive. That is a real but narrow risk, and the derivation is cheap.

## Correction to #9354

The description on #9354 says the 10248 check "includes the kubelet sync loop". That is wrong. Port 10248 uses `healthz.InstallHandler(mux)` with no checkers — it is a liveness ping. The `syncloop` checker is on the authenticated 10250 server (`pkg/kubelet/server/server.go`).

The check is still worth having: the listener starts only after `RunKubelet(...)` returns, so a 200 proves kubelet got past runtime-service initialization against containerd. That is exactly the race in the repro. It does not prove the node registered or reached `Ready` — RP still owns that.

## Endpoint contract

Verified in `cmd/kubelet/app/server.go` at v1.28.0, v1.30.0, v1.32.0, v1.34.0 and `master`: the listener is OS-independent, gated on `if s.HealthzPort > 0`, and started after `RunKubelet` returns. No deprecation upstream.

## Testing

- `TestGetKubeletHealthzURIForPowershell` — 10 cases covering defaults, overrides, IPv4/IPv6 wildcards, IPv6 bracketing, RP's `""""` unset marker, unparsable ports, and disabled (0, negative).
- `TestGetKubeletHealthzURIForPowershellHonorsWindowsCustomConfiguration`.
- `TestWindowsCustomDataRendersKubeletHealthzUri` — renders the actual Windows CustomData template and asserts the emitted line. This is the first Go test that renders that template at all, so it also guards the `GetKubeletHealthzUriPsh` func registration, which otherwise fails only at runtime.
- Pester cases for the healthy path, retry-until-healthy, bounded failure, a non-default URI, and both healthz-disabled branches.
