### PR TITLE
fix: remove kernel module mitigation on patched Ubuntu 20.04 FIPS

### DIFF
--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -4085,7 +4085,7 @@ func ValidateVulnerableKernelModulesDisabled(ctx context.Context, s *Scenario) e
 			`absent_reason=""`,
 			`case "$VERSION_ID" in`,
 			`  20.04)`,
-			`    if [[ "$kernel_release" =~ ^5\.4\.0-[0-9]+-azure-fips$ ]]; then`,
+			`    if printf '%s\n' "$kernel_release" | grep -Eq '^5\.4\.0-[0-9]+-azure-fips$'; then`,
 			`      fixed_kernel="5.4.0-1164-azure-fips"`,
 			`    fi`,
 			`    ;;`,

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -4020,7 +4020,8 @@ func ValidateCollectWindowsLogsScript(ctx context.Context, s *Scenario) error {
 //     blacklist entries. Ubuntu 22.04 linux-azure 5.15.0-1116-azure and Ubuntu 24.04
 //     linux-azure 6.8.0-1058-azure include the fixes, thus new VHDs must stop blocking
 //     legitimate module use. Future Ubuntu releases do not inherit this mitigation by default.
-//   - Ubuntu 20.04 and vulnerable/unknown 22.04 / 24.04 kernels / Mariner: full check —
+//     Ubuntu 20.04 also removes the mitigation on 5.4 Azure FIPS kernels at ABI 1164 or newer.
+//   - Other Ubuntu 20.04 and vulnerable/unknown 22.04 / 24.04 kernels / Mariner: full check —
 //     modprobe config entries are present, modules are NOT loaded, and modprobe refuses to load them.
 //   - AzureLinux 3.0: assert ABSENCE of the four modprobe blacklist entries. AzL3 is
 //     descoped from the mitigation because kernel 6.6.139.1-1.azl3 and later fix all
@@ -4084,6 +4085,11 @@ func ValidateVulnerableKernelModulesDisabled(ctx context.Context, s *Scenario) e
 			`absent_reason=""`,
 			`case "$VERSION_ID" in`,
 			`  20.04)`,
+			`    if [[ "$kernel_release" =~ ^5\.4\.0-[0-9]+-azure-fips$ ]]; then`,
+			`      fixed_kernel="5.4.0-1164-azure-fips"`,
+			`    fi`,
+			`    ;;`,
+			`  "")`,
 			`    ;;`,
 			`  22.04)`,
 			`    case "$kernel_release" in`,
@@ -4121,7 +4127,7 @@ func ValidateVulnerableKernelModulesDisabled(ctx context.Context, s *Scenario) e
 		}, "\n")
 		script += "\n" + kernelModuleFullBlockValidationScript()
 		if _, err := execScriptOnVMForScenarioValidateExitCode(ctx, s, script, 0,
-			"Ubuntu vulnerable kernel module validation failed (fixed/future Ubuntu should have no blacklist; Ubuntu 20.04 and older/unknown 22.04/24.04 kernels should keep algif_aead/esp4/esp6/rxrpc blocked)"); err != nil {
+			"Ubuntu vulnerable kernel module validation failed (fixed/future Ubuntu, including 20.04 Azure FIPS 5.4 ABI 1164+, should have no blacklist; other 20.04 and older/unknown 22.04/24.04 kernels should keep algif_aead/esp4/esp6/rxrpc blocked)"); err != nil {
 			return fmt.Errorf("validate vulnerable kernel modules on Ubuntu: %w", err)
 		}
 		return nil

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -752,8 +752,13 @@ ubuntuKernelNeedsVulnerableModuleMitigation() {
 
     case "$ubuntu_release" in
         20.04)
-            echo "Ubuntu 20.04 remains in scope for Copy Fail / DirtyFrag / Fragnesia vulnerable kernel module mitigation"
-            return 0
+            # Only linux-azure-fips 5.4 has a verified Focal fix for all applicable CVEs.
+            if [[ "$kernel_release" =~ ^5\.4\.0-[0-9]+-azure-fips$ ]]; then
+                fixed_kernel="5.4.0-1164-azure-fips"
+            else
+                echo "Ubuntu 20.04 remains in scope for Copy Fail / DirtyFrag / Fragnesia vulnerable kernel module mitigation on ${kernel_release}"
+                return 0
+            fi
             ;;
         22.04)
             case "$kernel_release" in

--- a/parts/linux/cloud-init/artifacts/cse_helpers.sh
+++ b/parts/linux/cloud-init/artifacts/cse_helpers.sh
@@ -753,7 +753,7 @@ ubuntuKernelNeedsVulnerableModuleMitigation() {
     case "$ubuntu_release" in
         20.04)
             # Only linux-azure-fips 5.4 has a verified Focal fix for all applicable CVEs.
