### PR TITLE
fix: stop SIG image-version GC from deleting every untagged version (backport of #9397)

### DIFF
--- a/vhdbuilder/packer/cleanup.sh
+++ b/vhdbuilder/packer/cleanup.sh
@@ -8,6 +8,10 @@ EXPIRATION_IN_HOURS=168 # 7 days
 (( expirationInSecs = ${EXPIRATION_IN_HOURS} * 60 * 60 ))
 # deadline = the "date +%s" representation of the oldest age we're willing to keep
 (( deadline=$(date +%s)-${expirationInSecs%.*} ))
+# SIG image versions never carry the "now" tag: packer applies azure_tags to the managed image
+# only, not to the shared_image_gallery_destination. They're aged off using the ARM-provided
+# publishingProfile.publishedDate instead, which is ISO-8601 UTC and so sorts lexicographically.
+publishedDateDeadline=$(date -u -d "@${deadline}" +%Y-%m-%dT%H:%M:%SZ)
 
 if [ -z "$SIG_GALLERY_NAME" ]; then
   SIG_GALLERY_NAME="PackerSigGalleryEastUS"
@@ -169,12 +173,14 @@ if [[ "${MODE}" == "linuxVhdMode" && -n "${AZURE_RESOURCE_GROUP_NAME}" && "${DRY
   # we limit deletion to 15 SIG image versions per image definition
   set +x
   for image_definition in $(az sig image-definition list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${SIG_GALLERY_NAME} | jq '.[].name' | tr -d '\"' || ""); do
-    for image_version in $(az sig image-version list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${SIG_GALLERY_NAME} -i ${image_definition} | jq --arg dl $deadline '.[] | select(.tags.now < $dl).name' | head -n 15 | tr -d '\"' || ""); do
+    for image_version in $(az sig image-version list -g ${AZURE_RESOURCE_GROUP_NAME} -r ${SIG_GALLERY_NAME} -i ${image_definition} | jq --arg dl "$publishedDateDeadline" '.[] | select(.publishingProfile.publishedDate != null) | select(.publishingProfile.publishedDate < $dl).name' | head -n 15 | tr -d '\"' || ""); do
       image_version_id="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/galleries/${SIG_GALLERY_NAME}/images/${image_definition}/versions/${image_version}"
 
       # TODO: remove 2404gen2arm64gbcontainerd exemption once released to official production galleries
-      # shellcheck disable=SC3010
-      if [ "${image_definition,,}" = "2404gen2arm64gbcontainerd" ] && [[ "$image_version" == "1.1."* ]]; then
+      # NOTE: this deliberately matches the whole image definition. It previously also required the
+      # version to start with "1.1.", which silently stopped protecting anything once GB builds moved
+      # to 1.2.x, and 1.2.103-1.2.106 were garbage collected as a result.
+      if [ "${image_definition,,}" = "2404gen2arm64gbcontainerd" ]; then
         echo "Will not consider garbage collection of image: ${image_version_id}"
         continue
       fi


### PR DESCRIPTION
Backport of #9397 onto the GB200/300 May build branch.

## Why this needs to be on *this* branch, not just `main`

ADO build [179633029](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=179633029) ran off `ganesh/gb-may-packagekit` — **this** branch — and deleted 39 SIG image versions, including `2404gen2arm64gbcontainerd` **1.2.103–1.2.106**.

`vhdbuilder/packer/cleanup.sh` here is byte-identical to `main`'s, so the bug is live on this branch too. Until this merges, **every** VHD build queued off this branch (or off `ganesh/gb-may-go127-pin`, which stacks on it) will run the same destructive GC again — including a failed one, because a failed build still runs cleanup:

> Build step did not produce an image version. Running cleanup and then exiting.

## The two defects

**1. The age filter is unconditionally true.**

```sh
jq --arg dl $deadline '.[] | select(.tags.now < $dl).name'
```

SIG image versions **never carry a `now` tag**. Packer applies `azure_tags` (the source of `now`) to the *managed image*; the `shared_image_gallery_destination` block has no tags. So `.tags.now` is `null` for every version — and in jq:

```console
$ jq -n '(null < "1787873664")'
true
```

`null` sorts below every string, so the filter always matches. "Delete versions older than 168 hours" actually means **delete the first 15 versions of every image definition on every `linuxVhdMode` build, regardless of age**. Only the `az lock list` check limited the damage.

The adjacent managed-image loop already guards this (`select(.tags.now != null)`, line 148) and managed images genuinely *are* tagged — so that loop is correct and is left untouched.

**2. The GB exemption was dead code.**

```sh
if [ "${image_definition,,}" = "2404gen2arm64gbcontainerd" ] && [[ "$image_version" == "1.1."* ]]; then
```

GB builds moved to `1.2.x`, so the `1.1.` clause silently stopped protecting anything. That is exactly why `1.2.103`–`1.2.106` were collected.

## The fix

Age SIG versions off the ARM-provided `publishingProfile.publishedDate` (ISO-8601 UTC, so it sorts lexicographically) with a `!= null` guard, and match the GB exemption on the image definition alone.

This is the pattern already used in-repo by `.pipelines/scripts/windows-sub-cleanup.sh:105`.

| version | published | before | after |
|---|---|---|---|
| `1.2.999` | today | **DELETED** ← bug | kept |
| `1.2.103` | 2026-05-28 | DELETED | **exempt (GB)** |
| stale non-GB | > 7d ago | deleted | deleted (unchanged) |

## Verification

- `cleanup.sh` on this branch is byte-identical to `main`'s before the change, and the resulting file is byte-identical to #9397's.
- `.pipelines/scripts/verify_shell.sh` is identical on this branch and `main`.
- `bash -n` clean; shellcheck run exactly as CI invokes it (bash mode via shebang + the repo ignore list) exits **0**, no new findings. The now-unnecessary `# shellcheck disable=SC3010` is dropped along with the `[[ ]]`.
- jq fixture confirms a version published today is selected for deletion before the change and skipped after.

Once this and #9392 (Go 1.26.7 pin) are in, a GB VHD build off this branch is safe to queue.
