### PR TITLE
fix: wait for os filesystem resize before creating swap file

### DIFF
--- a/e2e/scenario_test.go
+++ b/e2e/scenario_test.go
@@ -1944,6 +1944,50 @@ func Test_AzureLinuxV3_CustomLinuxOSConfigPersistsAfterReboot(t *testing.T) {
 	})
 }
 
+func Test_AzureLinuxV3_LargeSwapFileDuringOSDiskResize(t *testing.T) {
+	const (
+		vmSize         = "Standard_D2s_v5"
+		osDiskSizeGB   = 100
+		swapFileSizeMB = 40000
+	)
+
+	RunScenario(t, &Scenario{
+		Description: "tests that an AzureLinuxV3 scriptless node can create a large swap file while cloud-init resizes the OS disk",
+		Config: Config{
+			Cluster: ClusterKubenet,
+			VHD:     config.VHDAzureLinuxV3Gen2,
+			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
+				nbc.ContainerService.Properties.AgentPoolProfiles[0].VMSize = vmSize
+				nbc.AgentPoolProfile.VMSize = vmSize
+				nbc.AgentPoolProfile.CustomLinuxOSConfig = &datamodel.CustomLinuxOSConfig{
+					SwapFileSizeMB: to.Ptr[int32](swapFileSizeMB),
+				}
+				nbc.AgentPoolProfile.CustomKubeletConfig = &datamodel.CustomKubeletConfig{
+					FailSwapOn: to.Ptr(false),
+				}
+			},
+			AKSNodeConfigMutator: func(_ *Cluster, config *aksnodeconfigv1.Configuration) {
+				config.VmSize = vmSize
+				config.CustomLinuxOsConfig = &aksnodeconfigv1.CustomLinuxOsConfig{
+					EnableSwapConfig: true,
+					SwapFileSize:     swapFileSizeMB,
+				}
+				config.KubeletConfig.EnableKubeletConfigFile = true
+				config.KubeletConfig.KubeletConfigFileConfig.FailSwapOn = to.Ptr(false)
+			},
+			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
+				vmss.SKU.Name = to.Ptr(vmSize)
+				osDisk := vmss.Properties.VirtualMachineProfile.StorageProfile.OSDisk
+				osDisk.DiffDiskSettings = nil
+				osDisk.DiskSizeGB = to.Ptr[int32](osDiskSizeGB)
+			},
+			Validator: func(ctx context.Context, s *Scenario) error {
+				return ValidateSwapFileConfig(ctx, s, swapFileSizeMB)
+			},
+		},
+	})
+}
+
 func Test_Ubuntu2204_KubeletCustomConfig(t *testing.T) {
 	RunScenario(t, &Scenario{
 		Tags: Tags{

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -135,6 +135,42 @@ swapFileIsActive() {
     swapon --show --noheadings | awk '{print $1}' | grep -Fxq "${swap_location}"
 }
 
+getDiskFreeKB() {
+    local disk_path="$1"
+
+    df -P "${disk_path}" | awk 'NR == 2 {print $4}'
+}
+
+hasSufficientDiskSpace() {
+    local disk_path="$1"
+    local required_kb="$2"
+    local disk_free_kb
+
+    disk_free_kb="$(getDiskFreeKB "${disk_path}")"
+    case "${disk_free_kb}" in
+        ''|*[!0-9]*) return 1 ;;
+        *) [ "${disk_free_kb}" -gt "${required_kb}" ] ;;
+    esac
+}
+
+waitForDiskSpace() {
+    local disk_path="$1"
+    local required_kb="$2"
+    local timeout_seconds="$3"
+    local poll_interval_seconds="$4"
+    local elapsed_seconds=0
+
+    while [ "${elapsed_seconds}" -lt "${timeout_seconds}" ]; do
+        sleep "${poll_interval_seconds}"
+        elapsed_seconds=$((elapsed_seconds + poll_interval_seconds))
+        if hasSufficientDiskSpace "${disk_path}" "${required_kb}"; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 getFileMode() {
     local file="$1"
 
@@ -243,14 +279,17 @@ configureSwapFile() {
     if [ -z "${swap_location}" ]; then
         # Directly check size on the root directory since we can't rely on 'root-part1' always being the correct label
         os_device=$(readlink -f /dev/disk/azure/root)
-        disk_free_kb=$(df -P / | sed 1d | awk '{print $4}')
-        if [ "${disk_free_kb}" -gt "${swap_size_kb}" ]; then
-            echo "Will use OS disk for swap file"
-            swap_location=/swapfile
-        else
-            echo "Insufficient disk space on OS device ${os_device} to create swap file: request ${swap_size_kb} free ${disk_free_kb}"
-            exit $ERR_SWAP_CREATE_INSUFFICIENT_DISK_SPACE
+        disk_free_kb=$(getDiskFreeKB /)
+        if ! hasSufficientDiskSpace / "${swap_size_kb}"; then
+            echo "Insufficient disk space on OS device ${os_device}, waiting up to 30 seconds for filesystem resize: request ${swap_size_kb} free ${disk_free_kb}"
+            if ! waitForDiskSpace / "${swap_size_kb}" 30 1; then
+                disk_free_kb=$(getDiskFreeKB /)
+                echo "Insufficient disk space on OS device ${os_device} to create swap file after waiting for filesystem resize: request ${swap_size_kb} free ${disk_free_kb}"
+                exit $ERR_SWAP_CREATE_INSUFFICIENT_DISK_SPACE
+            fi
         fi
+        echo "Will use OS disk for swap file"
+        swap_location=/swapfile
     fi
 
     echo "Swap file will be saved to: ${swap_location}"

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -3273,6 +3273,48 @@ EOF
             The output should include "Swap file will be saved to: /swapfile"
             The output should include "reconcileSwapFilePersistence /swapfile"
         End
+
+        It 'waits for the OS filesystem resize before creating the swap file'
+            DISK_FREE_KB=500
+            findmnt() {
+                return 1
+            }
+            df() {
+                printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/sda1 1000000 0 %s 0%% /\n' "${DISK_FREE_KB}"
+            }
+            sleep() {
+                echo "sleep $1"
+                DISK_FREE_KB=1000000
+            }
+
+            When call configureSwapFile
+
+            The status should be success
+            The output should include "waiting up to 30 seconds for filesystem resize"
+            The output should include "sleep 1"
+            The output should include "Will use OS disk for swap file"
+            The output should include "Swap file will be saved to: /swapfile"
+        End
+
+        It 'fails after waiting 30 seconds when the OS disk remains too small'
+            DISK_FREE_KB=500
+            findmnt() {
+                return 1
+            }
+            df() {
+                printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/sda1 1000000 0 %s 0%% /\n' "${DISK_FREE_KB}"
+            }
+            sleep() {
+                echo "sleep $1"
+            }
+
+            When run configureSwapFile
+
+            The status should equal "$ERR_SWAP_CREATE_INSUFFICIENT_DISK_SPACE"
+            The output should include "waiting up to 30 seconds for filesystem resize"
+            The output should include "after waiting for filesystem resize"
+            The output should not include "Swap file will be saved to"
+        End
     End
 
     Describe 'reconcileSwapFilePersistence'


### PR DESCRIPTION
Scriptless CSE can check OS-disk capacity while cloud-init is still expanding the root filesystem, causing intermittent exit code 131 for large swap files. Retry the capacity check for up to 30 seconds before failing.