### PR TITLE
fix: update liveness probe to avoid clash

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -651,11 +651,11 @@
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/csi-node-driver-registrar",
-          "latestVersion": "v2.17.0"
+          "latestVersion": "v2.17.0-5"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/csi-node-driver-registrar",
-          "latestVersion": "v2.16.0"
+          "latestVersion": "v2.16.0-10"
         }
       ]
     },

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -617,21 +617,21 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
-          "latestVersion": "v2.19.0"
+          "latestVersion": "v2.20.0"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
-          "latestVersion": "v2.18.0"
+          "latestVersion": "v2.19.0-6"
         }
       ],
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
-          "latestVersion": "v2.19.0"
+          "latestVersion": "v2.20.0"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
-          "latestVersion": "v2.18.0"
+          "latestVersion": "v2.19.0-6"
         }
       ]
     },

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -631,7 +631,7 @@
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
-          "latestVersion": "v2.18.0"
+          "latestVersion": "v2.18.0-10"
         }
       ]
     },

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -627,11 +627,13 @@
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
-          "latestVersion": "v2.19.0-5"
+          "latestVersion": "v2.19.0-5",
+          "additionalTagsToApplyToContainer": ["v2.19.0"]
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
-          "latestVersion": "v2.18.0-10"
+          "latestVersion": "v2.18.0-10",
+          "additionalTagsToApplyToContainer": ["v2.18.0"]
         }
       ]
     },
@@ -651,11 +653,13 @@
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/csi-node-driver-registrar",
-          "latestVersion": "v2.17.0-5"
+          "latestVersion": "v2.17.0-5",
+          "additionalTagsToApplyToContainer": ["v2.17.0"]
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/csi-node-driver-registrar",
-          "latestVersion": "v2.16.0-10"
+          "latestVersion": "v2.16.0-10",
+          "additionalTagsToApplyToContainer": ["v2.16.0"]
         }
       ]
     },

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -621,7 +621,7 @@
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
-          "latestVersion": "v2.19.0-6"
+          "latestVersion": "v2.19.0"
         }
       ],
       "windowsVersions": [
@@ -631,7 +631,7 @@
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
-          "latestVersion": "v2.19.0-6"
+          "latestVersion": "v2.19.0-5"
         }
       ]
     },

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -617,21 +617,21 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
-          "latestVersion": "v2.20.0"
+          "latestVersion": "v2.19.0"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
-          "latestVersion": "v2.19.0"
+          "latestVersion": "v2.18.0"
         }
       ],
       "windowsVersions": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
-          "latestVersion": "v2.20.0"
+          "latestVersion": "v2.19.0-5"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes-csi/livenessprobe",
-          "latestVersion": "v2.19.0-5"
+          "latestVersion": "v2.18.0"
         }
       ]
     },

--- a/schemas/components.cue
+++ b/schemas/components.cue
@@ -29,6 +29,7 @@ package components
 	latestVersion:           string
 	previousLatestVersion?:  string
 	windowsSkuMatch?:        string
+	additionalTagsToApplyToContainer?: [...string]
 }
 
 #Images: [...#ContainerImage]

--- a/vhdbuilder/packer/windows/components_json_helpers.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.ps1
@@ -120,7 +120,7 @@ function GetContainerImageTagAliasesFromComponentsJson
         $versions = $containerImage.windowsVersions
         if ($versions -eq $null)
         {
-            $versions = $containerImage.multiArchVersionsV2
+            continue
         }
 
         $downloadUrl = $containerImage.windowsDownloadUrl
@@ -137,24 +137,19 @@ function GetContainerImageTagAliasesFromComponentsJson
                 continue
             }
 
-            $versionsToAlias = @($windowsVersion.latestVersion)
-            if (-not [string]::IsNullOrEmpty($windowsVersion.previousLatestVersion))
+            $additionalTags = $windowsVersion.additionalTagsToApplyToContainer
+            if ($additionalTags -eq $null)
             {
-                $versionsToAlias += $windowsVersion.previousLatestVersion
+                continue
             }
 
