### PR TITLE
fix: fail Linux content tests when Run Command retries are exhausted

### DIFF
--- a/spec/vhdbuilder/packer/test/run_test_spec.sh
+++ b/spec/vhdbuilder/packer/test/run_test_spec.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# shellcheck disable=SC2016,SC2034,SC2286,SC2288,SC2329
+
+Describe 'Linux content-test Run Command retries'
+  az() {
+    if [ "$1 $2" = 'group delete' ]; then echo cleanup; return; fi
+    local calls
+    calls=$(( $(cat "$CALLS") + 1 ))
+    printf '%s' "$calls" > "$CALLS"
+    printf '%s\n' "$RESPONSE"
+    [ "$calls" -ge "$SUCCESS_ON" ]
+  }
+  run_retry_loop() (
+    set -eu
+    VM_NAME=test-vm TEST_VM_RESOURCE_GROUP_NAME=test-rg SCRIPT_PATH=test.sh VHD_DEBUG=False
+    OS_VERSION=22.04 ENABLE_FIPS=false OS_SKU=Ubuntu GIT_BRANCH=refs/heads/main
+    IMG_SKU='' FEATURE_FLAGS='' GIT_COMMIT_HASH=commit
+    eval "$(sed -n '/^function cleanup()/,/^trap cleanup EXIT/p' vhdbuilder/packer/test/run-test.sh)"
+    eval "$(sed -n '/^  for i in $(seq 1 3); do$/,/^  done$/p' vhdbuilder/packer/test/run-test.sh)"
+  )
+
+  Parameters
+    1 0 1 ''
+    2 0 2 ''
+    3 0 3 ''
+    4 1 3 ''
+    4 1 3 'nonempty failure response'
+  End
+  It "fails only if all attempts fail: success on attempt $1"
+    SUCCESS_ON=$1 RESPONSE=$4 CALLS="${SHELLSPEC_WORKDIR}/calls"
+    printf 0 > "$CALLS"
+    When run run_retry_loop
+    The status should equal "$2"
+    The contents of file "$CALLS" should equal "$3"
+    The output should include cleanup
+    The output should not include '3: retrying'
+    if [ "$2" -eq 1 ]; then
+      The error should include 'Run Command failed after 3 attempts'
+    fi
+  End
+End

--- a/vhdbuilder/packer/test/run-test.sh
+++ b/vhdbuilder/packer/test/run-test.sh
@@ -148,6 +148,10 @@ if [ "${OS_TYPE,,}" = "linux" ]; then
       --resource-group "$TEST_VM_RESOURCE_GROUP_NAME" \
       --scripts "@$SCRIPT_PATH" \
       --parameters "${OS_VERSION}" "${ENABLE_FIPS}" "${OS_SKU}" "${GIT_BRANCH}" "${IMG_SKU}" "${FEATURE_FLAGS}" "${GIT_COMMIT_HASH}") && break
+    if [ "$i" -eq 3 ]; then
+      echo "Linux content-test Run Command failed after ${i} attempts." >&2
+      exit 1
+    fi
     echo "${i}: retrying az vm run-command"
   done
   # The error message for a Linux VM run-command is as follows:


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:

Fail the Linux content-test step when all three `az vm run-command invoke` attempts fail. Previously the loop continued with an empty result; the later stderr `:Error:` check found nothing and the build could pass without completed tests.

The runtime change adds four lines to the existing retry loop. A small ShellSpec regression covers success on attempts 1, 2, or 3, failure after all attempts with empty or nonempty output, and resource-group cleanup.

The existing retry policy, timeout behavior, result parsing, guest script, Windows path, and debug opt-out are unchanged. New deadlines and stricter result validation are outside this PR.

Observed in [build 180213898, Test, Scan, and Cleanup](https://dev.azure.com/msazure/CloudNativeCompute/_build/results?buildId=180213898&view=logs&j=868370dd-9689-5169-7b23-b421df332381&t=2c87a466-d1a6-5d6e-760d-47da05782486): three `VMExtensionProvisioningTimeout` errors, then empty `errMsg` and `Test Script Completed`, with the step marked successful. This fixes the false success, not the underlying guest timeout.

Local validation: `shellspec --shell bash spec/vhdbuilder/packer/test` (19 examples), ShellCheck on the new spec, and Bash syntax check. The existing three SC2086 warnings in `run-test.sh` are unchanged.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A