### PR TITLE
fix: pin msft-golang to 1.26.7 to unblock GB VHD build on Go 1.27 agents

### DIFF
--- a/hack/setup_golang.sh
+++ b/hack/setup_golang.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 set -euxo pipefail
 
+go_version="1.26.7"
+
 # This script installs Microsoft's Go distribution via apt-get (Ubuntu).
 # On hosts without apt-get (e.g. Azure Linux build agents), the build environment
-# is expected to provide Go through its own package manager, so just verify that
-# `go` is on PATH and exit.
+# is expected to provide the required Go version through its own package manager,
+# so verify it is on PATH and matches before exiting.
 if ! command -v apt-get >/dev/null 2>&1; then
     echo "apt-get not found; skipping Ubuntu-specific Go setup."
     if ! command -v go >/dev/null 2>&1; then
         echo "ERROR: 'go' is not on PATH; the build environment must install Go before invoking setup_golang.sh." >&2
+        exit 1
+    fi
+    actual_go_version=$(go env GOVERSION)
+    if [[ "${actual_go_version}" != "go${go_version}" ]]; then
+        echo "ERROR: expected Go ${go_version}, found ${actual_go_version}; the build environment must provide the required version." >&2
         exit 1
     fi
     echo "Using Go provided by the build environment:"
@@ -23,24 +30,26 @@ purge_go() {
 }
 
 setup_pmc() {
+    local ubuntu_release="$1"
     # see: https://github.com/microsoft/go/blob/microsoft/main/README.md#ubuntu
-    UBUNTU_RELEASE=$(sudo lsb_release -r -s 2>/dev/null || echo "")
-    curl -sSL -O https://packages.microsoft.com/config/ubuntu/${UBUNTU_RELEASE}/packages-microsoft-prod.deb
+    curl -sSL -O "https://packages.microsoft.com/config/ubuntu/${ubuntu_release}/packages-microsoft-prod.deb"
     sudo dpkg -i packages-microsoft-prod.deb
     sudo apt-get update
 }
+
+ubuntu_release=$(sudo lsb_release -r -s)
 
 # purge any existing go installation
 purge_go
 
 # setup access to packages.microsoft.com for the particular Ubuntu release
-setup_pmc
+setup_pmc "${ubuntu_release}"
 
 # install make
 sudo apt-get -y install make
 
 # install msft-golang
-sudo apt-get -y install msft-golang
+sudo apt-get -y install "msft-golang=${go_version}-ubuntu${ubuntu_release}u1"
 
 # make sure go is accessible from the command line
 go version

--- a/hack/setup_golang.sh
+++ b/hack/setup_golang.sh
@@ -14,6 +14,7 @@ if ! command -v apt-get >/dev/null 2>&1; then
         exit 1
     fi
     actual_go_version=$(go env GOVERSION)
+    # shellcheck disable=SC3010
     if [[ "${actual_go_version}" != "go${go_version}" ]]; then
         echo "ERROR: expected Go ${go_version}, found ${actual_go_version}; the build environment must provide the required version." >&2
         exit 1


### PR DESCRIPTION
## Problem

The first VHD build off `ganesh/gb-may-packagekit` (ADO [179635482](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=179635482)) fails in `build-image-fetcher`:

```
go: GOEXPERIMENT=ms_nocgo_opensslcrypto has been removed; system crypto supports
    CGO_ENABLED=0 automatically on platforms with a cgo-less OpenSSL implementation since Go 1.27
make[1]: *** [packer.mk:157: build-image-fetcher] Error 2
make: *** [packer.mk:104: run-packer] Error 2
```

Build log confirms `go version go1.27.0 linux/amd64` on an Ubuntu 22.04 (jammy) agent.

## Cause

This branch is based on a May commit, where `hack/setup_golang.sh` installs Go **unpinned**:

```sh
sudo apt-get -y install msft-golang
```

PMC now serves Go 1.27, which removed the `ms_nocgo_opensslcrypto` GOEXPERIMENT. `packer.mk` still sets that experiment in 5 places, so every Go build in `run-packer` fails.

## Fix

Cherry-pick main's fix, unchanged:

- `8a56f35719` — fix: go experiment variable removal (#9346)
- `abe421d96a` — fix: disable shellcheck SC3010, setup_golang (#9352)

which pin the toolchain instead of dropping the experiment:

```sh
go_version="1.26.7"
sudo apt-get -y install "msft-golang=${go_version}-ubuntu${ubuntu_release}u1"
```

## Notes

- `GOEXPERIMENT=ms_nocgo_opensslcrypto` is **still present on main** (`packer.mk` 144/145/150/151/156). Main did not remove it; it pinned Go. Removing the experiment instead would change the branch to non-OpenSSL-backed crypto, which is compliance-relevant for a shipped VHD — so this matches main rather than diverging.
- After this change `hack/setup_golang.sh` is **byte-identical to `origin/main`**.
- Verified: `bash -n` clean; file matches main so the existing shellcheck gate is unaffected.

## Test

Re-queue `AKS Linux VHD Build - Weekly Release Only` (def 165322) with `build2404arm64gbgen2containerd` off the base branch once merged.