### PR TITLE
fix: make Ubuntu Pro attachment state-aware

### DIFF
--- a/spec/vhdbuilder/packer/attach_ua_spec.sh
+++ b/spec/vhdbuilder/packer/attach_ua_spec.sh
@@ -1,0 +1,557 @@
+#!/bin/bash
+# ShellSpec parameter rows are data, not shell commands.
+# shellcheck disable=SC2329,SC2288
+
+Describe 'attachUA'
+  # Extract only the functions under test; never execute the image-build script.
+  BeforeAll "eval \"\$(sed -n '/^ubuntuProESMState()/,/^}$/p;/^attachUA()/,/^}$/p' vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh)\""
+
+  setup_ua() {
+    TEST_DIR="$(mktemp -d)"
+    TRACE="${TEST_DIR}/commands"
+    : > "${TRACE}"
+    UA_TOKEN="unit-test-only-secret"
+    ERR_UA_ATTACH=182
+    SUCCESS='{"_schema_version":"0.1","result":"success","errors":[],"failed_services":[],"processed_services":[]}'
+    UNATTACHED='{"_schema_version":"0.1","result":"success","errors":[],"execution_status":"inactive","attached":false,"services":[]}'
+    DISABLED='{"_schema_version":"0.1","result":"success","errors":[],"execution_status":"inactive","attached":true,"contract":{"id":"FAKE-PRO-PRIVATE-STATE"},"services":[{"name":"esm-apps","entitled":"yes","status":"disabled"},{"name":"esm-infra","entitled":"yes","status":"disabled"},{"name":"livepatch","entitled":"yes","status":"disabled"}]}'
+    READY="$(printf '%s' "${DISABLED}" | jq -c '.services |= map(if .name != "livepatch" then .status = "enabled" else . end)')"
+    APPS_READY="$(printf '%s' "${DISABLED}" | jq -c '.services[0].status = "enabled"')"
+    TRANSIENT='{"_schema_version":"0.1","result":"failure","errors":[{"type":"system","service":null,"message_code":"external-api-error","message":"FAKE-PRO-PRIVATE-STATE","additional_info":{"code":503,"body":"unit-test-only-secret"}}],"failed_services":[],"processed_services":[]}'
+    SERVICE_TRANSIENT="$(printf '%s' "${TRANSIENT}" | jq -c '.errors[0] += {"type":"service","service":"esm-infra"} | .failed_services = ["esm-infra"] | .processed_services = ["esm-apps"]')"
+    STATUS_RESPONSES=("${UNATTACHED}" "${DISABLED}" "${READY}")
+    STATUS_CODES=(0 0 0)
+    ATTACH_RESPONSES=("${SUCCESS}")
+    ATTACH_CODES=(0)
+    ENABLE_RESPONSES=("${SUCCESS}")
+    ENABLE_CODES=(0)
+  }
+  cleanup_ua() {
+    rm -f "${TRACE}"
+    rmdir "${TEST_DIR}"
+  }
+  BeforeEach 'setup_ua'
+  AfterEach 'cleanup_ua'
+
+  # All external operations are mocked. The command log survives command substitutions,
+  # while stdout/stderr deliberately contain private canaries to exercise log redaction.
+  ua() {
+    local index
+    case "$1" in
+      status)
+        [ "$*" = "status --all --format json" ] || return 99
+        index="$(grep -c '^status$' "${TRACE}")" || :
+        echo status >> "${TRACE}"
+        printf '%s\n' "${STATUS_RESPONSES[$index]:-}"
+        return "${STATUS_CODES[$index]:-99}"
+        ;;
+      attach)
+        [ "$#" -eq 5 ] && [ "$2 $3 $4" = "--no-auto-enable --format json" ] && [ "$5" = "${UA_TOKEN}" ] || return 99
+        index="$(grep -c '^attach$' "${TRACE}")" || :
+        echo attach >> "${TRACE}"
+        printf '%s\n' "${ATTACH_RESPONSES[$index]:-}"
+        echo "unit-test-only-secret FAKE-PRO-PRIVATE-STATE" >&2
+        return "${ATTACH_CODES[$index]:-99}"
+        ;;
+      enable)
+        [ "$2 $3 $4" = "--assume-yes --format json" ] || return 99
+        shift 4
+        case "$*" in
+          "esm-apps esm-infra"|"esm-apps"|"esm-infra") ;;
+          *) echo "UNEXPECTED SERVICE $*" >> "${TRACE}"; return 99 ;;
+        esac
+        index="$(grep -c '^enable ' "${TRACE}")" || :
+        echo "enable $*" >> "${TRACE}"
+        printf '%s\n' "${ENABLE_RESPONSES[$index]:-}"
+        return "${ENABLE_CODES[$index]:-99}"
+        ;;
+      *) echo "UNEXPECTED UA COMMAND $*" >> "${TRACE}"; return 99 ;;
+    esac
+  }
+  timeout() {
+    case "$1" in 120|1000) ;; *) return 99 ;; esac
+    shift
+    "$@"
+  }
+  sleep() { echo "sleep $*" >> "${TRACE}"; }
+
+  It 'attaches without auto-enable and enables exactly both ESM services, with no backoff or detach'
+    When run attachUA
+    The status should be success
+    The output should include 'Ubuntu Pro esm-apps and esm-infra are enabled'
+    The output should not include 'unit-test-only-secret'
+    The output should not include 'FAKE-PRO-PRIVATE-STATE'
+    The stderr should eq ''
+    The contents of file "${TRACE}" should eq "status
+attach
+status
+enable esm-apps esm-infra
+status"
+  End
+
+  It 'recovers partial attachment without repeating attach or detaching'
+    ATTACH_RESPONSES=("${TRANSIENT}")
+    ATTACH_CODES=(1)
+    When run attachUA
+    The status should be success
+    The output should include 'recovering once after 10 seconds'
+    The stderr should eq ''
+    The contents of file "${TRACE}" should eq "status
+attach
+sleep 10
+status
+enable esm-apps esm-infra
+status"
+  End
+
+  It 'retries an explicitly transient unattached failure only once'
+    STATUS_RESPONSES=("${UNATTACHED}" "${UNATTACHED}" "${DISABLED}" "${READY}")
+    STATUS_CODES=(0 0 0 0)
+    ATTACH_RESPONSES=("${TRANSIENT}" "${SUCCESS}")
+    ATTACH_CODES=(1 0)
+    When run attachUA
+    The status should be success
+    The output should include 'recovering once after 10 seconds'
+    The stderr should eq ''
+    The contents of file "${TRACE}" should eq "status
+attach
+sleep 10
+status
+attach
+status
+enable esm-apps esm-infra
+status"
+  End
+
+  It 'fails when the single attach retry is exhausted'
+    STATUS_RESPONSES=("${UNATTACHED}" "${UNATTACHED}")
+    ATTACH_RESPONSES=("${TRANSIENT}" "${TRANSIENT}")
+    ATTACH_CODES=(1 1)
+    When run attachUA
+    The status should eq 182
+    The output should include 'recovering once'
+    The stderr should include 'no safe recovery remaining'
+    The contents of file "${TRACE}" should eq "status
+attach
+sleep 10
+status
+attach"
+  End
+
+  It 'recovers enablement by enabling only the missing service'
+    STATUS_RESPONSES=("${UNATTACHED}" "${DISABLED}" "${APPS_READY}" "${READY}")
+    STATUS_CODES=(0 0 0 0)
+    ENABLE_RESPONSES=("${SERVICE_TRANSIENT}" "${SUCCESS}")
+    ENABLE_CODES=(1 0)
+    When run attachUA
+    The status should be success
+    The output should include 'recovering once'
+    The stderr should eq ''
+    The contents of file "${TRACE}" should eq "status
+attach
+status
+enable esm-apps esm-infra
+sleep 10
+status
+enable esm-infra
+status"
+  End
+
+  It 'accepts verified ESM readiness after a transient post-enable bookkeeping error'
+    ENABLE_RESPONSES=("${TRANSIENT}")
+    ENABLE_CODES=(1)
+    When run attachUA
+    The status should be success
+    The output should include 'recovering once'
+    The stderr should eq ''
+    The contents of file "${TRACE}" should eq "status
+attach
+status
+enable esm-apps esm-infra
+sleep 10
+status"
+  End
+
+  Describe 'incomplete readiness after system-level enable failures'
+    Parameters
+      '.'
+      '.errors += [{"type":"service","service":"esm-infra","message_code":"external-api-error","additional_info":{"code":503}}]'
+    End
+    It 'does not retry missing services when bookkeeping could have masked a permanent service error'
+      ENABLE_RESPONSES=("$(printf '%s' "${TRANSIENT}" | jq -c "$1")")
+      ENABLE_CODES=(1)
+      STATUS_RESPONSES=("${UNATTACHED}" "${DISABLED}" "${APPS_READY}")
+      When run attachUA
+      The status should eq 182
+      The output should include 'recovering once'
+      The stderr should include 'readiness incomplete after an ambiguous enable failure'
+      The contents of file "${TRACE}" should eq "status
+attach
+status
+enable esm-apps esm-infra
+sleep 10
+status"
+    End
+  End
+
+  Describe 'incomplete or untrusted service failure results'
+    Parameters
+      '.failed_services += ["esm-apps"]'
+      '.processed_services = []'
+      '.processed_services += ["esm-infra"]'
+      '.failed_services = null'
+      '.processed_services = [1]'
+      '.errors[0].service = "livepatch"'
+      '.errors += [{"type":"service","service":"esm-apps","message_code":"service-not-entitled"}]'
+    End
+    It 'requires a classified cause for every failed service and results for every requested service'
+      ENABLE_RESPONSES=("$(printf '%s' "${SERVICE_TRANSIENT}" | jq -c "$1")")
+      ENABLE_CODES=(1)
+      When run attachUA
+      The status should eq 182
+      The output should include 'enabling required Ubuntu Pro ESM services'
+      The stderr should include 'no safe recovery remaining'
+      The contents of file "${TRACE}" should eq "status
+attach
+status
+enable esm-apps esm-infra"
+    End
+  End
+
+  It 'shares one recovery budget between attach and enable'
+    ATTACH_RESPONSES=("${TRANSIENT}")
+    ATTACH_CODES=(1)
+    ENABLE_RESPONSES=("${TRANSIENT}")
+    ENABLE_CODES=(1)
+    When run attachUA
+    The status should eq 182
+    The output should include 'recovering once'
+    The stderr should include 'Ubuntu Pro enable failed'
+    The contents of file "${TRACE}" should eq "status
+attach
+sleep 10
+status
+enable esm-apps esm-infra"
+  End
+
+  It 'fails when required-service recovery also fails'
+    STATUS_RESPONSES=("${UNATTACHED}" "${DISABLED}" "${APPS_READY}")
+    ENABLE_RESPONSES=("${SERVICE_TRANSIENT}" "${SERVICE_TRANSIENT}")
+    ENABLE_CODES=(1 1)
+    When run attachUA
+    The status should eq 182
+    The output should include 'recovering once'
+    The stderr should include 'Ubuntu Pro enable failed'
+    The contents of file "${TRACE}" should eq "status
+attach
+status
+enable esm-apps esm-infra
+sleep 10
+status
+enable esm-infra"
+  End
+
+  It 'does not run package upgrades when attachment fails, even in a conditional caller'
+    ATTACH_RESPONSES=('{}')
+    guarded_caller() {
+      if attachUA; then
+        echo unexpected-upgrade >> "${TRACE}"
+      fi
+      echo unexpected-continuation >> "${TRACE}"
+    }
+    When run guarded_caller
+    The status should eq 182
+    The output should include 'attaching ua'
+    The stderr should include 'Invalid Ubuntu Pro attach success response'
+    The contents of file "${TRACE}" should eq "status
+attach"
+  End
+
+  Describe 'permanent or ambiguous errors'
+    Parameters
+      'attach-invalid-token'
+      'attach-forbidden-expired'
+      'attach-forbidden-not-yet'
+      'attach-forbidden-never'
+      'attach-experied-token'
+      'attach-failure'
+      'connectivity-error'
+      'attach-failure-default-service'
+      'attach-failure-unexpected-error'
+      'service-not-entitled'
+      'unknown-error'
+    End
+    It 'does not retry or normalize permanent, ambiguous or unknown attach errors'
+      ATTACH_RESPONSES=("$(printf '%s' "${TRANSIENT}" | jq -c --arg code "$1" '.errors[0].message_code = $code')")
+      ATTACH_CODES=(1)
+      When run attachUA
+      The status should eq 182
+      The output should include 'attaching ua'
+      The stderr should include 'no safe recovery remaining'
+      The contents of file "${TRACE}" should eq "status
+attach"
+    End
+  End
+
+  Describe 'retryable HTTP statuses'
+    Parameters
+      500
+      502
+      503
+      504
+    End
+    It 'allows recovery only for the selected numeric HTTP server failures'
+      ATTACH_RESPONSES=("$(printf '%s' "${TRANSIENT}" | jq -c --argjson code "$1" '.errors[0].additional_info.code = $code')")
+      ATTACH_CODES=(1)
+      When run attachUA
+      The status should be success
+      The output should include 'recovering once'
+      The stderr should eq ''
+    End
+  End
+
+  Describe 'untrusted error metadata'
+    Parameters
+      '.errors[0].additional_info.code = 401'
+      '.errors[0].additional_info.code = 403'
+      '.errors[0].additional_info.code = 429'
+      '.errors[0].additional_info.code = 501'
+      '.errors[0].additional_info.code = "503"'
+      '.errors[0].message_code = null'
+      '.errors[0].type = "unknown"'
+      'del(.errors[0].type)'
+      '.errors[0] += {"type":"service","service":"esm-infra"}'
+      '.errors += [{"message_code":"attach-invalid-token"}]'
+      '.errors = []'
+      '.errors = null'
+      'del(._schema_version)'
+      '._schema_version = "2.0"'
+    End
+    It 'fails closed on unclassified HTTP failures and unknown error schemas'
+      ATTACH_RESPONSES=("$(printf '%s' "${TRANSIENT}" | jq -c "$1")")
+      ATTACH_CODES=(1)
+      When run attachUA
+      The status should eq 182
+      The output should include 'attaching ua'
+      The stderr should include 'no safe recovery remaining'
+      The contents of file "${TRACE}" should eq "status
+attach"
+    End
+  End
+
+  Describe 'nonstandard exit statuses'
+    Parameters
+      2
+      4
+      124
+      137
+    End
+    It 'does not infer transience from already-attached, partial-success or timeout exit codes'
+      ATTACH_RESPONSES=("${TRANSIENT}")
+      ATTACH_CODES=("$1")
+      When run attachUA
+      The status should eq 182
+      The output should include 'attaching ua'
+      The stderr should include "exit $1"
+      The contents of file "${TRACE}" should eq "status
+attach"
+    End
+  End
+
+  Describe 'invalid operation results'
+    Parameters
+      ''
+      'not-json unit-test-only-secret'
+      '{}'
+      '{"_schema_version":"0.1","result":"failure","errors":[],"failed_services":[]}'
+      '{"_schema_version":"0.1","result":"success","errors":[],"failed_services":["esm-infra"]}'
+      '{"_schema_version":"0.1","result":"success","errors":[],"failed_services":[]} {}'
+      '{"_schema_version":"0.1","result":"success","errors":[],"failed_services":[],"processed_services":["livepatch"]}'
+    End
+    It 'does not accept exit zero with missing, invalid or contradictory operation JSON'
+      ATTACH_RESPONSES=("$1")
+      When run attachUA
+      The status should eq 182
+      The output should include 'attaching ua'
+      The stderr should include 'Invalid Ubuntu Pro attach success response'
+      The stderr should not include 'unit-test-only-secret'
+      The contents of file "${TRACE}" should eq "status
+attach"
+    End
+  End
+
+  Describe 'preexisting attachments'
+    Parameters
+      '.'
+      '.services += [{"name":"fips-updates","entitled":"yes","status":"enabled"}]'
+      '.contract.id = "different-contract"'
+    End
+    It 'refuses initially attached machines, including post-FIPS or different-contract state, without changes'
+      STATUS_RESPONSES=("$(printf '%s' "${READY}" | jq -c "$1")")
+      When run attachUA
+      The status should eq 182
+      The output should eq ''
+      The stderr should include 'initially attached'
+      The contents of file "${TRACE}" should eq 'status'
+    End
+  End
+
+  Describe 'untrusted initial status'
+    Parameters
+      'del(.attached)'
+      '.attached = "false"'
+      '._schema_version = "unknown"'
+      '.result = "failure"'
+      '.errors = [{}]'
+      '.execution_status = "active"'
+      '.execution_status = "unknown"'
+    End
+    It 'fails before attachment when initial status is untrusted'
+      STATUS_RESPONSES=("$(printf '%s' "${UNATTACHED}" | jq -c "$1")")
+      When run attachUA
+      The status should eq 182
+      The output should eq ''
+      The stderr should include 'Unable to determine initial Ubuntu Pro state'
+      The contents of file "${TRACE}" should eq 'status'
+    End
+  End
+
+  It 'does not mistake a failed status command for unattached even if its JSON looks valid'
+    STATUS_CODES=(1)
+    When run attachUA
+    The status should eq 182
+    The output should eq ''
+    The stderr should include 'Unable to determine initial Ubuntu Pro state'
+    The contents of file "${TRACE}" should eq 'status'
+  End
+
+  Describe 'required service readiness'
+    Parameters
+      '.services[1].status = "disabled"'
+      '.services[1].status = "warning"'
+      '.services[0].entitled = "no"'
+      '.services = [.services[0]]'
+      '.services += [.services[0]]'
+      '.services = null'
+      '.services = {"apps":.services[0],"infra":.services[1]}'
+      '.attached = false'
+    End
+    It 'requires both entitled ESM services to be enabled before returning success'
+      STATUS_RESPONSES=("${UNATTACHED}" "${DISABLED}" "$(printf '%s' "${READY}" | jq -c "$1")")
+      When run attachUA
+      The status should eq 182
+      The output should include 'enabling required Ubuntu Pro ESM services'
+      The stderr should be present
+      The contents of file "${TRACE}" should eq "status
+attach
+status
+enable esm-apps esm-infra
+status"
+    End
+  End
+
+  It 'does not enable services after an unreadable partial-attachment state'
+    ATTACH_RESPONSES=("${TRANSIENT}")
+    ATTACH_CODES=(1)
+    STATUS_RESPONSES=("${UNATTACHED}" '{}')
+    When run attachUA
+    The status should eq 182
+    The output should include 'recovering once'
+    The stderr should include 'Unable to determine Ubuntu Pro state after attach'
+    The contents of file "${TRACE}" should eq "status
+attach
+sleep 10
+status"
+  End
+
+  It 'fails a required ESM authorization error without retrying or reading it as success'
+    ENABLE_RESPONSES=("$(printf '%s' "${TRANSIENT}" | jq -c '.errors[0].message_code = "service-not-entitled"')")
+    ENABLE_CODES=(1)
+    When run attachUA
+    The status should eq 182
+    The output should include 'enabling required Ubuntu Pro ESM services'
+    The stderr should include 'Ubuntu Pro enable failed'
+    The contents of file "${TRACE}" should eq "status
+attach
+status
+enable esm-apps esm-infra"
+  End
+
+  run_with_xtrace() {
+    set -x
+    attachUA
+    case "$-" in *x*) ;; *) return 99 ;; esac
+    set +x
+  }
+  It 'keeps token and private JSON out of logs while preserving caller xtrace'
+    ATTACH_RESPONSES=("${TRANSIENT}")
+    ATTACH_CODES=(1)
+    When run run_with_xtrace
+    The status should be success
+    The output should include 'esm-apps and esm-infra are enabled'
+    The output should not include 'unit-test-only-secret'
+    The output should not include 'FAKE-PRO-PRIVATE-STATE'
+    The stderr should include 'set +x'
+    The stderr should not include 'unit-test-only-secret'
+    The stderr should not include 'FAKE-PRO-PRIVATE-STATE'
+  End
+
+  It 'fails before running Pro when the token is missing'
+    UA_TOKEN=''
+    When run attachUA
+    The status should eq 182
+    The output should eq ''
+    The stderr should include 'requires a token and jq'
+    The contents of file "${TRACE}" should eq ''
+  End
+
+  Describe 'Ubuntu build call paths'
+    Skip if 'the existing build caller requires Bash 4 case conversion' [ "${BASH_VERSINFO[0]}" -lt 4 ]
+    Parameters
+      '20.04' 'false' 'pro'
+      '20.04' 'true' 'pro'
+      '22.04' 'true' 'pro'
+      '24.04' 'true' 'pro'
+      '22.04' 'false' 'no-pro'
+      '24.04' 'false' 'no-pro'
+    End
+
+    run_ubuntu_upgrade_phase() {
+      local UBUNTU_RELEASE="$1" OS_VERSION="$1" ENABLE_FIPS="$2" VHD_BUILD_TIMESTAMP=""
+      local phase_script
+      apt_get_update() { echo apt-update >> "${TRACE}"; }
+      apt_get_dist_upgrade() { echo dist-upgrade >> "${TRACE}"; }
+      installFIPS() { echo install-fips >> "${TRACE}"; }
+      # Extract only the Ubuntu upgrade branch, including its final closing fi.
+      # All mutating commands in this branch are mocked; no full script is sourced.
+      phase_script="$(sed -n '/^  # Enable ESM only/,/^fi$/p' vhdbuilder/packer/pre-install-dependencies.sh)"
+      [ -n "${phase_script}" ] || return 99
+      eval "if false; then :; else
+${phase_script}"
+      set +x
+    }
+
+    It 'makes ESM ready before distro upgrades and retains the later FIPS phase'
+      expected=''
+      if [ "$3" = pro ]; then
+        expected="status
+attach
+status
+enable esm-apps esm-infra
+status
+"
+      fi
+      expected="${expected}apt-update
+dist-upgrade"
+      if [ "$2" = true ]; then
+        expected="${expected}
+install-fips"
+      fi
+      When run run_ubuntu_upgrade_phase "$1" "$2"
+      The status should be success
+      The output should not include 'unit-test-only-secret'
+      The stderr should not include 'unit-test-only-secret'
+      The contents of file "${TRACE}" should eq "${expected}"
+    End
+  End
+End

