### PR TITLE
chore: add saewoni and yewmsft as code owners for localdns e2e files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,6 +44,10 @@ parts/linux/cloud-init/artifacts/localdns_exporter.sh @saewoni @yewmsft
 spec/parts/linux/cloud-init/artifacts/localdns_exporter_spec.sh @saewoni @yewmsft
 e2e/localdns/validate-localdns-exporter-metrics.sh @saewoni @yewmsft
 
+# Code owners for AgentBaker e2e files
+
+e2e/ @saewoni
+
 # Code owners for Windows CSE files
 
 parts/windows/ @timmy-wright @r2k1 @benjamin-brady @djsly @awesomenix @cameronmeissner

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,9 +44,11 @@ parts/linux/cloud-init/artifacts/localdns_exporter.sh @saewoni @yewmsft
 spec/parts/linux/cloud-init/artifacts/localdns_exporter_spec.sh @saewoni @yewmsft
 e2e/localdns/validate-localdns-exporter-metrics.sh @saewoni @yewmsft
 
-# Code owners for AgentBaker e2e files
+# Code owners for localdns-related e2e files
 
-e2e/ @saewoni
+e2e/localdns/ @saewoni @yewmsft
+e2e/scenario/scenario_localdns_hosts.go @saewoni @yewmsft
+e2e/scenario/validate_localdns_exporter_metrics.go @saewoni @yewmsft
 
 # Code owners for Windows CSE files
 


### PR DESCRIPTION
## Summary

Adds `saewoni` and `yewmsft` as code owners for the localdns-related e2e files:

- `e2e/localdns/`
- `e2e/scenario/scenario_localdns_hosts.go`
- `e2e/scenario/validate_localdns_exporter_metrics.go`

This keeps ownership scoped to localdns e2e files (consistent with the existing localdns ownership entries elsewhere in CODEOWNERS) rather than the whole `e2e/` tree.