### PR TITLE
fix: deprecate old cached and conflicting versions

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -461,23 +461,19 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.33.17-2",
-          "previousLatestVersion": "v1.33.17-1"
+          "latestVersion": "v1.33.17-2"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.34.13-2",
-          "previousLatestVersion": "v1.34.13-1"
+          "latestVersion": "v1.34.13-2"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.35.8-2",
-          "previousLatestVersion": "v1.35.8-1"
+          "latestVersion": "v1.35.8-2"
         },
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-cloud-node-manager",
-          "latestVersion": "v1.36.5-2",
-          "previousLatestVersion": "v1.36.5-1"
+          "latestVersion": "v1.36.5-2"
         }
       ],
       "windowsVersions": [
@@ -1690,28 +1686,10 @@
           "current": {
             "versionsV2": [
               {
-                "k8sVersion": "1.31",
-                "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/binaries/kubernetes/kubernetes-node",
-                "latestVersion": "v1.31.14",
-                "previousLatestVersion": "v1.31.13"
-              },
-              {
-                "k8sVersion": "1.32",
-                "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/binaries/kubernetes/kubernetes-node",
-                "latestVersion": "v1.32.12",
-                "previousLatestVersion": "v1.32.11"
-              },
-              {
                 "k8sVersion": "1.33",
                 "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/binaries/kubernetes/kubernetes-node",
                 "latestVersion": "v1.33.13",
-                "previousLatestVersion": "v1.33.11"
-              },
-              {
-                "k8sVersion": "1.34",
-                "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/binaries/kubernetes/kubernetes-node",
-                "latestVersion": "v1.34.9",
-                "previousLatestVersion": "v1.34.7"
+                "previousLatestVersion": "v1.33.12"
               }
             ],
             "downloadURL": "mcr.microsoft.com/oss/binaries/kubernetes/kubernetes-node:${version}-linux-${CPU_ARCH}",
@@ -1834,8 +1812,7 @@
               {
                 "k8sVersion": "1.36",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=26.04",
-                "latestVersion": "1.36.5-ubuntu26.04u5",
-                "previousLatestVersion": "1.36.5-ubuntu26.04u1"
+                "latestVersion": "1.36.5-ubuntu26.04u5"
               }
             ]
           },
@@ -1849,20 +1826,17 @@
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=24.04",
-                "latestVersion": "1.34.13-ubuntu24.04u5",
-                "previousLatestVersion": "1.34.13-ubuntu24.04u1"
+                "latestVersion": "1.34.13-ubuntu24.04u5"
               },
               {
                 "k8sVersion": "1.35",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=24.04",
-                "latestVersion": "1.35.8-ubuntu24.04u5",
-                "previousLatestVersion": "1.35.8-ubuntu24.04u1"
+                "latestVersion": "1.35.8-ubuntu24.04u5"
               },
               {
                 "k8sVersion": "1.36",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=24.04",
-                "latestVersion": "1.36.5-ubuntu24.04u5",
-                "previousLatestVersion": "1.36.5-ubuntu24.04u1"
+                "latestVersion": "1.36.5-ubuntu24.04u5"
               }
             ]
           },
@@ -1876,20 +1850,17 @@
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "1.34.13-ubuntu22.04u5",
-                "previousLatestVersion": "1.34.13-ubuntu22.04u1"
+                "latestVersion": "1.34.13-ubuntu22.04u5"
               },
               {
                 "k8sVersion": "1.35",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "1.35.8-ubuntu22.04u5",
-                "previousLatestVersion": "1.35.8-ubuntu22.04u1"
+                "latestVersion": "1.35.8-ubuntu22.04u5"
               },
               {
                 "k8sVersion": "1.36",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=22.04",
-                "latestVersion": "1.36.5-ubuntu22.04u5",
-                "previousLatestVersion": "1.36.5-ubuntu22.04u1"
+                "latestVersion": "1.36.5-ubuntu22.04u5"
               }
             ]
           },
@@ -1903,8 +1874,7 @@
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "name=azure-acr-credential-provider, repository=production, os=ubuntu, release=20.04",
-                "latestVersion": "1.34.13-ubuntu20.04u5",
-                "previousLatestVersion": "1.34.13-ubuntu20.04u1"
+                "latestVersion": "1.34.13-ubuntu20.04u5"
               }
             ]
           }
@@ -1920,20 +1890,17 @@
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "RPM_registry=https://packages.microsoft.com/azurelinux/3.0/prod/cloud-native/x86_64/repodata, name=azure-acr-credential-provider, os=azurelinux, release=3.0",
-                "latestVersion": "1.34.13-5.azl3",
-                "previousLatestVersion": "1.34.13-1.azl3"
+                "latestVersion": "1.34.13-5.azl3"
               },
               {
                 "k8sVersion": "1.35",
                 "renovateTag": "RPM_registry=https://packages.microsoft.com/azurelinux/3.0/prod/cloud-native/x86_64/repodata, name=azure-acr-credential-provider, os=azurelinux, release=3.0",
-                "latestVersion": "1.35.8-5.azl3",
-                "previousLatestVersion": "1.35.8-1.azl3"
+                "latestVersion": "1.35.8-5.azl3"
               },
               {
                 "k8sVersion": "1.36",
                 "renovateTag": "RPM_registry=https://packages.microsoft.com/azurelinux/3.0/prod/cloud-native/x86_64/repodata, name=azure-acr-credential-provider, os=azurelinux, release=3.0",
-                "latestVersion": "1.36.5-5.azl3",
-                "previousLatestVersion": "1.36.5-1.azl3"
+                "latestVersion": "1.36.5-5.azl3"
               }
             ]
           }
@@ -1944,20 +1911,17 @@
               {
                 "k8sVersion": "1.34",
                 "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-acr-credential-provider-sysext",
-                "latestVersion": "v1.34.13-5-azlinux3",
-                "previousLatestVersion": "v1.34.13-3-azlinux3"
+                "latestVersion": "v1.34.13-5-azlinux3"
               },
               {
                 "k8sVersion": "1.35",
                 "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-acr-credential-provider-sysext",
-                "latestVersion": "v1.35.8-5-azlinux3",
-                "previousLatestVersion": "v1.35.8-3-azlinux3"
+                "latestVersion": "v1.35.8-5-azlinux3"
               },
               {
                 "k8sVersion": "1.36",
                 "renovateTag": "OCI_registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/azure-acr-credential-provider-sysext",
-                "latestVersion": "v1.36.5-5-azlinux3",
-                "previousLatestVersion": "v1.36.5-3-azlinux3"
+                "latestVersion": "v1.36.5-5-azlinux3"
               }
             ],
             "downloadURL": "mcr.microsoft.com/oss/v2/kubernetes/azure-acr-credential-provider-sysext:${version}-${SYSTEMD_ARCH}"


### PR DESCRIPTION
acr credential provider only choose latest available version so if we have 1.33.12 and 1.33.11 it will always choose .12 so stop caching previous latest version.

Cleanup kubenernetes binaries section