### PR TITLE
fix: cache managed GPU packages for Ubuntu 26.04

### DIFF
--- a/e2e/components/components_test.go
+++ b/e2e/components/components_test.go
@@ -126,6 +126,13 @@ func TestDCGMExporterCompatibility(t *testing.T) {
 			parseDeps:   parseDebDeps,
 		},
 		{
+			name:        "Ubuntu2604",
+			os:          "ubuntu",
+			osVersion:   "r2604",
+			downloadURL: "https://packages.microsoft.com/ubuntu/26.04/prod/pool/main/d/dcgm-exporter/dcgm-exporter_%s_amd64.deb",
+			parseDeps:   parseDebDeps,
+		},
+		{
 			name:        "AzureLinux3",
 			os:          "azurelinux",
 			osVersion:   "v3.0",

--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -2009,6 +2009,14 @@
       "downloadLocation": "/opt/nvidia-device-plugin/downloads",
       "downloadURIs": {
         "ubuntu": {
+          "r2604": {
+            "versionsV2": [
+              {
+                "renovateTag": "name=nvidia-device-plugin, repository=production, os=ubuntu, release=26.04",
+                "latestVersion": "0.19.3-ubuntu26.04u6"
+              }
+            ]
+          },
           "r2404": {
             "versionsV2": [
               {
@@ -2077,6 +2085,14 @@
       "downloadLocation": "/opt/datacenter-gpu-manager-4-core/downloads",
       "downloadURIs": {
         "ubuntu": {
+          "r2604": {
+            "versionsV2": [
+              {
+                "renovateTag": "name=datacenter-gpu-manager-4-core, repository=nvidia, os=ubuntu, release=26.04",
+                "latestVersion": "1:4.6.0-1"
+              }
+            ]
+          },
           "r2404": {
             "versionsV2": [
               {
@@ -2111,6 +2127,14 @@
       "downloadLocation": "/opt/datacenter-gpu-manager-4-proprietary/downloads",
       "downloadURIs": {
         "ubuntu": {
+          "r2604": {
+            "versionsV2": [
+              {
+                "renovateTag": "name=datacenter-gpu-manager-4-proprietary, repository=nvidia, os=ubuntu, release=26.04",
+                "latestVersion": "1:4.6.0-1"
+              }
+            ]
+          },
           "r2404": {
             "versionsV2": [
               {
@@ -2145,6 +2169,14 @@
       "downloadLocation": "/opt/dcgm-exporter/downloads",
       "downloadURIs": {
         "ubuntu": {
+          "r2604": {
+            "versionsV2": [
+              {
+                "renovateTag": "name=dcgm-exporter, repository=production, os=ubuntu, release=26.04",
+                "latestVersion": "4.8.3-ubuntu26.04u4"
+              }
+            ]
+          },
           "r2404": {
             "versionsV2": [
               {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the Ubuntu 26.04 (`r2604`) package pins needed to cache fully managed GPU components in the VHD:

- `datacenter-gpu-manager-4-core`: `1:4.6.0-1`
- `datacenter-gpu-manager-4-proprietary`: `1:4.6.0-1`
- `dcgm-exporter`: `4.8.3-ubuntu26.04u4`
- `nvidia-device-plugin`: `0.19.3-ubuntu26.04u6`

The DCGM versions match the exact dependencies in the Ubuntu 26.04 exporter package. Existing Ubuntu 22.04, Ubuntu 24.04, and Azure Linux package pins remain unchanged.

Extend the existing `TestDCGMExporterCompatibility` table with Ubuntu 26.04. The test downloads the exporter package and checks its DCGM dependencies against `components.json`.

The current Ubuntu 26.04 VHD fails managed GPU provisioning with CSE exit code 227 because the cached DCGM core package is missing. This PR supplies the package configuration for a new VHD build. It changes only `parts/common/components.json` and `e2e/components/components_test.go`; GPU node E2E scenarios are intentionally left for a later PR after the VHD is rebuilt.

**Validation**:

- `go test -mod=readonly ./components -run '^TestDCGMExporterCompatibility$' -count=1 -v -timeout 5m` from `e2e/`: passed for Ubuntu 22.04, 24.04, 26.04, and Azure Linux 3.
- `jq -e . parts/common/components.json`: passed.
- `git diff --check`: passed.

A VHD build and a fresh managed GPU E2E run are still required. This PR does not claim a passing node E2E run.

**Which issue(s) this PR fixes**:

No linked issue.
