### PR TITLE
feat: support dual script hotfix delivery in generator

### DIFF
--- a/.github/workflows/hotfix-generate.yml
+++ b/.github/workflows/hotfix-generate.yml
@@ -2,8 +2,9 @@ name: Hotfix Template Update
 # Auto-detects whether a hotfix is needed for a PR targeting an official/* release
 # branch and, if so, computes the version numbers and updates the generated files:
 #   - If aks-node-controller/ changed vs the base branch, bumps `version`.
-#   - Changed CSE scripts are rendered into platform-specific nodecustomdata YAML
-#     files and embedded in the hotfix ANC package.
+#   - Changed CSE scripts are injected into nodecustomdata.yml and rendered into
+#     platform-specific YAML files for optional embedded ANC delivery.
+#   - Script changes use `scripts_version` by default.
 #   - Writes the result to
 #     parts/linux/cloud-init/artifacts/aks-node-controller-hotfix.json (embedded
 #     directly into scriptless customData by pkg/agent/baker.go).
@@ -95,6 +96,7 @@ jobs:
           done < <(
             git status --porcelain --untracked-files=all -- \
               parts/linux/cloud-init/artifacts/aks-node-controller-hotfix.json \
+              parts/linux/cloud-init/nodecustomdata.yml \
               aks-node-controller/generated
           )
           if [ "${#FILES[@]}" -eq 0 ]; then

--- a/aks-node-controller/app.go
+++ b/aks-node-controller/app.go
@@ -167,11 +167,11 @@ func (a *App) Run(ctx context.Context, args []string) int {
 				},
 			},
 			{
-				Name:  "apply-hotfix",
+				Name:  "apply-embedded-hotfix",
 				Usage: "Apply embedded hotfix scripts",
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					if len(cmd.Args().Slice()) > 0 {
-						return fmt.Errorf("unexpected apply-hotfix arguments: %s", strings.Join(cmd.Args().Slice(), " "))
+						return fmt.Errorf("unexpected apply-embedded-hotfix arguments: %s", strings.Join(cmd.Args().Slice(), " "))
 					}
 					return a.runApplyHotfixCommand(ctx)
 				},

--- a/aks-node-controller/app.go
+++ b/aks-node-controller/app.go
@@ -167,6 +167,16 @@ func (a *App) Run(ctx context.Context, args []string) int {
 				},
 			},
 			{
+				Name:  "apply-hotfix",
+				Usage: "Apply embedded hotfix scripts",
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					if len(cmd.Args().Slice()) > 0 {
+						return fmt.Errorf("unexpected apply-hotfix arguments: %s", strings.Join(cmd.Args().Slice(), " "))
+					}
+					return a.runApplyHotfixCommand(ctx)
+				},
+			},
+			{
 				Name:  "check-hotfix",
 				Usage: "Read the hotfix pointer from the live-patching-service and stage it (fail-open)",
 				Action: func(ctx context.Context, cmd *cli.Command) error {
@@ -232,6 +242,23 @@ func (a *App) runDownloadHotfixCommand(ctx context.Context) error {
 		return err
 	}
 	slog.Info("aks-node-controller hotfix download finished")
+	return nil
+}
+
+func (a *App) runApplyHotfixCommand(context.Context) error {
+	slog.Info("aks-node-controller hotfix apply started")
+	applyHotfix := a.applyEmbeddedHotfix
+	if applyHotfix == nil {
+		applyHotfix = func(osReleasePath string) error {
+			return applyEmbeddedNodeCustomData(embeddedGeneratedNodeCustomData, osReleasePath, embeddedNodeCustomDataPath)
+		}
+	}
+	if err := applyHotfix(a.osReleasePath); err != nil {
+		slog.Error("aks-node-controller failed to apply embedded hotfix payload", "error", err)
+		return err
+	}
+
+	slog.Info("aks-node-controller apply embedded hotfix payload finished")
 	return nil
 }
 
@@ -705,16 +732,6 @@ func (a *App) runProvision(ctx context.Context, flags ProvisionFlags, dryRun boo
 	}
 	if dryRun {
 		a.cmdRun = cmdRunnerDryRun
-	} else {
-		applyHotfix := a.applyEmbeddedHotfix
-		if applyHotfix == nil {
-			applyHotfix = func(osReleasePath string) error {
-				return applyEmbeddedNodeCustomData(embeddedGeneratedNodeCustomData, osReleasePath, embeddedNodeCustomDataPath)
-			}
-		}
-		if err := applyHotfix(a.osReleasePath); err != nil {
-			slog.Warn("failed to apply embedded hotfix payload; continuing provisioning", "error", err)
-		}
 	}
 	return a.Provision(ctx, flags)
 }