-            if [[ "$kernel_release" =~ ^5\.4\.0-[0-9]+-azure-fips$ ]]; then
+            if printf '%s\n' "$kernel_release" | grep -Eq '^5\.4\.0-[0-9]+-azure-fips$'; then
                 fixed_kernel="5.4.0-1164-azure-fips"
             else
                 echo "Ubuntu 20.04 remains in scope for Copy Fail / DirtyFrag / Fragnesia vulnerable kernel module mitigation on ${kernel_release}"

--- a/parts/linux/cloud-init/artifacts/cse_main.sh
+++ b/parts/linux/cloud-init/artifacts/cse_main.sh
@@ -109,7 +109,10 @@ reconcileVulnerableKernelModuleMitigation() {
     # basePrep or carry stale modprobe files.
     # To add a new CVE mitigation, add a disableVulnerableKernelModule call below.
     #
-    # Ubuntu 20.04 remains in scope. Future Ubuntu releases are intentionally skipped
+    # Ubuntu 20.04 remains in scope except 5.4.0-1164-azure-fips and newer ABIs in the
+    # 5.4 Azure FIPS stream: linux-azure-fips 5.4.0-1164.170+fips1 fixes Copy Fail and
+    # DirtyFrag; Focal 5.4 is not affected by Fragnesia. Other 20.04 streams stay blocked.
+    # Future Ubuntu releases are intentionally skipped
     # unless explicitly added here so they do not inherit this deny mitigation by default.
     # Ubuntu 22.04 picked up the fixes in linux-azure 5.15.0-1116-azure (generic
     # fallback 5.15.0-181-generic); Ubuntu 24.04 picked up the fixes in linux-azure

--- a/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
+++ b/spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
@@ -262,11 +262,98 @@ Describe 'ubuntuKernelNeedsVulnerableModuleMitigation()'
     End
 End
 
+# Exercise the Ubuntu 20.04 Azure FIPS exception across all four shell policies.
+# Extract only the functions: never run VHD setup/cleanup or real modprobe operations.
+Describe 'Ubuntu 20.04 Azure FIPS mitigation policy consistency'
+    get_ubuntu_release() { echo "$UBUNTU_RELEASE"; }
+    uname() { echo "$KERNEL_RELEASE"; }
+    awk() { echo "$UBUNTU_RELEASE"; }
+
+    verify_policy() {
+        UBUNTU_RELEASE="$1"
+        OS_VERSION="$1"
+        KERNEL_RELEASE="$2"
+        local expected="$3"
+        local actual
+        local source_file
+        local output
+
+        load_kernel_mitigation_helpers
+        if output="$(ubuntuKernelNeedsVulnerableModuleMitigation)"; then
+            actual="keep"
+        else
+            actual="remove"
+        fi
+        if [ "$actual" != "$expected" ]; then
+            echo "CSE: expected ${expected}, got ${actual}: ${output}"
+            return 1
+        fi
+
+        for source_file in \
+            vhdbuilder/packer/packer_source.sh \
+            vhdbuilder/packer/cleanup-vhd.sh \
+            vhdbuilder/packer/test/linux-vhd-content-test.sh; do
+            eval "$(sed -n '/^kernelVersionGe()/,/^}/p' "$source_file")"
+            eval "$(sed -n '/^ubuntuKernelIncludesVulnerableModuleFixes()/,/^}/p' "$source_file")"
+            if ubuntuKernelIncludesVulnerableModuleFixes "$UBUNTU_RELEASE"; then
+                actual="remove"
+            else
+                actual="keep"
+            fi
+            if [ "$actual" != "$expected" ]; then
+                echo "${source_file}: expected ${expected}, got ${actual}"
+                return 1
+            fi
+        done
+    }
+
+    Parameters
+        "20.04" "5.4.0-1162-azure-fips" "keep"
+        "20.04" "5.4.0-1163-azure-fips" "keep"
+        "20.04" "5.4.0-1164-azure-fips" "remove"
+        "20.04" "5.4.0-1165-azure-fips" "remove"
+        "20.04" "5.4.0-1200-azure-fips" "remove"
+        "20.04" "5.4.0-1164-azure" "keep"
+        "20.04" "5.4.0-1200-azure" "keep"
+        "20.04" "5.4.0-1164-azure-fde" "keep"
+        "20.04" "5.15.0-1114-azure-fde" "keep"
+        "20.04" "5.4.0-1164-generic" "keep"
+        "20.04" "5.4.0-1164-azure-nvidia" "keep"
+        "20.04" "6.14.0-1010-azure-nvidia" "keep"
+        "20.04" "5.15.0-1116-azure-fips" "keep"
+        "20.04" "6.8.0-1058-azure-fips" "keep"
+        "20.04" "5.4.1-1164-azure-fips" "keep"
+        "20.04" "5.4.0-1164-azure-fips-custom" "keep"
+        "20.04" "5.4.0-1164.170-azure-fips" "keep"
+        "20.04" "5.4.0-1164custom-azure-fips" "keep"
+        "20.04" "5.4.0-unknown-azure-fips" "keep"
+        "20.04" "unknown" "keep"
+        "20.04" "" "keep"
+        "" "5.4.0-1164-azure-fips" "keep"
+        "" "" "keep"
+        "22.04" "5.15.0-1115-azure" "keep"
+        "22.04" "5.15.0-1116-azure" "remove"
+        "22.04" "5.15.0-1116-azure-fips" "remove"
+        "22.04" "5.15.0-1120-azure-fde" "remove"
+        "24.04" "6.8.0-1057-azure" "keep"
+        "24.04" "6.8.0-1058-azure" "remove"
+        "24.04" "6.8.0-1061-azure-fde" "remove"
+        "24.04" "6.8.0-1058-azure-fips" "remove"
+        "24.04" "6.14.0-1010-azure" "remove"
+    End
+
+    It 'only exempts fixed 5.4 Azure FIPS kernels on 20.04 and preserves later Ubuntu behavior'
+        When call verify_policy "$1" "$2" "$3"
+        The status should be success
+        The output should be blank
+    End
+End
+
 # Tests the OS gate that decides whether to apply or remove vulnerable-module
-# deny rules during VHD build and provisioning. Apply on: Ubuntu 20.04, vulnerable Ubuntu 22.04 / 24.04
+# deny rules during VHD build and provisioning. Apply on: other Ubuntu 20.04, vulnerable Ubuntu 22.04 / 24.04
 # kernels, Mariner/AzureLinux 2.0 (AzL2), AzureLinux OSGuard (defense-in-depth —
 # hardened secure-boot variant intentionally retains the mitigation). Remove stale deny rules on
-# fixed Ubuntu 22.04 / 24.04 kernels and future Ubuntu releases. Skip on AzureLinux
+# fixed Ubuntu 20.04 Azure FIPS 5.4, fixed Ubuntu 22.04 / 24.04 kernels and future Ubuntu releases. Skip on AzureLinux
 # 3.0 regular/Kata (kernel 6.6.139.1-1.azl3+ has the upstream fix and customers reported
 # the blacklist actively blocks legitimate workloads), ACL, Flatcar.
 # See https://github.com/Azure/AKS/issues/5753.
@@ -357,6 +444,42 @@ Describe 'CVE kernel module mitigation OS gate'
         When call gate
         The output should include "REMOVE"
         The output should not include "APPLY"
+    End
+
+    It 'removes stale deny rules on fixed Ubuntu 20.04 Azure FIPS kernels'
+        OS="${UBUNTU_OS_NAME}"
+        OS_VERSION="20.04"
+        UBUNTU_RELEASE="20.04"
+        KERNEL_RELEASE="5.4.0-1164-azure-fips"
+        When call gate
+        The output should include "REMOVE"
+        The output should not include "APPLY"
+    End
+
+    It 'applies all four deny rules on older Ubuntu 20.04 Azure FIPS kernels'
+        OS="${UBUNTU_OS_NAME}"
+        OS_VERSION="20.04"
+        UBUNTU_RELEASE="20.04"
+        KERNEL_RELEASE="5.4.0-1163-azure-fips"
+        When call gate
+        The output should include "APPLY:algif_aead"
+        The output should include "APPLY:esp4"
+        The output should include "APPLY:esp6"
+        The output should include "APPLY:rxrpc"
+        The output should not include "REMOVE"
+    End
+
+    It 'applies all four deny rules on Ubuntu 20.04 CVM kernels'
+        OS="${UBUNTU_OS_NAME}"
+        OS_VERSION="20.04"
+        UBUNTU_RELEASE="20.04"
+        KERNEL_RELEASE="5.15.0-1114-azure-fde"
+        When call gate
+        The output should include "APPLY:algif_aead"
+        The output should include "APPLY:esp4"
+        The output should include "APPLY:esp6"
+        The output should include "APPLY:rxrpc"
+        The output should not include "REMOVE"
     End
 
     It 'applies the mitigation when a fixed Ubuntu generic kernel has an unexpected suffix'

--- a/vhdbuilder/packer/cleanup-vhd.sh
+++ b/vhdbuilder/packer/cleanup-vhd.sh
@@ -29,7 +29,10 @@ ubuntuKernelIncludesVulnerableModuleFixes() {
   fi
 
   case "$ubuntu_release" in
-    20.04) return 1 ;;
+    20.04)
+      [[ "$kernel_release" =~ ^5\.4\.0-[0-9]+-azure-fips$ ]] || return 1
+      fixed_kernel="5.4.0-1164-azure-fips"
+      ;;
     22.04)
       case "$kernel_release" in
         # azure-fde (CVM) and azure-fips share the azure kernel ABI and fix threshold.

