### PR TITLE
fix: restore node-level DNS after unexpected LocalDNS exit

### DIFF
--- a/e2e/scenario/scenario_localdns_hosts.go
+++ b/e2e/scenario/scenario_localdns_hosts.go
@@ -159,21 +159,25 @@ fi
 # asynchronously, so poll (like wait_for_localdns_removed_from_resolv_conf does)
 # until the listener IP is gone rather than checking once. Prefer resolvectl
 # (the per-link view the drop-in configures); fall back to the resolved stub.
+# Only accept a successful, non-empty resolver snapshot: an errored or empty
+# read must not be treated as "restored", or a failed read would mask the very
+# regression under test. Retry those instead.
 dns_reverted=false
 for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
     if command -v resolvectl >/dev/null 2>&1; then
-        current_dns=$(resolvectl status 2>/dev/null || true)
+        current_dns=$(resolvectl status 2>/dev/null)
     else
-        current_dns=$(cat /run/systemd/resolve/resolv.conf 2>/dev/null || true)
+        current_dns=$(cat /run/systemd/resolve/resolv.conf 2>/dev/null)
     fi
-    if ! printf '%s' "$current_dns" | grep -q '169\.254\.10\.10'; then
+    # Require a non-empty snapshot before trusting the absence check.
+    if [ -n "$current_dns" ] && ! printf '%s' "$current_dns" | grep -q '169\.254\.10\.10'; then
         dns_reverted=true
         break
     fi
     sleep 1
 done
 if [ "$dns_reverted" != true ]; then
-    echo "FAIL: link DNS still points at 169.254.10.10 after localdns died"
+    echo "FAIL: link DNS still points at 169.254.10.10 (or resolver state unreadable) after localdns died"
     exit 1
 fi
 

--- a/e2e/scenario/scenario_localdns_hosts.go
+++ b/e2e/scenario/scenario_localdns_hosts.go
@@ -80,6 +80,39 @@ sudo systemctl is-active --quiet localdns.service
 # process and falsely declare recovery. Save the killed PID and require the
 # new MainPID to be nonzero and different from it.
 test_start=$(date +%s)
+
+# The terminal-dead test installs a runtime systemd drop-in below. Always
+# remove it when this validation exits, including when set -e stops the script
+# after a failed assertion, so a failed scenario cannot contaminate a node or
+# subsequent validation. Preserve the original test result and report cleanup
+# failures separately instead of masking either result.
+NORESTART=/run/systemd/system/localdns.service.d/99-e2e-no-restart.conf
+restore_localdns_test_state() {
+    test_status=$?
+    trap - EXIT
+    set +e
+
+    if [ -f "$NORESTART" ]; then
+        cleanup_status=0
+        sudo rm -f "$NORESTART" || { echo "ERROR: failed to remove $NORESTART"; cleanup_status=1; }
+        sudo systemctl daemon-reload || { echo "ERROR: systemd daemon-reload failed during test cleanup"; cleanup_status=1; }
+        sudo systemctl reset-failed localdns.service || { echo "ERROR: reset-failed localdns.service failed during test cleanup"; cleanup_status=1; }
+        if ! sudo systemctl is-active --quiet localdns.service; then
+            sudo systemctl start localdns.service || { echo "ERROR: failed to restart localdns.service during test cleanup"; cleanup_status=1; }
+        fi
+        if ! sudo systemctl is-active --quiet localdns.service; then
+            echo "ERROR: localdns.service is not active after test cleanup"
+            cleanup_status=1
+        fi
+        if [ "$test_status" -eq 0 ] && [ "$cleanup_status" -ne 0 ]; then
+            test_status=$cleanup_status
+        fi
+    fi
+
+    exit "$test_status"
+}
+trap restore_localdns_test_state EXIT
+
 for i in 1 2 3; do
     killed=$(sudo systemctl show -p MainPID --value localdns.service)
     test "$killed" -gt 0
@@ -122,8 +155,8 @@ dig +short +time=5 +tries=1 mcr.microsoft.com @169.254.10.10 | grep -q .
 # by disabling auto-restart with a transient drop-in, then killing the
 # supervisor -- tripping StartLimit via rapid kills is timing dependent and
 # flaky. ExecStopPost runs on the SIGKILL path regardless of Restart=.
-sudo mkdir -p /run/systemd/system/localdns.service.d
-printf '[Service]\nRestart=no\n' | sudo tee /run/systemd/system/localdns.service.d/99-e2e-no-restart.conf >/dev/null
+sudo mkdir -p "$(dirname "$NORESTART")"
+printf '[Service]\nRestart=no\n' | sudo tee "$NORESTART" >/dev/null
 sudo systemctl daemon-reload
 
 dead_main=$(sudo systemctl show -p MainPID --value localdns.service)
@@ -181,13 +214,8 @@ if [ "$dns_reverted" != true ]; then
     exit 1
 fi
 
