### PR TITLE
fix(windows): gate provisioning on kubelet readiness instead of NSSM service state

### DIFF
--- a/parts/windows/windowscsehelper.ps1
+++ b/parts/windows/windowscsehelper.ps1
@@ -298,6 +298,55 @@ function Set-ExitCode {
     exit $ExitCode
 }
 
+# Kubelet installs its healthz handler only after PreInitRuntimeService has connected to the
+# container runtime, so a 200 proves kubelet cleared `\\.\pipe\containerd-containerd` and finished
+# local initialization. NSSM service state cannot show that: `Running` can precede a crash, and
+# `Paused` is normal while NSSM waits out AppRestartDelay before restarting kubelet.
+$global:KubeletHealthzUri="http://127.0.0.1:10248/healthz"
+
+function Test-KubeletHealthz {
+    try {
+        $request=[System.Net.WebRequest]::Create($global:KubeletHealthzUri)
+        $request.Proxy=$null # a loopback probe must never go through a node proxy
+        $request.Timeout=5000
+        $response=$request.GetResponse()
+        try {
+            return ([int]$response.StatusCode -eq 200)
+        } finally {
+            $response.Close()
+        }
+    } catch {
+        return $false
+    }
+}
+
+function Wait-ForKubeletReady {
+    Param(
+        # Covers the worst legitimate startup: kubeletstart.ps1 runs securetlsbootstrap.ps1
+        # synchronously before launching kubelet.exe, and the bootstrap client's default RPC
+        # timeouts total 480 seconds.
+        [Parameter(Mandatory=$false)][int]
+        $TimeoutSeconds=600
+    )
+
+    Logs-To-Event -TaskName "AKS.WindowsCSE.WaitForKubeletReady" -TaskMessage "Start to wait for kubelet to report ready at $global:KubeletHealthzUri"
+
+    $timer=[Diagnostics.Stopwatch]::StartNew()
+    while (-not (Test-KubeletHealthz)) {
+        if ($timer.Elapsed.TotalSeconds -gt $TimeoutSeconds) {
+            $status=(Get-Service -Name "kubelet" -ErrorAction SilentlyContinue).Status
+            Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet did not report ready at $global:KubeletHealthzUri within [$TimeoutSeconds] seconds. kubelet service status: $status"
+        }
+
+        # A failed probe never ends the wait: kubelet may be exiting and restarting under NSSM.
+        Write-Log "Waiting on kubelet to report ready..."
+        Start-Sleep -Seconds 3
+    }
+    $timer.Stop()
+
+    Write-Log "kubelet reported ready after [$($timer.Elapsed.TotalSeconds)] seconds"
+}
+
 function Start-NodeResetScriptTask {
     Param(
         [Parameter(Mandatory=$false)][int]
@@ -333,12 +382,9 @@ function Start-NodeResetScriptTask {
         Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "NodeResetScriptTask failed with result $($taskInfo.LastTaskResult)"
     }
 
-    $kubeletService=Get-Service -Name "kubelet" -ErrorAction SilentlyContinue
-    if ($null -eq $kubeletService -or $kubeletService.Status -ne "Running") {
-        Set-ExitCode -ExitCode $global:WINDOWS_CSE_ERROR_START_NODE_RESET_SCRIPT_TASK -ErrorMessage "kubelet service is not running after NodeResetScriptTask completed"
-    }
-
     Write-Log -Message "We waited [$($timer.Elapsed.TotalSeconds)] seconds on NodeResetScriptTask"
+
+    Wait-ForKubeletReady
 }
 
 function Postpone-RestartComputer {

--- a/parts/windows/windowscsehelper.tests.ps1
+++ b/parts/windows/windowscsehelper.tests.ps1
@@ -602,19 +602,20 @@ Describe "Start-NodeResetScriptTask" {
       }
       return [pscustomobject]@{ LastRunTime = [datetime]"2026-01-02"; LastTaskResult = 0 }
     }
-    Mock Get-Service -MockWith { return [pscustomobject]@{ Status = "Running" } }
     Mock Start-Sleep -MockWith {}
     Mock Write-Log -MockWith {}
+    Mock Wait-ForKubeletReady -MockWith {}
     Mock Set-ExitCode -MockWith {
       Param($ExitCode, $ErrorMessage)
       throw $ErrorMessage
     }
   }
 
-  It "waits for a new successful run and running kubelet" {
+  It "waits for a new successful run and then for kubelet" {
     Start-NodeResetScriptTask
 
     Assert-MockCalled -CommandName Start-ScheduledTask -Exactly -Times 1
+    Assert-MockCalled -CommandName Wait-ForKubeletReady -Exactly -Times 1
     Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
   }
 
@@ -660,10 +661,116 @@ Describe "Start-NodeResetScriptTask" {
 
     { Start-NodeResetScriptTask } | Should -Throw "*failed with result 1*"
   }
+}
 