--- a/vhdbuilder/packer/cleanup-vhd.sh
+++ b/vhdbuilder/packer/cleanup-vhd.sh
@@ -30,7 +30,7 @@ ubuntuKernelIncludesVulnerableModuleFixes() {
 
   case "$ubuntu_release" in
     20.04)
-      [[ "$kernel_release" =~ ^5\.4\.0-[0-9]+-azure-fips$ ]] || return 1
+      printf '%s\n' "$kernel_release" | grep -Eq '^5\.4\.0-[0-9]+-azure-fips$' || return 1
       fixed_kernel="5.4.0-1164-azure-fips"
       ;;
     22.04)

--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -37,7 +37,10 @@ ubuntuKernelIncludesVulnerableModuleFixes() {
   fi
 
   case "$os_version" in
-    20.04) return 1 ;;
+    20.04)
+      [[ "$kernel_release" =~ ^5\.4\.0-[0-9]+-azure-fips$ ]] || return 1
+      fixed_kernel="5.4.0-1164-azure-fips"
+      ;;
     22.04)
       case "$kernel_release" in
         # azure-fde (CVM) and azure-fips share the azure kernel ABI and fix threshold.
@@ -567,7 +570,7 @@ copyPackerFiles() {
   # is still baked in, so AzureLinux 3.0 keeps the same CIS module hardening as every other
   # OS stream instead of silently losing the whole file. See
   # https://github.com/Azure/AKS/issues/5753.
-  # Ubuntu 20.04, Mariner / AzureLinux 2.0, and AzureLinux OSGuard still get the unmodified bake-in.
+  # Other Ubuntu 20.04 kernels, Mariner / AzureLinux 2.0, and AzureLinux OSGuard still get the unmodified bake-in.
   if isUbuntu "$OS" && ubuntuKernelIncludesVulnerableModuleFixes; then
     bakeModprobeCISWithoutVulnerableModules "on Ubuntu ${OS_VERSION} (fixed or future Ubuntu kernels are not in mitigation scope)"
   elif isAzureLinux "$OS" "$OS_VARIANT" && [ "${OS_VERSION}" = "3.0" ] && ! isAzureLinuxOSGuard "$OS" "$OS_VARIANT"; then

--- a/vhdbuilder/packer/packer_source.sh
+++ b/vhdbuilder/packer/packer_source.sh
@@ -38,7 +38,7 @@ ubuntuKernelIncludesVulnerableModuleFixes() {
 
   case "$os_version" in
     20.04)
-      [[ "$kernel_release" =~ ^5\.4\.0-[0-9]+-azure-fips$ ]] || return 1
+      printf '%s\n' "$kernel_release" | grep -Eq '^5\.4\.0-[0-9]+-azure-fips$' || return 1
       fixed_kernel="5.4.0-1164-azure-fips"
       ;;
     22.04)

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1486,7 +1486,8 @@ testNfsServerService() {
 # is still baked in and asserted below. Ubuntu 22.04 linux-azure 5.15.0-1116-azure and Ubuntu
 # 24.04 linux-azure 6.8.0-1058-azure include the fixes, so newly-built Ubuntu
 # 22.04/24.04 VHDs with a fixed running kernel also stop baking the vulnerable-module
-# blacklist while keeping the baseline CIS module deny list. Ubuntu 20.04 and vulnerable
+# blacklist while keeping the baseline CIS module deny list. Ubuntu 20.04 Azure FIPS
+# 5.4 kernels at ABI 1164 or newer also assert ABSENCE. Other Ubuntu 20.04 and vulnerable
 # 22.04/24.04 kernels assert presence + load-refusal; fixed 22.04/24.04 kernels and
 # future Ubuntu releases assert ABSENCE so future releases do not inherit the mitigation.
 # Mariner/AzureLinux 2.0 and AzureLinux OSGuard still assert presence + load-refusal.
@@ -1507,12 +1508,15 @@ ubuntuKernelIncludesVulnerableModuleFixes() {
   local fixed_kernel
 
   kernel_release="$(uname -r 2>/dev/null || true)"
-  if [ -z "$kernel_release" ]; then
+  if [ -z "$os_version" ] || [ -z "$kernel_release" ]; then
     return 1
   fi
 
   case "$os_version" in
-    20.04) return 1 ;;
+    20.04)
+      [[ "$kernel_release" =~ ^5\.4\.0-[0-9]+-azure-fips$ ]] || return 1
+      fixed_kernel="5.4.0-1164-azure-fips"
+      ;;
     22.04)
       case "$kernel_release" in
         # azure-fde (CVM) and azure-fips share the azure kernel ABI and fix threshold.

