### PR TITLE
chore: return correct exit code from provision.json upon early exit

### DIFF
--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -3,13 +3,10 @@
 ERR_FILE_WATCH_TIMEOUT=6
 set -x
 
-PROVISION_JSON_FILEPATH=/var/log/azure/aks/provision.json
-
-if [ -f "${PROVISION_JSON_FILEPATH}" ]; then
-    local exit_code
-    exit_code=$(jq -r '.ExitCode' "${PROVISION_JSON_FILEPATH}")
-    echo "Already ran provisioning, exiting with code ${exit_code}..."
-    exit "${exit_code}"
+if [ -f /opt/azure/containers/provision.complete ]; then
+    EXIT_CODE=$(jq -r '.ExitCode' /var/log/azure/aks/provision.json)
+    echo "Already ran provisioning, exiting with code ${EXIT_CODE}..."
+    exit "${EXIT_CODE}"
 fi
 
 # Cleanup cache file to force fetch fresh instance metadata from IMDS

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -3,11 +3,6 @@
 ERR_FILE_WATCH_TIMEOUT=6
 set -x
 
-if [ -f /opt/azure/containers/provision.complete ]; then
-    echo "Already ran to success exiting..."
-    exit 0
-fi
-
 # Cleanup cache file to force fetch fresh instance metadata from IMDS
 rm -f /opt/azure/containers/imds_instance_metadata_cache.json
 

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -3,6 +3,15 @@
 ERR_FILE_WATCH_TIMEOUT=6
 set -x
 
+PROVISION_JSON_FILEPATH=/var/log/azure/aks/provision.json
+
+if [ -f "${PROVISION_JSON_FILEPATH}" ]; then
+    local exit_code
+    exit_code=$(jq -r '.ExitCode' "${PROVISION_JSON_FILEPATH}")
+    echo "Already ran provisioning, exiting with code ${exit_code}..."
+    exit "${exit_code}"
+fi
+
 # Cleanup cache file to force fetch fresh instance metadata from IMDS
 rm -f /opt/azure/containers/imds_instance_metadata_cache.json
 


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
Upon cse rerun, return the correct exit code from `provision.json` instead of always returning 0.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
