### PR TITLE
chore(deps): cache coredns v1.14.7-1 in VHD for LocalDNS

### DIFF
--- a/parts/common/components.json
+++ b/parts/common/components.json
@@ -120,6 +120,10 @@
       "multiArchVersionsV2": [
         {
           "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/coredns",
+          "latestVersion": "v1.14.7-1"
+        },
+        {
+          "renovateTag": "registry=https://mcr.microsoft.com, name=oss/v2/kubernetes/coredns",
           "latestVersion": "v1.14.3-11"
         },
         {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `coredns v1.14.7-1` (`mcr.microsoft.com/oss/v2/kubernetes/coredns`) to `parts/common/components.json` so it is cached in the VHD.

LocalDNS does not download coredns directly — `extractAndCacheCoreDnsBinary` (in `vhdbuilder/packer/install-dependencies.sh`) extracts the `/usr/bin/coredns` binary from the **highest** cached coredns image tag (it sorts tags with `sort -V -r`) into `/opt/azure/containers/localdns/binary/coredns`. Pinning `v1.14.7-1` promotes it to the newest cached tag, so LocalDNS will run coredns 1.14.7 on the next VHD build.

The upstream v1.14.7 release is now published to MCR (built via the DALEC spec in Azure/dalec-build-defs#23322).

**Why this is a manual bump:** the Renovate `coredns` rule (`.github/renovate.json`) only proposes `patch`-revision bumps within an existing line and has `automerge: false`, so crossing `1.14.3 -> 1.14.7` requires a manual edit (same pattern as the prior manual bump in #7651).

**Notes for reviewers:**
- Existing lower-line entries (1.14.3, 1.13.1, 1.12.1, 1.11.3) are intentionally left in place; LocalDNS only consumes the single highest cached tag. Let me know if the convention is to replace the 1.14.3 entry instead of adding alongside it.
- `v1.14.7-1` verified present in MCR: `oss/v2/kubernetes/coredns`.

**Which issue(s) this PR fixes**:
Fixes #