### PR TITLE
fix: support two-component GRID driver versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -666,7 +666,7 @@
         "aks/aks-gpu-grid"
       ],
       "groupName": "nvidia-gpu-grid",
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<prerelease>\\d{14})$",
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?-(?<prerelease>\\d{14})$",
       "automerge": false,
       "enabled": true,
       "ignoreUnstable": false,


### PR DESCRIPTION
## What

Allow the `aks/aks-gpu-grid` Renovate rule to parse image tags whose NVIDIA driver version has either two or three numeric components.

## Why

NVIDIA publishes the vGPU 18.8 driver as `570.237`, so the current image tag is:

```
570.237-20260831155850
```

The existing regex requires a three-component driver version such as `570.211.01`. Renovate therefore ignores the new tag and only proposes timestamp updates within `570.211.01`.

This change is scoped to `aks/aks-gpu-grid`. The CUDA and GRID v20 rules are unchanged.

## Validation

- `jq empty .github/renovate.json`
- `renovate-config-validator .github/renovate.json`
- Focused Renovate 44.48.0 dry run against MCR
  - Detected `570.237-20260831155850`
  - Classified it as a minor update
  - Produced the expected `renovate/nvidia-gpu-grid` branch proposal