-# Restore the node to a healthy state for any subsequent validation.
-sudo rm -f /run/systemd/system/localdns.service.d/99-e2e-no-restart.conf
-sudo systemctl daemon-reload
-sudo systemctl reset-failed localdns.service || true
-sudo systemctl start localdns.service
-sudo systemctl is-active --quiet localdns.service
-dig +short +time=5 +tries=1 mcr.microsoft.com @169.254.10.10 | grep -q .
+# The EXIT trap removes the temporary override and restores LocalDNS even if
+# an assertion above exits the validation early.
 `, 0, "LocalDNS lifecycle validation failed")
 	return err
 }

--- a/e2e/scenario/scenario_localdns_hosts.go
+++ b/e2e/scenario/scenario_localdns_hosts.go
@@ -1,6 +1,8 @@
 package scenario
 
 import (
+	"context"
+
 	aksnodeconfigv1 "github.com/Azure/agentbaker/aks-node-controller/pkg/gen/aksnodeconfig/v1"
 	"github.com/Azure/agentbaker/e2e/config"
 	"github.com/Azure/agentbaker/pkg/agent/datamodel"
@@ -23,6 +25,7 @@ func init() {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		cluster := ClusterKubenet
 		if tt.name == "Ubuntu2604Minimal" {
 			cluster = ClusterLatestKubernetesVersionKubenet
@@ -42,7 +45,145 @@ func init() {
 					config.LocalDnsProfile.EnableLocalDns = true
 				},
 				VMConfigMutator: tt.vmConfigMutator,
+				Validator: func(ctx context.Context, s *Scenario) error {
+					// Validate the full LocalDNS service lifecycle (including the
+					// unexpected-exit DNS teardown this PR fixes) on the target
+					// distros. The hosts-plugin functionality itself is covered by
+					// the scenario's default provisioning validation.
+					if tt.name == "Ubuntu2204" || tt.name == "Ubuntu2404" || tt.name == "AzureLinuxV3" {
+						return validateLocalDNSLifecycle(ctx, s)
+					}
+					return nil
+				},
 			},
 		})
 	}
+}
+
+func validateLocalDNSLifecycle(ctx context.Context, s *Scenario) error {
+	_, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, `
+set -eu
+sudo systemctl is-active --quiet localdns.service
+
+# Normal systemd stop must complete cleanup and return success.
+sudo systemctl restart localdns.service
+sudo systemctl is-active --quiet localdns.service
+sudo systemctl stop localdns.service
+test "$(sudo systemctl show localdns.service -p ActiveState --value)" = inactive
+sudo systemctl start localdns.service
+sudo systemctl is-active --quiet localdns.service
+
+# Repeatedly kill the supervisor and wait for Restart=on-failure recovery.
+# Require a genuinely new MainPID after each kill: immediately after kill -9,
+# systemd may still report the killed invocation as active/running until it
+# processes SIGCHLD, so checking active/running alone can observe the old
+# process and falsely declare recovery. Save the killed PID and require the
+# new MainPID to be nonzero and different from it.
+test_start=$(date +%s)
+for i in 1 2 3; do
+    killed=$(sudo systemctl show -p MainPID --value localdns.service)
+    test "$killed" -gt 0
+    sudo kill -9 "$killed"
+
+    recovered=false
+    for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+        state=$(sudo systemctl show localdns.service -p ActiveState -p SubState --value)
+        main=$(sudo systemctl show -p MainPID --value localdns.service)
+        if [ "$state" = $'active\nrunning' ] && [ "$main" -gt 0 ] && [ "$main" != "$killed" ]; then
+            recovered=true
+            break
+        fi
+        sleep 1
+    done
+    test "$recovered" = true
+done
+
+state=$(sudo systemctl show localdns.service -p ActiveState -p SubState -p Result -p ControlGroup)
+printf '%s\n' "$state"
+printf '%s\n' "$state" | grep -q '^ActiveState=active$'
+printf '%s\n' "$state" | grep -q '^SubState=running$'
+printf '%s\n' "$state" | grep -q '^Result=success$'
+# The cgroup teardown warning is diagnostic only: fixing it is out of scope for
+# this PR (which is about restoring node DNS after an unexpected exit), so we
+# surface it but do not fail on it.
+if sudo journalctl -u localdns.service --since "@$test_start" --no-pager | grep -q 'Failed to kill control group'; then
+    echo "WARNING: LocalDNS cgroup teardown warning observed"
+fi
+if sudo journalctl -u localdns.service --since "@$test_start" --no-pager | grep -q 'Start request repeated too quickly'; then
+    echo "LocalDNS reached systemd StartLimit"
+    exit 1
+fi
+dig +short +time=5 +tries=1 mcr.microsoft.com @169.254.10.10 | grep -q .
+
+# Terminal dead-service case: this is the incident scenario the PR fixes.
+# When localdns ends up dead (systemd exhausts restart attempts), ExecStopPost
+# must still revert node DNS so the node does not keep pointing at the dead
+# localdns listener (169.254.10.10). We reach the dead state deterministically
+# by disabling auto-restart with a transient drop-in, then killing the
+# supervisor -- tripping StartLimit via rapid kills is timing dependent and
+# flaky. ExecStopPost runs on the SIGKILL path regardless of Restart=.
+sudo mkdir -p /run/systemd/system/localdns.service.d
+printf '[Service]\nRestart=no\n' | sudo tee /run/systemd/system/localdns.service.d/99-e2e-no-restart.conf >/dev/null
+sudo systemctl daemon-reload
+
+dead_main=$(sudo systemctl show -p MainPID --value localdns.service)
+test "$dead_main" -gt 0
+sudo kill -9 "$dead_main"
+
+# Wait for the service to reach a terminal ActiveState (failed or inactive).
+# A non-running SubState is not sufficient: SubState passes through transitional
+# values such as stop-post while ExecStopPost is still running the cleanup under
+# test, so asserting on drop-in removal then could race the cleanup. ActiveState
+# only becomes failed/inactive after ExecStopPost has completed.
+dead=false
+for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    active_state=$(sudo systemctl show localdns.service -p ActiveState --value)
+    if [ "$active_state" = failed ] || [ "$active_state" = inactive ]; then
+        dead=true
+        break
+    fi
+    sleep 1
+done
+test "$dead" = true
+
+# The localdns network drop-in must have been removed by ExecStopPost. This is
+# the authoritative signal that DNS was reverted: the drop-in is what points the
+# link's DNS at the localdns listener.
+if ls /run/systemd/network/*.d/70-localdns.conf >/dev/null 2>&1; then
+    echo "FAIL: 70-localdns.conf still present after localdns died"
+    exit 1
+fi
+
+# The live link DNS must no longer include the localdns node listener. This is
+# eventually consistent: networkctl reload propagates to systemd-resolved
+# asynchronously, so poll (like wait_for_localdns_removed_from_resolv_conf does)
+# until the listener IP is gone rather than checking once. Prefer resolvectl
+# (the per-link view the drop-in configures); fall back to the resolved stub.
+dns_reverted=false
+for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    if command -v resolvectl >/dev/null 2>&1; then
+        current_dns=$(resolvectl status 2>/dev/null || true)
+    else
+        current_dns=$(cat /run/systemd/resolve/resolv.conf 2>/dev/null || true)
+    fi
+    if ! printf '%s' "$current_dns" | grep -q '169\.254\.10\.10'; then
+        dns_reverted=true
+        break
+    fi
+    sleep 1
+done
+if [ "$dns_reverted" != true ]; then
+    echo "FAIL: link DNS still points at 169.254.10.10 after localdns died"
+    exit 1
+fi
+
+# Restore the node to a healthy state for any subsequent validation.
+sudo rm -f /run/systemd/system/localdns.service.d/99-e2e-no-restart.conf
+sudo systemctl daemon-reload
+sudo systemctl reset-failed localdns.service || true
+sudo systemctl start localdns.service
+sudo systemctl is-active --quiet localdns.service
+dig +short +time=5 +tries=1 mcr.microsoft.com @169.254.10.10 | grep -q .
+`, 0, "LocalDNS lifecycle validation failed")
+	return err
 }

--- a/e2e/scenario/scenario_localdns_hosts.go
+++ b/e2e/scenario/scenario_localdns_hosts.go
@@ -63,6 +63,43 @@ func init() {
 func validateLocalDNSLifecycle(ctx context.Context, s *Scenario) error {
 	_, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, `
 set -eu
+
+# This validation requires the ExecStopPost hook baked into the branch VHD.
+# Standalone E2E may run against an older published VHD, where this behavior
+# is unavailable and should be skipped rather than reported as a false failure.
+if ! sudo systemctl show localdns.service -p ExecStopPost --value | grep -q 'localdns.sh cleanup'; then
+    echo "SKIP: VHD predates the ExecStopPost cleanup hook"
+    exit 0
+fi
+
+NORESTART=/run/systemd/system/localdns.service.d/99-e2e-no-restart.conf
+
+# Install cleanup before any service mutation so set -e cannot leave the node
+# with the temporary Restart=no override or a failed LocalDNS unit.
+restore_localdns_test_state() {
+    test_status=$?
+    trap - EXIT
+    set +e
+    cleanup_status=0
+    if [ -f "$NORESTART" ]; then
+        sudo rm -f "$NORESTART" || { echo "ERROR: failed to remove $NORESTART"; cleanup_status=1; }
+        sudo systemctl daemon-reload || { echo "ERROR: systemd daemon-reload failed during test cleanup"; cleanup_status=1; }
+        sudo systemctl reset-failed localdns.service || { echo "ERROR: reset-failed localdns.service failed during test cleanup"; cleanup_status=1; }
+    fi
+    if ! sudo systemctl is-active --quiet localdns.service; then
+        sudo systemctl start localdns.service || { echo "ERROR: failed to restart localdns.service during test cleanup"; cleanup_status=1; }
+    fi
+    if ! sudo systemctl is-active --quiet localdns.service; then
+        echo "ERROR: localdns.service is not active after test cleanup"
+        cleanup_status=1
+    fi
+    if [ "$test_status" -eq 0 ] && [ "$cleanup_status" -ne 0 ]; then
+        test_status=$cleanup_status
+    fi
+    exit "$test_status"
+}
+trap restore_localdns_test_state EXIT
+
 sudo systemctl is-active --quiet localdns.service
 
 # Normal systemd stop must complete cleanup and return success.
@@ -74,44 +111,14 @@ sudo systemctl start localdns.service
 sudo systemctl is-active --quiet localdns.service
 
 # Repeatedly kill the supervisor and wait for Restart=on-failure recovery.
+# This loop validates ordinary service recovery; the terminal dead-service
+# regression for ExecStopPost is covered by the block below.
 # Require a genuinely new MainPID after each kill: immediately after kill -9,
 # systemd may still report the killed invocation as active/running until it
 # processes SIGCHLD, so checking active/running alone can observe the old
 # process and falsely declare recovery. Save the killed PID and require the
 # new MainPID to be nonzero and different from it.
 test_start=$(date +%s)
-
-# The terminal-dead test installs a runtime systemd drop-in below. Always
-# remove it when this validation exits, including when set -e stops the script
-# after a failed assertion, so a failed scenario cannot contaminate a node or
-# subsequent validation. Preserve the original test result and report cleanup
-# failures separately instead of masking either result.
-NORESTART=/run/systemd/system/localdns.service.d/99-e2e-no-restart.conf
-restore_localdns_test_state() {
-    test_status=$?
-    trap - EXIT
-    set +e
-
-    if [ -f "$NORESTART" ]; then
-        cleanup_status=0
-        sudo rm -f "$NORESTART" || { echo "ERROR: failed to remove $NORESTART"; cleanup_status=1; }
-        sudo systemctl daemon-reload || { echo "ERROR: systemd daemon-reload failed during test cleanup"; cleanup_status=1; }
-        sudo systemctl reset-failed localdns.service || { echo "ERROR: reset-failed localdns.service failed during test cleanup"; cleanup_status=1; }
-        if ! sudo systemctl is-active --quiet localdns.service; then
-            sudo systemctl start localdns.service || { echo "ERROR: failed to restart localdns.service during test cleanup"; cleanup_status=1; }
-        fi
-        if ! sudo systemctl is-active --quiet localdns.service; then
-            echo "ERROR: localdns.service is not active after test cleanup"
-            cleanup_status=1
-        fi
-        if [ "$test_status" -eq 0 ] && [ "$cleanup_status" -ne 0 ]; then
-            test_status=$cleanup_status
-        fi
-    fi
-
-    exit "$test_status"
-}
-trap restore_localdns_test_state EXIT
 
 for i in 1 2 3; do
     killed=$(sudo systemctl show -p MainPID --value localdns.service)
@@ -198,9 +205,9 @@ fi
 dns_reverted=false
 for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
     if command -v resolvectl >/dev/null 2>&1; then
-        current_dns=$(resolvectl status 2>/dev/null)
+        current_dns=$(resolvectl status 2>/dev/null) || current_dns=""
     else
-        current_dns=$(cat /run/systemd/resolve/resolv.conf 2>/dev/null)
+        current_dns=$(cat /run/systemd/resolve/resolv.conf 2>/dev/null) || current_dns=""
     fi
     # Require a non-empty snapshot before trusting the absence check.
     if [ -n "$current_dns" ] && ! printf '%s' "$current_dns" | grep -q '169\.254\.10\.10'; then
@@ -211,6 +218,13 @@ for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
 done
 if [ "$dns_reverted" != true ]; then
     echo "FAIL: link DNS still points at 169.254.10.10 (or resolver state unreadable) after localdns died"
+    exit 1
+fi
+
+# Removing the LocalDNS address is not sufficient: verify the node has a
+# working resolver after cleanup.
+if ! getent hosts mcr.microsoft.com >/dev/null 2>&1; then
+    echo "FAIL: node cannot resolve DNS after localdns died"
     exit 1
 fi
 

--- a/parts/linux/cloud-init/artifacts/localdns.service
+++ b/parts/linux/cloud-init/artifacts/localdns.service
@@ -14,6 +14,8 @@ NotifyAccess=all
 WatchdogSec=60
 Restart=on-failure
 KillMode=mixed
+# Revert node DNS configuration even when the supervisor exits unexpectedly.
+ExecStopPost=/opt/azure/containers/localdns/localdns.sh cleanup
 TimeoutStopSec=30
 Slice=localdns.slice
 EnvironmentFile=-/etc/localdns/environment

--- a/parts/linux/cloud-init/artifacts/localdns.sh
+++ b/parts/linux/cloud-init/artifacts/localdns.sh
@@ -740,11 +740,15 @@ cleanup_iptables_and_dns() {
 
 # localdns_cleanup_mode is the entry point for `localdns.sh cleanup`, invoked by
 # localdns.service ExecStopPost after both graceful and unexpected exits. It only
-# restores node DNS configuration; systemd owns process cleanup. It always exits
-# 0 so that a best-effort cleanup failure cannot wedge systemd's recovery of the
-# unit. Cleanup failures are logged (and surfaced by cleanup_iptables_and_dns).
+# restores node DNS configuration. It intentionally does not delete the dummy
+# localdns interface or its .10/.11 addresses: if an orphaned CoreDNS child
+# survives a failed cgroup teardown, removing the interface could break a
+# listener that is still serving pods and turn a fast failure into default-route
+# DNS timeouts. Service/process recovery handles the next-start interface
+# lifecycle separately. It always exits 0 so that a best-effort cleanup failure
+# cannot wedge systemd's recovery. Cleanup failures are logged.
 localdns_cleanup_mode() {
-    cleanup_iptables_and_dns || echo "Best-effort LocalDNS DNS cleanup reported errors."
+    cleanup_iptables_and_dns || echo "LocalDNS cleanup failed: network drop-in may not have been removed; node DNS may still point at the dead listener ${LOCALDNS_NODE_LISTENER_IP}."
     exit 0
 }
 
@@ -941,7 +945,10 @@ start_localdns_watchdog() {
             # Update resource metrics .prom file for the exporter (best-effort, non-fatal)
             export_resource_metrics
 
-            sleep "${HEALTH_CHECK_INTERVAL}"
+            # Run sleep in a child so SIGTERM can interrupt the wait and let
+            # the service's signal/exit cleanup run promptly.
+            sleep "${HEALTH_CHECK_INTERVAL}" &
+            wait $!
         done
     else
         # No watchdog configured — write metrics once then wait for CoreDNS to exit
@@ -1082,9 +1089,6 @@ build_localdns_iptable_rules
 # cleanup_localdns_configs function will be run on script exit/crash to revert config.
 # Ensure cleanup runs before exiting on an error.
 trap 'echo "Error occurred. Cleaning up..."; cleanup_localdns_configs; exit $ERR_LOCALDNS_FAIL' ABRT ERR INT PIPE
-
-# SIGTERM is the normal systemd stop signal and must be reported as a clean stop.
-trap 'echo "Received SIGTERM. Cleaning up..."; cleanup_localdns_configs || true; exit 0' TERM
 
 # Always cleanup when exiting.
 trap 'echo "Executing cleanup function."; cleanup_localdns_configs || echo "Cleanup failed with error code: $ERR_LOCALDNS_FAIL."' EXIT

--- a/parts/linux/cloud-init/artifacts/localdns.sh
+++ b/parts/linux/cloud-init/artifacts/localdns.sh
@@ -663,15 +663,21 @@ cleanup_iptables_and_dns() {
     # localdns listener via the network drop-in.
     local cleanup_failed=false
 
-    # Ensure network variables are initialized if not already set.
-    # This is needed here because this function can be called from cleanup traps or systemd restarts initiated by watchdog.
-    if [ -z "${DEFAULT_ROUTE_INTERFACE:-}" ] || [ -z "${NETWORK_DROPIN_FILE:-}" ] || [ -z "${NETWORK_DROPIN_DIR:-}" ]; then
-        echo "Network variables not initialized, attempting to determine them..."
-        if ! initialize_network_variables; then
-            echo "Failed to initialize network variables during cleanup."
-            return 1
-        fi
+    # Do not derive the route/interface during post-exit cleanup. At this point
+    # network state may already be torn down, so ip route/networkctl discovery
+    # can fail and leave the node pointed at the dead LocalDNS listener. Sweep
+    # the known drop-in name directly; the glob also handles a cleanup call
+    # where NETWORK_DROPIN_FILE was never initialized in this process.
+    local network_dropin_file
+    local -a network_dropin_files=()
+    if [ -n "${NETWORK_DROPIN_FILE:-}" ]; then
+        network_dropin_files+=("${NETWORK_DROPIN_FILE}")
     fi
+    for network_dropin_file in /run/systemd/network/*.d/70-localdns.conf; do
+        if [ -e "$network_dropin_file" ] && [ "$network_dropin_file" != "${NETWORK_DROPIN_FILE:-}" ]; then
+            network_dropin_files+=("$network_dropin_file")
+        fi
+    done
 
     # Remove any existing localdns iptables rules by searching for our comment.
     echo "Cleaning up any existing localdns iptables rules..."
@@ -702,14 +708,20 @@ cleanup_iptables_and_dns() {
         echo "No existing localdns iptables rules found."
     fi
 
-    # Revert DNS configuration and network reload.
-    echo "Removing network drop-in file ${NETWORK_DROPIN_FILE}."
-    if ! rm -f "$NETWORK_DROPIN_FILE"; then
-        echo "Failed to remove network drop-in file ${NETWORK_DROPIN_FILE}."
-        cleanup_failed=true
-    else
-        echo "Successfully removed network drop-in file."
-    fi
+    # Revert DNS configuration and network reload. Keep the dummy interface
+    # and its .10/.11 addresses here: if an orphaned CoreDNS child survived a
+    # failed cgroup teardown, removing the interface would break a listener
+    # that may still be serving pods. The service-recovery path handles the
+    # next-start interface lifecycle separately.
+    for network_dropin_file in "${network_dropin_files[@]}"; do
+        echo "Removing network drop-in file ${network_dropin_file}."
+        if ! rm -f "$network_dropin_file"; then
+            echo "Failed to remove network drop-in file ${network_dropin_file}."
+            cleanup_failed=true
+        else
+            echo "Successfully removed network drop-in file."
+        fi
+    done
 
     echo "Attempt to reload network configuration."
     if ! eval "$NETWORKCTL_RELOAD_CMD"; then

--- a/parts/linux/cloud-init/artifacts/localdns.sh
+++ b/parts/linux/cloud-init/artifacts/localdns.sh
@@ -656,6 +656,13 @@ EOF
 
 # Remove iptables rules and revert DNS configuration.
 cleanup_iptables_and_dns() {
+    # Track failures across all cleanup steps so that a failure in one step
+    # (e.g. removing an iptables rule) does not skip the more important DNS
+    # restoration steps below. Restoring node DNS is the priority: if we return
+    # early on an iptables error we could leave the node pointed at a dead
+    # localdns listener via the network drop-in.
+    local cleanup_failed=false
+
     # Ensure network variables are initialized if not already set.
     # This is needed here because this function can be called from cleanup traps or systemd restarts initiated by watchdog.
     if [ -z "${DEFAULT_ROUTE_INTERFACE:-}" ] || [ -z "${NETWORK_DROPIN_FILE:-}" ] || [ -z "${NETWORK_DROPIN_DIR:-}" ]; then
@@ -688,7 +695,8 @@ cleanup_iptables_and_dns() {
             done
         done
         if [ "$failure_occurred" = true ]; then
-            return 1
+            # Record the failure but continue so DNS restoration still runs.
+            cleanup_failed=true
         fi
     else
         echo "No existing localdns iptables rules found."
@@ -696,22 +704,36 @@ cleanup_iptables_and_dns() {
 
     # Revert DNS configuration and network reload.
     echo "Removing network drop-in file ${NETWORK_DROPIN_FILE}."
-    rm -f "$NETWORK_DROPIN_FILE"
-    if [ "$?" -ne 0 ]; then
+    if ! rm -f "$NETWORK_DROPIN_FILE"; then
         echo "Failed to remove network drop-in file ${NETWORK_DROPIN_FILE}."
-        return 1
+        cleanup_failed=true
+    else
+        echo "Successfully removed network drop-in file."
     fi
-    echo "Successfully removed network drop-in file."
 
     echo "Attempt to reload network configuration."
-    eval "$NETWORKCTL_RELOAD_CMD"
-    if [ "$?" -ne 0 ]; then
+    if ! eval "$NETWORKCTL_RELOAD_CMD"; then
         echo "Failed to reload network after removing the DNS configuration."
+        cleanup_failed=true
+    else
+        echo "Reloading network configuration succeeded."
+    fi
+
+    if [ "$cleanup_failed" = true ]; then
         return 1
     fi
-    echo "Reloading network configuration succeeded."
 
     return 0
+}
+
+# localdns_cleanup_mode is the entry point for `localdns.sh cleanup`, invoked by
+# localdns.service ExecStopPost after both graceful and unexpected exits. It only
+# restores node DNS configuration; systemd owns process cleanup. It always exits
+# 0 so that a best-effort cleanup failure cannot wedge systemd's recovery of the
+# unit. Cleanup failures are logged (and surfaced by cleanup_iptables_and_dns).
+localdns_cleanup_mode() {
+    cleanup_iptables_and_dns || echo "Best-effort LocalDNS DNS cleanup reported errors."
+    exit 0
 }
 
 # Cleanup function to remove localdns related configurations.
@@ -983,6 +1005,13 @@ select_localdns_corefile() {
 
 ${__SOURCED__:+return}
 
+# ExecStopPost invokes this mode after both graceful and unexpected exits.
+# Only restore node DNS configuration here; systemd owns process cleanup.
+# Always exit successfully so a cleanup error cannot wedge systemd recovery.
+if [ "${1:-}" = "cleanup" ]; then
+    localdns_cleanup_mode
+fi
+
 # --------------------------------------- Main Execution starts here --------------------------------------------------
 
 # Regenerate corefile on every startup to enable dynamic variant selection.
@@ -1041,6 +1070,9 @@ build_localdns_iptable_rules
 # cleanup_localdns_configs function will be run on script exit/crash to revert config.
 # Ensure cleanup runs before exiting on an error.
 trap 'echo "Error occurred. Cleaning up..."; cleanup_localdns_configs; exit $ERR_LOCALDNS_FAIL' ABRT ERR INT PIPE
+
+# SIGTERM is the normal systemd stop signal and must be reported as a clean stop.
+trap 'echo "Received SIGTERM. Cleaning up..."; cleanup_localdns_configs || true; exit 0' TERM
 
 # Always cleanup when exiting.
 trap 'echo "Executing cleanup function."; cleanup_localdns_configs || echo "Cleanup failed with error code: $ERR_LOCALDNS_FAIL."' EXIT

--- a/spec/parts/linux/cloud-init/artifacts/localdns_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/localdns_spec.sh
@@ -987,36 +987,35 @@ EOF
             The stdout should include "No existing localdns iptables rules found."
         End
 
-        It 'should initialize network variables when DEFAULT_ROUTE_INTERFACE is unset and still remove the drop-in'
-            # Regression cover for the guard that now also checks DEFAULT_ROUTE_INTERFACE:
-            # cleanup can be invoked from a trap/watchdog restart with the interface unset,
-            # so it must call initialize_network_variables (re-deriving the interface via the
-            # mocked ip/networkctl) and still complete cleanup successfully.
+        It 'should remove the known drop-in without deriving network variables'
             iptables() { mock_iptables "$@"; }
-            AZURE_DNS_IP="168.63.129.16"
             NETWORKCTL_RELOAD_CMD="true"
-            # A real network file must exist for verify_network_file during initialization.
-            NETWORK_FILE="/tmp/test-eth0.network"
-            touch "$NETWORK_FILE"
-            networkctl() {
-                if [[ "$1" == "--json=short" && "$2" == "status" && "$3" == "eth0" ]]; then
-                    echo "{\"NetworkFile\":\"${NETWORK_FILE}\"}"
-                elif [[ "$1" == "reload" ]]; then
-                    return 0
-                else
-                    command networkctl "$@"
-                fi
-            }
             touch "$NETWORK_DROPIN_FILE"
-            # Force the new initialization branch: interface not yet known.
+            # Cleanup must not need route/networkctl discovery.
             unset DEFAULT_ROUTE_INTERFACE
+            unset NETWORK_DROPIN_DIR
             When call cleanup_iptables_and_dns
             The status should be success
-            The stdout should include "Network variables not initialized, attempting to determine them..."
             The stdout should include "Removing network drop-in file"
-            The variable DEFAULT_ROUTE_INTERFACE should equal "eth0"
             The file "${NETWORK_DROPIN_FILE}" should not be exist
-            rm -f "$NETWORK_FILE"
+        End
+
+        It 'continues DNS cleanup when network variable discovery would fail'
+            iptables() { mock_iptables "$@"; }
+            NETWORK_DROPIN_FILE="/tmp/localdns-cleanup-test/network/10-netplan-eth0.network.d/70-localdns.conf"
+            mkdir -p "$(dirname "$NETWORK_DROPIN_FILE")"
+            touch "$NETWORK_DROPIN_FILE"
+            NETWORKCTL_RELOAD_CMD="true"
+            unset NETWORK_DROPIN_DIR
+            unset DEFAULT_ROUTE_INTERFACE
+            # If the old implementation attempted network discovery here, this
+            # mock would fail. The cleanup path must remove the known drop-in
+            # without attempting discovery.
+            initialize_network_variables() { return 1; }
+            When call cleanup_iptables_and_dns
+            The status should be success
+            The file "${NETWORK_DROPIN_FILE}" should not be exist
+            rm -rf /tmp/localdns-cleanup-test
         End
     End
 

--- a/spec/parts/linux/cloud-init/artifacts/localdns_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/localdns_spec.sh
@@ -2110,7 +2110,7 @@ EOF
             cleanup_iptables_and_dns() { return 1; }
             When run localdns_cleanup_mode
             The status should be success
-            The stdout should include "Best-effort LocalDNS DNS cleanup reported errors."
+            The stdout should include "LocalDNS cleanup failed: network drop-in may not have been removed"
         End
     End
 End

--- a/spec/parts/linux/cloud-init/artifacts/localdns_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/localdns_spec.sh
@@ -2023,6 +2023,7 @@ KUBECTL_EOF
             Include "./parts/linux/cloud-init/artifacts/localdns.sh"
 
             TEST_DIR="$(mktemp -d)"
+            DEFAULT_ROUTE_INTERFACE="eth0"
             NETWORK_DROPIN_DIR="${TEST_DIR}/run/systemd/network/eth0.network.d"
             NETWORK_DROPIN_FILE="${NETWORK_DROPIN_DIR}/70-localdns.conf"
             mkdir -p "${NETWORK_DROPIN_DIR}"

--- a/spec/parts/linux/cloud-init/artifacts/localdns_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/localdns_spec.sh
@@ -1014,6 +1014,8 @@ EOF
             initialize_network_variables() { return 1; }
             When call cleanup_iptables_and_dns
             The status should be success
+            The stdout should include "Successfully removed existing localdns iptables rule"
+            The stdout should include "Reloading network configuration succeeded."
             The file "${NETWORK_DROPIN_FILE}" should not be exist
             rm -rf /tmp/localdns-cleanup-test
         End

--- a/spec/parts/linux/cloud-init/artifacts/localdns_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/localdns_spec.sh
@@ -2010,4 +2010,107 @@ KUBECTL_EOF
             The stdout should include "Timeout waiting for node testnode123 to be registered"
         End
     End
+
+# This section tests cleanup_iptables_and_dns and the "cleanup" mode contract
+# invoked by localdns.service ExecStopPost. The key guarantees under test:
+#   1. DNS restoration (drop-in removal + network reload) still runs even when
+#      iptables rule deletion fails (no early return).
+#   2. cleanup_iptables_and_dns reports overall failure when any step fails.
+#   3. "cleanup" mode exits 0 whether cleanup succeeds or fails, so a cleanup
+#      error cannot wedge systemd recovery.
+#------------------------------------------------------------------------------------------------------------------------------------
+    Describe 'cleanup_iptables_and_dns'
+        setup() {
+            Include "./parts/linux/cloud-init/artifacts/localdns.sh"
+
+            TEST_DIR="$(mktemp -d)"
+            NETWORK_DROPIN_DIR="${TEST_DIR}/run/systemd/network/eth0.network.d"
+            NETWORK_DROPIN_FILE="${NETWORK_DROPIN_DIR}/70-localdns.conf"
+            mkdir -p "${NETWORK_DROPIN_DIR}"
+            cat > "${NETWORK_DROPIN_FILE}" <<'EOF'
+[Network]
+DNS=169.254.10.10
+EOF
+            # No localdns iptables rules by default (empty listing).
+            iptables() { return 0; }
+            # networkctl reload succeeds by default.
+            NETWORKCTL_RELOAD_CMD="networkctl_reload_mock"
+            networkctl_reload_mock() { return 0; }
+        }
+
+        cleanup_dirs() {
+            rm -rf "$TEST_DIR"
+        }
+
+        BeforeEach 'setup'
+        AfterEach 'cleanup_dirs'
+
+        It 'removes the DNS drop-in and reloads network on success'
+            When call cleanup_iptables_and_dns
+            The status should be success
+            The stdout should include "Successfully removed network drop-in file."
+            The stdout should include "Reloading network configuration succeeded."
+            The path "$NETWORK_DROPIN_FILE" should not be exist
+        End
+
+        It 'removes existing localdns iptables rules and reports success'
+            # Simulate existing localdns rules whose deletion succeeds. The
+            # listing output must contain the "localdns: skip conntrack" comment
+            # so the script's grep keeps it; the rule number is the first field.
+            iptables() {
+                case "$*" in
+                    *"-D "*) return 0 ;;   # deletion succeeds
+                    *"-L "*) echo "1    RETURN  all  --  0.0.0.0/0  0.0.0.0/0  /* localdns: skip conntrack */" ;;
+                    *) return 0 ;;
+                esac
+            }
+            When call cleanup_iptables_and_dns
+            The status should be success
+            The stdout should include "Successfully removed existing localdns iptables rule"
+            The stdout should include "Successfully removed network drop-in file."
+            The stdout should include "Reloading network configuration succeeded."
+            The path "$NETWORK_DROPIN_FILE" should not be exist
+        End
+
+        It 'still removes the DNS drop-in and reloads when iptables deletion fails'
+            # Simulate existing localdns rules whose deletion fails. The listing
+            # output must contain the "localdns: skip conntrack" comment so the
+            # script's grep keeps it; the rule number is the first field.
+            iptables() {
+                case "$*" in
+                    *"-D "*) return 1 ;;   # deletion always fails
+                    *"-L "*) echo "1    RETURN  all  --  0.0.0.0/0  0.0.0.0/0  /* localdns: skip conntrack */" ;;
+                    *) return 0 ;;
+                esac
+            }
+            When call cleanup_iptables_and_dns
+            # Overall status is failure because iptables cleanup failed...
+            The status should be failure
+            # ...but DNS restoration still ran.
+            The stdout should include "Failed to remove existing localdns iptables rule"
+            The stdout should include "Successfully removed network drop-in file."
+            The stdout should include "Reloading network configuration succeeded."
+            The path "$NETWORK_DROPIN_FILE" should not be exist
+        End
+
+        It 'reports failure when network reload fails'
+            networkctl_reload_mock() { return 1; }
+            When call cleanup_iptables_and_dns
+            The status should be failure
+            The stdout should include "Failed to reload network after removing the DNS configuration."
+        End
+
+        It 'cleanup mode exits 0 when cleanup succeeds'
+            cleanup_iptables_and_dns() { return 0; }
+            When run localdns_cleanup_mode
+            The status should be success
+        End
+
+        It 'cleanup mode exits 0 even when cleanup fails'
+            cleanup_iptables_and_dns() { return 1; }
+            When run localdns_cleanup_mode
+            The status should be success
+            The stdout should include "Best-effort LocalDNS DNS cleanup reported errors."
+        End
+    End
 End


