### PR TITLE
fix: cap parallel container image pulls

### DIFF
--- a/vhdbuilder/packer/install-dependencies.sh
+++ b/vhdbuilder/packer/install-dependencies.sh
@@ -815,13 +815,17 @@ string_replace() {
   echo ${1//\*/$2}
 }
 
-# Limit number of parallel pulls to 2 less than number of processor cores in order to prevent issues with network, CPU, and disk resources
-# Account for possibility that number of cores is 3 or less
+# Each image fetch can open several layer downloads. Cap the worker count so high-vCPU
+# builders do not overload the registry or network connection.
+max_parallel_container_image_pulls=16
 num_proc=$(nproc)
 if [ "$num_proc" -gt 3 ]; then
-  parallel_container_image_pull_limit=$(nproc --ignore=2)
+  parallel_container_image_pull_limit=$((num_proc - 2))
 else
   parallel_container_image_pull_limit=1
+fi
+if [ "$parallel_container_image_pull_limit" -gt "$max_parallel_container_image_pulls" ]; then
+  parallel_container_image_pull_limit="$max_parallel_container_image_pulls"
 fi
 echo "Limit for parallel container image pulls set to $parallel_container_image_pull_limit"
 


### PR DESCRIPTION
## Summary

- cap concurrent VHD container-image fetch workers at 16
- retain the existing `nproc - 2` behavior for builders below the cap
- avoid changing CSE image-pull retries or node-provisioning behavior

## Root cause

Build `179661456` used a `Standard_D32pds_v5` builder. The existing `nproc - 2` calculation allowed 30 image-fetch processes to run concurrently. Each process can download several image layers, which creates substantially more concurrent MCR connections.

The first build attempt failed while fetching `mcr.microsoft.com/oss/v2/kubernetes/kube-proxy:v1.35.4-3` because the TCP connection was reset by the peer. The image manifest is available, so this was a transient transfer failure rather than a missing image. Bounding the worker count reduces registry and network pressure while preserving the existing retry behavior.

## Validation

- `bash -n vhdbuilder/packer/install-dependencies.sh`
- focused ShellCheck with the repository exclusion set
- `git diff --check`

For the 32-vCPU GB builder, the pull limit changes from 30 to 16. Existing builders with lower calculated limits are unchanged.