--- a/vhdbuilder/packer/test/linux-vhd-content-test.sh
+++ b/vhdbuilder/packer/test/linux-vhd-content-test.sh
@@ -1514,7 +1514,7 @@ ubuntuKernelIncludesVulnerableModuleFixes() {
 
   case "$os_version" in
     20.04)
-      [[ "$kernel_release" =~ ^5\.4\.0-[0-9]+-azure-fips$ ]] || return 1
+      printf '%s\n' "$kernel_release" | grep -Eq '^5\.4\.0-[0-9]+-azure-fips$' || return 1
       fixed_kernel="5.4.0-1164-azure-fips"
       ;;
     22.04)


### PR DESCRIPTION
**What this PR does / why we need it**:

Ubuntu 20.04 Azure FIPS images contain the kernel fixes for Copy Fail and DirtyFrag starting with VHD `202606.08.1`, but the existing Ubuntu 20.04 gate still applies the temporary `algif_aead`, `esp4`, `esp6`, and `rxrpc` restrictions unconditionally. This prevents legitimate use of those modules on patched nodes.

Allow the existing cleanup only for Ubuntu 20.04 running an exact `5.4.0-<numeric ABI>-azure-fips` kernel at ABI **1164 or newer**. Keep mitigation for older FIPS kernels and every other Ubuntu 20.04 family, including FDE/CVM, generic, NVIDIA, unrecognized names and missing detection. Ubuntu 22.04/24.04 branches and cutoffs are unchanged.

