### PR TITLE
fix: stop SIG image-version GC from deleting every untagged version

### DIFF
--- a/vhdbuilder/packer/cleanup.sh
+++ b/vhdbuilder/packer/cleanup.sh
@@ -8,6 +8,10 @@ EXPIRATION_IN_HOURS=168 # 7 days
 (( expirationInSecs = ${EXPIRATION_IN_HOURS} * 60 * 60 ))
 # deadline = the "date +%s" representation of the oldest age we're willing to keep
 (( deadline=$(date +%s)-${expirationInSecs%.*} ))
+# SIG image versions never carry the "now" tag: packer applies azure_tags to the managed image
+# only, not to the shared_image_gallery_destination. They're aged off using the ARM-provided
+# publishingProfile.publishedDate instead, which is ISO-8601 UTC and so sorts lexicographically.
+publishedDateDeadline=$(date -u -d "@${deadline}" +%Y-%m-%dT%H:%M:%SZ)
 
 if [ -z "$SIG_GALLERY_NAME" ]; then
   SIG_GALLERY_NAME="PackerSigGalleryEastUS"
@@ -169,12 +173,14 @@ if [[ "${MODE}" == "linuxVhdMode" && -n "${AZURE_RESOURCE_GROUP_NAME}" && "${DRY
   # we limit deletion to 15 SIG image versions per image definition
   set +x
   for image_definition in $(az sig image-definition list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${SIG_GALLERY_NAME} | jq '.[].name' | tr -d '\"' || ""); do
-    for image_version in $(az sig image-version list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${SIG_GALLERY_NAME} -i ${image_definition} | jq --arg dl $deadline '.[] | select(.tags.now < $dl).name' | head -n 15 | tr -d '\"' || ""); do
+    for image_version in $(az sig image-version list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${SIG_GALLERY_NAME} -i ${image_definition} | jq --arg dl "$publishedDateDeadline" '.[] | select(.publishingProfile.publishedDate != null) | select(.publishingProfile.publishedDate < $dl).name' | head -n 15 | tr -d '\"' || ""); do
       image_version_id="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/galleries/${SIG_GALLERY_NAME}/images/${image_definition}/versions/${image_version}"
 
       # TODO: remove 2404gen2arm64gbcontainerd exemption once released to official production galleries
-      # shellcheck disable=SC3010
-      if [ "${image_definition,,}" = "2404gen2arm64gbcontainerd" ] && [[ "$image_version" == "1.1."* ]]; then
+      # NOTE: this deliberately matches the whole image definition. It previously also required the
+      # version to start with "1.1.", which silently stopped protecting anything once GB builds moved
+      # to 1.2.x, and 1.2.103-1.2.106 were garbage collected as a result.
+      if [ "${image_definition,,}" = "2404gen2arm64gbcontainerd" ]; then
         echo "Will not consider garbage collection of image: ${image_version_id}"
         continue
       fi


### PR DESCRIPTION
ADO build [179633029](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=179633029) deleted **39 SIG image versions** — including `2404gen2arm64gbcontainerd` **1.2.103–1.2.106** (the GB200/GB300 images), 30 Flatcar versions, and five Windows definitions — from a **failed** `AzureLinuxV3gen1` build that never produced an image.

## Root cause

`vhdbuilder/packer/cleanup.sh` ages off SIG image versions with:

```sh
az sig image-version list ... | jq --arg dl $deadline ".[] | select(.tags.now < \$dl).name"
```

**SIG image versions never carry a `now` tag.** Packer applies `azure_tags` (which is where `now` comes from) to the *managed image*; the `shared_image_gallery_destination` block has no tags at all — see `vhd-image-builder-arm64-gb.json` and every other template.

So `.tags.now` is `null` for every version, and in jq `null` sorts below every string:

```console
$ jq -n "(null < \"1787873664\")"
true
```

The filter is therefore **unconditionally true**. The "delete versions older than 168 hours" pass actually deletes the first 15 versions of *every* image definition in the gallery, on *every* `linuxVhdMode` build, regardless of age — including versions created minutes earlier. Only the resource-lock check limited the blast radius.

Reproduced against a fixture (deadline `2026-08-27`):

| version | published | before | after |
|---|---|---|---|
| `1.2.103` | 2026-05-28 | DELETE | DELETE |
| `1.2.999` | **2026-09-03 (today)** | **DELETE** ← bug | keep |
| `1.1755629795.32733` | 2025-08-19 | DELETE | DELETE |
| `260819.045326.24524` | 2026-08-19 | DELETE | DELETE |

## Fix

Age SIG versions off `publishingProfile.publishedDate`, which ARM always populates, with a null guard so anything lacking it is skipped rather than swept.

Two existing precedents in this repo confirm the shape of the fix:

- the adjacent **managed image** loop already guards with `select(.tags.now != null)` — and managed images genuinely *do* carry the tag (packer `azure_tags`), so that loop is correct as-is and is left alone;
- `.pipelines/scripts/windows-sub-cleanup.sh:105` already ages SIG versions off `publishingProfile.publishedDate`.

This aligns `cleanup.sh` with both.

## Second defect: the GB exemption was dead

```sh
if [ "${image_definition,,}" = "2404gen2arm64gbcontainerd" ] && [[ "$image_version" == "1.1."* ]]; then
```

The exemption also required the version to start with `1.1.`. GB builds moved to `1.2.x`, so it silently stopped protecting anything, which is why `1.2.103`–`1.2.106` were collected despite the guard being present. It now matches on the image definition, per the existing `TODO` (protect GB until it is released to official production galleries).

| version | before | after |
|---|---|---|
| `1.1.99` | PROTECTED | PROTECTED |
| `1.2.103`–`1.2.107` | **DELETED** | PROTECTED |

## Testing

- `bash -n` clean.
- `shellcheck` run exactly as `verify_shell.sh` invokes it (bash mode, repo ignore list): exit 0 before and after; no new findings. `SC3014` count actually drops 5 → 4 since a `[[ ]]` is removed.
- jq filter behaviour verified against a fixture mirroring `az sig image-version list` output (table above).
- `date -u -d "@1787873664" +%Y-%m-%dT%H:%M:%SZ` → `2026-08-27T23:34:24Z`, verified with GNU date, matching the deadline in the failing run. ISO-8601 UTC compares correctly against ARM's `...+00:00` form.

## Note on scope

This does **not** change the behaviour of the managed-image loop, the resource-group loops, or the storage-account loop; those operate on resources that really are tagged with `now`.