-  It "fails when kubelet is not running" {
-    Mock Get-Service -MockWith { return [pscustomobject]@{ Status = "Stopped" } }
+Describe "Wait-ForKubeletReady" {
+  BeforeEach {
+    Mock Start-Sleep -MockWith {}
+    Mock Write-Log -MockWith {}
+    Mock Logs-To-Event -MockWith {}
+    Mock Get-Service -MockWith { return [pscustomobject]@{ Status = "Running" } }
+    Mock Set-ExitCode -MockWith {
+      Param($ExitCode, $ErrorMessage)
+      throw $ErrorMessage
+    }
+  }
 
-    { Start-NodeResetScriptTask } | Should -Throw "*kubelet service is not running*"
+  It "returns without delay when kubelet is already ready" {
+    Mock Test-KubeletHealthz -MockWith { return $true }
+
+    Wait-ForKubeletReady
+
+    Assert-MockCalled -CommandName Test-KubeletHealthz -Exactly -Times 1
+    Assert-MockCalled -CommandName Start-Sleep -Exactly -Times 0
+    Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
+  }
+
+  It "keeps waiting while NSSM restarts a kubelet that exited once" {
+    $script:probeCount = 0
+    Mock Test-KubeletHealthz -MockWith {
+      $script:probeCount++
+      return ($script:probeCount -ge 3)
+    }
+    # NSSM reports Paused during AppRestartDelay, which must not be treated as terminal.
+    Mock Get-Service -MockWith { return [pscustomobject]@{ Status = "Paused" } }
+
+    Wait-ForKubeletReady
+
+    Assert-MockCalled -CommandName Test-KubeletHealthz -Exactly -Times 3
+    Assert-MockCalled -CommandName Set-ExitCode -Exactly -Times 0
+  }
+
+  It "fails within the timeout when kubelet never initializes" {
+    Mock Test-KubeletHealthz -MockWith { return $false }
+    # Use a real sleep so the bound is enforced by wall clock rather than by spinning.
+    Mock Start-Sleep -MockWith { Param($Seconds) [System.Threading.Thread]::Sleep($Seconds * 1000) }
+
+    $timer = [Diagnostics.Stopwatch]::StartNew()
+    { Wait-ForKubeletReady -TimeoutSeconds 1 } | Should -Throw '*within `[1`] seconds*'
+    $timer.Stop()
+
+    $timer.Elapsed.TotalSeconds | Should -BeGreaterOrEqual 1
+  }
+}
+
+Describe "Test-KubeletHealthz" {
+  BeforeAll {
+    # Serve one request on the kubelet healthz port so the real probe is exercised end to end.
+    function Start-TestHealthzResponder {
+      Param($StatusLine)
+
+      $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 10248)
+      $listener.Start()
+      $job = Start-ThreadJob -ScriptBlock {
+        Param($listener, $statusLine)
+        $client = $listener.AcceptTcpClient()
+        $stream = $client.GetStream()
+        $stream.Read((New-Object byte[] 1024), 0, 1024) | Out-Null
+        $bytes = [Text.Encoding]::ASCII.GetBytes("$statusLine`r`nContent-Length: 2`r`nConnection: close`r`n`r`nok")
+        $stream.Write($bytes, 0, $bytes.Length)
+        $stream.Flush()
+        $client.Close()
+      } -ArgumentList $listener, $StatusLine
+
+      return [pscustomobject]@{ Listener = $listener; Job = $job }
+    }
+  }
+
+  It "returns true for a 200 response" {
+    $responder = Start-TestHealthzResponder -StatusLine "HTTP/1.1 200 OK"
+    try {
+      Test-KubeletHealthz | Should -BeTrue
+    } finally {
+      $responder.Listener.Stop()
+      Remove-Job $responder.Job -Force
+    }
+  }
+
+  It "returns false for a non-200 response" {
+    $responder = Start-TestHealthzResponder -StatusLine "HTTP/1.1 500 Internal Server Error"
+    try {
+      Test-KubeletHealthz | Should -BeFalse
+    } finally {
+      $responder.Listener.Stop()
+      Remove-Job $responder.Job -Force
+    }
+  }
+
+  It "returns false when kubelet is not listening" {
+    Test-KubeletHealthz | Should -BeFalse
+  }
+
+  It "does not route the loopback probe through a configured proxy" {
+    $responder = Start-TestHealthzResponder -StatusLine "HTTP/1.1 200 OK"
+    $originalProxy = [System.Net.WebRequest]::DefaultWebProxy
+    try {
+      # An unreachable proxy would break the probe if it were honored.
+      [System.Net.WebRequest]::DefaultWebProxy = [System.Net.WebProxy]::new("http://127.0.0.1:1/", $false)
+      Test-KubeletHealthz | Should -BeTrue
+    } finally {
+      [System.Net.WebRequest]::DefaultWebProxy = $originalProxy
+      $responder.Listener.Stop()
+      Remove-Job $responder.Job -Force
+    }
   }
 }

