### PR TITLE
fix: classify temporary vhd build storage accounts as non-recovery critical

### DIFF
--- a/vhdbuilder/packer/produce-packer-settings-functions.sh
+++ b/vhdbuilder/packer/produce-packer-settings-functions.sh
@@ -141,6 +141,7 @@ function extract_windows_image_urls() {
 }
 
 function create_windows_storage_account() {
+	local mirs_classification_tag="ms-resiliency-classification=Non-Recovery Critical"
 
 	avail=$(az storage account check-name -n "${STORAGE_ACCOUNT_NAME}" -o json | jq -r .nameAvailable)
 	if $avail; then
@@ -149,7 +150,7 @@ function create_windows_storage_account() {
 			-n "$STORAGE_ACCOUNT_NAME" \
 			-g "$AZURE_RESOURCE_GROUP_NAME" \
 			--sku "Standard_RAGRS" \
-			--tags "now=${CREATE_TIME}" \
+			--tags "now=${CREATE_TIME}" "${mirs_classification_tag}" \
 			--allow-shared-key-access false \
 			--min-tls-version TLS1_2 \
 			--location "${AZURE_LOCATION}"

--- a/vhdbuilder/prefetch/scripts/optimize.sh
+++ b/vhdbuilder/prefetch/scripts/optimize.sh
@@ -282,10 +282,11 @@ convert_specialized_sig_version_to_managed_image() {
 }
 
 create_temp_storage() {
+    local mirs_classification_tag="ms-resiliency-classification=Non-Recovery Critical"
     storage_account_name="${VHD_NAME//./}"
     if ! az storage account show --account-name "${storage_account_name}" >/dev/null 2>&1; then
         echo "creating temporary storage account ${storage_account_name} in resource group ${IMAGE_BUILDER_RG_NAME} in location ${LOCATION}"
-        az storage account create -n "${storage_account_name}" -g "${IMAGE_BUILDER_RG_NAME}" --sku "Standard_RAGRS" --allow-shared-key-access false --min-tls-version TLS1_2 --location "${LOCATION}" || return $?
+        az storage account create -n "${storage_account_name}" -g "${IMAGE_BUILDER_RG_NAME}" --sku "Standard_RAGRS" --tags "${mirs_classification_tag}" --allow-shared-key-access false --min-tls-version TLS1_2 --location "${LOCATION}" || return $?
     fi
     storage_container_name="vhd"
     if [ "$(az storage container exists -n "${storage_container_name}" --account-name "${storage_account_name}" --auth-mode login | jq -r '.exists')" = "false" ]; then


### PR DESCRIPTION
Add the MIRS non-recovery-critical tag when creating temporary Windows and prefetch VHD storage accounts while preserving cleanup tags.