Align the runtime helper, Packer build gate, final post-reboot cleanup, VHD content validation and E2E validator. Existing reconciliation remains in both `basePrep` and `nodePrep`, covering PIS nodes that skip base preparation. No new downloads, dependencies or provisioning phase changes.

**Vendor and image evidence**:

Canonical records Focal `linux-azure-fips` Copy Fail fixed in `5.4.0-1163.169+fips1`, and both DirtyFrag fixes in `5.4.0-1164.170+fips1`. Focal's 5.4 kernel is not affected by Fragnesia.

- [Copy Fail](https://ubuntu.com/security/CVE-2026-31431)
- [DirtyFrag ESP](https://ubuntu.com/security/CVE-2026-43284) / [RxRPC](https://ubuntu.com/security/CVE-2026-43500)
- [Fragnesia](https://ubuntu.com/security/CVE-2026-46300)
- [Gen1 FIPS image packages](https://github.com/Azure/AgentBaker/blob/main/vhdbuilder/release-notes/AKSUbuntu/gen1/2004fipscontainerd/202606.08.1.txt) / [Gen2 FIPS image packages](https://github.com/Azure/AgentBaker/blob/main/vhdbuilder/release-notes/AKSUbuntu/gen2/2004fipscontainerd/202606.08.1.txt)

**Compatibility and release**:

The gate checks the running kernel, not merely installed packages. New scripts retain mitigation on older kernels; scriptless nodes need an image containing the updated scripts, and older CSE can reapply the rules. This is provisioning reconciliation, not automatic cleanup of existing nodes. This PR has **no published cleanup VHD yet**; `202606.08.1` is the kernel-fix floor, not this change's release vehicle.

**Testing**:

- 70 targeted ShellSpec examples passed, including a 32-case policy matrix across four shell implementations and Focal FIPS reconciliation regressions.
- Embedded E2E gate passed the same matrix; E2E compilation passed.
- Agent tests and snapshot regeneration passed without snapshot changes.
- Bash syntax, formatting and diff checks passed. Error-level ShellCheck passed excluding the confirmed pre-existing SC2068.
- No live VHD build or cluster E2E run performed.

**Which issue(s) this PR fixes**:

AB#39616047

Related to Azure/AKS#5753. **Do not close the advisory on merge**: it remains open until this cleanup is included in a published VHD, with the release vehicle documented there.

> 🤖 *Generated by GitHub Copilot*