-            foreach ($versionToAlias in $versionsToAlias)
-            {
-                if ($versionToAlias -notmatch '^(?<mainTag>.+)-\d+$')
-                {
-                    continue
-                }
+            $sourceImage = SafeReplaceString($downloadUrl)
+            $sourceImage = $sourceImage.replace("*", $windowsVersion.latestVersion)
 
-                $mainTag = $Matches.mainTag
-                $sourceImage = SafeReplaceString($downloadUrl)
-                $sourceImage = $sourceImage.replace("*", $versionToAlias)
+            foreach ($additionalTag in $additionalTags)
+            {
                 $targetImage = SafeReplaceString($downloadUrl)
-                $targetImage = $targetImage.replace("*", $mainTag)
+                $targetImage = $targetImage.replace("*", $additionalTag)
 
                 if ($targetImages.ContainsKey($targetImage))
                 {

--- a/vhdbuilder/packer/windows/components_json_helpers.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.ps1
@@ -105,6 +105,74 @@ function GetComponentsFromComponentsJson
     return $output
 }
 
+function GetContainerImageTagAliasesFromComponentsJson
+{
+    Param(
+        [Parameter(Mandatory = $true)][Object]
+        $componentsJsonContent
+    )
+
+    $output = New-Object System.Collections.ArrayList
+    $targetImages = @{}
+
+    foreach ($containerImage in $componentsJsonContent.ContainerImages)
+    {
+        $versions = $containerImage.windowsVersions
+        if ($versions -eq $null)
+        {
+            $versions = $containerImage.multiArchVersionsV2
+        }
+
+        $downloadUrl = $containerImage.windowsDownloadUrl
+        if ($downloadUrl -eq $null)
+        {
+            $downloadUrl = $containerImage.downloadUrl
+        }
+
+        foreach ($windowsVersion in $versions)
+        {
+            $skuMatch = $windowsVersion.windowsSkuMatch
+            if ($skuMatch -ne $null -and $windowsSku -ne $null -and $windowsSku -NotLike $skuMatch)
+            {
+                continue
+            }
+
+            $versionsToAlias = @($windowsVersion.latestVersion)
+            if (-not [string]::IsNullOrEmpty($windowsVersion.previousLatestVersion))
+            {
+                $versionsToAlias += $windowsVersion.previousLatestVersion
+            }
+
+            foreach ($versionToAlias in $versionsToAlias)
+            {
+                if ($versionToAlias -notmatch '^(?<mainTag>.+)-\d+$')
+                {
+                    continue
+                }
+
+                $mainTag = $Matches.mainTag
+                $sourceImage = SafeReplaceString($downloadUrl)
+                $sourceImage = $sourceImage.replace("*", $versionToAlias)
+                $targetImage = SafeReplaceString($downloadUrl)
+                $targetImage = $targetImage.replace("*", $mainTag)
+
+                if ($targetImages.ContainsKey($targetImage))
+                {
+                    continue
+                }
+
+                $targetImages[$targetImage] = $true
+                $output += [PSCustomObject]@{
+                    Source = $sourceImage
+                    Target = $targetImage
+                }
+            }
+        }
+    }
+
+    return $output
+}
+
 function GetPackagesFromComponentsJson
 {
 
@@ -431,6 +499,7 @@ function GetAllCachedThings {
     )
 
     $items = GetComponentsFromComponentsJson $componentsJsonContent
+    $imageTagAliases = GetContainerImageTagAliasesFromComponentsJson $componentsJsonContent
     $packages = GetPackagesFromComponentsJson $componentsJsonContent
     $ociArtifacts = GetOCIArtifactsFromComponentsJson $componentsJsonContent
     $regKeys = GetRegKeysToApply $windowsSettingsContent
@@ -438,6 +507,10 @@ function GetAllCachedThings {
     $baseVersionBlock = $windowsSettingsContent.WindowsBaseVersions."$windowsSku"
 
     $items += "Windows ${windowsSku} base version: ${baseVersion}"
+    foreach ($imageTagAlias in $imageTagAliases) {
+        $items += $imageTagAlias.Target
+    }
+
     if ($baseVersionBlock -ne $null) {
         $items += "Windows ${windowsSku} base image sku: $($baseVersionBlock.base_image_sku)"
         $items += "Windows ${windowsSku} os disk size: $($baseVersionBlock.os_disk_size)"

--- a/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
@@ -128,6 +128,7 @@ Describe 'Tests of GetAllCachedThings ' {
     it 'has a derived container image tag alias in it' {
         $windowsSku = "2019-containerd"
         $componentsJson.ContainerImages[0].windowsVersions[0].latestVersion = "win-version-10"
+        $componentsJson.ContainerImages[0].windowsVersions[0] | Add-Member -NotePropertyName additionalTagsToApplyToContainer -NotePropertyValue @("win-version")
 
         $allpackages = GetAllCachedThings $componentsJson $windowsSettings
 
@@ -1097,14 +1098,15 @@ Describe 'Gets container image tag aliases' {
   "multiArchVersionsV2": [],
   "windowsVersions": [
     {
-      "latestVersion": "v2.19.0-5"
+      "latestVersion": "v2.19.0-5",
+      "additionalTagsToApplyToContainer": ["v2.19.0"]
     }
   ]
 }]}'
         $componentsJson = echo $testString | ConvertFrom-Json
     }
 
-    It 'derives the main tag from a numeric build suffix' {
+    It 'creates an explicitly configured tag alias' {
         $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
 
         $aliases | Should -HaveCount 1
@@ -1112,43 +1114,60 @@ Describe 'Gets container image tag aliases' {
         $aliases[0].Target | Should -Be "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.19.0"
     }
 
-    It 'removes the complete multi-digit build suffix' {
-        $componentsJson.ContainerImages[0].windowsVersions[0].latestVersion = "v2.18.0-10"
-
-        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
-
-        $aliases | Should -HaveCount 1
-        $aliases[0].Target | Should -Be "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.18.0"
-    }
-
-    It 'does not create an alias for a version without a build suffix' {
-        $componentsJson.ContainerImages[0].windowsVersions[0].latestVersion = "v2.19.0"
-
-        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
-
-        $aliases | Should -Be @()
-    }
-
-    It 'does not create an alias for a non-numeric suffix' {
-        $componentsJson.ContainerImages[0].windowsVersions[0].latestVersion = "v1.34.8-windows-hp"
-
-        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
-
-        $aliases | Should -Be @()
-    }
-
-    It 'creates an alias for a previous latest version with a build suffix' {
-        $componentsJson.ContainerImages[0].windowsVersions[0] | Add-Member -NotePropertyName previousLatestVersion -NotePropertyValue "v2.18.0-10"
+    It 'creates multiple explicitly configured tag aliases' {
+        $componentsJson.ContainerImages[0].windowsVersions[0].additionalTagsToApplyToContainer = @("v2.19.0", "stable")
 
         $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
 
         $aliases | Should -HaveCount 2
-        $aliases[1].Source | Should -Be "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.18.0-10"
-        $aliases[1].Target | Should -Be "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.18.0"
+        $aliases[0].Target | Should -Be "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.19.0"
+        $aliases[1].Target | Should -Be "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:stable"
     }
 
-    It 'uses the first build version when aliases have the same target' {
-        $componentsJson.ContainerImages[0].windowsVersions[0] | Add-Member -NotePropertyName previousLatestVersion -NotePropertyValue "v2.19.0-4"
+    It 'does not infer an alias when additional tags are not configured' {
+        $componentsJson.ContainerImages[0].windowsVersions[0].PSObject.Properties.Remove("additionalTagsToApplyToContainer")
+
+        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
+
+        $aliases | Should -Be @()
+    }
+
+    It 'does not create an alias when additional tags are empty' {
+        $componentsJson.ContainerImages[0].windowsVersions[0].additionalTagsToApplyToContainer = @()
+
+        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
+
+        $aliases | Should -Be @()
+    }
+
+    It 'does not create aliases from multi-architecture fallback versions' {
+        $componentsJson.ContainerImages[0].windowsVersions = $null
+        $componentsJson.ContainerImages[0].multiArchVersionsV2 = @(
+            [PSCustomObject]@{
+                latestVersion = "v2.19.0-5"
+                additionalTagsToApplyToContainer = @("v2.19.0")
+            }
+        )
+
+        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
+
+        $aliases | Should -Be @()
+    }
+
+    It 'applies additional tags to the latest version only' {
+        $componentsJson.ContainerImages[0].windowsVersions[0] | Add-Member -NotePropertyName previousLatestVersion -NotePropertyValue "v2.18.0-10"
+
+        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
+
+        $aliases | Should -HaveCount 1
+        $aliases[0].Source | Should -Be "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.19.0-5"
+    }
+
+    It 'uses the first source version when aliases have the same target' {
+        $componentsJson.ContainerImages[0].windowsVersions += [PSCustomObject]@{
+            latestVersion = "v2.19.0-4"
+            additionalTagsToApplyToContainer = @("v2.19.0")
+        }
 
         $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
 

--- a/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
+++ b/vhdbuilder/packer/windows/components_json_helpers.tests.ps1
@@ -125,6 +125,15 @@ Describe 'Tests of GetAllCachedThings ' {
         $allpackages | Should -Contain "mcr.microsoft.com/container/with/seperate/win/and/linux/versions:win-version"
     }
 
+    it 'has a derived container image tag alias in it' {
+        $windowsSku = "2019-containerd"
+        $componentsJson.ContainerImages[0].windowsVersions[0].latestVersion = "win-version-10"
+
+        $allpackages = GetAllCachedThings $componentsJson $windowsSettings
+
+        $allpackages | Should -Contain "mcr.microsoft.com/container/with/seperate/win/and/linux/versions:win-version"
+    }
+
     it 'has a package in it' {
         $windowsSku = "2019-containerd"
 
@@ -1075,6 +1084,95 @@ Describe 'Gets The Versions' {
         $components = GetComponentsFromComponentsJson $componentsJson
 
         $components | Should -Be @()
+    }
+}
+
+Describe 'Gets container image tag aliases' {
+    BeforeEach {
+        $testString = '{
+"ContainerImages": [
+{
+  "downloadURL": "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:*",
+  "amd64OnlyVersions": [],
+  "multiArchVersionsV2": [],
+  "windowsVersions": [
+    {
+      "latestVersion": "v2.19.0-5"
+    }
+  ]
+}]}'
+        $componentsJson = echo $testString | ConvertFrom-Json
+    }
+
+    It 'derives the main tag from a numeric build suffix' {
+        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
+
+        $aliases | Should -HaveCount 1
+        $aliases[0].Source | Should -Be "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.19.0-5"
+        $aliases[0].Target | Should -Be "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.19.0"
+    }
+
+    It 'removes the complete multi-digit build suffix' {
+        $componentsJson.ContainerImages[0].windowsVersions[0].latestVersion = "v2.18.0-10"
+
+        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
+
+        $aliases | Should -HaveCount 1
+        $aliases[0].Target | Should -Be "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.18.0"
+    }
+
+    It 'does not create an alias for a version without a build suffix' {
+        $componentsJson.ContainerImages[0].windowsVersions[0].latestVersion = "v2.19.0"
+
+        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
+
+        $aliases | Should -Be @()
+    }
+
+    It 'does not create an alias for a non-numeric suffix' {
+        $componentsJson.ContainerImages[0].windowsVersions[0].latestVersion = "v1.34.8-windows-hp"
+
+        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
+
+        $aliases | Should -Be @()
+    }
+
+    It 'creates an alias for a previous latest version with a build suffix' {
+        $componentsJson.ContainerImages[0].windowsVersions[0] | Add-Member -NotePropertyName previousLatestVersion -NotePropertyValue "v2.18.0-10"
+
+        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
+
+        $aliases | Should -HaveCount 2
+        $aliases[1].Source | Should -Be "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.18.0-10"
+        $aliases[1].Target | Should -Be "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.18.0"
+    }
+
+    It 'uses the first build version when aliases have the same target' {
+        $componentsJson.ContainerImages[0].windowsVersions[0] | Add-Member -NotePropertyName previousLatestVersion -NotePropertyValue "v2.19.0-4"
+
+        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
+
+        $aliases | Should -HaveCount 1
+        $aliases[0].Source | Should -Be "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.19.0-5"
+    }
+
+    It 'uses the Windows download URL and replaces CPU_ARCH' {
+        $componentsJson.ContainerImages[0] | Add-Member -NotePropertyName windowsDownloadURL -NotePropertyValue "mcr.microsoft.com/oss/kubernetes-csi/`${CPU_ARCH}/livenessprobe:*"
+        $CPU_ARCH = "amd64"
+
+        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
+
+        $aliases | Should -HaveCount 1
+        $aliases[0].Target | Should -Be "mcr.microsoft.com/oss/kubernetes-csi/amd64/livenessprobe:v2.19.0"
+    }
+
+    It 'does not create an alias when the Windows SKU does not match' {
+        $componentsJson.ContainerImages[0].windowsVersions[0] | Add-Member -NotePropertyName windowsSkuMatch -NotePropertyValue "2022-containerd*"
+        $windowsSku = "2019-containerd"
+
+        $aliases = GetContainerImageTagAliasesFromComponentsJson $componentsJson
+
+        $aliases | Should -Be @()
     }
 }
 

--- a/vhdbuilder/packer/windows/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/windows/configure-windows-vhd.ps1
@@ -431,6 +431,16 @@ function Get-ContainerImages
         Retry-Command -ScriptBlock {
             & ctr.exe -n k8s.io image tag $imageTag.Source $imageTag.Target
         } -ErrorMessage "Failed to tag image $($imageTag.Source) as $($imageTag.Target)"
+
+        # ctr copies the CRI-managed label from the source, which prevents CRI from
+        # registering the new reference. Change it to trigger CRI reconciliation.
+        Retry-Command -ScriptBlock {
+            & ctr.exe -n k8s.io images label $imageTag.Target io.cri-containerd.image=unmanaged
+        } -ErrorMessage "Failed to trigger CRI registration for image alias $($imageTag.Target)"
+
+        Retry-Command -ScriptBlock {
+            & crictl.exe -c $configPath inspecti $imageTag.Target | Out-Null
+        } -ErrorMessage "CRI failed to register image alias $($imageTag.Target)"
     }
 
     # before stopping containerd, let's echo the cached images and their sizes.

--- a/vhdbuilder/packer/windows/configure-windows-vhd.ps1
+++ b/vhdbuilder/packer/windows/configure-windows-vhd.ps1
@@ -425,6 +425,14 @@ function Get-ContainerImages
         }
     }
 
+    foreach ($imageTag in $imageTagsToCreate)
+    {
+        Write-Log "Tagging image $($imageTag.Source) as $($imageTag.Target)"
+        Retry-Command -ScriptBlock {
+            & ctr.exe -n k8s.io image tag $imageTag.Source $imageTag.Target
+        } -ErrorMessage "Failed to tag image $($imageTag.Source) as $($imageTag.Target)"
+    }
+
     # before stopping containerd, let's echo the cached images and their sizes.
     crictl -c $configPath images show
 

--- a/vhdbuilder/packer/windows/windows-vhd-configuration.ps1
+++ b/vhdbuilder/packer/windows/windows-vhd-configuration.ps1
@@ -68,6 +68,7 @@ $global:patchUrls = $patch_data | % { $_.url }
 $global:patchIDs = $patch_data | % { $_.id }
 
 $global:imagesToPull = GetComponentsFromComponentsJson $componentsJson
+$global:imageTagsToCreate = GetContainerImageTagAliasesFromComponentsJson $componentsJson
 $global:ociArtifactsToPull = GetOCIArtifactsFromComponentsJson $componentsJson
 $global:keysToSet = GetRegKeysToApply $windowsSettingsJson
 $global:map = GetPackagesFromComponentsJson $componentsJson


### PR DESCRIPTION
Mutable Windows variants of the CSI livenessprobe and node-driver-registrar images currently resolve to revisions with an incompatible Windows base-layer archive layout. This causes Windows VHD builds to fail while containerd processes the base layer.

**What this PR does / why we need it**:

- Pins Windows `livenessprobe:v2.19.0` to `v2.19.0-5`.
- Pins Windows `livenessprobe:v2.18.0` to `v2.18.0-10`.
- Pins Windows `csi-node-driver-registrar:v2.17.0` to `v2.17.0-5`.
- Pins Windows `csi-node-driver-registrar:v2.16.0` to `v2.16.0-10`.
- Adds `additionalTagsToApplyToContainer` to Windows component versions so a pulled image can be cached under explicitly configured aliases.
- Tags each pinned CSI image with its normal version in containerd's `k8s.io` namespace after the build-specific image is pulled.
- Leaves Linux/multi-architecture image versions and all other Windows container images unchanged.

The build-specific revisions remain the only images pulled from the registry. The additional tags point to those already-cached images:

| Image | Pulled tag | Additional cached tag |
|---|---|---|
| livenessprobe | `v2.18.0-10` | `v2.18.0` |
| livenessprobe | `v2.19.0-5` | `v2.19.0` |
| csi-node-driver-registrar | `v2.16.0-10` | `v2.16.0` |
| csi-node-driver-registrar | `v2.17.0-5` | `v2.17.0` |

This allows pods referencing the normal tag to use the known-good image cached in the VHD instead of downloading the broken mutable revision when local image reuse is permitted. Alias creation uses the existing Windows image selection, SKU filtering, and retry behavior. Additional tags are opt-in and are only applied to the `latestVersion` entry that declares them.

The mutable tags currently resolve as follows:

| Image | Mutable tag | Current revision | Pinned revision |
|---|---|---|---|
| livenessprobe | `v2.18.0` | `v2.18.0-11` | `v2.18.0-10` |
| livenessprobe | `v2.19.0` | `v2.19.0-6` | `v2.19.0-5` |
| csi-node-driver-registrar | `v2.16.0` | `v2.16.0-11` | `v2.16.0-10` |
| csi-node-driver-registrar | `v2.17.0` | `v2.17.0-6` | `v2.17.0-5` |

All affected revisions share the same malformed Windows root layers for each Windows version. Unlike the previous revisions, the affected root archives place the operating-system directories directly at the archive root:

```text
Affected revisions:
  Windows/
  ProgramData/
  Users/
  License.txt

Pinned revisions:
  Files/
    Windows/
    ProgramData/
    Users/
  UtilityVM/
```

Containerd imports Windows layers through `ociwclayer.ImportLayerFromTar`. The importer preserves the tar entry names and, for a parentless layer, calls `hcsshim::ProcessBaseLayer`. Because the affected archives do not create the required `Files/` directory, base-layer processing fails with `ERROR_PATH_NOT_FOUND`. The missing `UtilityVM/` payload is another consequence of the repackaging, but it is not the cause of this extraction failure.

The [failing Windows VHD build](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=179971811&view=results) reproduced the livenessprobe failure on two containerd versions:

| Windows build | containerd | Failing base-layer DiffID |
|---|---|---|
| Windows Server 2022 | `1.6.35-azure.1` | `sha256:66545f5a12285a70850304d489f0c3065552f68bcdc3199a7c74bab49d60f44c` |
| Windows Server 2025 | `2.0.4-azure.1` | `sha256:b3a59411a9182db2a9656bce00537904c2f1b7d71cbc9782f5155263f1b6336c` |

```text
failed to pull and unpack image:
failed to extract layer:
hcsshim::ProcessBaseLayer ... The system cannot find the path specified
```

Retries failed against new snapshot directories with the same base-layer DiffID, confirming this was not a transient download or snapshot failure. The Windows Server 2019 variants have the same incompatible archive structure and are also affected, although that platform was not exercised by the cited build.

The node-driver-registrar mutable tags use the exact same malformed root-layer digests as the affected livenessprobe revisions:

| Windows base | Malformed compressed root digest |
|---|---|
| LTSC 2019 | `sha256:06aaa22f843ee9448c25ab50b08937c2754b1d50591e94f898df0fef9da96c2b` |
| LTSC 2022 | `sha256:a20336801d45e01082ccf9e7a799da2901e008ffc51d7e170f685c8102ea2bfc` |
| LTSC 2025 | `sha256:4ec983932fc2c7e85f176f52ab1926d588a4323a2c808e9cc1b61c9add15eaaf` |

The publishing regression was caused by the DALEC frontend applying build-time source filtering to Windows base images. Re-materializing a Windows base through `llb.Scratch()` loses the special Windows layer semantics and produces the flattened archive. The upstream fix is [project-dalec/dalec#1228](https://github.com/project-dalec/dalec/pull/1228), with the v0.22 backport in [project-dalec/dalec#1229](https://github.com/project-dalec/dalec/pull/1229) and release [v0.22.1](https://github.com/project-dalec/dalec/releases/tag/v0.22.1).

This PR is a tactical mitigation for Windows VHD builds until the affected CSI images are republished with the fixed DALEC frontend.

**Which issue(s) this PR fixes**:

None.
