### PR TITLE
fix: renovate match new ciprod tag format (X.Y.Z-ci-prod-DATE-HASH)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -254,6 +254,10 @@
       "matchPackageNames": [
         "azuremonitor/containerinsights/ciprod"
       ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-ci-prod-(?<prerelease>\\d{2}-\\d{2}-\\d{4}-[0-9a-f]+))?$",
       "groupName": "ciprod",
       "ignoreUnstable": false,
       "reviewers": [


### PR DESCRIPTION
## What

Adds a regex `versioning` scheme to the `azuremonitor/containerinsights/ciprod` Renovate rule so it parses the new image tag format.

## Why

The `ciprod` tag format is changing from plain semver like `containerinsights/ciprod:3.6.0` to a date/hash-suffixed form like `containerinsights/ciprod:3.7.0-ci-prod-08-28-2026-925ade3d`. Renovate's default `docker` versioning can't sort/compare the new suffix, so it would stop raising update PRs.

## How

- New versioning regex: `^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-ci-prod-(?<prerelease>\d{2}-\d{2}-\d{4}-[0-9a-f]+))?$`
- The `-ci-prod-DATE-HASH` suffix is **optional**, so the one regex parses both the current `3.6.0` value in `parts/common/components.json` and the new format — bridging the transition without hardcoding a new component version.
- Placed on the rule **without** `matchUpdateTypes` (per Renovate docs, `versioning` should not be combined with `matchUpdateTypes`), and scoped with `matchDatasources: ["docker"]`.

This follows the same pattern already used by the **ama-metrics** rule (`azuremonitor/containerinsights/ciprod/prometheus-collector/images`), which uses an equivalent date-hash regex versioning (`-main-DATE-HASH`).

## Notes

- The existing second `ciprod` rule (`matchUpdateTypes: ["minor","patch"]`, `enabled: true`) is unchanged and still re-enables updates (minor is disabled globally).
- Verified the file is valid JSON and the regex matches `3.6.0`, `3.7.0-ci-prod-08-28-2026-925ade3d`, and future values like `3.10.2-ci-prod-12-01-2026-abcdef01`.