### PR TITLE
feat: add reload plugin to LocalDNS Corefile

### DIFF
--- a/aks-node-controller/parser/helper_test.go
+++ b/aks-node-controller/parser/helper_test.go
@@ -1687,6 +1687,7 @@ health-check.localdns.local:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -1714,6 +1715,7 @@ cluster.local:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -1732,6 +1734,7 @@ testdomain456.com:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -1758,6 +1761,7 @@ testdomain456.com:53 {
         policy sequential
         max_concurrent 2000
     }
+    reload
     ready 169.254.10.11:8181
     cache 3600 {
         success 9984

--- a/aks-node-controller/parser/templates/localdns.toml.gtpl
+++ b/aks-node-controller/parser/templates/localdns.toml.gtpl
@@ -58,6 +58,7 @@ health-check.localdns.local:53 {
         failfast_all_unhealthy_upstreams
         {{- end}}
     }
+    reload
     ready {{getLocalDnsNodeListenerIp}}:8181
     cache {{$override.CacheDurationInSeconds}} {
         success 9984
@@ -135,6 +136,7 @@ health-check.localdns.local:53 {
         failfast_all_unhealthy_upstreams
         {{- end}}
     }
+    reload
     ready {{getLocalDnsClusterListenerIp}}:8181
     cache {{$override.CacheDurationInSeconds}} {
         success 9984

--- a/pkg/agent/baker.go
+++ b/pkg/agent/baker.go
@@ -2427,6 +2427,7 @@ health-check.localdns.local:53 {
         failfast_all_unhealthy_upstreams
         {{- end}}
     }
+    reload
     ready {{$.NodeListenerIP}}:8181
     cache {{$override.CacheDurationInSeconds}} {
         success 9984
@@ -2504,6 +2505,7 @@ health-check.localdns.local:53 {
         failfast_all_unhealthy_upstreams
         {{- end}}
     }
+    reload
     ready {{$.ClusterListenerIP}}:8181
     cache {{$override.CacheDurationInSeconds}} {
         success 9984

--- a/pkg/agent/baker_test.go
+++ b/pkg/agent/baker_test.go
@@ -550,6 +550,7 @@ health-check.localdns.local:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -577,6 +578,7 @@ cluster.local:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -595,6 +597,7 @@ testdomain456.com:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -621,6 +624,7 @@ testdomain456.com:53 {
         policy sequential
         max_concurrent 2000
     }
+    reload
     ready 169.254.10.11:8181
     cache 3600 {
         success 9984
@@ -742,6 +746,7 @@ health-check.localdns.local:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -769,6 +774,7 @@ cluster.local:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -787,6 +793,7 @@ testdomain456.com:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.10:8181
     cache 3600 {
         success 9984
@@ -813,6 +820,7 @@ testdomain456.com:53 {
         policy sequential
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.11:8181
     cache 3600 {
         success 9984
@@ -840,6 +848,7 @@ cluster.local:53 {
         policy round_robin
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.11:8181
     cache 3600 {
         success 9984
@@ -858,6 +867,7 @@ testdomain567.com:53 {
         policy random
         max_concurrent 1000
     }
+    reload
     ready 169.254.10.11:8181
     cache 3600 {
         success 9984


### PR DESCRIPTION
## Summary

Add the CoreDNS `reload` plugin to the LocalDNS Corefile.

## Why

LocalDNS generates and updates its Corefile as part of node configuration. The
CoreDNS `reload` plugin watches the Corefile and automatically reloads CoreDNS
when the file changes, allowing new configuration to take effect without
restarting the LocalDNS service or interrupting DNS traffic.

This matters for configuration changes that occur after CoreDNS has started,
including upstream VNET DNS server updates and other LocalDNS Corefile
changes. Without the plugin, the file on disk may contain the new
configuration while the running CoreDNS process continues serving the old
configuration until an explicit service restart.

The plugin uses CoreDNS's supported periodic file polling and reload behavior:
https://coredns.io/plugins/reload/

## Testing

- Added parser and Baker coverage for rendering the `reload` plugin.
- `git diff --check` passes.
- Full ShellSpec validation is provided by the repository CI workflow.