--- a/aks-node-controller/app_test.go
+++ b/aks-node-controller/app_test.go
@@ -230,8 +230,8 @@ func TestApp_Run(t *testing.T) {
 	})
 }
 
-func TestApp_Provision(t *testing.T) {
-	t.Run("embedded hotfix runs before command construction and execution", func(t *testing.T) {
+func TestApp_ApplyHotfix(t *testing.T) {
+	t.Run("apply embedded hotfix payload", func(t *testing.T) {
 		tt := NewTestApp(t, TestAppConfig{})
 		applied := false
 		tt.App.applyEmbeddedHotfix = func(string) error {
@@ -239,17 +239,13 @@ func TestApp_Provision(t *testing.T) {
 			return nil
 		}
 
-		_, err := tt.App.runProvision(
-			context.Background(),
-			ProvisionFlags{ProvisionConfig: "does-not-exist.json"},
-			false,
-		)
+		err := tt.App.runApplyHotfixCommand(context.Background())
 
-		require.Error(t, err)
-		assert.True(t, applied, "embedded payload must run before config parsing")
+		require.NoError(t, err)
+		assert.True(t, applied)
 	})
 
-	t.Run("embedded hotfix failure is logged and provisioning continues", func(t *testing.T) {
+	t.Run("embedded hotfix failure is logged ", func(t *testing.T) {
 		logs := installLogCapturer(t)
 		executed := false
 		tt := NewTestApp(t, TestAppConfig{
@@ -262,21 +258,20 @@ func TestApp_Provision(t *testing.T) {
 			return errors.New("rendered nodecustomdata application failed")
 		}
 
-		_, err := tt.App.runProvision(
-			context.Background(),
-			ProvisionFlags{NBCCmd: "parser/testdata/test_nbccmd.sh"},
-			false,
-		)
+		err := tt.App.runApplyHotfixCommand(context.Background())
 
-		require.NoError(t, err)
-		assert.True(t, executed)
+		require.Error(t, err)
+		assert.False(t, executed)
 		assert.Contains(t, logs.getRecords(), logRecord{
-			Level:   slog.LevelWarn,
-			Message: "failed to apply embedded hotfix payload; continuing provisioning",
+			Level:   slog.LevelError,
+			Message: "aks-node-controller failed to apply embedded hotfix payload",
 			Attrs:   map[string]string{"error": "rendered nodecustomdata application failed"},
 		})
 	})
 
+}
+
+func TestApp_Provision(t *testing.T) {
 	t.Run("dry-run does not apply embedded hotfix payload", func(t *testing.T) {
 		tt := NewTestApp(t, TestAppConfig{})
 		applied := false

--- a/aks-node-controller/app_test.go
+++ b/aks-node-controller/app_test.go
@@ -268,7 +268,6 @@ func TestApp_ApplyHotfix(t *testing.T) {
 			Attrs:   map[string]string{"error": "rendered nodecustomdata application failed"},
 		})
 	})
-
 }
 
 func TestApp_Provision(t *testing.T) {

--- a/hotfix/hotfix_generate.py
+++ b/hotfix/hotfix_generate.py
@@ -11,20 +11,24 @@ Auto-detects what needs a hotfix and generates the version numbers for it:
 2. Detects which CSE provisioning scripts differ from the immutable VHD baseline
    (the release tag the VHD was built from, derived from linux_sig_version.json),
    selects their write_files entries from parts/linux/cloud-init/nodecustomdata.yml,
-   and renders self-contained ANC payloads for Ubuntu and Mariner with AgentBaker's
-   canonical Go-template renderer. Diffing against the frozen baseline (rather than
-   the moving base branch) keeps every generated payload cumulative: a later hotfix
-   re-renders all scripts changed since the VHD, so it never silently drops an
-   earlier hotfix's script.
+   injects those entries into the scriptless section of nodecustomdata.yml, and
+   renders self-contained ANC payloads for Ubuntu and Mariner with AgentBaker's
+   canonical Go-template renderer. Diffing against the frozen baseline keeps both
+   delivery paths cumulative.
 
-3. Writes the resolved ANC `version` to
-   parts/linux/cloud-init/artifacts/aks-node-controller-hotfix.json when active.
+3. Writes `scripts_version` for script hotfixes. With --use-anc-for-scripts, also
+   writes `version` to activate the embedded ANC payload. Independent ANC code
+   changes always write `version`.
 
-Usage: python3 hotfix/hotfix_generate.py <base_ref>
+Usage: python3 hotfix/hotfix_generate.py <base_ref> [options]
   base_ref: git ref for the PR base branch, used only to detect ANC Go-module
             changes for the version bump (e.g., origin/official/v20260219). The
             changed-script detection instead diffs against the VHD baseline tag
             derived from linux_sig_version.json.
+  --baseline-ref: optional testing override for changed-script detection. Payloads
+                  generated with this option are not necessarily cumulative.
+  --use-anc-for-scripts: additionally activate generated script payloads through
+                         the ANC version.
 
 This script is called by the hotfix-generate GH Action.
 """
@@ -45,6 +49,10 @@ ANC_DIR = "aks-node-controller/"
 GENERATED_DIR = os.path.join(ANC_DIR, "generated")
 
 VERSION_RE = re.compile(r'^\d{6}\.\d{2}\.\d+$')
+
+# Marker comments for idempotent injection of the selected script blocks.
+SCRIPTS_BEGIN = "# ---- hotfix-scripts: auto-generated ----"
+SCRIPTS_END = "# ---- end hotfix-scripts ----"
 
 # Map from source file paths (relative to artifacts/) to the GetVariableProperty
 # keys used in nodecustomdata.yml. Only scripts that appear as write_files entries
@@ -164,7 +172,7 @@ def baseline_tag(base_version):
     return f"v0.{yyyymm}{dd}.{patch}"
 
 
-def resolve_baseline_ref(base_version):
+def resolve_baseline_ref(base_version, override_ref=None):
     """Resolve the VHD baseline git ref, fetching the tag if needed.
 
     Script hotfixes are cumulative, so changed-script detection diffs against the
@@ -172,6 +180,13 @@ def resolve_baseline_ref(base_version):
     cannot be resolved, since diffing against a missing ref would silently produce
     a non-cumulative (or empty) payload.
     """
+    if override_ref:
+        print(
+            f"WARNING: using non-cumulative script baseline override {override_ref}",
+            file=sys.stderr,
+        )
+        return override_ref
+
     tag = baseline_tag(base_version)
     # Best-effort fetch of just this tag in case the checkout did not include it.
     subprocess.run(
@@ -196,20 +211,43 @@ def path_changed(base_ref, *paths):
     raise subprocess.CalledProcessError(result.returncode, result.args)
 
 
-def write_hotfix_file(version):
-    """Write a new ANC version while retaining any active inherited pointer."""
-    if not version:
+def write_hotfix_file(version, scripts_version):
+    """Write resolved hotfix pointers while retaining inherited pointers if idle."""
+    payload = {}
+    if version:
+        payload["version"] = version
+    if scripts_version:
+        payload["scripts_version"] = scripts_version
+
+    if not payload:
         print(
-            f"No new ANC hotfix version; preserving {TARGET_FILE} if present",
+            f"No new hotfix version; preserving {TARGET_FILE} if present",
             file=sys.stderr,
         )
         return
 
-    payload = {"version": version}
     with open(TARGET_FILE, "w") as f:
         json.dump(payload, f, indent=4)
         f.write("\n")
     print(f"Wrote {payload} to {TARGET_FILE}", file=sys.stderr)
+
+
+def resolve_hotfix_versions(
+    base_version,
+    anc_changed,
+    script_hotfix_changed,
+    use_anc_for_scripts,
+):
+    """Resolve pointer fields for independent ANC and script hotfix changes."""
+    if not anc_changed and not script_hotfix_changed:
+        return "", ""
+
+    hotfix_version = bump_version(base_version)
+    version = hotfix_version if anc_changed or (
+        script_hotfix_changed and use_anc_for_scripts
+    ) else ""
+    scripts_version = hotfix_version if script_hotfix_changed else ""
+    return version, scripts_version
 
 
 def detect_changed_varkeys(base_ref, available_varkeys=None):
@@ -402,6 +440,51 @@ def build_hotfix_template(target_varkeys, traditional_lines):
     return "".join(rendered)
 
 
+def update_nodecustomdata(target_varkeys):
+    """Replace the generated script block in the scriptless template section."""
+    with open(TEMPLATE) as template_file:
+        content = template_file.read()
+
+    clean_content = re.sub(
+        rf'\n?{re.escape(SCRIPTS_BEGIN)}\n.*?{re.escape(SCRIPTS_END)}\n',
+        '',
+        content,
+        flags=re.DOTALL,
+    )
+    if not target_varkeys:
+        if clean_content != content:
+            with open(TEMPLATE, "w") as template_file:
+                template_file.write(clean_content)
+            print(f"Removed previous hotfix script block from {TEMPLATE}", file=sys.stderr)
+        return
+
+    lines = clean_content.splitlines(keepends=True)
+    _, else_line, end_line = find_block_boundaries(lines)
+    if else_line is None or end_line is None:
+        raise GenerationError(
+            f"could not find traditional write_files section in {TEMPLATE}"
+        )
+
+    selected_blocks = []
+    for varkeys, block_lines in parse_write_files_blocks(lines[else_line + 1:end_line]):
+        if varkeys & target_varkeys:
+            selected_blocks.append(block_lines)
+    if not selected_blocks:
+        raise GenerationError("no matching write_files blocks found for nodecustomdata")
+
+    injected_lines = ["\n", f"{SCRIPTS_BEGIN}\n"]
+    for block_lines in selected_blocks:
+        injected_lines.extend(block_lines)
+    injected_lines.append(f"{SCRIPTS_END}\n")
+
+    with open(TEMPLATE, "w") as template_file:
+        template_file.writelines(lines[:else_line] + injected_lines + lines[else_line:])
+    print(
+        f"Injected {len(selected_blocks)} hotfix script blocks into {TEMPLATE}",
+        file=sys.stderr,
+    )
+
+
 def write_rendered_payload(target_varkeys, traditional_lines):
     """Render platform-specific YAML through AgentBaker's production template path."""
     if not target_varkeys:
@@ -449,6 +532,21 @@ def main():
         "base_ref",
         help="git ref for the PR base branch, used to detect ANC module changes",
     )
+    parser.add_argument(
+        "--baseline-ref",
+        help=(
+            "testing override for changed-script detection; defaults to the "
+            "immutable VHD baseline tag"
+        ),
+    )
+    parser.add_argument(
+        "--use-anc-for-scripts",
+        action="store_true",
+        help=(
+            "also set version for script hotfixes to activate the embedded ANC "
+            "payload"
+        ),
+    )
     args = parser.parse_args()
     base_ref = args.base_ref
 
@@ -463,7 +561,7 @@ def main():
         validate_source_mappings()
         # Diff changed scripts against the frozen VHD baseline (not the moving base
         # branch) so the rendered payload stays cumulative across hotfixes.
-        baseline_ref = resolve_baseline_ref(base_version)
+        baseline_ref = resolve_baseline_ref(base_version, args.baseline_ref)
         with open(TEMPLATE, "r") as template_file:
             template_lines = template_file.readlines()
         _, else_line, end_line = find_block_boundaries(template_lines)
@@ -480,25 +578,51 @@ def main():
             available_varkeys=available_varkeys,
         )
         write_rendered_payload(changed_varkeys, traditional_lines)
+        update_nodecustomdata(changed_varkeys)
     except GenerationError as err:
         print(f"ERROR: {err}", file=sys.stderr)
         sys.exit(1)
 
-    version = ""
-    if path_changed(
+    template_changed = path_changed(base_ref, TEMPLATE)
+    embedded_payload_changed = path_changed(base_ref, GENERATED_DIR)
+    script_hotfix_changed = template_changed or embedded_payload_changed
+    anc_changed = path_changed(
         base_ref,
         ANC_DIR,
         f":(exclude,glob){ANC_DIR}**/*_test.go",
         f":(exclude,glob){ANC_DIR}**/testdata/**",
-    ):
-        version = bump_version(base_version)
-        print(f"aks-node-controller/ production files changed vs {base_ref}; "
-              f"version={version}", file=sys.stderr)
+        f":(exclude,glob){GENERATED_DIR}/**",
+    )
+    version, scripts_version = resolve_hotfix_versions(
+        base_version,
+        anc_changed,
+        script_hotfix_changed,
+        args.use_anc_for_scripts,
+    )
+
+    if version:
+        reason = "ANC production files changed"
+        if script_hotfix_changed and args.use_anc_for_scripts:
+            reason = "ANC production files or generated script payloads changed"
+        print(f"{reason} vs {base_ref}; version={version}", file=sys.stderr)
     else:
         print(f"aks-node-controller/ has no production changes vs {base_ref}; "
               "version not set", file=sys.stderr)
 
-    write_hotfix_file(version)
+    if scripts_version:
+        print(
+            f"Script hotfix payload changed vs {base_ref}; "
+            f"scripts_version={scripts_version}",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"Script hotfix payload unchanged vs {base_ref}; "
+            "scripts_version not set",
+            file=sys.stderr,
+        )
+
+    write_hotfix_file(version, scripts_version)
 
 
 if __name__ == '__main__':

--- a/hotfix/hotfix_generate_test.py
+++ b/hotfix/hotfix_generate_test.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os
 from pathlib import Path
@@ -253,31 +254,114 @@ write_files:
                     ).read_text(),
                 )
 
-    def test_write_hotfix_file_contains_only_anc_version_and_preserves_it(self):
+    def test_update_nodecustomdata_injects_and_removes_selected_blocks(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            template = Path(temp_dir) / "nodecustomdata.yml"
+            template.write_text(
+                "#cloud-config\n"
+                "write_files:\n"
+                "{{if EnableScriptlessCSECmd}}\n"
+                "{{- else }}\n"
+                f"{TRADITIONAL_TEMPLATE}"
+                "{{- end }}\n"
+            )
+            with mock.patch.object(hotfix_generate, "TEMPLATE", str(template)):
+                hotfix_generate.update_nodecustomdata({"provisionSource"})
+                injected = template.read_text()
+                self.assertIn(hotfix_generate.SCRIPTS_BEGIN, injected)
+                self.assertIn("provisionSource", injected)
+                self.assertNotIn(
+                    "provisionSourceUbuntu",
+                    injected.split(hotfix_generate.SCRIPTS_END, 1)[0],
+                )
+
+                hotfix_generate.update_nodecustomdata(set())
+                cleaned = template.read_text()
+                self.assertNotIn(hotfix_generate.SCRIPTS_BEGIN, cleaned)
+                self.assertEqual(1, cleaned.count("provisionSourceUbuntu"))
+
+    def test_write_hotfix_file_contains_both_versions_and_preserves_them(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             target = Path(temp_dir) / "hotfix.json"
             with mock.patch.object(
                 hotfix_generate, "TARGET_FILE", str(target)
             ):
-                hotfix_generate.write_hotfix_file("202608.14.1")
+                hotfix_generate.write_hotfix_file(
+                    "202608.14.1",
+                    "202608.14.2",
+                )
                 self.assertEqual(
-                    {"version": "202608.14.1"},
+                    {
+                        "version": "202608.14.1",
+                        "scripts_version": "202608.14.2",
+                    },
                     json.loads(target.read_text()),
                 )
-                hotfix_generate.write_hotfix_file("")
+                hotfix_generate.write_hotfix_file("", "")
                 self.assertEqual(
-                    {"version": "202608.14.1"},
+                    {
+                        "version": "202608.14.1",
+                        "scripts_version": "202608.14.2",
+                    },
                     json.loads(target.read_text()),
                 )
 
-    def test_write_hotfix_file_without_version_keeps_missing_target_absent(self):
+    def test_write_hotfix_file_without_versions_keeps_missing_target_absent(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             target = Path(temp_dir) / "hotfix.json"
             with mock.patch.object(
                 hotfix_generate, "TARGET_FILE", str(target)
             ):
-                hotfix_generate.write_hotfix_file("")
+                hotfix_generate.write_hotfix_file("", "")
                 self.assertFalse(target.exists())
+
+    def test_resolve_hotfix_versions_defaults_scripts_to_scripts_version(self):
+        with mock.patch.object(
+            hotfix_generate,
+            "bump_version",
+            return_value="202608.14.1",
+        ):
+            self.assertEqual(
+                ("", "202608.14.1"),
+                hotfix_generate.resolve_hotfix_versions(
+                    "202608.14.0",
+                    anc_changed=False,
+                    script_hotfix_changed=True,
+                    use_anc_for_scripts=False,
+                ),
+            )
+
+    def test_resolve_hotfix_versions_adds_version_for_anc_script_delivery(self):
+        with mock.patch.object(
+            hotfix_generate,
+            "bump_version",
+            return_value="202608.14.1",
+        ):
+            self.assertEqual(
+                ("202608.14.1", "202608.14.1"),
+                hotfix_generate.resolve_hotfix_versions(
+                    "202608.14.0",
+                    anc_changed=False,
+                    script_hotfix_changed=True,
+                    use_anc_for_scripts=True,
+                ),
+            )
+
+    def test_resolve_hotfix_versions_keeps_independent_anc_version(self):
+        with mock.patch.object(
+            hotfix_generate,
+            "bump_version",
+            return_value="202608.14.1",
+        ):
+            self.assertEqual(
+                ("202608.14.1", "202608.14.1"),
+                hotfix_generate.resolve_hotfix_versions(
+                    "202608.14.0",
+                    anc_changed=True,
+                    script_hotfix_changed=True,
+                    use_anc_for_scripts=False,
+                ),
+            )
 
     def test_cse_start_hotfix_fails_even_with_supported_changes(self):
         self.assertNotIn("cse_start.sh", hotfix_generate.SOURCE_TO_VARKEY)
@@ -380,6 +464,22 @@ write_files:
                 "v0.20260826.0",
                 hotfix_generate.resolve_baseline_ref("202608.26.0"),
             )
+
+    def test_resolve_baseline_ref_uses_testing_override(self):
+        with mock.patch.object(
+            hotfix_generate.subprocess, "run"
+        ) as run, mock.patch.object(
+            hotfix_generate, "tag_exists"
+        ) as tag_exists, mock.patch(
+            "sys.stderr", new_callable=io.StringIO
+        ) as stderr:
+            self.assertEqual(
+                "HEAD",
+                hotfix_generate.resolve_baseline_ref("202608.26.0", "HEAD"),
+            )
+        run.assert_not_called()
+        tag_exists.assert_not_called()
+        self.assertIn("non-cumulative script baseline override HEAD", stderr.getvalue())
 
     def test_detect_changed_varkeys_accumulates_all_scripts_since_baseline(self):
         # A later hotfix must re-select every script that differs from the VHD

--- a/parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh
@@ -90,6 +90,14 @@ else
     log "Using VHD-baked binary: $BIN_PATH"
 fi
 
+if [ -x "$HOTFIX_BIN" ]; then
+    f "$HOTFIX_BIN" apply-hotfix; then
+        log "ANC apply-hotfix completed"
+    else
+        log "ANC apply-hotfix failed"
+    fi
+fi
+
 command=("$BIN_PATH" provision)
 if [ -f "$CONFIG_PATH" ]; then
     log "Launching aks-node-controller with config ${CONFIG_PATH}"

--- a/parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh
+++ b/parts/linux/cloud-init/artifacts/aks-node-controller-launcher.sh
@@ -91,10 +91,10 @@ else
 fi
 
 if [ -x "$HOTFIX_BIN" ]; then
-    f "$HOTFIX_BIN" apply-hotfix; then
-        log "ANC apply-hotfix completed"
+    if "$HOTFIX_BIN" apply-embedded-hotfix; then
+        log "ANC apply-embedded-hotfix completed"
     else
-        log "ANC apply-hotfix failed"
+        log "ANC apply-embedded-hotfix failed"
     fi
 fi
 


### PR DESCRIPTION
Generate both legacy  nodecustomdata.yml  updates and embedded ANC payloads. 
Script hotfixes use  scripts_version  by default;  --use-anc-for-scripts  additionally sets  version  to enable ANC delivery. Also adds  --baseline-ref  for local testing.