### PR TITLE
fix: lower image fetcher pull size threshold to address VHD size issue

### DIFF
--- a/image-fetcher/main.go
+++ b/image-fetcher/main.go
@@ -17,8 +17,8 @@ const (
 	defaultNS     = "k8s.io"
 	// images with compressed content size below this threshold are
 	// unpacked after fetch, effectively turning the operation into a
-	// full pull (~200 MiB compressed ≈ ~400 MiB unpacked).
-	pullSizeThreshold = 200 * 1024 * 1024 // 200 MiB
+	// full pull (~145 MiB compressed ≈ ~290 MiB unpacked).
+	pullSizeThreshold = 145 * 1024 * 1024 // 145 MiB
 )
 
 func main() {


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
Lowers image-fetch threshold to 145 MB. 
Effect: only  blob-csi  (all 4 pinned versions, ~151 MiB compressed each) crosses into fetch-only mode. Everything else — CNI, coredns, kube-proxy, azurefile-csi, cilium-distroless-init — stays exactly as before, since they're all comfortably below 145 MiB.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