--- a/spec/vhdbuilder/packer/attach_ua_spec.sh
+++ b/spec/vhdbuilder/packer/attach_ua_spec.sh
@@ -75,6 +75,24 @@ Describe 'attachUA'
   }
   sleep() { echo "sleep $*" >> "${TRACE}"; }
 
+  Describe 'setup state and pending ESM service names'
+    Parameters
+      '.attached = false' 'unattached'
+      '.' 'needs-esm esm-apps esm-infra'
+      '.services[0].status = "enabled"' 'needs-esm esm-infra'
+      '.services[1].status = "enabled"' 'needs-esm esm-apps'
+      '.services[0].status = "enabled" | .services[1].status = "enabled"' 'ready'
+    End
+    It 'returns a state marker followed only by services that still need enabling'
+      STATUS_RESPONSES=("$(printf '%s' "${DISABLED}" | jq -c "$1")")
+      When run ubuntuProESMState
+      The status should be success
+      The output should eq "$2"
+      The stderr should eq ''
+      The contents of file "${TRACE}" should eq 'status'
+    End
+  End
+
   It 'attaches without auto-enable and enables exactly both ESM services, with no backoff or detach'
     When run attachUA
     The status should be success

--- a/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
+++ b/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
@@ -219,12 +219,135 @@ listInstalledPackages() {
     apt list --installed
 }
 
