### PR TITLE
feat: enable Ubuntu 26.04 GRID v20 and GPU E2E coverage

### DIFF
--- a/e2e/scenario_gpu_daemonset_test.go
+++ b/e2e/scenario_gpu_daemonset_test.go
@@ -33,10 +33,10 @@ func Test_Ubuntu2204_NvidiaDevicePlugin_Daemonset(t *testing.T) {
 	RunScenario(t, nvidiaDevicePluginDaemonsetScenario(config.VHDUbuntu2204Gen2Containerd, "Standard_NV6ads_A10_v5"))
 }
 
-// Test_Ubuntu2604Minimal_GPUCUDA checks the CUDA LTS driver and kubelet stability
+// Test_Ubuntu2604Minimal_CUDA checks the CUDA LTS driver and kubelet stability
 // on a T4 node, then validates GPU resources and scheduling with a device plugin
 // DaemonSet. The managed GPU experience remains disabled.
-func Test_Ubuntu2604Minimal_GPUCUDA(t *testing.T) {
+func Test_Ubuntu2604Minimal_CUDA(t *testing.T) {
 	scenario := nvidiaDevicePluginDaemonsetScenario(config.VHDUbuntu2604MinimalGen2Containerd, "Standard_NC4as_T4_v3")
 	scenario.Cluster = ClusterLatestKubernetesVersionKubenet
 	scenario.Description = "Tests the Ubuntu 26.04 minimal CUDA LTS driver and GPU scheduling with a customer-managed device plugin"
@@ -63,10 +63,10 @@ func Test_Ubuntu2604Minimal_GPUCUDA(t *testing.T) {
 	RunScenario(t, scenario)
 }
 
-// Test_Ubuntu2604Minimal_NvidiaDevicePlugin_Daemonset_GridV20 checks the pinned
+// Test_Ubuntu2604Minimal_GridV20 checks the pinned
 // GRID v20 driver on A10 with a customer-managed device plugin, without managed DCGM.
 // Ubuntu 26.04 selects GRID v20 at provision time even on non-RTX GRID SKUs.
-func Test_Ubuntu2604Minimal_NvidiaDevicePlugin_Daemonset_GridV20(t *testing.T) {
+func Test_Ubuntu2604Minimal_GridV20(t *testing.T) {
 	scenario := nvidiaDevicePluginDaemonsetScenario(config.VHDUbuntu2604MinimalGen2Containerd, "Standard_NV6ads_A10_v5")
 	scenario.Cluster = ClusterLatestKubernetesVersionKubenet
 

--- a/e2e/scenario_gpu_daemonset_test.go
+++ b/e2e/scenario_gpu_daemonset_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/agentbaker/e2e/assert"
 	"github.com/Azure/agentbaker/e2e/config"
+	"github.com/Azure/agentbaker/pkg/agent"
 	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
@@ -29,24 +30,81 @@ const (
 // Test_Ubuntu2204_NvidiaDevicePlugin_Daemonset tests the upstream, customer-managed
 // NVIDIA device plugin DaemonSet deployment model instead of the systemd service.
 func Test_Ubuntu2204_NvidiaDevicePlugin_Daemonset(t *testing.T) {
-	RunScenario(t, &Scenario{
+	RunScenario(t, nvidiaDevicePluginDaemonsetScenario(config.VHDUbuntu2204Gen2Containerd, "Standard_NV6ads_A10_v5"))
+}
+
+// Test_Ubuntu2604Minimal_GPUCUDA checks the CUDA LTS driver and kubelet stability
+// on a T4 node, then validates GPU resources and scheduling with a device plugin
+// DaemonSet. The managed GPU experience remains disabled.
+func Test_Ubuntu2604Minimal_GPUCUDA(t *testing.T) {
+	scenario := nvidiaDevicePluginDaemonsetScenario(config.VHDUbuntu2604MinimalGen2Containerd, "Standard_NC4as_T4_v3")
+	scenario.Cluster = ClusterLatestKubernetesVersionKubenet
+	scenario.Description = "Tests the Ubuntu 26.04 minimal CUDA LTS driver and GPU scheduling with a customer-managed device plugin"
+
+	validateDaemonset := scenario.Validator
+	scenario.Validator = func(ctx context.Context, s *Scenario) error {
+		if err := errors.Join(
+			ValidateKubeletHasNotStopped(ctx, s),
+			ValidateServicesDoNotRestartKubelet(ctx, s),
+		); err != nil {
+			return err
+		}
+		result, err := execScriptOnVMForScenarioValidateExitCode(ctx, s,
+			"sudo nvidia-smi --query-gpu=driver_version --format=csv,noheader", 0, "could not query NVIDIA driver version")
+		if err != nil {
+			return err
+		}
+		if err := assert.Equal(strings.TrimSpace(result.stdout), datamodel.NvidiaCudaLTSDriverVersion,
+			"expected the CUDA LTS driver pinned in components.json"); err != nil {
+			return err
+		}
+		return validateDaemonset(ctx, s)
+	}
+	RunScenario(t, scenario)
+}
+
+// Test_Ubuntu2604Minimal_NvidiaDevicePlugin_Daemonset_GridV20 checks the pinned
+// GRID v20 driver on A10 with a customer-managed device plugin, without managed DCGM.
+// Ubuntu 26.04 selects GRID v20 at provision time even on non-RTX GRID SKUs.
+func Test_Ubuntu2604Minimal_NvidiaDevicePlugin_Daemonset_GridV20(t *testing.T) {
+	scenario := nvidiaDevicePluginDaemonsetScenario(config.VHDUbuntu2604MinimalGen2Containerd, "Standard_NV6ads_A10_v5")
+	scenario.Cluster = ClusterLatestKubernetesVersionKubenet
+
+	validateDaemonset := scenario.Validator
+	scenario.Validator = func(ctx context.Context, s *Scenario) error {
+		if err := ValidateNvidiaGridV20DriverInstalled(ctx, s); err != nil {
+			return err
+		}
+		return validateDaemonset(ctx, s)
+	}
+	RunScenario(t, scenario)
+}
+
+// nvidiaDevicePluginDaemonsetScenario installs the AKS GPU driver and validates
+// a node-scoped, customer-managed device plugin DaemonSet. Managed GPU services
+// remain disabled; the scenario owns and cleans up the DaemonSet.
+func nvidiaDevicePluginDaemonsetScenario(vhd *config.Image, vmSize string) *Scenario {
+	return &Scenario{
 		Description: "Tests that the NVIDIA device plugin works as a DaemonSet instead of a systemd service",
 		Tags: Tags{
 			GPU: true,
 		},
 		Config: Config{
 			Cluster: ClusterKubenet,
-			VHD:     config.VHDUbuntu2204Gen2Containerd,
+			VHD:     vhd,
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.AgentPoolProfile.VMSize = "Standard_NV6ads_A10_v5"
+				nbc.ContainerService.Properties.AgentPoolProfiles[0].VMSize = vmSize
+				nbc.AgentPoolProfile.VMSize = vmSize
 				nbc.ConfigGPUDriverIfNeeded = true
-				// Don't enable the managed GPU experience - the test deploys the upstream DaemonSet.
-				// By not setting EnableManagedGPU=true or the VMSS tag, the systemd-based device plugin won't start.
+				// The test deploys the upstream DaemonSet, not the managed GPU services.
 				nbc.EnableGPUDevicePluginIfNeeded = false
 				nbc.EnableNvidia = true
+				nbc.EnableManagedGPU = false
+				nbc.EnableManagedGPUDRA = false
+				nbc.ManagedGPUExperienceAFECEnabled = false
 			},
 			VMConfigMutator: func(vmss *armcompute.VirtualMachineScaleSet) {
-				vmss.SKU.Name = to.Ptr("Standard_NV6ads_A10_v5")
+				vmss.SKU.Name = to.Ptr(vmSize)
 			},
 			Validator: func(ctx context.Context, s *Scenario) error {
 				// The device plugin is only meaningful once the driver is present and the
@@ -80,7 +138,61 @@ func Test_Ubuntu2204_NvidiaDevicePlugin_Daemonset(t *testing.T) {
 				return nil
 			},
 		},
-	})
+	}
+}
+
+func TestNvidiaDevicePluginDaemonsetScenario(t *testing.T) {
+	cases := []struct {
+		name          string
+		vhd           *config.Image
+		vmSize        string
+		driverType    string
+		driverVersion string
+	}{
+		{"Ubuntu2204", config.VHDUbuntu2204Gen2Containerd, "Standard_NV6ads_A10_v5", "grid", datamodel.NvidiaGridDriverVersion},
+		// The SKU-only bootstrap defaults are promoted to GRID v20 by the shared
+		// installer on Ubuntu 26.04. The E2E validator checks the installed version.
+		{"Ubuntu2604GridV20", config.VHDUbuntu2604MinimalGen2Containerd, "Standard_NV6ads_A10_v5", "grid", datamodel.NvidiaGridDriverVersion},
+		{"Ubuntu2604CUDA", config.VHDUbuntu2604MinimalGen2Containerd, "Standard_NC4as_T4_v3", "cuda-lts", datamodel.NvidiaCudaLTSDriverVersion},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scenario := nvidiaDevicePluginDaemonsetScenario(tc.vhd, tc.vmSize)
+			// Keep the profile pointers distinct to check both bootstrap inputs.
+			pool := &datamodel.AgentPoolProfile{}
+			nbc := &datamodel.NodeBootstrappingConfiguration{
+				ContainerService: &datamodel.ContainerService{Properties: &datamodel.Properties{
+					AgentPoolProfiles: []*datamodel.AgentPoolProfile{pool},
+				}},
+				AgentPoolProfile:                &datamodel.AgentPoolProfile{},
+				EnableGPUDevicePluginIfNeeded:   true,
+				EnableManagedGPU:                true,
+				EnableManagedGPUDRA:             true,
+				ManagedGPUExperienceAFECEnabled: true,
+			}
+			scenario.BootstrapConfigMutator(nil, nbc)
+			vmss := &armcompute.VirtualMachineScaleSet{SKU: &armcompute.SKU{}}
+			scenario.VMConfigMutator(vmss)
+			if err := errors.Join(
+				assert.Equal(scenario.VHD, tc.vhd),
+				assert.Equal(scenario.Tags.GPU, true),
+				assert.Equal(scenario.UseNVMe, false),
+				assert.Equal(pool.VMSize, tc.vmSize),
+				assert.Equal(nbc.AgentPoolProfile.VMSize, tc.vmSize),
+				assert.Equal(*vmss.SKU.Name, tc.vmSize),
+				assert.Equal(nbc.ConfigGPUDriverIfNeeded, true),
+				assert.Equal(nbc.EnableNvidia, true),
+				assert.Equal(nbc.EnableGPUDevicePluginIfNeeded, false),
+				assert.Equal(nbc.EnableManagedGPU, false),
+				assert.Equal(nbc.EnableManagedGPUDRA, false),
+				assert.Equal(nbc.ManagedGPUExperienceAFECEnabled, false),
+				assert.Equal(agent.GetGPUDriverType(tc.vmSize), tc.driverType),
+				assert.Equal(agent.GetGPUDriverVersion(tc.vmSize), tc.driverVersion),
+			); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
 }
 
 // validateNvidiaDevicePluginServiceNotRunning verifies that the systemd-based

--- a/e2e/scenario_gpu_managed_experience_test.go
+++ b/e2e/scenario_gpu_managed_experience_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/agentbaker/e2e/assert"
 	"github.com/Azure/agentbaker/e2e/components"
 	"github.com/Azure/agentbaker/e2e/config"
+	"github.com/Azure/agentbaker/pkg/agent"
 	"github.com/Azure/agentbaker/pkg/agent/datamodel"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
@@ -829,16 +830,30 @@ func Test_Ubuntu2404_NvidiaDevicePluginRunning_MIG_MultiGPU(t *testing.T) {
 }
 
 func Test_Ubuntu2204_NvidiaDevicePluginRunning_WithoutVMSSTag(t *testing.T) {
-	RunScenario(t, &Scenario{
+	RunScenario(t, managedGPUWithoutVMSSTagScenario(config.VHDUbuntu2204Gen2Containerd, "r2204", "Standard_NV6ads_A10_v5"))
+}
+
+func Test_Ubuntu2604Minimal_NvidiaDevicePluginRunning_WithoutVMSSTag(t *testing.T) {
+	scenario := managedGPUWithoutVMSSTagScenario(config.VHDUbuntu2604MinimalGen2Containerd, "r2604", "Standard_NC4as_T4_v3")
+	scenario.Cluster = ClusterLatestKubernetesVersionKubenet
+	RunScenario(t, scenario)
+}
+
+// managedGPUWithoutVMSSTagScenario checks the managed device plugin, DCGM, and
+// NPD on an Ubuntu GPU node, plus GRID licensing for GRID SKUs. osVersion selects
+// the components.json package pins (for example, "r2604"). No enabling VMSS tag is set.
+func managedGPUWithoutVMSSTagScenario(vhd *config.Image, osVersion, vmSize string) *Scenario {
+	return &Scenario{
 		Description: "Tests that NVIDIA device plugin and DCGM Exporter work via NBC EnableManagedGPU field without VMSS tag",
 		Tags: Tags{
 			GPU: true,
 		},
 		Config: Config{
 			Cluster: ClusterKubenet,
-			VHD:     config.VHDUbuntu2204Gen2Containerd,
+			VHD:     vhd,
 			BootstrapConfigMutator: func(_ *Cluster, nbc *datamodel.NodeBootstrappingConfiguration) {
-				nbc.AgentPoolProfile.VMSize = "Standard_NV6ads_A10_v5"
+				nbc.ContainerService.Properties.AgentPoolProfiles[0].VMSize = vmSize
+				nbc.AgentPoolProfile.VMSize = vmSize
 				nbc.ConfigGPUDriverIfNeeded = true
 				nbc.EnableGPUDevicePluginIfNeeded = true
 				nbc.EnableNvidia = true
@@ -846,7 +861,7 @@ func Test_Ubuntu2204_NvidiaDevicePluginRunning_WithoutVMSSTag(t *testing.T) {
 				nbc.EnableManagedGPU = true
 			},
 			VMConfigMutatorWithError: func(ctx context.Context, vmss *armcompute.VirtualMachineScaleSet) error {
-				vmss.SKU.Name = to.Ptr("Standard_NV6ads_A10_v5")
+				vmss.SKU.Name = to.Ptr(vmSize)
 				// Explicitly DO NOT set the EnableManagedGPUExperience VMSS tag
 				// to test that NBC EnableManagedGPU field works independently
 
@@ -860,7 +875,6 @@ func Test_Ubuntu2204_NvidiaDevicePluginRunning_WithoutVMSSTag(t *testing.T) {
 			},
 			Validator: func(ctx context.Context, s *Scenario) error {
 				os := "ubuntu"
-				osVersion := "r2204"
 
 				// Validate that the NVIDIA device plugin binary was installed correctly
 				devicePluginVersion, err := expectedPackageVersion("nvidia-device-plugin", os, osVersion)
@@ -906,11 +920,14 @@ func Test_Ubuntu2204_NvidiaDevicePluginRunning_WithoutVMSSTag(t *testing.T) {
 				if err := validateNPDNvidiaConditions(ctx, s); err != nil {
 					return err
 				}
-				// Verify NVIDIA GRID license status checks are reporting status correctly.
-				return validateNPDNvidiaGridLicense(ctx, s)
+				// CUDA nodes do not run the GRID licensing service.
+				if strings.HasPrefix(agent.GetGPUDriverType(vmSize), "grid") {
+					return validateNPDNvidiaGridLicense(ctx, s)
+				}
+				return nil
 			},
 		},
-	})
+	}
 }
 
 func Test_CreateVMExtensionLinuxAKSNode_Timing(t *testing.T) {

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -586,19 +586,25 @@ func ValidateNvidiaPersistencedRunning(ctx context.Context, s *Scenario) error {
 	return err
 }
 
-// ValidateNvidiaGridV20DriverInstalled asserts the node installed the grid-v20
-// (595.x) driver from the aks-gpu-grid-v20 image rather than falling back to a
-// cuda/grid driver. This is the grid-v20-specific check: if SKU->driver-type
-// selection regressed, nvidia-smi would report a different driver major.
+// ValidateNvidiaGridV20DriverInstalled checks the installed driver against the
+// aks-gpu-grid-v20 version pinned in components.json, including the patch version.
 func ValidateNvidiaGridV20DriverInstalled(ctx context.Context, s *Scenario) error {
-	command := []string{
-		"set -ex",
-		"driver_version=$(sudo nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n1 | tr -d '[:space:]')",
-		"echo \"nvidia driver_version=$driver_version\"",
-		"case \"$driver_version\" in 595.*) ;; *) echo \"expected grid-v20 595.x driver, got '$driver_version'\"; exit 1 ;; esac",
+	result, err := execScriptOnVMForScenarioValidateExitCode(ctx, s,
+		"sudo nvidia-smi --query-gpu=driver_version --format=csv,noheader", 0, "could not query the GRID v20 driver version")
+	if err != nil {
+		return err
 	}
-	_, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, strings.Join(command, "\n"), 0, "expected grid-v20 (595.x) NVIDIA driver version")
-	return err
+	versions := strings.Fields(result.stdout)
+	if len(versions) == 0 {
+		return fmt.Errorf("nvidia-smi returned no GRID v20 driver version")
+	}
+	for _, version := range versions {
+		if err := assert.Equal(version, datamodel.NvidiaGridV20DriverVersion,
+			"expected the GRID v20 driver pinned in components.json"); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func ValidateNonEmptyDirectory(ctx context.Context, s *Scenario, dirName string) error {

--- a/parts/linux/cloud-init/artifacts/cse_config.sh
+++ b/parts/linux/cloud-init/artifacts/cse_config.sh
@@ -1497,6 +1497,41 @@ configAzurePolicyAddon() {
     sed -i "s|<resourceId>|/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP|g" $AZURE_POLICY_ADDON_FILE
 }
 
+# Select the OS-specific driver image before checking the cache or installing it.
+# AgentBaker and AKS node controller both call this installer, so the Ubuntu 26.04
+# GRID policy is applied here using the node's OS and the VHD's component pin.
+# Other OS versions, CUDA, and explicit grid-v20 selections retain their inputs.
+# A missing or invalid GRID v20 pin fails provisioning; do not fall back to GRID.
+selectGPUDriverImage() {
+    if [ "${OS:-}" != "UBUNTU" ] || [ "${OS_VERSION:-}" != "26.04" ] || [ "${NVIDIA_GPU_DRIVER_TYPE:-}" != "grid" ]; then
+        return 0
+    fi
+
+    local grid_v20_tag
+    if ! grid_v20_tag=$(jq -er '
+        [.GPUContainerImages[] |
+            select(.downloadURL == "mcr.microsoft.com/aks/aks-gpu-grid-v20:*") |
+            .gpuVersion.latestVersion] |
+        select(length == 1) | .[0] |
+        select(test("^[0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+$"))
+    ' "$COMPONENTS_FILEPATH") || [ -z "$grid_v20_tag" ]; then
+        echo "Ubuntu 26.04 requires a valid aks-gpu-grid-v20 pin in $COMPONENTS_FILEPATH" >&2
+        return 1
+    fi
+
+    export GPU_DRIVER_TYPE="grid-v20"
+    export GPU_DRIVER_VERSION="${grid_v20_tag%-*}"
+    export GPU_IMAGE_SHA="${grid_v20_tag##*-}"
+    export GPU_DV="$GPU_DRIVER_VERSION"
+    export NVIDIA_GPU_DRIVER_TYPE="$GPU_DRIVER_TYPE"
+    export NVIDIA_DRIVER_IMAGE_SHA="$GPU_IMAGE_SHA"
+    export NVIDIA_DRIVER_IMAGE_TAG="$grid_v20_tag"
+    export NVIDIA_DRIVER_IMAGE="mcr.microsoft.com/aks/aks-gpu-${NVIDIA_GPU_DRIVER_TYPE}"
+    local mcr_base="${MCR_REPOSITORY_BASE:-mcr.microsoft.com}"
+    export NVIDIA_DRIVER_IMAGE_PULL_REF="${mcr_base%/}/aks/aks-gpu-${NVIDIA_GPU_DRIVER_TYPE}"
+    echo "Ubuntu 26.04 GRID driver image: ${NVIDIA_DRIVER_IMAGE}:${NVIDIA_DRIVER_IMAGE_TAG}"
+}
+
 # Wrapped as functions so logs_to_events can time each step; the install's
 # bash -c command can't be passed to logs_to_events inline (it word-splits args).
 pullGPUDriverImage() {
@@ -1535,6 +1570,7 @@ configureNvidiaCDIRefresh() {
 }
 
 configGPUDrivers() {
+    selectGPUDriverImage || exit $ERR_GPU_DRIVERS_START_FAIL
     if [ "$OS" = "$UBUNTU_OS_NAME" ]; then
         waitForContainerdReady || exit $ERR_GPU_DRIVERS_START_FAIL
         mkdir -p /opt/{actions,gpu}

--- a/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
@@ -2909,6 +2909,129 @@ OVERRIDE_EOF
         End
     End
 
+    Describe 'selectGPUDriverImage'
+        setup_gpu_image() {
+            OS="UBUNTU"
+            OS_VERSION="26.04"
+            GPU_DRIVER_TYPE="grid"
+            GPU_DRIVER_VERSION="570.211.01"
+            GPU_IMAGE_SHA="old-suffix"
+            GPU_DV="$GPU_DRIVER_VERSION"
+            NVIDIA_GPU_DRIVER_TYPE="$GPU_DRIVER_TYPE"
+            NVIDIA_DRIVER_IMAGE_SHA="$GPU_IMAGE_SHA"
+            NVIDIA_DRIVER_IMAGE_TAG="${GPU_DRIVER_VERSION}-${GPU_IMAGE_SHA}"
+            NVIDIA_DRIVER_IMAGE="mcr.microsoft.com/aks/aks-gpu-grid"
+            NVIDIA_DRIVER_IMAGE_PULL_REF="$NVIDIA_DRIVER_IMAGE"
+            unset MCR_REPOSITORY_BASE
+            COMPONENTS_FILEPATH="parts/common/components.json"
+            expected_grid_v20_tag=$(jq -r '.GPUContainerImages[] | select(.downloadURL == "mcr.microsoft.com/aks/aks-gpu-grid-v20:*") | .gpuVersion.latestVersion' "$COMPONENTS_FILEPATH")
+        }
+        BeforeEach 'setup_gpu_image'
+
+        It 'selects the complete GRID v20 image pin for Ubuntu 26.04'
+            When call selectGPUDriverImage
+
+            The status should be success
+            The output should include "Ubuntu 26.04 GRID driver image: mcr.microsoft.com/aks/aks-gpu-grid-v20:$expected_grid_v20_tag"
+            The variable GPU_DRIVER_TYPE should equal "grid-v20"
+            The variable NVIDIA_GPU_DRIVER_TYPE should equal "grid-v20"
+            The variable GPU_DRIVER_VERSION should equal "${expected_grid_v20_tag%-*}"
+            The variable GPU_DV should equal "${expected_grid_v20_tag%-*}"
+            The variable GPU_IMAGE_SHA should equal "${expected_grid_v20_tag##*-}"
+            The variable NVIDIA_DRIVER_IMAGE_SHA should equal "${expected_grid_v20_tag##*-}"
+            The variable NVIDIA_DRIVER_IMAGE_TAG should equal "$expected_grid_v20_tag"
+            The variable NVIDIA_DRIVER_IMAGE should equal "mcr.microsoft.com/aks/aks-gpu-grid-v20"
+            The variable NVIDIA_DRIVER_IMAGE_PULL_REF should equal "mcr.microsoft.com/aks/aks-gpu-grid-v20"
+        End
+
+        It 'preserves the cloud-specific pull registry and canonical image name'
+            MCR_REPOSITORY_BASE="mcr.example/"
+            When call selectGPUDriverImage
+
+            The status should be success
+            The output should include "Ubuntu 26.04 GRID driver image:"
+            The variable NVIDIA_DRIVER_IMAGE should equal "mcr.microsoft.com/aks/aks-gpu-grid-v20"
+            The variable NVIDIA_DRIVER_IMAGE_PULL_REF should equal "mcr.example/aks/aks-gpu-grid-v20"
+            The variable NVIDIA_DRIVER_IMAGE_TAG should equal "$expected_grid_v20_tag"
+        End
+
+        Describe 'unchanged selections'
+            Parameters
+                "UBUNTU" "22.04" "grid"
+                "UBUNTU" "24.04" "grid"
+                "AZURELINUX" "3.0" "grid"
+                "MARINER" "2.0" "grid"
+                "AZURELINUX" "26.04" "grid"
+                "UBUNTU" "26.04" "cuda-lts"
+                "UBUNTU" "26.04" "cuda"
+                "UBUNTU" "26.04" "grid-v20"
+                "UBUNTU" "26.04" ""
+            End
+
+            It 'does not change image inputs or read components.json for other selections'
+                OS="$1"
+                OS_VERSION="$2"
+                NVIDIA_GPU_DRIVER_TYPE="$3"
+                COMPONENTS_FILEPATH="not-needed.json"
+                When call selectGPUDriverImage
+
+                The status should be success
+                The output should be blank
+                The variable NVIDIA_GPU_DRIVER_TYPE should equal "$3"
+                The variable GPU_DV should equal "570.211.01"
+                The variable NVIDIA_DRIVER_IMAGE_TAG should equal "570.211.01-old-suffix"
+                The variable NVIDIA_DRIVER_IMAGE should equal "mcr.microsoft.com/aks/aks-gpu-grid"
+                The variable NVIDIA_DRIVER_IMAGE_PULL_REF should equal "mcr.microsoft.com/aks/aks-gpu-grid"
+            End
+        End
+
+        It 'fails without changing the image when components.json is missing'
+            COMPONENTS_FILEPATH="missing-grid-v20-components.json"
+            When call selectGPUDriverImage
+
+            The status should be failure
+            The stderr should include "Ubuntu 26.04 requires a valid aks-gpu-grid-v20 pin"
+            The variable NVIDIA_GPU_DRIVER_TYPE should equal "grid"
+            The variable NVIDIA_DRIVER_IMAGE_TAG should equal "570.211.01-old-suffix"
+        End
+
+        It 'fails if components.json is empty'
+            COMPONENTS_FILEPATH="/dev/null"
+            When call selectGPUDriverImage
+
+            The status should be failure
+            The stderr should include "Ubuntu 26.04 requires a valid aks-gpu-grid-v20 pin"
+            The variable NVIDIA_GPU_DRIVER_TYPE should equal "grid"
+        End
+
+        Describe 'invalid GRID v20 pins'
+            setup_invalid_pin() {
+                pin_dir=$(mktemp -d)
+                COMPONENTS_FILEPATH="$pin_dir/components.json"
+                jq "$1" parts/common/components.json > "$COMPONENTS_FILEPATH"
+            }
+            cleanup_invalid_pin() { rm -rf "$pin_dir"; }
+            AfterEach 'cleanup_invalid_pin'
+
+            Parameters
+                'del(.GPUContainerImages[] | select(.downloadURL == "mcr.microsoft.com/aks/aks-gpu-grid-v20:*"))'
+                '(.GPUContainerImages[] | select(.downloadURL == "mcr.microsoft.com/aks/aks-gpu-grid-v20:*") | .gpuVersion.latestVersion) = "595.58.03"'
+                '(.GPUContainerImages[] | select(.downloadURL == "mcr.microsoft.com/aks/aks-gpu-grid-v20:*") | .gpuVersion.latestVersion) = "null"'
+                '.GPUContainerImages += [.GPUContainerImages[] | select(.downloadURL == "mcr.microsoft.com/aks/aks-gpu-grid-v20:*")]'
+            End
+
+            It 'rejects missing, malformed, or duplicate pins'
+                setup_invalid_pin "$1"
+                When call selectGPUDriverImage
+
+                The status should be failure
+                The stderr should include "Ubuntu 26.04 requires a valid aks-gpu-grid-v20 pin"
+                The variable NVIDIA_GPU_DRIVER_TYPE should equal "grid"
+                The variable NVIDIA_DRIVER_IMAGE_TAG should equal "570.211.01-old-suffix"
+            End
+        End
+    End
+
     Describe 'configGPUDrivers'
         # Assert the per-step CSE timing event names emitted via logs_to_events,
         # without running the real (hardware/daemon) driver steps. logs_to_events
@@ -2932,6 +3055,37 @@ OVERRIDE_EOF
         NVIDIA_GPU_DRIVER_TYPE="cuda"
         OS_VARIANT=""
         ERR_GPU_DRIVERS_START_FAIL=88
+
+        It 'selects GRID v20 before checking the cache and installing on Ubuntu 26.04'
+            OS="UBUNTU"
+            OS_VERSION="26.04"
+            NVIDIA_GPU_DRIVER_TYPE="grid"
+            COMPONENTS_FILEPATH="parts/common/components.json"
+            expected_grid_v20_tag=$(jq -r '.GPUContainerImages[] | select(.downloadURL == "mcr.microsoft.com/aks/aks-gpu-grid-v20:*") | .gpuVersion.latestVersion' "$COMPONENTS_FILEPATH")
+            logs_to_events() { shift; eval "$@"; }
+            ctr() { echo "ctr $*" >&2; }
+            pullGPUDriverImage() { echo "pull $NVIDIA_DRIVER_IMAGE_PULL_REF:$NVIDIA_DRIVER_IMAGE_TAG"; }
+            installGPUDriverImage() { echo "install $NVIDIA_DRIVER_IMAGE:$NVIDIA_DRIVER_IMAGE_TAG"; }
+
+            When call configGPUDrivers
+
+            The status should be success
+            The stderr should include "images ls -q name==mcr.microsoft.com/aks/aks-gpu-grid-v20:$expected_grid_v20_tag"
+            The output should include "pull mcr.microsoft.com/aks/aks-gpu-grid-v20:$expected_grid_v20_tag"
+            The output should include "install mcr.microsoft.com/aks/aks-gpu-grid-v20:$expected_grid_v20_tag"
+        End
+
+        It 'does not pull or install an old GRID driver when the Ubuntu 26.04 pin is missing'
+            OS="UBUNTU"
+            OS_VERSION="26.04"
+            NVIDIA_GPU_DRIVER_TYPE="grid"
+            COMPONENTS_FILEPATH="missing-grid-v20-components.json"
+            When run configGPUDrivers
+
+            The status should equal 88
+            The stderr should include "Ubuntu 26.04 requires a valid aks-gpu-grid-v20 pin"
+            The output should be blank
+        End
 
         It 'times the image pull and install steps on Ubuntu'
             OS="UBUNTU"


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up on #9417, which added the Ubuntu 26.04 managed GPU package pins for the VHD build.

- Select `aks-gpu-grid-v20` for Ubuntu 26.04 GRID nodes, including A10 SKUs. Read the complete image tag from the VHD's `components.json` before checking the image cache or installing the driver. Fail if the pin is missing, malformed, or duplicated. Keep CUDA, existing explicit GRID v20 selections, and other OS versions unchanged.
- Add `Test_Ubuntu2604Minimal_CUDA` in the device-plugin DaemonSet test file. Use T4 and check the pinned CUDA LTS driver, kubelet stability, GPU resource advertisement, and GPU workload scheduling with a customer-managed device plugin.
- Add `Test_Ubuntu2604Minimal_GridV20` on `Standard_NV6ads_A10_v5`. This does not depend on an RTX PRO 6000 SKU or NVMe placement. Validate the exact GRID v20 driver version from `components.json`.
- Add `Test_Ubuntu2604Minimal_NvidiaDevicePluginRunning_WithoutVMSSTag` on T4. Enable the managed GPU experience through NBC and reuse the Ubuntu 22.04 validators for the systemd device plugin, DCGM packages/exporter, GPU scheduling, and NPD fault detection. GRID licensing checks remain limited to GRID SKUs.
- Share the scenario setup with the existing Ubuntu 22.04 tests and add configuration and ShellSpec regression coverage.

The production change is in the shared provision-time GPU installer used by AgentBaker and AKS node controller. Scriptless provisioning requires a VHD containing the updated CSE script. This PR changes only these five files:

```text
e2e/scenario_gpu_daemonset_test.go
e2e/scenario_gpu_managed_experience_test.go
e2e/validators.go
parts/linux/cloud-init/artifacts/cse_config.sh
spec/parts/linux/cloud-init/artifacts/cse_config_spec.sh
```

There are no package-pin updates, fixed VHD versions, PR-specific image selectors, credentials, log bundles, or unrelated local files in the commit.

**Validation**:

Live validation on September 8, 2026:

The names below match the current code. These live runs preceded the name-only rename; no fresh-node E2E rerun was performed for the rename.

| Check | Result |
| --- | --- |
| Fresh-node GRID/A10 E2E: `Test_Ubuntu2604Minimal_GridV20` | Passed in 551.88 seconds. Driver `595.58.03`, device-plugin DaemonSet ready, one GPU advertised, and GPU workload running. |
| Fresh-node fully managed CUDA/T4 E2E: `Test_Ubuntu2604Minimal_NvidiaDevicePluginRunning_WithoutVMSSTag` | Passed in 755.83 seconds. Driver `580.159.04`, managed device plugin and DCGM services enabled/active, metrics available, GPU workload running, and NPD fault-detection checks passed. Post-test checks confirmed healthy services and one allocatable GPU. |
| CUDA/T4 DaemonSet checks on an existing node | Passed the actual `deployNvidiaDevicePluginDaemonset`, `ValidateNodeAdvertisesGPUResources`, and `ValidateGPUWorkloadSchedulable` helpers. Driver/version and kubelet stability were also checked on the host. This was not a fresh-node rerun of the full CUDA E2E. |

Both fresh-node runs used the VHD generated for #9417, version `1.1788901550.9800`, in West US3 with Ubuntu 26.04.1 and kernel `7.0.0-1012-azure`:

```bash
export SIG_VERSION_TAG_NAME=branch
export SIG_VERSION_TAG_VALUE=refs/pull/9417/merge
export E2E_LOCATION=westus3
export KEEP_VMSS=true
export DISABLE_SCRIPTLESS=true
```

These were run-time settings, not changes to the tests. `DISABLE_SCRIPTLESS=true` exercised the local CSE change. The fresh-node runs preceded the rebase onto current `main`; `git range-diff` confirmed the GPU patch was unchanged. Local checks were rerun after the rebase:

- `go test -mod=readonly ./pkg/agent ./pkg/agent/datamodel -count=1 -timeout 8m`: passed.
- `TestNvidiaDevicePluginDaemonsetScenario`: passed all three cases.
- ShellSpec `selectGPUDriverImage` and `configGPUDrivers`: 25 examples, zero failures.
- `shellcheck --severity=error parts/linux/cloud-init/artifacts/cse_config.sh`: passed.
- Bash syntax, Go formatting, and `git diff --check`: passed.

Local E2E compilation used a temporary Go overlay to exclude unrelated, untracked NVSentinel files with existing build errors. Those files and the overlay are not included in this PR. The broader CSE shell suite previously reported one unrelated LocalDNS executable-permission test failure; the same failure was reproduced on the unchanged baseline. All targeted GPU shell tests passed.

**Which issue(s) this PR fixes**:

No linked issue. Follow-up to #9417.
