### PR TITLE
fix: fail open if cannot determine vm sku generation in e2e

### DIFF
--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -1163,10 +1163,7 @@ func vmSKUGeneration(sku string) (int, error) {
 func ensureMinVMGeneration(minSku string) string {
 	// Ensure that the VM SKU used is at least the minimum generation required for the test
 	// Get the minimum generation for the specified SKU
-	defaultGen, err := vmSKUGeneration(config.Config.DefaultVMSKU)
-	if err != nil {
-		panic(fmt.Sprintf("Warning: No minimum generation found for SKU %s", config.Config.DefaultVMSKU))
-	}
+	defaultGen, _ := vmSKUGeneration(config.Config.DefaultVMSKU)
 	minGen, err := vmSKUGeneration(minSku)
 	if err != nil {
 		panic(fmt.Sprintf("Warning: No minimum generation found for SKU %s", minSku))


### PR DESCRIPTION
<!--
Pull Request Requirements - PLEASE READ BEFORE CREATING A PR AGAINST Azure/AgentBaker:
1. Pull requests MUST NOT come from personal forks. PRs will only be accepted from branches created directly off Azure/AgentBaker.
   You'll need to gain write access to Azure/AgentBaker by requesting membership to the GitHub team: https://github.com/orgs/Azure/teams/agentbakerwrite/.
   Note that to gain access to this team, you must be a member of the Azure GitHub organization: https://github.com/Azure.
2. All commits must be signed by a GPG key and marked as "Verified" by GitHub. Refer to https://github.com/Azure/AgentBaker/blob/main/CONTRIBUTING.md for more details regarding
   setting up a GPG key for your own account.
3. Pull request titles must adhere to our tailored version of the conventional commit messages policy: https://www.conventionalcommits.org/. For specifics on
   how pull request titles will be validated, refer to our lint workflow definition: https://github.com/Azure/AgentBaker/blob/main/.github/workflows/pr-lint.yaml.
4. Read up on the contributor guidance outlined within the repo root: https://github.com/Azure/AgentBaker/tree/main?tab=readme-ov-file#contributing.
-->

**What this PR does / why we need it**:
Some VM sizes do not follow standard generation format, e.g. MA35D GPUs. We should fail open instead of returning error when checking.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