-attachUA() {
-    echo "attaching ua..."
-    retrycmd_silent 5 10 1000 ua attach $UA_TOKEN || exit $ERR_UA_ATTACH
+# Only emit attachment/readiness state, never the account, contract or machine identity.
+ubuntuProESMState() {
+    local status_json
+    status_json="$(timeout 120 ua status --all --format json 2>/dev/null)" || return 1
+    printf '%s' "${status_json}" | jq -ser '
+        if length != 1 then error("invalid status") else .[0] end
+        | if ._schema_version != "0.1" or .result != "success" or .errors != []
+             or (.attached | type) != "boolean"
+             or (.services | type) != "array"
+             or (.execution_status != "inactive" and .execution_status != "reboot-required")
+          then error("invalid status")
+          elif .attached == false then "unattached"
+          else
+            [.services[] | select(.name == "esm-apps" or .name == "esm-infra")]
+            | sort_by(.name)
+            | if map(.name) != ["esm-apps", "esm-infra"]
+                 or any(.[]; .entitled != "yes" or (.status != "enabled" and .status != "disabled"))
+              then error("ESM unavailable")
+              else
+                map(select(.status != "enabled") | .name)
+                | if length == 0 then "ready" else join(" ") end
+              end
+          end
+    ' 2>/dev/null
+}
 
-    echo "disabling ua livepatch..."
-    retrycmd_if_failure 5 10 300 ua disable livepatch || exit $ERR_UA_DISABLE_LIVEPATCH
+attachUA() {
+    # Keep both the token and captured Pro JSON out of xtrace, even for new callers.
+    # A subshell restores the caller's options without exposing private local variables.
+    (
+        set +x
+        local state response rc phase recovery recovered=false
+        local services=()
+        if [ -z "${UA_TOKEN:-}" ] || ! command -v jq >/dev/null 2>&1; then
+            echo "Ubuntu Pro attachment requires a token and jq" >&2
+            exit 1
+        fi
+        state="$(ubuntuProESMState)" || {
+            echo "Unable to determine initial Ubuntu Pro state" >&2
+            exit 1
+        }
+        if [ "${state}" != "unattached" ]; then
+            echo "Refusing to change an initially attached Ubuntu Pro machine" >&2
+            exit 1
+        fi
+
+        while [ "${state}" != "ready" ]; do
+            rc=0
+            recovery=""
+            if [ "${state}" = "unattached" ]; then
+                phase=attach
+                echo "attaching ua without auto-enabling services..."
+                response="$(timeout 1000 ua attach --no-auto-enable --format json "${UA_TOKEN}" 2>/dev/null)" || rc=$?
+            else
+                phase=enable
+                # State contains only these two allowlisted service names, in order.
+                read -r -a services <<< "${state}"
+                echo "enabling required Ubuntu Pro ESM services: ${state}..."
+                response="$(timeout 1000 ua enable --assume-yes --format json "${services[@]}" 2>/dev/null)" || rc=$?
+            fi
+
+            if [ "${rc}" -eq 0 ]; then
+                if ! printf '%s' "${response}" | jq -se --arg phase "${phase}" '
+                    length == 1 and (.[0] | ._schema_version == "0.1"
+                        and .result == "success" and .errors == [] and .failed_services == []
+                        and ($phase != "attach" or .processed_services == []))
+                ' >/dev/null 2>&1; then
+                    echo "Invalid Ubuntu Pro ${phase} success response" >&2
+                    exit 1
+                fi
+            else
+                # Pro 31.2/35.1 expose HTTP status via external-api-error.additional_info.code.
+                # Generic attach-failure/connectivity-error also cover permanent failures.
+                # Share ONE recovery across attachment and ESM setup, not one per command.
+                # Service retries require complete results and an explicit cause for every failure.
+                if [ "${recovered}" = true ] || [ "${rc}" -ne 1 ] || ! recovery="$(printf '%s' "${response}" | jq -ser --arg phase "${phase}" --arg requested "${state}" '
+                    if length != 1 then error("invalid response") else .[0] end
+                    | if ._schema_version == "0.1" and .result == "failure"
+                        and (.errors | type) == "array" and (.errors | length) > 0
+                        and all(.errors[]; .message_code == "external-api-error"
+                            and ((.type == "system" and .service == null)
+                                 or ($phase == "enable" and .type == "service"
+                                     and (.service == "esm-apps" or .service == "esm-infra")))
+                            and (.additional_info.code == 500 or .additional_info.code == 502
+                                 or .additional_info.code == 503 or .additional_info.code == 504))
+                      then
+                        if $phase == "enable" and any(.errors[]; .type == "system")
+                        then "check-only"
+                        elif $phase == "enable" then
+                          if (.failed_services | type) == "array" and (.processed_services | type) == "array"
+                              and (.processed_services + .failed_services | all(.[]; type == "string"))
+                              and (.failed_services | unique) == ([.errors[].service] | unique)
+                              and (.processed_services - .failed_services) == .processed_services
+                              and (.processed_services + .failed_services | unique) == ($requested | split(" ") | unique)
+                          then "retry" else error("incomplete service results") end
+                        else "retry" end
+                      else error("unclassified failure") end
+                ' 2>/dev/null)"; then
+                    echo "Ubuntu Pro ${phase} failed (exit ${rc}); no safe recovery remaining" >&2
+                    exit 1
+                fi
+                echo "Transient Ubuntu Pro ${phase} HTTP failure; recovering once after 10 seconds..."
+                sleep 10 || exit 1
+                recovered=true
+            fi
+
+            # Even --no-auto-enable can fail AFTER persisting attachment credentials.
+            # Resume only missing ESM services; never reattach that machine or detach it.
+            state="$(ubuntuProESMState)" || {
+                echo "Unable to determine Ubuntu Pro state after ${phase}" >&2
+                exit 1
+            }
+            # Enable reports accumulated service errors AFTER updating its activity token.
+            # A system HTTP failure there can hide permanent service errors: check, never retry.
+            if [ "${recovery}" = "check-only" ] && [ "${state}" != "ready" ]; then
+                echo "Ubuntu Pro ESM readiness incomplete after an ambiguous enable failure" >&2
+                exit 1
+            fi
+            if { [ "${phase}" = "enable" ] || [ "${rc}" -eq 0 ]; } && [ "${state}" = "unattached" ]; then
+                echo "Ubuntu Pro attachment missing after ${phase}" >&2
+                exit 1
+            fi
+            if [ "${phase}" = "enable" ] && [ "${rc}" -eq 0 ] && [ "${state}" != "ready" ]; then
+                echo "Required Ubuntu Pro ESM services are not enabled" >&2
+                exit 1
+            fi
+        done
+        echo "Ubuntu Pro esm-apps and esm-infra are enabled"
+    ) || exit "${ERR_UA_ATTACH}"
 }
 
 # disableAndMaskUbuntuProUnit stops, disables and masks a single Ubuntu Pro background

--- a/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
+++ b/vhdbuilder/scripts/linux/ubuntu/tool_installs_ubuntu.sh
@@ -219,7 +219,11 @@ listInstalledPackages() {
     apt list --installed
 }
 
-# Only emit attachment/readiness state, never the account, contract or machine identity.
+# Report setup state separately from the Ubuntu Pro services still needing enablement:
+#   unattached
+#   ready
+#   needs-esm esm-apps esm-infra   (or just the one disabled ESM service)
+# Only esm-apps and esm-infra are required; never emit private account/contract/machine data.
 ubuntuProESMState() {
     local status_json
     status_json="$(timeout 120 ua status --all --format json 2>/dev/null)" || return 1
@@ -239,7 +243,7 @@ ubuntuProESMState() {
               then error("ESM unavailable")
               else
                 map(select(.status != "enabled") | .name)
-                | if length == 0 then "ready" else join(" ") end
+                | if length == 0 then "ready" else "needs-esm " + join(" ") end
               end
           end
     ' 2>/dev/null
@@ -250,34 +254,38 @@ attachUA() {
     # A subshell restores the caller's options without exposing private local variables.
     (
         set +x
-        local state response rc phase recovery recovered=false
-        local services=()
+        local status_summary setup_state pending_esm_services response rc phase recovery recovered=false
+        local services_to_enable=()
         if [ -z "${UA_TOKEN:-}" ] || ! command -v jq >/dev/null 2>&1; then
             echo "Ubuntu Pro attachment requires a token and jq" >&2
             exit 1
         fi
-        state="$(ubuntuProESMState)" || {
+        status_summary="$(ubuntuProESMState)" || {
             echo "Unable to determine initial Ubuntu Pro state" >&2
             exit 1
         }
-        if [ "${state}" != "unattached" ]; then
+        read -r setup_state pending_esm_services <<< "${status_summary}"
+        if [ "${setup_state}" != "unattached" ]; then
             echo "Refusing to change an initially attached Ubuntu Pro machine" >&2
             exit 1
         fi
 
-        while [ "${state}" != "ready" ]; do
+        while [ "${setup_state}" != "ready" ]; do
             rc=0
             recovery=""
-            if [ "${state}" = "unattached" ]; then
+            if [ "${setup_state}" = "unattached" ]; then
                 phase=attach
                 echo "attaching ua without auto-enabling services..."
                 response="$(timeout 1000 ua attach --no-auto-enable --format json "${UA_TOKEN}" 2>/dev/null)" || rc=$?
-            else
+            elif [ "${setup_state}" = "needs-esm" ]; then
                 phase=enable
-                # State contains only these two allowlisted service names, in order.
-                read -r -a services <<< "${state}"
-                echo "enabling required Ubuntu Pro ESM services: ${state}..."
-                response="$(timeout 1000 ua enable --assume-yes --format json "${services[@]}" 2>/dev/null)" || rc=$?
+                # Split only the pending names (e.g. "esm-infra"), not the setup-state marker.
+                read -r -a services_to_enable <<< "${pending_esm_services}"
+                echo "enabling required Ubuntu Pro ESM services: ${pending_esm_services}..."
+                response="$(timeout 1000 ua enable --assume-yes --format json "${services_to_enable[@]}" 2>/dev/null)" || rc=$?
+            else
+                echo "Invalid Ubuntu Pro setup state" >&2
+                exit 1
             fi
 
             if [ "${rc}" -eq 0 ]; then
@@ -294,7 +302,7 @@ attachUA() {
                 # Generic attach-failure/connectivity-error also cover permanent failures.
                 # Share ONE recovery across attachment and ESM setup, not one per command.
                 # Service retries require complete results and an explicit cause for every failure.
-                if [ "${recovered}" = true ] || [ "${rc}" -ne 1 ] || ! recovery="$(printf '%s' "${response}" | jq -ser --arg phase "${phase}" --arg requested "${state}" '
+                if [ "${recovered}" = true ] || [ "${rc}" -ne 1 ] || ! recovery="$(printf '%s' "${response}" | jq -ser --arg phase "${phase}" --arg requested "${pending_esm_services}" '
                     if length != 1 then error("invalid response") else .[0] end
                     | if ._schema_version == "0.1" and .result == "failure"
                         and (.errors | type) == "array" and (.errors | length) > 0
@@ -327,21 +335,22 @@ attachUA() {
 
             # Even --no-auto-enable can fail AFTER persisting attachment credentials.
             # Resume only missing ESM services; never reattach that machine or detach it.
-            state="$(ubuntuProESMState)" || {
+            status_summary="$(ubuntuProESMState)" || {
                 echo "Unable to determine Ubuntu Pro state after ${phase}" >&2
                 exit 1
             }
+            read -r setup_state pending_esm_services <<< "${status_summary}"
             # Enable reports accumulated service errors AFTER updating its activity token.
             # A system HTTP failure there can hide permanent service errors: check, never retry.
-            if [ "${recovery}" = "check-only" ] && [ "${state}" != "ready" ]; then
+            if [ "${recovery}" = "check-only" ] && [ "${setup_state}" != "ready" ]; then
                 echo "Ubuntu Pro ESM readiness incomplete after an ambiguous enable failure" >&2
                 exit 1
             fi
-            if { [ "${phase}" = "enable" ] || [ "${rc}" -eq 0 ]; } && [ "${state}" = "unattached" ]; then
+            if { [ "${phase}" = "enable" ] || [ "${rc}" -eq 0 ]; } && [ "${setup_state}" = "unattached" ]; then
                 echo "Ubuntu Pro attachment missing after ${phase}" >&2
                 exit 1
             fi
-            if [ "${phase}" = "enable" ] && [ "${rc}" -eq 0 ] && [ "${state}" != "ready" ]; then
+            if [ "${phase}" = "enable" ] && [ "${rc}" -eq 0 ] && [ "${setup_state}" != "ready" ]; then
                 echo "Required Ubuntu Pro ESM services are not enabled" >&2
                 exit 1
             fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Build 180337511 failed after Ubuntu Pro persisted attachment credentials but failed during default-service enablement around Livepatch. Subsequent blind `ua attach` retries returned already-attached and exhausted with `ERR_UA_ATTACH` (182). Other attempts showed HTTP 500/502/503. The exact original Canonical/network cause is not established; this change fixes our retry weakness and removes unnecessary Livepatch enable-then-disable work.

This is a **standalone build-reliability PR targeting `main`**, independent of #9431. Only the two Ubuntu Pro attachment commits are included; no inherited kernel/CIS policy changes are part of this PR.

- Attach with `--no-auto-enable --format json`, then explicitly enable only missing `esm-apps` and `esm-infra`. Require both entitled services to be enabled before package/distro upgrades. FIPS installation remains in its existing later phase.
- Read structured state before attachment and after operations. Reject initially attached machines; same-invocation partial attachment resumes ESM setup without repeating attach. No detach or Livepatch command is introduced, and final-image FIPS-preserving cleanup is unchanged.
- Share at most **one wrapper-level recovery** across attachment and ESM setup, with a 10-second backoff only for validated exit-1 `external-api-error` HTTP 500/502/503/504. Canonical's own internal transport retries are separate.
- Retry service enablement only when complete service-scoped results establish a classified transient cause for every failed service. In Pro 35.1, a final activity-token error can mask earlier permanent service failures: system-scoped enable errors permit a readiness recheck only, and fail if either ESM service remains incomplete.
- Keep authorization, expiration, entitlement, generic connectivity, unknown/schema errors, timeout exits and unsuccessful recovery fatal with exit 182. Capture private Pro JSON and suppress token-bearing xtrace without changing caller shell options.

**Validation (before the patch-equivalent standalone rebase)**:

```bash
/opt/homebrew/bin/shellspec --shell /opt/homebrew/bin/bash --format progress \
  spec/vhdbuilder/packer/attach_ua_spec.sh \
  spec/vhdbuilder/packer/produce_ua_token_spec.sh \
  spec/vhdbuilder/packer/detach_and_cleanup_ua_spec.sh \
  spec/parts/linux/cloud-init/artifacts/cse_main_disable_modules_spec.sh
```

186 examples passed. Mocks enforce exact flags/services, no detach, recovery bounds, no credential output, failure propagation, and the real extracted Ubuntu 20.04/22.04/24.04 pre-upgrade/FIPS call ordering. Existing token routing, no-final-detach and parent kernel-policy coverage remain passing.

Attachment + cleanup under `/bin/bash` 3.2: 96 examples, zero failures, six expected skips for the unchanged Bash-4-only build caller; those six pass under Bash 5.3. Exact `make validate-shell` passed using isolated official ShellCheck 0.9.0 (matching CI), without modifying system tools or suppressing unrelated baseline diagnostics. Independent read-only review found no substantive remaining findings.

**Limits / upstream contract**:

No live VHD build was run or manually retried. CLI contracts were checked against the observed pre-upgrade [Pro 35.1 attach implementation](https://github.com/canonical/ubuntu-pro-client/blob/35.1/uaclient/actions.py#L57-L217), [enable failure handling](https://github.com/canonical/ubuntu-pro-client/blob/35.1/uaclient/cli/enable.py#L452-L505), and structured status/event output. Unsupported flags or unknown schemas fail closed; this does not upgrade or pin the Pro client. PR CI is still required for live image coverage.

**Which issue(s) this PR fixes**:

AB#39620164 — [Make Ubuntu Pro attachment resilient to partial success during FIPS VHD builds](https://dev.azure.com/msazure/CloudNativeCompute/_workitems/edit/39620164). Existing bug retained Active pending shipment.

🤖 *Generated by GitHub Copilot*