--- a/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
+++ b/staging/cse/windows/provisioningscripts/windowsnodereset.ps1
@@ -139,7 +139,7 @@ if ($global:CsiProxyEnabled) {
 }
 
 Write-Log "Starting kubelet service"
-Start-Service kubelet
+try { Start-Service kubelet -ErrorAction Stop } catch { Write-Log "Failed to start kubelet service: $_" }
 
 Write-Log "Do not start kubeproxy service since kubelet will restart kubeproxy"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Windows NodePrep fails CSE when `Get-Service kubelet` is not `Running` immediately after the `k8s-restart-job` scheduled task completes. NSSM service state cannot answer the question that check is asking.

Kubelet can start before containerd creates `\\.\pipe\containerd-containerd`, exit, and be restarted by NSSM about 7s later (`AppRestartDelay` 5s + `AppThrottle` 1.5s). Reproduced sequence:

| time | event |
| --- | --- |
| `21:15:46.758` | node reset requests kubelet startup |
| `21:15:55.945` | first kubelet process starts |
| `21:15:55.956` | kubelet exits, `\\.\pipe\containerd-containerd` does not exist |
| `21:15:57.049` | containerd creates the pipe |
| `21:15:57.851` | NSSM reports `Paused` during its restart delay |
| `21:16:04.381` | NSSM reports `Running` |
| `21:16:08.035` | second kubelet process starts and stays healthy |

The one-shot check turns that self-healing node into a provisioning failure. It also cannot detect the opposite case: a kubelet that crash-loops forever still flaps back to `Running`, so the check passes.

### The signal

Poll kubelet's healthz endpoint instead of sampling NSSM state once.

Verified against `cmd/kubelet/app/server.go` on `release-1.27`, `release-1.30`, `release-1.32`, `release-1.34` and `master`: `run()` calls `kubelet.PreInitRuntimeService(...)` — which dials `ContainerRuntimeEndpoint` and returns an error when the pipe is absent — strictly before the `if s.HealthzPort > 0 { ... healthz.InstallHandler ... }` block. A 200 therefore proves kubelet got past the containerd pipe and finished local initialization. That is exactly the distinction NSSM state cannot make.

Behaviour against the three outcomes:

| outcome | result |
| --- | --- |
| kubelet initialized | returns on the first probe, no fixed delay |
| kubelet failed once, NSSM recovering | a failed probe never ends the wait, succeeds when healthz answers |
| kubelet cannot initialize | fails CSE within a defined bound, with the service status |

Signals considered and rejected: `Start-Service` result (does not prove the child stayed alive), NSSM state (the bug), containerd pipe alone (does not prove kubelet initialized), Node `Ready` (requires control-plane polling and is later than local initialization).

### The bound

600s, one constant. `kubeletstart.ps1` runs `securetlsbootstrap.ps1` **synchronously before it launches kubelet.exe**, while NSSM already reports `Running`, and that client's default RPC timeouts total 480s (15 + 60 + 15 + 15 + 15 + 360, from `Azure/aks-secure-tls-bootstrap` `client/internal/bootstrap/config.go`). 600s covers that plus kubelet start. The healthy path returns on the first probe, so a generous bound costs nothing on success — it only affects how long a genuinely broken node takes to fail, and RP node-readiness is the backstop there either way.

The healthz address is kubelet's own default and is not configurable on AKS Windows (`--healthz-port` is not in the `CustomKubeletConfig` allowlist), so it is a constant rather than parsed from kubelet args.

### Delivery

This lands in `parts/windows/windowscsehelper.ps1`, which is zipped into CustomData, so it reaches nodes running older cached CSE script packages. The `windowsnodereset.ps1` change is one line and only logs a direct `Start-Service` failure to `windowsnodereset.log` instead of swallowing it; correctness does not depend on it.

A new `AKS.WindowsCSE.WaitForKubeletReady` event is emitted so the bound can be re-tuned from production timing data rather than from a single reproduction.

### Production context

Over 60 days, Windows CSE exit code 32 occurred 31 times, all `NodeResetScriptTask is not finished after [~180] seconds`. Zero were `kubelet service is not running` — that check only shipped in #8970 and the tag carrying it (`v0.20260806.3`) is still rolling out, so the false failure is latent rather than already visible. The separate 180s node-reset-task timeout is a different root cause and is **not** addressed here.

**Testing**

44 lines of production code. 71 Pester tests pass (`parts/windows/`), plus `go test ./pkg/agent/...`.

`Test-KubeletHealthz` is covered against a real loopback listener on port 10248 rather than only through mocks: 200 → true, 500 → false, nothing listening → false, and an unreachable `DefaultWebProxy` still returns true (proxy bypass). Persistent failure is tested with a positive timeout asserting real elapsed wall clock.

**Which issue(s) this PR fixes**:

N/A
