### PR TITLE
fix(e2e): handle SKUs without generation suffix

### DIFF
--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -1146,33 +1146,33 @@ func runScenarioUbuntu2404GPUNPD(name, vmSize, location, k8sSystemPoolSKU string
 		}}
 }
 
-// vmSKUGeneration extracts a generation from a _vN suffix. The boolean reports
-// whether the SKU name encodes a generation.
-func vmSKUGeneration(sku string) (int, bool, error) {
+// vmSKUGeneration extracts a generation from a _vN suffix, or returns zero
+// when the SKU name does not encode a generation.
+func vmSKUGeneration(sku string) (int, error) {
 	sku = strings.ToLower(sku)
 	idx := strings.LastIndex(sku, "_v")
 	if idx < 0 {
-		return 0, false, nil
+		return 0, nil
 	}
 	gen, err := strconv.Atoi(sku[idx+2:])
 	if err != nil {
-		return 0, false, fmt.Errorf("SKU %q has non-numeric generation suffix: %w", sku, err)
+		return 0, fmt.Errorf("SKU %q has non-numeric generation suffix: %w", sku, err)
 	}
-	return gen, true, nil
+	return gen, nil
 }
 
 func ensureMinVMGeneration(minSku string) string {
 	// Ensure that the VM SKU used is at least the minimum generation required for the test
 	// Get the minimum generation for the specified SKU
-	defaultGen, defaultHasGeneration, err := vmSKUGeneration(config.Config.DefaultVMSKU)
+	defaultGen, err := vmSKUGeneration(config.Config.DefaultVMSKU)
 	if err != nil {
 		panic(fmt.Sprintf("Warning: No minimum generation found for SKU %s", config.Config.DefaultVMSKU))
 	}
-	minGen, minHasGeneration, err := vmSKUGeneration(minSku)
-	if err != nil || !minHasGeneration {
+	minGen, err := vmSKUGeneration(minSku)
+	if err != nil || minGen == 0 {
 		panic(fmt.Sprintf("Warning: No minimum generation found for SKU %s", minSku))
 	}
-	if !defaultHasGeneration || defaultGen < minGen {
+	if defaultGen < minGen {
 		return minSku
 	} else {
 		return config.Config.DefaultVMSKU

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -1146,32 +1146,33 @@ func runScenarioUbuntu2404GPUNPD(name, vmSize, location, k8sSystemPoolSKU string
 		}}
 }
 
-func vmSKUGeneration(sku string) (int, error) {
-	// Extract the generation number from the SKU string (e.g., "Standard_D2s_v3" -> 3)
+// vmSKUGeneration extracts a generation from a _vN suffix. The boolean reports
+// whether the SKU name encodes a generation.
+func vmSKUGeneration(sku string) (int, bool, error) {
 	sku = strings.ToLower(sku)
 	idx := strings.LastIndex(sku, "_v")
 	if idx < 0 {
-		return 0, fmt.Errorf("invalid SKU format: %s", sku)
+		return 0, false, nil
 	}
 	gen, err := strconv.Atoi(sku[idx+2:])
 	if err != nil {
-		return 0, fmt.Errorf("SKU %q has non-numeric generation suffix: %w", sku, err)
+		return 0, false, fmt.Errorf("SKU %q has non-numeric generation suffix: %w", sku, err)
 	}
-	return gen, nil
+	return gen, true, nil
 }
 
 func ensureMinVMGeneration(minSku string) string {
 	// Ensure that the VM SKU used is at least the minimum generation required for the test
 	// Get the minimum generation for the specified SKU
-	defaultGen, err := vmSKUGeneration(config.Config.DefaultVMSKU)
+	defaultGen, defaultHasGeneration, err := vmSKUGeneration(config.Config.DefaultVMSKU)
 	if err != nil {
 		panic(fmt.Sprintf("Warning: No minimum generation found for SKU %s", config.Config.DefaultVMSKU))
 	}
-	minGen, err := vmSKUGeneration(minSku)
-	if err != nil {
+	minGen, minHasGeneration, err := vmSKUGeneration(minSku)
+	if err != nil || !minHasGeneration {
 		panic(fmt.Sprintf("Warning: No minimum generation found for SKU %s", minSku))
 	}
-	if defaultGen < minGen {
+	if !defaultHasGeneration || defaultGen < minGen {
 		return minSku
 	} else {
 		return config.Config.DefaultVMSKU

--- a/e2e/test_helpers_test.go
+++ b/e2e/test_helpers_test.go
@@ -13,26 +13,22 @@ func TestVMSKUGeneration(t *testing.T) {
 		name           string
 		sku            string
 		wantGeneration int
-		wantFound      bool
 		wantError      bool
 	}{
 		{
 			name:           "versioned SKU",
 			sku:            "Standard_D2s_v3",
 			wantGeneration: 3,
-			wantFound:      true,
 		},
 		{
 			name:           "uppercase version marker",
 			sku:            "Standard_D2pds_V5",
 			wantGeneration: 5,
-			wantFound:      true,
 		},
 		{
 			name:           "GPU SKU with hardware suffix",
 			sku:            "Standard_ND96isr_H100_v5",
 			wantGeneration: 5,
-			wantFound:      true,
 		},
 		{
 			name: "SKU without version marker",
@@ -47,15 +43,13 @@ func TestVMSKUGeneration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			generation, found, err := vmSKUGeneration(tt.sku)
+			generation, err := vmSKUGeneration(tt.sku)
 			if tt.wantError {
 				require.Error(t, err)
 				return
 			}
-
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantGeneration, generation)
-			assert.Equal(t, tt.wantFound, found)
 		})
 	}
 }
@@ -68,4 +62,10 @@ func TestEnsureMinVMGenerationUsesMinimumForUnversionedDefault(t *testing.T) {
 	})
 
 	assert.Equal(t, "Standard_D2ds_v6", ensureMinVMGeneration("Standard_D2ds_v6"))
+}
+
+func TestEnsureMinVMGenerationRejectsUnversionedMinimum(t *testing.T) {
+	require.Panics(t, func() {
+		ensureMinVMGeneration("Standard_NM16ads_MA35D")
+	})
 }

--- a/e2e/test_helpers_test.go
+++ b/e2e/test_helpers_test.go
@@ -1,0 +1,71 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/Azure/agentbaker/e2e/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVMSKUGeneration(t *testing.T) {
+	tests := []struct {
+		name           string
+		sku            string
+		wantGeneration int
+		wantFound      bool
+		wantError      bool
+	}{
+		{
+			name:           "versioned SKU",
+			sku:            "Standard_D2s_v3",
+			wantGeneration: 3,
+			wantFound:      true,
+		},
+		{
+			name:           "uppercase version marker",
+			sku:            "Standard_D2pds_V5",
+			wantGeneration: 5,
+			wantFound:      true,
+		},
+		{
+			name:           "GPU SKU with hardware suffix",
+			sku:            "Standard_ND96isr_H100_v5",
+			wantGeneration: 5,
+			wantFound:      true,
+		},
+		{
+			name: "SKU without version marker",
+			sku:  "Standard_NM16ads_MA35D",
+		},
+		{
+			name:      "non-numeric generation",
+			sku:       "Standard_D2s_vNext",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			generation, found, err := vmSKUGeneration(tt.sku)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantGeneration, generation)
+			assert.Equal(t, tt.wantFound, found)
+		})
+	}
+}
+
+func TestEnsureMinVMGenerationUsesMinimumForUnversionedDefault(t *testing.T) {
+	originalDefaultVMSKU := config.Config.DefaultVMSKU
+	config.Config.DefaultVMSKU = "Standard_NM16ads_MA35D"
+	t.Cleanup(func() {
+		config.Config.DefaultVMSKU = originalDefaultVMSKU
+	})
+
+	assert.Equal(t, "Standard_D2ds_v6", ensureMinVMGeneration("Standard_D2ds_v6"))
+}

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -3581,12 +3581,12 @@ func ValidateRxBufferDefault(ctx context.Context, s *Scenario) error {
 		vmSKUDescription = "VM SKU"
 	}
 
-	vmSKUGen, hasVMGeneration, err := vmSKUGeneration(vmSKU)
+	vmSKUGen, err := vmSKUGeneration(vmSKU)
 	if err != nil {
 		return fmt.Errorf("get %s generation for %s: %w", vmSKUDescription, vmSKU, err)
 	}
 
-	if hasVMGeneration && vmSKUGen >= 6 && skipValidationForDistro {
+	if vmSKUGen >= 6 && skipValidationForDistro {
 		return nil
 	}
 

--- a/e2e/validators.go
+++ b/e2e/validators.go
@@ -3581,12 +3581,12 @@ func ValidateRxBufferDefault(ctx context.Context, s *Scenario) error {
 		vmSKUDescription = "VM SKU"
 	}
 
-	vmSKUGen, err := vmSKUGeneration(vmSKU)
+	vmSKUGen, hasVMGeneration, err := vmSKUGeneration(vmSKU)
 	if err != nil {
 		return fmt.Errorf("get %s generation for %s: %w", vmSKUDescription, vmSKU, err)
 	}
 
-	if vmSKUGen >= 6 && skipValidationForDistro {
+	if hasVMGeneration && vmSKUGen >= 6 && skipValidationForDistro {
 		return nil
 	}
 


### PR DESCRIPTION
## What changed
- treat VM SKUs without a `_vN` suffix as having an unknown generation instead of rejecting them
- only apply the Azure Linux/ACL v6+ RX-buffer skip when the SKU explicitly encodes a generation
- use the minimum required SKU when `DEFAULT_VM_SKU` does not encode a generation
- add regression coverage for `Standard_NM16ads_MA35D` and existing versioned GPU SKU formats

## Why
`ValidateRxBufferDefault` runs for the MA35D scenario and attempted to parse `Standard_NM16ads_MA35D` as a versioned SKU. `MA35D` is an accelerator model suffix, so the validator failed before checking the node.

## Testing
- `cd e2e && go test ./...`