### PR TITLE
chore: use repository-wide owners for e2e

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,15 +38,14 @@ spec/parts/linux/cloud-init/artifacts/localdns_spec.sh @saewoni @yewmsft
 parts/common/components.json
 vhdbuilder/packer/windows/windows_settings.json
 
-# Code owners for E2E tests
+# No code-owner requirement for E2E tests
 
-/e2e/ @r2k1
+/e2e/
 
 # Code owners for localdns exporter
 
 parts/linux/cloud-init/artifacts/localdns_exporter.sh @saewoni @yewmsft
 spec/parts/linux/cloud-init/artifacts/localdns_exporter_spec.sh @saewoni @yewmsft
-e2e/localdns/validate-localdns-exporter-metrics.sh @saewoni @yewmsft @r2k1
 
 # Code owners for Windows CSE files
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,10 +38,6 @@ spec/parts/linux/cloud-init/artifacts/localdns_spec.sh @saewoni @yewmsft
 parts/common/components.json
 vhdbuilder/packer/windows/windows_settings.json
 
-# No code-owner requirement for E2E tests
-
-/e2e/
-
 # Code owners for localdns exporter
 
 parts/linux/cloud-init/artifacts/localdns_exporter.sh @saewoni @yewmsft

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,11 +38,15 @@ spec/parts/linux/cloud-init/artifacts/localdns_spec.sh @saewoni @yewmsft
 parts/common/components.json
 vhdbuilder/packer/windows/windows_settings.json
 
+# Code owners for E2E tests
+
+/e2e/ @r2k1
+
 # Code owners for localdns exporter
 
 parts/linux/cloud-init/artifacts/localdns_exporter.sh @saewoni @yewmsft
 spec/parts/linux/cloud-init/artifacts/localdns_exporter_spec.sh @saewoni @yewmsft
-e2e/localdns/validate-localdns-exporter-metrics.sh @saewoni @yewmsft
+e2e/localdns/validate-localdns-exporter-metrics.sh @saewoni @yewmsft @r2k1
 
 # Code owners for Windows CSE files
 


### PR DESCRIPTION
Remove the LocalDNS exporter E2E ownership override so the file uses repository-wide code owners, without changing ownership outside `/e2e/`.