### PR TITLE
chore(windows): update base image versions

### DIFF
--- a/vhdbuilder/packer/windows/windows_settings.json
+++ b/vhdbuilder/packer/windows/windows_settings.json
@@ -18,7 +18,7 @@
       "base_image_offer": "windowsserver2022",
       "base_image_sku": "2022-Datacenter-Core-smalldisk",
       "windows_image_name": "windows-2022-containerd",
-      "base_image_version": "20348.5499.260809",
+      "base_image_version": "20348.5622.260906",
       "patches_to_apply": []
     },
     "2022-containerd-gen2": {
@@ -27,7 +27,7 @@
       "base_image_offer": "windowsserver2022",
       "base_image_sku": "2022-datacenter-core-smalldisk-g2",
       "windows_image_name": "windows-2022-containerd",
-      "base_image_version": "20348.5499.260809",
+      "base_image_version": "20348.5622.260906",
       "patches_to_apply": []
     },
     "2025": {
@@ -36,7 +36,7 @@
       "os_disk_size": "45",
       "base_image_sku": "2025-datacenter-core-smalldisk",
       "windows_image_name": "windows-2025",
-      "base_image_version": "26100.33296.260809",
+      "base_image_version": "26100.33438.260905",
       "patches_to_apply": []
     },
     "2025-gen2": {
@@ -45,7 +45,7 @@
       "os_disk_size": "45",
       "base_image_sku": "2025-datacenter-core-smalldisk-g2",
       "windows_image_name": "windows-2025",
-      "base_image_version": "26100.33296.260809",
+      "base_image_version": "26100.33438.260905",
       "patches_to_apply": []
     },
     "2025-gen2-tl": {
@@ -54,7 +54,7 @@
       "os_disk_size": "45",
       "base_image_sku": "2025-datacenter-core-smalldisk-g2",
       "windows_image_name": "windows-2025",
-      "base_image_version": "26100.33296.260809",
+      "base_image_version": "26100.33438.260905",
       "patches_to_apply": []
     }
   },


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup

## What this PR does / why we need it
Updates the Windows Server base image versions to the latest Azure Marketplace releases:

- Windows Server 2022: `20348.5499.260809` -> `20348.5622.260906`
- Windows Server 2025: `26100.33296.260809` -> `26100.33438.260905`

## Validation
- Ran `make update-windows-base-versions` underlying updater successfully for all five Windows image entries.