### PR DESCRIPTION
## Problem

This PR addresses the LocalDNS failure reported by [Azure/AKS#5930](https://github.com/Azure/AKS/issues/5930). `localdns.service` supervises `localdns.sh`, which starts CoreDNS as a background process. During an unexpected supervisor exit, such as `SIGKILL`, the script cannot run its cleanup traps. The node can therefore retain the network drop-in that points DNS at LocalDNS while the resolver is no longer available. Restart attempts can also encounter leftover processes and fail, eventually leaving the service dead and causing a node-level DNS outage.

**Scope: this PR restores node-level (host) DNS only.** It reverts the node host resolver (the `169.254.10.10` node-listener drop-in and iptables rules) after an unexpected LocalDNS exit. It does **not** restore pod DNS. Pods receive `nameserver 169.254.10.11` (the cluster listener) from kubelet `--cluster-dns`, baked into each pod's `/etc/resolv.conf` at creation and not repointable from the node for the pod's lifetime, so `ExecStopPost` cannot give already-running pods a working resolver. Restoring pod DNS requires keeping the `.11` cluster listener answering -- guaranteeing LocalDNS service recovery from the terminal dead state (the cgroup / StartLimit cause) and/or a `.11` cluster-DNS fallback -- which is a distinct root cause tracked as a separate follow-up PR. This PR therefore does not by itself fully close AKS#5930; it addresses the node-DNS redirect and validates that behavior.

## Fix

- Add `ExecStopPost=/opt/azure/containers/localdns/localdns.sh cleanup` so DNS cleanup runs after both normal and unexpected service exits.
- Add a `cleanup` mode to `localdns.sh` that restores node DNS configuration and always exits successfully; systemd remains responsible for process cleanup.
- Keep cleanup mode separate from normal process cleanup; genuine startup/error paths retain their existing failure status. Systemd manages process termination, while `ExecStopPost` handles node-DNS restoration after unexpected exits.
- Add isolated AgentBaker E2E coverage for Ubuntu 22.04, Ubuntu 24.04, and Azure Linux V3. The lifecycle validation exercises the LocalDNS systemd unit files (`ExecStopPost` DNS cleanup) baked into the VHD, which are identical regardless of the bootstrap path, so the scenario runs under the default (aks-node-controller / scriptless) provisioning path.

The following are intentionally out of scope and tracked separately: pod-level DNS restoration (cluster-listener `.11` recovery / fallback), guaranteed LocalDNS service recovery from the terminal dead state (cgroup delegation / StartLimit), and the unrelated network reconfiguration change.

## Live reproduction

The original failure was historically reproduced twice on the disposable cluster `sakwa-localdns-repro-0710` using the affected Ubuntu 24.04 image `AKSUbuntu-2404gen2containerd-202608.06.1`. That cluster is no longer retained. The historical reproduction targeted the single system-pool node `aks-sysnp-14424852-vmss000000` with LocalDNS enabled.

Healthy baseline:

```text
ActiveState=active
SubState=running
Result=success
NRestarts=0
nameserver 169.254.10.10
```

Fault injection:

```bash
for i in 1 2 3 4 5 6 7 8 9 10; do
  main=$(systemctl show -p MainPID --value localdns.service)
  if [ "$main" -gt 0 ]; then
    kill -9 "$main" || true
  fi
  sleep 0.25
done
```

Observed failure:

```text
Failed to kill control group /localdns.slice/localdns.service, ignoring: Invalid argument
Start request repeated too quickly
Failed to start localdns.service
ActiveState=failed
SubState=failed
Result=signal
```

The first run reached `NRestarts=13`; the second reached `NRestarts=6`. Each run was recovered with `systemctl reset-failed localdns.service` followed by `systemctl restart localdns.service`.

## Validation summary

| Test | Environment | Result |
| --- | --- | --- |
| Historical reproduction | `sakwa-localdns-repro-0710`, shipped Ubuntu 24.04 image | Reproduced the node-DNS blackhole after LocalDNS `SIGKILL` and restart-limit exhaustion |
| Live A/B validation | Fresh LocalDNS-enabled `Standard_D4s_v3` node in `southcentralus` | Shipped artifacts reproduced the failure; PR artifacts removed `70-localdns.conf` and restored node DNS |
| ShellSpec cleanup tests | `localdns.sh` cleanup suite | 12 cleanup examples passed |
| E2E package compilation | `go test ./... -run '^$' -count=1` in `e2e` | Passed |
| Branch-VHD cloud E2E | Branch-built VHDs from the earlier branch state | LocalDNS lifecycle scenarios passed for that run; a fresh run is required after subsequent test/code hardening |

The live A/B test manually replaced the LocalDNS artifacts on a running node. The earlier branch-VHD E2E validated artifacts baked from the branch at that time; it is a separate validation layer and must be rerun after subsequent code/test hardening. The lifecycle validator is attached to the existing LocalDNS hosts-plugin scenarios for Ubuntu 22.04, Ubuntu 24.04, and Azure Linux V3.

## Live validation

The core `ExecStopPost` behavior was tested on a fresh LocalDNS-enabled AKS node in `southcentralus` (`Standard_D4s_v3`, Ubuntu 24.04) through `az vmss run-command`. The live A/B used the cleanup implementation available at that time. Subsequent cleanup and E2E hardening changes are covered by ShellSpec, syntax checks, and E2E compilation; a fresh branch-VHD cloud E2E is still required for the current head. The test used an A/B on the same node: shipped artifacts first, then the PR artifacts. Each phase installed a temporary runtime `Restart=no` drop-in, read the service `MainPID`, sent `SIGKILL`, waited for a terminal `ActiveState`, and checked the node resolver state. The test always restored the original files, removed the temporary drop-in, reloaded systemd, reset the failed state, and restarted LocalDNS before exiting.

`SIGKILL` is intentional: it cannot be caught by Bash, so the normal shell traps do not run. The test therefore exercises the systemd `ExecStopPost` path directly. The cleanup mode restores node DNS only; it intentionally does not delete the dummy interface or claim to recover the LocalDNS process/cgroup.

### Phase A — shipped artifacts

```text
ExecStopPost: absent
localdns.service after SIGKILL: failed
70-localdns.conf: still present
node DNS: still points at 169.254.10.10
```

This reproduced the node-level DNS blackhole from the reported failure.

### Phase B — PR #9360 artifacts

```text
ExecStopPost: present
localdns.service after SIGKILL: failed
70-localdns.conf: removed
169.254.10.10: removed from active node DNS
getent hosts mcr.microsoft.com: succeeded
```

The journal confirmed the cleanup path ran on the live test node:

```text
Removing network drop-in file .../70-localdns.conf.
Successfully removed network drop-in file.
Reloading network configuration succeeded.
```

Normal stop/start was also verified:

```text
stop_state=inactive
result=success
restart_state=active
```

### Result

| Phase | `ExecStopPost` | State after `SIGKILL` | `70-localdns.conf` | Node DNS |
| --- | --- | --- | --- | --- |
| Shipped artifacts | absent | `failed` | still present | still points to `.10`; DNS blackhole |
| PR #9360 artifacts | present | `failed` | removed | `.10` removed; `getent` succeeds |

### Meaning for AKS#5930

This live test proves the **node-level** part of the incident: after an untrappable LocalDNS `SIGKILL`, PR #9360 removes the stale node DNS configuration and restores host-level DNS even when the service remains `failed`.

It does **not** prove pod-DNS recovery. Pods use the separate cluster listener `169.254.10.11`, which is baked into existing pods' `/etc/resolv.conf`. Recovery of that listener is handled by the stacked follow-up work in PR #9439. Therefore, PR #9360 should claim node-level DNS restoration, not complete closure of every pod-DNS failure mode in AKS#5930.

The node was restored to the shipped artifacts and left healthy after the test. The current branch passes the cleanup-focused ShellSpec coverage and E2E compilation checks. A fresh branch-VHD cloud E2E remains required to validate the latest baked artifacts.



